### PR TITLE
feat: Add make-prod-{remove,override}

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,15 @@ storage-push: .venv storage-pull
 	@ echo "Pushing storage..."
 	@ docker compose run --rm --remove-orphans  abi bash -c 'poetry run python scripts/storage_push.py | sh'
 
+storage-prod-remove: .venv
+	@ echo "Removing storage..."
+	@ docker compose run --rm -it --remove-orphans  abi bash -c 'poetry run python scripts/storage_remove_prod.py'
+
+storage-prod-override: .venv
+	@ echo "Overriding storage..."
+	@ make storage-push
+	@ docker compose run -it --rm --remove-orphans  abi bash -c 'poetry run python scripts/storage_override_prod.py'
+
 clean:
 	@echo "Cleaning up build artifacts..."
 	rm -rf __pycache__ .pytest_cache build dist *.egg-info lib/.venv .venv

--- a/scripts/storage_override_prod.py
+++ b/scripts/storage_override_prod.py
@@ -1,0 +1,20 @@
+from common import get_config, get_storage_credentials
+import os
+from datetime import datetime
+
+if __name__ == "__main__":
+    
+    # Ask user to validate storage? (y/n): " confirm
+    confirm = input("Are you sure you want to override the storage? (y/n): ")
+    if confirm != "y":
+        print("Storage override cancelled.")
+        exit()
+    
+    naas_api_key, workspace_id, storage_name = get_config()
+    bucket, access_key_id, secret_access_key, session_token = get_storage_credentials(naas_api_key, workspace_id, storage_name)
+    
+    # Backup the prod before overriding
+    backup_timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+    os.system(f'AWS_ACCESS_KEY_ID={access_key_id} AWS_SECRET_ACCESS_KEY={secret_access_key} AWS_SESSION_TOKEN={session_token} aws s3 mv --recursive {bucket}/ontologies {bucket}/ontologies-backups/{backup_timestamp}')
+    
+    os.system(f'AWS_ACCESS_KEY_ID={access_key_id} AWS_SECRET_ACCESS_KEY={secret_access_key} AWS_SESSION_TOKEN={session_token} aws s3 cp --recursive {bucket}/storage/triplestore {bucket}/ontologies')

--- a/scripts/storage_remove_prod.py
+++ b/scripts/storage_remove_prod.py
@@ -1,0 +1,17 @@
+from common import get_config, get_storage_credentials
+import os
+from datetime import datetime
+if __name__ == "__main__":
+    
+    confirm = input("Are you sure you want to remove the storage? (y/n): ")
+    if confirm != "y":
+        print("Storage removal cancelled.")
+        exit()
+    
+    naas_api_key, workspace_id, storage_name = get_config()
+    bucket, access_key_id, secret_access_key, session_token = get_storage_credentials(naas_api_key, workspace_id, storage_name)
+    
+    backup_timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+    os.system(f'AWS_ACCESS_KEY_ID={access_key_id} AWS_SECRET_ACCESS_KEY={secret_access_key} AWS_SESSION_TOKEN={session_token} aws s3 mv --recursive {bucket}/ontologies {bucket}/ontologies-backups/{backup_timestamp}')
+    
+    os.system(f'AWS_ACCESS_KEY_ID={access_key_id} AWS_SECRET_ACCESS_KEY={secret_access_key} AWS_SESSION_TOKEN={session_token} aws s3 rm --recursive {bucket}/ontologies')


### PR DESCRIPTION
# Add Storage Management Commands for Production Environment

## Overview
This PR introduces new Makefile commands and scripts to safely manage production storage operations, specifically for handling ontologies in S3.

## Changes
- Added two new Makefile commands:
  - `storage-prod-remove`: Safely removes production storage with backup
  - `storage-prod-override`: Overrides production storage with local storage data

- Added two new Python scripts:
  - `storage_remove_prod.py`: Handles production storage removal
  - `storage_override_prod.py`: Manages production storage override

## Safety Features
- Both operations require explicit user confirmation
- Automatic backup creation before any destructive operation
- Backups are timestamped and stored in `ontologies-backups/{timestamp}`

## Usage
```bash
# To remove production storage
make storage-prod-remove

# To override production storage with local data
make storage-prod-override
```

## Implementation Details
- Uses AWS S3 commands with temporary credentials
- Maintains existing storage management patterns
- Includes safety checks and confirmations
- Leverages existing configuration and credential management
