### PR TITLE
fix: Make templatableSparqlQuery load faster

### DIFF
--- a/lib/abi/services/triple_store/adaptors/secondary/AWSNeptune.py
+++ b/lib/abi/services/triple_store/adaptors/secondary/AWSNeptune.py
@@ -482,6 +482,7 @@ class AWSNeptune(ITripleStorePort):
             o: Identifier | None = row.get("o")
 
             assert s is not None and p is not None and o is not None
+            
 
             graph.add((s, p, o))
 
@@ -688,6 +689,9 @@ class AWSNeptune(ITripleStorePort):
         # Build the INSERT DATA statement
         triples = []
         for s, p, o in graph:
+            # Skip if any term is a blank node
+            if isinstance(s, rdflib.BNode) or isinstance(p, rdflib.BNode) or isinstance(o, rdflib.BNode):
+                continue
             # Convert each term to N3 format
             s_str = s.n3()
             p_str = p.n3()

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -148,25 +148,33 @@ logger.debug("Loading modules")
 modules = get_modules()
 
 
-async def load_ontologies_async():
-    """Load all ontologies asynchronously"""
-    tasks = []
-    for module in modules:
-        # Loading ontologies
-        for ontology in module.ontologies:
-            # Create async task for each load_schema call
-            task = asyncio.create_task(
-                asyncio.to_thread(services.triple_store_service.load_schema, ontology)
-            )
-            tasks.append(task)
+# async def load_ontologies_async():
+#     """Load all ontologies asynchronously"""
+#     tasks = []
+#     for module in modules:
+#         # Loading ontologies
+#         for ontology in module.ontologies:
+#             # Create async task for each load_schema call
+#             task = asyncio.create_task(
+#                 asyncio.to_thread(services.triple_store_service.load_schema, ontology)
+#             )
+#             tasks.append(task)
 
-    # Wait for all tasks to complete
-    if tasks:
-        await asyncio.gather(*tasks)
+#     # Wait for all tasks to complete
+#     if tasks:
+#         await asyncio.gather(*tasks)
 
 
-# Run the async ontology loading
-asyncio.run(load_ontologies_async())
+# # Run the async ontology loading
+# asyncio.run(load_ontologies_async())
+
+ontology_filepaths = []
+
+for module in modules:
+    for ontology in module.ontologies:
+        ontology_filepaths.append(ontology)
+        
+services.triple_store_service.load_schemas(ontology_filepaths)
 
 logger.debug("Loading triggers")
 for module in modules:

--- a/src/core/modules/intentmapping/TemplatableSparqlQuery.py
+++ b/src/core/modules/intentmapping/TemplatableSparqlQuery.py
@@ -1,5 +1,6 @@
 from pydantic import Field, create_model
 import asyncio
+from rdflib import Graph, URIRef, RDF
 
 from abi import logger
 
@@ -48,9 +49,33 @@ def templatable_queries():
         }
 
     arguments = {}
+    
+    argument_graph = Graph()
+    argument_graph.bind("intentMapping", URIRef("http://ontology.naas.ai/intentMapping/"))
+    results = services.triple_store_service.query("""
+                PREFIX intentMapping: <http://ontology.naas.ai/intentMapping/>
+                
+                SELECT ?argument ?name ?description ?validationPattern ?validationFormat
+                WHERE {
+                    ?argument a intentMapping:QueryArgument ;
+                        intentMapping:argumentName ?name ;
+                        intentMapping:argumentDescription ?description ;
+                        intentMapping:validationPattern ?validationPattern ;
+                        intentMapping:validationFormat ?validationFormat .
+                }
+            """)
+    
+    for argument, name, description, validationPattern, validationFormat in results:
+        argument_graph.add((argument, RDF.type, URIRef("http://ontology.naas.ai/intentMapping/QueryArgument")))
+        argument_graph.add((argument, URIRef("http://ontology.naas.ai/intentMapping/argumentName"), name))
+        argument_graph.add((argument, URIRef("http://ontology.naas.ai/intentMapping/argumentDescription"), description))
+        argument_graph.add((argument, URIRef("http://ontology.naas.ai/intentMapping/validationPattern"), validationPattern))
+        argument_graph.add((argument, URIRef("http://ontology.naas.ai/intentMapping/validationFormat"), validationFormat))
+        print(f"Argument: {argument}, Name: {name}, Description: {description}, Validation Pattern: {validationPattern}, Validation Format: {validationFormat}")
+    
 
