### PR TITLE
refactor: Update how routes are found

### DIFF
--- a/scripts/publish_remote_agents.py
+++ b/scripts/publish_remote_agents.py
@@ -10,6 +10,7 @@ from src.core.modules.support.integrations.GithubIntegration import (
     GithubIntegrationConfiguration,
 )
 from src import load_modules
+from fastapi import APIRouter
 
 def publish_remote_agent(
     naas_api_key: str, 
@@ -28,13 +29,14 @@ def publish_remote_agent(
     logger.info(f"==> Existing plugins: {len(existing_plugins)}")
 
     # Init Github Integration
-    github_integration = GithubIntegration(GithubIntegrationConfiguration(access_token=github_access_token))
-    logger.info(f"==> Updating \"ABI_API_KEY\" secret in Github repository: {github_repository}")
-    github_integration.create_or_update_repository_secret(
-        repo_name=github_repository,
-        secret_name="ABI_API_KEY",
-        value=abi_api_key
-    )
+    if github_access_token is not None and github_repository is not None:
+        github_integration = GithubIntegration(GithubIntegrationConfiguration(access_token=github_access_token))
+        logger.info(f"==> Updating \"ABI_API_KEY\" secret in Github repository: {github_repository}")
+        github_integration.create_or_update_repository_secret(
+            repo_name=github_repository,
+            secret_name="ABI_API_KEY",
+            value=abi_api_key
+        )
 
     # Get all agents from the modules
     load_modules()
@@ -70,13 +72,19 @@ def publish_remote_agent(
             if as_api is not None:
                 # Get the index of 'route_name' in co_varnames tuple
                 try:
-                    # Get route_name from function signature
-                    signature = inspect.signature(as_api)
-                    route_name = signature.parameters.get('route_name').default # type: ignore
-                except ValueError:
+                    router = APIRouter()
+                    as_api(router)
+                    
+                    for route in router.routes:
+                        if route.path.endswith("/stream-completion"):
+                            route_name = route.path.replace("/stream-completion", "")
+                            break
+                except (ValueError, AttributeError):
                     route_name = name
+                    
             if route_name is None:
-                raise ValueError(f"Route name not found for agent {name}")
+                route_name = name
+                #raise ValueError(f"Route name not found for agent {name}")
             
             plugin_data = {
                 "id": name.lower(),
@@ -91,7 +99,7 @@ def publish_remote_agent(
                 "temperature": temperature,
                 "type": "CUSTOM",
                 "remote": {
-                    "url": f"{api_base_url}/agents/{route_name}/stream-completion?token={abi_api_key}"
+                    "url": f"{api_base_url}/agents/{route_name}/stream-completion?token={abi_api_key}".replace("//", "/")
                 },
                 "suggestions": suggestions,
             }
@@ -125,6 +133,6 @@ if __name__ == "__main__":
     github_repository = config.github_project_repository
     default_agent = "Supervisor"
     agents_to_publish = ["Supervisor", "Ontology", "Naas", "Multi_Models", "Support"]
-    if naas_api_key is None or api_base_url is None or abi_api_key is None or workspace_id is None or github_access_token is None or github_repository is None:
-        raise ValueError("NAAS_API_KEY, API_BASE_URL, ABI_API_KEY, WORKSPACE_ID, GITHUB_ACCESS_TOKEN, and GITHUB_REPOSITORY must be set")
+    if naas_api_key is None or api_base_url is None or abi_api_key is None or workspace_id is None:
+        raise ValueError("NAAS_API_KEY, API_BASE_URL, ABI_API_KEY, WORKSPACE_ID must be set")
     publish_remote_agent(naas_api_key, api_base_url, abi_api_key, workspace_id, github_access_token, github_repository, default_agent, agents_to_publish)


### PR DESCRIPTION
### Summary
This update enhances the `publish_remote_agents.py` script by introducing several improvements and fixes:

1. **Conditional GitHub Integration Initialization**: 
   - The GitHub Integration is now only initialized if both `github_access_token` and `github_repository` are provided. This prevents unnecessary operations when these parameters are not available.

2. **Route Name Handling**:
   - Introduced a more robust method to determine the `route_name` using FastAPI's `APIRouter`. This change ensures that the correct route name is extracted, and defaults to the agent's name if not found.
   - Removed the exception raising when `route_name` is not found, defaulting to the agent's name instead.

3. **URL Formatting**:
   - Fixed the URL formatting issue by replacing double slashes (`//`) with a single slash (`/`) in the `remote.url` field.

4. **Environment Variable Checks**:
   - Updated the environment variable checks to remove the requirement for `GITHUB_ACCESS_TOKEN` and `GITHUB_REPOSITORY` when they are not necessary for the operation.

These changes improve the script's robustness and flexibility, especially in environments where GitHub integration is optional.