### PR TITLE
feat: Add CORS management

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,6 +10,8 @@ config:
   favicon_path: "assets/favicon.ico" # Path to the favicon
   storage_name: "abi" # Name of the storage
   space_name: "abi" # Name of the space
+  cors_origins:
+    - "http://localhost:9879"
   
 pipelines:
   - name: github.GithubIssuesPipeline

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -49,6 +49,7 @@ class Config:
     favicon_path: str
     pipelines: List[PipelineConfig]
     space_name: str
+    cors_origins: List[str]
 
     @classmethod
     def from_yaml(cls, yaml_path: str = "config.yaml") -> "Config":
@@ -75,6 +76,7 @@ class Config:
                     favicon_path=config_data["favicon_path"],
                     pipelines=pipeline_configs,
                     space_name=config_data.get("space_name"),
+                    cors_origins=config_data.get("cors_origins"),
                 )
         except FileNotFoundError:
             return cls(
@@ -90,6 +92,7 @@ class Config:
                 favicon_path="",
                 pipelines=[],
                 space_name="",
+                cors_origins=[],
             )
 
 

--- a/src/api.py
+++ b/src/api.py
@@ -6,6 +6,7 @@ from fastapi.security.oauth2 import OAuth2
 from fastapi.openapi.models import OAuthFlows as OAuthFlowsModel
 from fastapi.security.utils import get_authorization_scheme_param
 from fastapi.openapi.docs import get_swagger_ui_html, get_redoc_html
+from fastapi.middleware.cors import CORSMiddleware
 import subprocess
 import os
 from abi import logger
@@ -33,6 +34,18 @@ logo_name = os.path.basename(logo_path)
 # Set favicon path
 favicon_path = config.favicon_path
 favicon_name = os.path.basename(favicon_path)
+
+origins = config.cors_origins
+
+logger.debug(f"CORS origins: {origins}")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 # Mount the static directory
 app.mount("/static", StaticFiles(directory="assets"), name="static")


### PR DESCRIPTION
This pull request resolves #477

### Summary
This pull request introduces CORS (Cross-Origin Resource Sharing) configuration to the application, allowing it to specify which origins are permitted to access resources. This is particularly useful for enabling local development and testing.

### Changes Made
- **Configuration Update**: Added a new `cors_origins` field in the `config.yaml` file to specify allowed origins. Initially, `http://localhost:9879` is added to facilitate local development.
- **Code Update**: Updated the `Config` class in `src/__init__.py` to include the `cors_origins` attribute, ensuring it is loaded from the configuration file.
- **API Update**: Integrated `CORSMiddleware` from FastAPI in `src/api.py` to handle CORS, using the origins specified in the configuration.

### Impact
These changes allow the application to handle CORS requests, which is essential for web applications that interact with resources from different origins. This setup is particularly beneficial for developers working in local environments.

### Testing
- Verified that the application correctly loads the CORS configuration from `config.yaml`.
- Tested the application to ensure that requests from `http://localhost:9879` are allowed.

### Notes
Further origins can be added to the `cors_origins` list in `config.yaml` as needed for different environments or deployment scenarios.