### PR TITLE
ci: Make it possible to override runs-on

### DIFF
--- a/.github/scripts/generate_schedulers.py
+++ b/.github/scripts/generate_schedulers.py
@@ -36,6 +36,10 @@ def generate_schedulers(config : dict, template : str):
       cicd = yaml.safe_load(template_str)
       del cicd[True]
       
+      # Override runs-on
+      if "runs-on" in scheduler:
+        cicd["jobs"]["scheduler"]["runs-on"] = scheduler["runs-on"]
+      
       # Add docker pull
       abi_version = scheduler.get("abi_version", "latest")
       


### PR DESCRIPTION
This pull request makes it possible to override runs-on in the CI/CD configuration. 

Pretty useful if you want to run the schedulers on a self-hosted runner in your own infrastructure.