### PR TITLE
chore: Make the app crash if a module fails to load

### DIFF
--- a/lib/abi/utils/Module.py
+++ b/lib/abi/utils/Module.py
@@ -1,6 +1,7 @@
 from abc import ABC
 from abi.services.triple_store.TripleStorePorts import OntologyEvent
 from abi.services.agent.Agent import Agent
+from abi import logger
 from typing import Callable, List, Any
 import os
 import importlib
@@ -41,16 +42,17 @@ class IModule(ABC):
             self.__load_triggers()
             self.__load_ontologies()
         except Exception as e:
-            print(f"❌ Error loading module {self.module_import_path}: {e}")
+            logger.error(f"❌ Critical error loading module {self.module_import_path}: {e}")
+            raise SystemExit(f"Application crashed due to module loading failure: {self.module_import_path}")
 
     def load_agents(self):
         try:
             self.__load_agents()
         except Exception as e:
-            print(f"❌ Error loading agents for module {self.module_import_path}: {e}")
-            if os.environ.get("LOG_LEVEL") == "DEBUG":
-                import traceback
-                print(traceback.format_exc())
+            import traceback
+            logger.error(f"❌ Critical error loading agents for module {self.module_import_path}: {e}")
+            traceback.print_exc()
+            raise SystemExit(f"Application crashed due to agent loading failure: {self.module_import_path}")
 
     def __load_agents(self):
         # Load agents

--- a/src/__modules__.py
+++ b/src/__modules__.py
@@ -1,4 +1,5 @@
 from abi.utils.Module import IModule
+from abi import logger
 from typing import List
 import importlib
 import os
@@ -49,9 +50,10 @@ def get_modules():
                         __modules.append(mod)
                     except Exception as e:
                         import traceback
-
-                        print(f"❌ Error loading module {module.name}: {e}")
+                        
+                        logger.error(f"❌ Critical error loading module {module.name}: {e}")
                         traceback.print_exc()
+                        raise SystemExit(f"Application crashed due to module loading failure: {module.name}")
 
         __loaded = True
 


### PR DESCRIPTION
### Summary
This pull request introduces changes to improve error handling in the module loading process. The changes ensure that the application will crash with a clear error message when a critical error occurs during the loading of modules or agents, instead of continuing execution in an unstable state.

### Changes
- **Error Logging**: Replaced `print` statements with `logger.error` for logging critical errors when loading modules and agents.
- **Application Crash**: Introduced `SystemExit` to terminate the application when a critical error is encountered during module or agent loading.
- **Traceback Printing**: Ensured that traceback is printed for debugging purposes when an error occurs during agent loading.

### Files Modified
- `lib/abi/utils/Module.py`: Updated error handling in `IModule` class methods.
- `src/__modules__.py`: Enhanced error handling in the `get_modules` function.

These changes aim to provide better visibility into errors and ensure that the application does not continue running in an inconsistent state.