### PR TITLE
feat: Make it possible to run trigger in background

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -9,6 +9,7 @@ from typing import List, Dict, Any, Optional
 from pathlib import Path
 from lib.abi import logger
 from lib.abi.services.object_storage.ObjectStorageFactory import ObjectStorageFactory
+import atexit
 
 @dataclass
 class PipelineConfig:
@@ -94,6 +95,10 @@ for module in modules:
     # Loading ontologies
     for ontology in module.ontologies:
         services.triple_store_service.load_schema(ontology)
+
+@atexit.register
+def shutdown_services():
+    services.triple_store_service.__del__()
 
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
# Add Background Trigger Support for Triple Store Events

## Description
This PR introduces the ability to run triple store event triggers in the background using a worker pool. This enhancement improves performance by allowing long-running event handlers to execute asynchronously without blocking the main triple store operations.

## Key Changes
- Added a worker pool implementation for handling background triggers
- Modified the triple store service to support background event processing
- Added proper cleanup of worker pools on service shutdown
- Updated the subscription API to support background execution

## Technical Details
- Introduced a new `background` parameter in the `subscribe` method to specify if a trigger should run asynchronously
- Added a configurable worker pool size (default: 10 workers) for handling background tasks
- Implemented proper cleanup using `atexit` to ensure worker pools are shut down gracefully
- Enhanced the `Job` class to support optional queue parameter for more flexible job handling

## Benefits
- Improved performance for long-running event handlers
- Better resource utilization through asynchronous processing
- Reduced blocking of main triple store operations
- Graceful cleanup of resources on application shutdown

## Testing
- The changes have been tested with both synchronous and asynchronous event handlers
- Worker pool cleanup has been verified to work correctly on application shutdown
- Event handling continues to work as expected for non-background triggers

## Related Issues
Closes #411 