### PR TITLE
feat: Add get_subject_graph to TripleStoreService and secondary adapters

### DIFF
--- a/lib/abi/services/triple_store/TripleStorePorts.py
+++ b/lib/abi/services/triple_store/TripleStorePorts.py
@@ -4,6 +4,10 @@ from typing import List, Callable, Dict, Tuple
 from enum import Enum
 
 class Exceptions:
+    
+    class SubjectNotFoundError(Exception):
+        pass
+    
     class SubscriptionNotFoundError(Exception):
             pass
         
@@ -39,6 +43,11 @@ class ITripleStorePort(ABC):
     @abstractmethod
     def query_view(self, view: str, query: str) -> Graph:
         pass
+    
+    @abstractmethod
+    def get_subject_graph(self, subject: str) -> Graph:
+        pass
+    
 
 class ITripleStoreService(ABC):
     
@@ -151,6 +160,21 @@ class ITripleStoreService(ABC):
         
     @abstractmethod
     def query_view(self, view: str, query: str) -> Graph:
+        pass
+    
+    @abstractmethod
+    def get_subject_graph(self, subject: str) -> Graph:
+        """Get the RDF graph containing all triples for a specific subject.
+        
+        This method retrieves and returns an RDFlib Graph containing all triples
+        that have the specified subject.
+        
+        Args:
+            subject (str): The subject to retrieve triples for
+            
+        Returns:
+            Graph: An RDFlib Graph containing all triples for the specified subject
+        """
         pass
     
     @abstractmethod

--- a/lib/abi/services/triple_store/TripleStoreService.py
+++ b/lib/abi/services/triple_store/TripleStoreService.py
@@ -146,6 +146,10 @@ class TripleStoreService(ITripleStoreService):
             for event_type in self.__event_listeners[topic]:
                 self.__event_listeners[topic][event_type] = pydash.filter_(self.__event_listeners[topic][event_type], lambda x: x[0] != subscription_id)
 
+    def get_subject_graph(self, subject: str) -> Graph:
+        return self.__ontology_adaptor.get_subject_graph(subject)
+
+
     ############################################################
     # Schema Management
     ############################################################

--- a/lib/abi/services/triple_store/adaptors/secondary/TripleStoreService__SecondaryAdaptor__Filesystem.py
+++ b/lib/abi/services/triple_store/adaptors/secondary/TripleStoreService__SecondaryAdaptor__Filesystem.py
@@ -76,6 +76,14 @@ class TripleStoreService__SecondaryAdaptor__Filesystem(ITripleStorePort, TripleS
     def get(self) -> Graph:
         return self.__live_graph
     
+    def get_subject_graph(self, subject: str) -> Graph:
+        subject_hash = self.iri_hash(subject)
+        
+        if os.path.exists(self.hash_triples_path(subject_hash)):
+            return Graph().parse(self.hash_triples_path(subject_hash), format='turtle')
+
+        raise Exceptions.SubjectNotFoundError(f"Subject {subject} not found")
+    
     def load(self) -> Graph:
         triples = Graph()
         

--- a/lib/abi/services/triple_store/adaptors/secondary/TripleStoreService__SecondaryAdaptor__ObjectStorage.py
+++ b/lib/abi/services/triple_store/adaptors/secondary/TripleStoreService__SecondaryAdaptor__ObjectStorage.py
@@ -1,4 +1,4 @@
-from lib.abi.services.triple_store.TripleStorePorts import ITripleStorePort, OntologyEvent
+from lib.abi.services.triple_store.TripleStorePorts import ITripleStorePort, OntologyEvent, Exceptions
 from lib.abi.services.object_storage.ObjectStorageService import ObjectStorageService
 from lib.abi.services.object_storage.ObjectStoragePort import Exceptions as ObjectStorageExceptions
 from lib.abi.services.triple_store.adaptors.secondary.base.TripleStoreService__SecondaryAdaptor__FileBase import TripleStoreService__SecondaryAdaptor__FileBase
@@ -91,7 +91,16 @@ class TripleStoreService__SecondaryAdaptor__NaasStorage(ITripleStorePort, Triple
             self.__live_graph.bind(prefix, namespace)
             
         self.__live_graph -= triples
-    
+
+    def get_subject_graph(self, subject: str) -> Graph:
+        subject_hash = self.iri_hash(subject)
+        
+        try:
+            graph = self.load_triples(subject_hash)
+            return graph
+        except ObjectStorageExceptions.ObjectNotFound:
+            raise Exceptions.SubjectNotFoundError(f"Subject {subject} not found")
+
     def load(self) -> Graph:
         logger.debug("Loading triples from object storage")
         triples = Graph()


### PR DESCRIPTION
This pull request resolves #415

It works by loading the subject file directly and not running a SPARQL query which is more efficient.