### PR TITLE
feat: Add lazy loading of modules and services

### DIFF
--- a/lib/abi/utils/LazyLoader.py
+++ b/lib/abi/utils/LazyLoader.py
@@ -1,0 +1,44 @@
+from typing import Callable, Any
+
+class LazyLoader:
+    loaded : bool
+    loader : Callable
+    value : Any
+    
+    def __init__(self, loader: Callable):
+        self.loaded = False
+        self.loader = loader
+        self.value = None
+        
+    def is_loaded(self):
+        return self.loaded
+        
+    def __getattr__(self, name):
+        if not self.loaded:
+            self.value = self.loader()
+            self.loaded = True
+        return getattr(self.value, name)
+    
+    def __iter__(self):
+        if not self.loaded:
+            self.value = self.loader()
+            self.loaded = True
+        return iter(self.value)
+    
+    def __len__(self):
+        if not self.loaded:
+            self.value = self.loader()
+            self.loaded = True
+        return len(self.value)
+    
+    def __getitem__(self, key):
+        if not self.loaded:
+            self.value = self.loader()
+            self.loaded = True
+        return self.value[key]
+    
+    def __repr__(self):
+        if not self.loaded:
+            self.value = self.loader()
+            self.loaded = True
+        return repr(self.value)

--- a/src/api.py
+++ b/src/api.py
@@ -10,6 +10,7 @@ from fastapi.middleware.cors import CORSMiddleware
 import subprocess
 import os
 from abi import logger
+from src import modules
 
 # Authentication
 from fastapi.security import OAuth2PasswordRequestForm
@@ -189,8 +190,7 @@ def overridden_redoc():
 def root():
     return API_LANDING_HTML.replace("[TITLE]", TITLE).replace("[LOGO_NAME]", logo_name)
 
-
-for module in get_modules():
+for module in modules:
     for agent in module.agents:
         logger.debug(f"Loading agent: {agent.name}")
         agent.as_api(agents_router)

--- a/src/core/apps/terminal_agent/main.py
+++ b/src/core/apps/terminal_agent/main.py
@@ -104,7 +104,7 @@ def generic_run_agent(agent_class: Optional[str] = None) -> None:
         finding and running the requested agent from the loaded modules. The agent
         must be properly registered in a module under src/modules for this to work.
     """
-    from src.__modules__ import get_modules
+    from src import modules
 
     if agent_class is None:
         print(
@@ -112,7 +112,7 @@ def generic_run_agent(agent_class: Optional[str] = None) -> None:
         )
         return
 
-    for module in get_modules():
+    for module in modules:
         for agent in module.agents:
             print(agent.__class__.__name__)
             if agent.__class__.__name__ == agent_class:


### PR DESCRIPTION
### Summary
This pull request introduces a new `LazyLoader` utility class and refactors the existing codebase to utilize lazy loading for services and modules. The `LazyLoader` class is designed to delay the loading of an object until it is actually needed, which can improve performance and resource utilization.

### Key Changes
- **New `LazyLoader` Class**: Added `LazyLoader.py` in `lib/abi/utils/` to provide a mechanism for lazy loading objects. This class uses a callable to load the object only when an attribute is accessed.
- **Refactor `src/__init__.py`**: 
  - Replaced direct initialization of `services` and `modules` with `LazyLoader` instances.
  - Modified the `shutdown_services` function to check if services are loaded before attempting to shut them down.
  - Consolidated module loading logic into a new `load_modules` function.
- **Update `src/api.py` and `src/core/apps/terminal_agent/main.py`**:
  - Replaced calls to `get_modules()` with the lazy-loaded `modules` object.

### Benefits
- **Performance Improvement**: By deferring the loading of services and modules until they are actually needed, the application can start up faster and use resources more efficiently.
- **Cleaner Code**: The use of `LazyLoader` simplifies the initialization logic and reduces the need for conditional checks throughout the codebase.

### Testing
- Ensure that all unit tests pass with the new lazy loading implementation.
- Verify that services and modules are loaded correctly when accessed.
- Test the application startup and shutdown processes to confirm that lazy loading does not introduce any regressions.