### PR TITLE
feat: Working on agents auto publish

### DIFF
--- a/.github/workflows/auto-publish-agents.yml
+++ b/.github/workflows/auto-publish-agents.yml
@@ -1,0 +1,120 @@
+name: Auto Publish Remote Agents
+
+on:
+  workflow_run:
+    workflows: ["ABI API"] # This matches the actual API deployment workflow name
+    types:
+      - completed
+    branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      force_publish:
+        description: 'Force publish all agents regardless of changes'
+        required: false
+        default: 'false'
+        type: boolean
+
+jobs:
+  auto-publish:
+    runs-on: ubuntu-latest
+    # Only run if the API deployment was successful or if manually triggered
+    if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v2
+
+    - name: Install dependencies
+      run: |
+        uv sync --all-extras
+
+    - name: Check auto-publish configuration
+      id: check-config
+      run: |
+        # Check if auto-publish is enabled and get API URL
+        CONFIG_DATA=$(uv run python -c "
+        import yaml
+        with open('config.yaml', 'r') as f:
+            config = yaml.safe_load(f)
+        
+        config_section = config.get('config', {})
+        auto_publish = config_section.get('auto_publish', {})
+        space_name = config_section.get('space_name', '')
+        
+        print('AUTO_PUBLISH_ENABLED=' + str(auto_publish.get('enabled', False)).lower())
+        print('API_BASE_URL=https://' + space_name + '-api.default.space.naas.ai')
+        print('SPACE_NAME=' + space_name)
+        ")
+        
+        # Parse the output
+        eval "$CONFIG_DATA"
+        
+        echo "auto_publish_enabled=${AUTO_PUBLISH_ENABLED}" >> $GITHUB_OUTPUT
+        echo "api_base_url=${API_BASE_URL}" >> $GITHUB_OUTPUT
+        echo "space_name=${SPACE_NAME}" >> $GITHUB_OUTPUT
+        
+        if [ "$AUTO_PUBLISH_ENABLED" = "true" ]; then
+          echo "✅ Auto-publish is enabled in configuration"
+          echo "🌐 API Base URL: ${API_BASE_URL}"
+        else
+          echo "❌ Auto-publish is disabled in configuration"
+        fi
+
+    - name: Verify API accessibility
+      if: steps.check-config.outputs.auto_publish_enabled == 'true' || github.event.inputs.force_publish == 'true'
+      run: |
+        API_URL="${{ steps.check-config.outputs.api_base_url }}"
+        echo "🔍 Checking if API is accessible at: ${API_URL}"
+        
+        # Wait for API to be ready (up to 5 minutes)
+        for i in {1..30}; do
+          if curl -s --connect-timeout 10 "${API_URL}/health" > /dev/null 2>&1 || \
+             curl -s --connect-timeout 10 "${API_URL}/docs" > /dev/null 2>&1 || \
+             curl -s --connect-timeout 10 "${API_URL}/" > /dev/null 2>&1; then
+            echo "✅ API is accessible"
+            break
+          fi
+          
+          echo "⏳ API not ready yet (attempt $i/30), waiting 10 seconds..."
+          sleep 10
+          
+          if [ $i -eq 30 ]; then
+            echo "❌ API is not accessible after 5 minutes. Proceeding anyway..."
+            echo "⚠️ Published agents may not work until API is fully deployed"
+          fi
+        done
+
+    - name: Publish remote agents
+      if: steps.check-config.outputs.auto_publish_enabled == 'true' || github.event.inputs.force_publish == 'true'
+      env:
+        NAAS_API_KEY: ${{ secrets.NAAS_API_KEY }}
+        ABI_API_KEY: ${{ secrets.ABI_API_KEY }}
+        GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        echo "🚀 Starting automatic agent publishing..."
+        uv run python scripts/publish_remote_agents.py
+
+    - name: Notify on success
+      if: success() && (steps.check-config.outputs.auto_publish_enabled == 'true' || github.event.inputs.force_publish == 'true')
+      run: |
+        echo "✅ Remote agents successfully published to workspace!"
+
+    - name: Notify on failure
+      if: failure() && (steps.check-config.outputs.auto_publish_enabled == 'true' || github.event.inputs.force_publish == 'true')
+      run: |
+        echo "❌ Failed to publish remote agents. Check the logs for details."
+        exit 1
+
+    - name: Skip publishing
+      if: steps.check-config.outputs.auto_publish_enabled == 'false' && github.event.inputs.force_publish != 'true'
+      run: |
+        echo "⏭️ Auto-publish is disabled. Skipping agent publishing."
+        echo "To enable automatic publishing, set 'config.auto_publish.enabled: true' in config.yaml"

--- a/Makefile
+++ b/Makefile
@@ -230,6 +230,10 @@ publish-remote-agents: deps
 	@ echo "Publishing remote agents..."
 	@ uv run python scripts/publish_remote_agents.py
 
+publish-remote-agents-dry-run: deps
+	@ echo "Dry-run: Previewing remote agent publishing..."
+	@ uv run python scripts/publish_remote_agents.py --dry-run
+
 clean:
 	@echo "Cleaning up build artifacts..."
 	rm -rf __pycache__ .pytest_cache build dist *.egg-info lib/.venv .venv
@@ -272,7 +276,8 @@ help:
 	@echo "  triplestore-prod-override Override the production triplestore with local data"
 	@echo "  triplestore-prod-pull    Pull triplestore data from production"
 	@echo "  docs-ontology            Generate ontology documentation"
-	@echo "  publish-remote-agents    Publish remote agents"
+	@echo "  publish-remote-agents    Publish remote agents to workspace"
+	@echo "  publish-remote-agents-dry-run Preview what agents would be published (dry-run mode)"
 	@echo ""
 	@echo "BUILDING:"
 	@echo "  build                    Build the Docker image (alias for build.linux.x86_64)"

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,9 @@
 config:
   workspace_id: "96ce7ee7-e5f5-4bca-acf9-9d5d41317f81" # Naas workspace ID
+  auto_publish:
+    enabled: true # Enable automatic publishing of agents to workspace
+    exclude_agents: [] # Agents to exclude from auto-publishing (empty list means publish all enabled agents)
+    default_agent: "Abi" # Which agent to set as default in workspace
   github_project_repository: "jupyter-naas/abi" # Github repository name (e.g. jupyter-naas/abi)
   github_support_repository: "jupyter-naas/abi" # Github repository name (e.g. jupyter-naas/abi)
   github_project_id: 12 # Github project number stored in Github URL (e.g. https://github.com/jupyter-naas/abi/projects/1)

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,5 +1,9 @@
 config:
   workspace_id: # Naas workspace ID
+  auto_publish:
+    enabled: true # Enable automatic publishing of agents to workspace
+    exclude_agents: [] # Agents to exclude from auto-publishing (empty list means publish all enabled agents)
+    default_agent: "Abi" # Which agent to set as default in workspace
   github_project_repository: # Github repository name (e.g. jupyter-naas/abi)
   github_support_repository: # Github repository name (e.g. jupyter-naas/abi)
   github_project_id: # Github project number stored in Github URL (e.g. https://github.com/jupyter-naas/abi/projects/1)

--- a/docs/developer_tool_chain/publish_remote_agents.md
+++ b/docs/developer_tool_chain/publish_remote_agents.md
@@ -2,6 +2,10 @@
 
 This guide explains how to publish ABI agents as remote plugins on the Naas platform. This feature is only available if you have access to the Naas platform.
 
+## Automatic Publishing (Recommended)
+
+The system now supports automatic publishing of remote agents to your workspace. When enabled, agents will be automatically published to the specified workspace using `config.workspace_id` whenever the API is deployed.
+
 ## Prerequisites
 
 Before publishing remote agents, ensure you have:
@@ -32,32 +36,79 @@ Update your `config.yaml` file with the following settings:
 ```yaml
 config:
   workspace_id: "your_naas_workspace_id"
+  auto_publish:
+    enabled: true # Enable automatic publishing of agents to workspace
+    exclude_agents: [] # Agents to exclude from auto-publishing (empty list means publish all enabled agents)
+    default_agent: "Abi" # Which agent to set as default in workspace
   github_project_repository: "your_github_username/your_repository_name"
   space_name: "your_naas_space_name"
   # ... other configuration options
 ```
 
+#### Auto-Publish Configuration Options
+
+| Option | Description | Default | Example |
+|--------|-------------|---------|---------|
+| `enabled` | Enable/disable automatic publishing | `true` | `true` |
+| `exclude_agents` | List of agent names to exclude from publishing | `[]` | `["TestAgent", "DebugAgent"]` |
+| `default_agent` | Agent to set as default in the workspace | `"Abi"` | `"MyCustomAgent"` |
+
 ## How to Publish Remote Agents
 
-### Method 1: Using Make Command (Recommended)
+### Method 1: Automatic Publishing (Recommended)
 
-The easiest way to publish remote agents is using the provided Make command:
+When `auto_publish.enabled` is set to `true` in your `config.yaml`, agents will be automatically published to your workspace after each API deployment via GitHub Actions.
+
+**Benefits:**
+- ✅ Simplifies deployment workflow  
+- ✅ Ensures agents are up-to-date
+- ✅ Reduces manual intervention
+- ✅ Publishes all enabled agents automatically
+- ✅ Excludes only specified agents via `exclude_agents`
+
+**How it works:**
+1. GitHub Actions workflow triggers after successful API deployment
+2. Checks if auto-publish is enabled in configuration
+3. Verifies API accessibility
+4. Publishes all enabled agents except those in `exclude_agents`
+5. Sets the `default_agent` as the workspace default
+
+### Method 2: Manual Publishing with Make Command
+
+You can also manually publish agents using:
 
 ```bash
 make publish-remote-agents
 ```
-This command performs the following actions:
-1. Reads configuration settings from your environment and config files
-2. Publishes a predefined set of agents:
-   - `Abi` (set as default)
-   - `Ontology` 
-   - `Naas`
-   - `Multi_Models`
-   - `Support`
-3. Configures the published agents with appropriate settings
 
-To customize which agents are published, you can modify the `agents_to_publish` list directly in the script.
-Use the agent name to add more agents to publish.
+**Dry-Run Mode (Preview Changes):**
+To preview what agents would be published without making actual changes:
+
+```bash
+make publish-remote-agents-dry-run
+```
+
+Or directly:
+```bash
+uv run python scripts/publish_remote_agents.py --dry-run
+# Alternative flags: --dryrun, -n
+```
+
+**Dry-run benefits:**
+- ✅ Preview all agents that would be published
+- ✅ See detailed plugin configuration data
+- ✅ Test configuration without API keys
+- ✅ Identify excluded agents
+- ✅ Verify API URLs and workspace settings
+- ✅ No actual changes made to workspace or GitHub
+
+**Legacy behavior (when `auto_publish.enabled: false`):**
+- Publishes only specific agents: `Abi`, `Ontology`, `Naas`, `Multi_Models`, `Support`
+- Requires manual execution
+
+**New behavior (when `auto_publish.enabled: true`):**  
+- Publishes all enabled agents except those in `exclude_agents`
+- Uses configuration from `config.yaml`
 
 ### Method 2: Running the Script Directly
 
@@ -97,7 +148,9 @@ agents_to_publish=["Abi", "Ontology", "Naas"]
 | `github_access_token` | GitHub personal access token | Yes | - |
 | `github_repository` | GitHub repository name (format: `username/repository`) | Yes | - |
 | `default_agent` | Name of the agent to set as default | No | "Abi" |
-| `agents_to_publish` | List of agent names to publish | No | ["Abi", "Ontology", "Naas", "Multi_Models", "Support"] |
+| `agents_to_publish` | List of agent names to publish (legacy mode) | No | ["Abi", "Ontology", "Naas", "Multi_Models", "Support"] |
+| `exclude_agents` | List of agent names to exclude from publishing | No | [] |
+| `auto_publish_enabled` | Enable automatic publishing mode | No | false |
 
 ## What the Script Does
 
@@ -113,11 +166,16 @@ The `publish_remote_agents.py` script performs the following process:
 - This secret is used by the remote agents to authenticate with your ABI API
 
 ### 3. Agent Discovery and Processing
-For each agent specified in `agents_to_publish`:
 
-- **Loads Agent Modules**: Dynamically loads all available ABI agent modules
+**Auto-publish mode (when `auto_publish.enabled: true`):**
+- **Loads All Agent Modules**: Dynamically loads all available ABI agent modules
+- **Filters by Exclusion**: Publishes all agents except those listed in `exclude_agents`
+- **Extracts Agent Metadata**: Gathers agent information for all valid agents
+
+**Legacy mode (when `auto_publish.enabled: false`):**
+- **Loads Specific Agents**: Only processes agents listed in `agents_to_publish`
 - **Extracts Agent Metadata**: Gathers agent information including:
-  - Name and description
+  - Name and description  
   - System prompt from agent configuration
   - Avatar URL and suggestions from the module
   - API route name for remote access
@@ -141,18 +199,91 @@ For each agent:
 - Sets the specified `default_agent` as the default plugin in the workspace
 - This agent will be pre-selected when users access your workspace
 
+## GitHub Actions Workflow
+
+The automatic publishing is handled by the `.github/workflows/auto-publish-agents.yml` workflow:
+
+### Workflow Triggers
+- **After API Deployment**: Automatically runs after the "ABI API" workflow completes successfully
+- **Manual Trigger**: Can be manually triggered via GitHub Actions UI with force publish option
+
+### Workflow Steps
+1. **Checkout Code**: Gets the latest code from the repository
+2. **Setup Environment**: Installs Python 3.10 and uv package manager
+3. **Install Dependencies**: Installs all project dependencies
+4. **Check Configuration**: Verifies auto-publish is enabled and gets API URL
+5. **Verify API Access**: Waits up to 5 minutes for the API to be accessible
+6. **Publish Agents**: Runs the publishing script with proper configuration
+7. **Notify Results**: Reports success or failure
+
+### Required Secrets
+The workflow requires these GitHub repository secrets:
+- `NAAS_API_KEY`: Your Naas platform API key
+- `ABI_API_KEY`: Your ABI API authentication key  
+- `GITHUB_TOKEN`: Automatically provided by GitHub Actions
+
+### Workflow Configuration
+The workflow is configured to trigger after the "ABI API" deployment workflow:
+```yaml
+workflows: ["ABI API"] # Matches the actual API deployment workflow name
+```
+
 ## Expected Output
 
 When running the script successfully, you should see output similar to:
 
+**Auto-publish mode:**
 ```
-==> Getting existing plugins from workspace: your_workspace_id
-==> Existing plugins: 5
-==> Updating "ABI_API_KEY" secret in Github repository: your_username/your_repo
+🚀 Auto-publish enabled: True
+🚫 Excluded agents: None
+⭐ Default agent: Abi
+🔍 Getting existing plugins from workspace: your_workspace_id
+==> Getting agents from module: src/core/modules/abi
 ==> Publishing agent: Abi
-Plugin 'Abi' updated in workspace 'your_workspace_id'
+✅ Plugin 'Abi' updated in workspace 'your_workspace_id'
 ==> Publishing agent: Ontology
-Plugin 'Ontology' created in workspace 'your_workspace_id'
+✅ Plugin 'Ontology' created in workspace 'your_workspace_id'
+==> Skipping excluded agent: TestAgent
+...
+```
+
+**Legacy mode:**
+```
+🚀 Auto-publish enabled: False
+📝 Publishing specific agents: ['Abi', 'Ontology', 'Naas', 'Multi_Models', 'Support']
+⭐ Default agent: Abi
+🔍 Getting existing plugins from workspace: your_workspace_id
+==> Publishing agent: Abi
+✅ Plugin 'Abi' updated in workspace 'your_workspace_id'
+...
+```
+
+**Dry-run mode:**
+```
+🧪 DRY RUN MODE - No changes will be made
+==================================================
+🚀 Auto-publish enabled: True
+🚫 Excluded agents: ['TestAgent']
+⭐ Default agent: Abi
+🌐 API Base URL: https://abi-api.default.space.naas.ai
+🏢 Workspace ID: your_workspace_id
+🧪 DRY RUN MODE: No actual changes will be made
+🧪 [DRY RUN] Would fetch existing plugins from workspace
+🧪 [DRY RUN] Would update "ABI_API_KEY" secret in Github repository: your_repo
+==> Getting agents from module: src/core/modules/abi
+🧪 [DRY RUN] Would publish agent: Abi
+🧪 [DRY RUN] Plugin data for 'Abi':
+    - ID: abi
+    - Name: Abi
+    - Type: CORE
+    - Default: True
+    - Remote URL: https://abi-api.default.space.naas.ai/agents/abi/stream-completion?token=dummy_abi_api_key
+    - Avatar: https://naasai-public.s3.eu-west-3.amazonaws.com/abi-demo/ontology_ABI.png
+    - Description: I'm Abi, your Artificial Business Intelligence assistant...
+    - Suggestions: 4 items
+🧪 [DRY RUN] Would check if plugin 'abi' already exists
+🧪 [DRY RUN] Would create/update plugin in workspace 'your_workspace_id'
+🧪 [DRY RUN] Would skip excluded agent: TestAgent
 ...
 ```
 

--- a/scripts/publish_remote_agents.py
+++ b/scripts/publish_remote_agents.py
@@ -19,22 +19,38 @@ def publish_remote_agent(
     github_access_token: str,
     github_repository: str,
     default_agent: str = "Abi",
-    agents_to_publish: list[str] = []
+    agents_to_publish: list[str] = [],
+    exclude_agents: list[str] = [],
+    auto_publish_enabled: bool = False,
+    dry_run: bool = False
     ):
+    # Add dry-run header
+    if dry_run:
+        logger.info("🧪 DRY RUN MODE - No changes will be made")
+        logger.info("=" * 50)
+    
     # Init Naas Integration
     naas_integration = NaasIntegration(NaasIntegrationConfiguration(api_key=naas_api_key))
     logger.info(f"🔍 Getting existing plugins from workspace: {workspace_id}")
-    existing_plugins = naas_integration.get_plugins(workspace_id).get("workspace_plugins", [])
+    
+    if dry_run:
+        logger.info("🧪 [DRY RUN] Would fetch existing plugins from workspace")
+        existing_plugins = []  # Skip actual API call in dry run
+    else:
+        existing_plugins = naas_integration.get_plugins(workspace_id).get("workspace_plugins", [])
 
     # Init Github Integration
     if github_access_token is not None and github_repository is not None:
-        github_integration = GitHubIntegration(GitHubIntegrationConfiguration(access_token=github_access_token))
-        logger.info(f"🔑 Updating \"ABI_API_KEY\" secret in Github repository: {github_repository}")
-        github_integration.create_or_update_repository_secret(
-            repo_name=github_repository,
-            secret_name="ABI_API_KEY",
-            value=abi_api_key
-        )
+        if dry_run:
+            logger.info(f"🧪 [DRY RUN] Would update \"ABI_API_KEY\" secret in Github repository: {github_repository}")
+        else:
+            github_integration = GitHubIntegration(GitHubIntegrationConfiguration(access_token=github_access_token))
+            logger.info(f"🔑 Updating \"ABI_API_KEY\" secret in Github repository: {github_repository}")
+            github_integration.create_or_update_repository_secret(
+                repo_name=github_repository,
+                secret_name="ABI_API_KEY",
+                value=abi_api_key
+            )
 
     # Get all agents from the modules
     load_modules()
@@ -53,9 +69,25 @@ def publish_remote_agent(
             agent_type = "CUSTOM"
         for agent in module.agents:
             name = getattr(agent, "name", "")
-            if len(agents_to_publish) > 0 and name not in agents_to_publish:
-                continue
-            logger.info(f"==> Publishing agent: {name}")
+            
+            # Filter agents based on configuration
+            if auto_publish_enabled:
+                # When auto-publish is enabled, publish all agents except excluded ones
+                if name in exclude_agents:
+                    if dry_run:
+                        logger.info(f"🧪 [DRY RUN] Would skip excluded agent: {name}")
+                    else:
+                        logger.info(f"==> Skipping excluded agent: {name}")
+                    continue
+            else:
+                # Legacy behavior: only publish specified agents
+                if len(agents_to_publish) > 0 and name not in agents_to_publish:
+                    continue
+            
+            if dry_run:
+                logger.info(f"🧪 [DRY RUN] Would publish agent: {name}")
+            else:
+                logger.info(f"==> Publishing agent: {name}")
             
             # Get SUGGESTIONS and AVATAR_URL from the module
             module_name = agent.__class__.__module__
@@ -118,36 +150,103 @@ def publish_remote_agent(
                 },
                 "suggestions": suggestions,
             }
-            logger.debug(f"==> plugin_data: {plugin_data}")
-
-             # Check if plugin already exists
-            existing_plugin_id = naas_integration.search_plugin(
-                key="id", value=plugin_data["id"], plugins=existing_plugins
-            )
-            if existing_plugin_id:
-                naas_integration.update_plugin(
-                    workspace_id=config.workspace_id,
-                    plugin_id=existing_plugin_id,
-                    data=plugin_data,
-                )
-                message = f"✅ Plugin '{plugin_data['name']}' updated in workspace '{config.workspace_id}'"
+            
+            if dry_run:
+                logger.info(f"🧪 [DRY RUN] Plugin data for '{name}':")
+                logger.info(f"    - ID: {plugin_data['id']}")
+                logger.info(f"    - Name: {plugin_data['name']}")
+                logger.info(f"    - Type: {plugin_data['type']}")
+                logger.info(f"    - Default: {plugin_data['default']}")
+                logger.info(f"    - Remote URL: {plugin_data['remote']['url']}")
+                logger.info(f"    - Avatar: {plugin_data['avatar']}")
+                logger.info(f"    - Description: {plugin_data['description'][:100]}{'...' if len(plugin_data['description']) > 100 else ''}")
+                if plugin_data['suggestions']:
+                    logger.info(f"    - Suggestions: {len(plugin_data['suggestions'])} items")
+                
+                # Simulate checking for existing plugin
+                logger.info(f"🧪 [DRY RUN] Would check if plugin '{plugin_data['id']}' already exists")
+                logger.info(f"🧪 [DRY RUN] Would create/update plugin in workspace '{config.workspace_id}'")
             else:
-                naas_integration.create_plugin(
-                    workspace_id=config.workspace_id, data=plugin_data
+                logger.debug(f"==> plugin_data: {plugin_data}")
+
+                # Check if plugin already exists
+                existing_plugin_id = naas_integration.search_plugin(
+                    key="id", value=plugin_data["id"], plugins=existing_plugins
                 )
-                message = f"✅ Plugin '{plugin_data['name']}' created in workspace '{config.workspace_id}'"
-            logger.info(message)
+                if existing_plugin_id:
+                    naas_integration.update_plugin(
+                        workspace_id=config.workspace_id,
+                        plugin_id=existing_plugin_id,
+                        data=plugin_data,
+                    )
+                    message = f"✅ Plugin '{plugin_data['name']}' updated in workspace '{config.workspace_id}'"
+                else:
+                    naas_integration.create_plugin(
+                        workspace_id=config.workspace_id, data=plugin_data
+                    )
+                    message = f"✅ Plugin '{plugin_data['name']}' created in workspace '{config.workspace_id}'"
+                logger.info(message)
 
 if __name__ == "__main__":
+    import sys
     from src import secret, config
+    
+    # Check for dry-run flag
+    dry_run = "--dry-run" in sys.argv or "--dryrun" in sys.argv or "-n" in sys.argv
+    
     naas_api_key = secret.get("NAAS_API_KEY")
     api_base_url = f"https://{config.space_name}-api.default.space.naas.ai"
     abi_api_key = secret.get("ABI_API_KEY")
     workspace_id = config.workspace_id
     github_access_token = secret.get("GITHUB_ACCESS_TOKEN")
     github_repository = config.github_project_repository
-    default_agent = "Abi"
+    
+    # Get auto-publish configuration
+    auto_publish_config = getattr(config, 'auto_publish', {})
+    auto_publish_enabled = auto_publish_config.get('enabled', False)
+    exclude_agents = auto_publish_config.get('exclude_agents', [])
+    default_agent = auto_publish_config.get('default_agent', "Abi")
+    
+    # Legacy support for manual agent selection (when auto-publish is disabled)
     agents_to_publish = []
-    if naas_api_key is None or api_base_url is None or abi_api_key is None or workspace_id is None:
+    if not auto_publish_enabled:
+        # Default agents when auto-publish is disabled (backward compatibility)
+        agents_to_publish = ["Abi", "Ontology", "Naas", "Multi_Models", "Support"]
+    
+    # In dry-run mode, relax the API key requirements
+    if not dry_run and (naas_api_key is None or api_base_url is None or abi_api_key is None or workspace_id is None):
         raise ValueError("NAAS_API_KEY, API_BASE_URL, ABI_API_KEY, WORKSPACE_ID must be set")
-    publish_remote_agent(naas_api_key, api_base_url, abi_api_key, workspace_id, github_access_token, github_repository, default_agent, agents_to_publish)
+    
+    # Set dummy values for dry-run if missing
+    if dry_run:
+        naas_api_key = naas_api_key or "dummy_naas_api_key"
+        abi_api_key = abi_api_key or "dummy_abi_api_key"
+        workspace_id = workspace_id or "dummy_workspace_id"
+        github_access_token = github_access_token or "dummy_github_token"
+        github_repository = github_repository or "dummy_repo"
+    
+    logger.info(f"🚀 Auto-publish enabled: {auto_publish_enabled}")
+    if auto_publish_enabled:
+        logger.info(f"🚫 Excluded agents: {exclude_agents if exclude_agents else 'None'}")
+    else:
+        logger.info(f"📝 Publishing specific agents: {agents_to_publish}")
+    logger.info(f"⭐ Default agent: {default_agent}")
+    logger.info(f"🌐 API Base URL: {api_base_url}")
+    logger.info(f"🏢 Workspace ID: {workspace_id}")
+    
+    if dry_run:
+        logger.info("🧪 DRY RUN MODE: No actual changes will be made")
+    
+    publish_remote_agent(
+        naas_api_key, 
+        api_base_url, 
+        abi_api_key, 
+        workspace_id, 
+        github_access_token, 
+        github_repository, 
+        default_agent, 
+        agents_to_publish,
+        exclude_agents,
+        auto_publish_enabled,
+        dry_run
+    )


### PR DESCRIPTION
# Auto-Publish Remote Agents to NAAS Workspace

This PR implements automatic publishing of remote agents to a specified workspace using `config.workspace.id`, streamlining the deployment process and ensuring agents are consistently updated in the desired workspace.

## ✨ Key Features

- **Automatic Publishing**: Agents are automatically published to the workspace after successful API deployment via GitHub Actions
- **Exclusion-Based Filtering**: Uses `exclude_agents` list for more flexible agent selection (publish all except specified)
- **Dry-Run Mode**: Preview what agents would be published without making actual changes
- **Enhanced Configuration**: New `auto_publish` section in `config.yaml` with intuitive settings
- **Backward Compatibility**: Maintains support for legacy manual agent selection

## 🔧 Configuration Changes

Added new `auto_publish` configuration section:
```yaml
config:
  workspace_id: "your-workspace-id"
  auto_publish:
    enabled: true # Enable automatic publishing
    exclude_agents: [] # Agents to exclude (empty = publish all)
    default_agent: "Abi" # Default workspace agent
```

## 🚀 Benefits Achieved

- ✅ **Simplifies deployment workflow** - No manual intervention needed
- ✅ **Ensures agents are up-to-date** - Automatic sync after each deployment  
- ✅ **Reduces manual intervention** - Runs automatically via CI/CD
- ✅ **Smart API handling** - Waits for API accessibility before publishing
- ✅ **Safe testing** - Dry-run mode for local preview

## 📋 Usage

**Automatic Mode** (recommended):
```bash
# Agents publish automatically after API deployment
# Configure via config.yaml auto_publish section
```

**Manual Mode**:
```bash
make publish-remote-agents
```

**Dry-Run Mode** (preview changes):
```bash
make publish-remote-agents-dry-run
```

## 🔄 GitHub Actions Integration

- Triggers after "ABI API" workflow completes successfully
- Verifies API accessibility (waits up to 5 minutes)
- Supports manual triggering with force option
- Proper error handling and notifications

## 📁 Files Changed

- `config.yaml` - Added auto-publish configuration
- `scripts/publish_remote_agents.py` - Enhanced with auto-publish and dry-run support
- `.github/workflows/auto-publish-agents.yml` - New workflow for automatic publishing
- `Makefile` - Added dry-run target
- `docs/developer_tool_chain/publish_remote_agents.md` - Comprehensive documentation update

## 🧪 Testing

Dry-run mode allows safe testing without API keys:
```bash
uv run python scripts/publish_remote_agents.py --dry-run
```

## Test plan

- [ ] Test auto-publish configuration parsing
- [ ] Verify exclusion-based agent filtering works correctly
- [ ] Test dry-run mode shows expected output without making changes
- [ ] Confirm GitHub Actions workflow triggers after API deployment
- [ ] Validate API accessibility verification works
- [ ] Test backward compatibility with legacy agent selection
- [ ] Verify proper error handling when API keys are missing

🤖 Generated with [Claude Code](https://claude.ai/code)