### PR TITLE
Remove startup user information prompts

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -142,27 +142,6 @@ def ensure_ollama_running():
                 json.loads(line)
                 # Don't show progress bar - just let it happen quietly
 
-def personnal_information():
-    if "FIRST_NAME" in dv:
-        return
-    
-    # Natural setup experience
-    print("\nHello! I'm ABI, your AI assistant.")
-    print("Since this is our first time meeting, I'd like to ask you a few quick questions.")
-    print("This will help me understand how to work best with you.\n")
-    
-    # Collect basic user info
-    first_name = Prompt.ask("What's your first name?")
-    last_name = Prompt.ask("And your last name?")
-    email = Prompt.ask("What's your email address?", default="")
-    
-    print(f"\nNice to meet you, {first_name}.")
-    
-    append_to_dotenv("FIRST_NAME", first_name)
-    append_to_dotenv("LAST_NAME", last_name)
-    append_to_dotenv("EMAIL", email)
-
-
 def define_ai_mode():
     if "AI_MODE" in dv:
         return
@@ -459,7 +438,6 @@ def check_modules_requirements():
         console.print("\n🎉 All enabled modules have their requirements satisfied!\n", style="green")
 
 checks = [
-    personnal_information,
     define_ai_mode,
     define_naas_api_key,
     define_config_file,


### PR DESCRIPTION
## Summary

This PR removes the friction-inducing personal information prompts that appear during ABI startup.

## Changes

- Removed `personnal_information` function from startup checks
- Eliminates prompts for first name, last name, and email address
- Maintains clean, frictionless startup experience

## Before
Users were forced to enter personal information on first startup:
```
Hello! I'm ABI, your AI assistant.
Since this is our first time meeting, I'd like to ask you a few quick questions.
This will help me understand how to work best with you.

What's your first name?: 
And your last name?: 
What's your email address? (): 
```

## After
ABI starts immediately without personal information prompts.

## Testing
- [x] Verified startup checks no longer include `personnal_information`
- [x] All linting and type checks pass
- [x] No regression in other startup functionality

Fixes #609