-    def __load_arguments(templatableQuery):
-        arguments = {}
+    arguments = {}
+    for templatableQuery in queries:
         for argument in queries[templatableQuery].get("hasArgument"):
             q = (
                 """
@@ -70,7 +95,8 @@ def templatable_queries():
             """
             )
             logger.debug(f"Query: {q}")
-            results = services.triple_store_service.query(q)
+            # results = services.triple_store_service.query(q)
+            results = argument_graph.query(q)
 
             for result in results:
                 argument, name, description, validationPattern, validationFormat = (
@@ -83,11 +109,47 @@ def templatable_queries():
                     "validationPattern": validationPattern,
                     "validationFormat": validationFormat,
                 }
-        return arguments
 
-    jobs = [(__load_arguments, templatableQuery) for templatableQuery in queries]
-    for args in asyncio_thread_job(jobs):
-        arguments.update(args)
+    # def __load_arguments(templatableQuery):
+    #     arguments = {}
+    #     for argument in queries[templatableQuery].get("hasArgument"):
+    #         q = (
+    #             """
+    #             PREFIX intentMapping: <http://ontology.naas.ai/intentMapping/>
+                
+    #             SELECT ?argument ?name ?description ?validationPattern ?validationFormat
+    #             WHERE {
+    #                 BIND(<"""
+    #             + str(argument)
+    #             + """> AS ?argument)
+    #                 ?argument a intentMapping:QueryArgument ;
+    #                     intentMapping:argumentName ?name ;
+    #                     intentMapping:argumentDescription ?description ;
+    #                     intentMapping:validationPattern ?validationPattern ;
+    #                     intentMapping:validationFormat ?validationFormat .
+    #             }
+    #         """
+    #         )
+    #         logger.debug(f"Query: {q}")
+    #         # results = services.triple_store_service.query(q)
+    #         results = argument_graph.query(q)
+
+    #         for result in results:
+    #             argument, name, description, validationPattern, validationFormat = (
+    #                 result
+    #             )
+
+    #             arguments[argument] = {
+    #                 "name": name,
+    #                 "description": description,
+    #                 "validationPattern": validationPattern,
+    #                 "validationFormat": validationFormat,
+    #             }
+    #     return arguments
+
+    # jobs = [(__load_arguments, templatableQuery) for templatableQuery in queries]
+    # for args in asyncio_thread_job(jobs):
+    #     arguments.update(args)
 
     return queries, arguments
 

--- a/src/core/modules/intentmapping/__init__.py
+++ b/src/core/modules/intentmapping/__init__.py
@@ -3,6 +3,7 @@ from abi import logger
 
 workflows: list = []
 tools: list = []
+loaded = False
 
 
 def get_workflows():
@@ -10,13 +11,18 @@ def get_workflows():
 
 
 def get_tools(tool_names: list[str] = []):
+    global loaded
+    if not loaded:
+        load_tools()
+        loaded = True
+
     if len(tool_names) == 0:
         return tools
     else:
         return [tool for tool in tools if tool.name in tool_names]
 
 
-def on_initialized():
+def load_tools():
     logger.debug("Loading Intent Mapping workflows")
     w = load_workflows()
     workflows.extend(w)


### PR DESCRIPTION
This pull request resolves #improve-boot-speed

### Summary
This pull request introduces several optimizations and improvements to the `TripleStoreService` and related components to enhance the boot speed and efficiency of schema loading and querying processes.

### Key Changes

1. **Schema Loading Optimization**
   - Refactored the `load_schema` method to `load_schemas`, allowing multiple schemas to be loaded simultaneously, which reduces the overhead of individual schema loading.
   - Implemented a schema cache to store and query existing schemas, minimizing redundant queries to the triple store.
   - Enhanced the schema update mechanism to check for changes using file hashes and update only when necessary.

2. **AWS Neptune Adapter Improvements**
   - Added a check to skip blank nodes when building the INSERT DATA statement, preventing potential errors during data insertion.

3. **Asynchronous Ontology Loading**
   - Replaced the asynchronous `load_ontologies_async` function with a synchronous approach using `load_schemas`, simplifying the loading process and reducing complexity.

4. **Intent Mapping Module Enhancements**
   - Introduced an `argument_graph` to store and query argument details, improving the efficiency of templatable query processing.
   - Refactored the `get_tools` function to ensure tools are loaded only once, preventing redundant operations.

### Additional Notes
- The changes aim to improve the overall performance and maintainability of the codebase, particularly in environments with large numbers of schemas and ontologies.
- Error handling has been added to the `load_schema` method to log any exceptions during schema loading.

These improvements are expected to significantly reduce the boot time and enhance the responsiveness of the system.