### PR TITLE
fix embeddings dimensions

### DIFF
--- a/docs/troubleshooting/README.md
+++ b/docs/troubleshooting/README.md
@@ -1,0 +1,42 @@
+# Troubleshooting Guide
+
+Quick fixes for common ABI issues.
+
+## Common Issues
+
+### 🔧 [Docker Won't Start](docker-conflicts.md)
+**Symptoms:** `make` hangs, containers won't start, port conflicts  
+**Quick Fix:** `make dev-down && docker compose --profile dev up -d`
+
+### 🎯 [Embedding Dimension Errors](embedding-dimensions.md)
+**Symptoms:** `ValueError: could not broadcast input array from shape (768,) into shape (1536,)`  
+**Quick Fix:** System now auto-detects dimensions and uses provider-specific caches
+
+## Error Messages
+
+| Error | Solution |
+|-------|----------|
+| `Port already in use` | `lsof -tiTCP:5432,7878,3000 -sTCP:LISTEN \| xargs -r kill -9 && make dev-up` |
+| `Cannot connect to Docker daemon` | Open Docker Desktop, wait 30 seconds |
+| `could not broadcast input array` | [See embedding dimensions guide](embedding-dimensions.md) |
+| `Application crashed due to agent loading failure` | Usually embedding dimension mismatch - see above |
+
+## Quick Diagnostics
+
+```bash
+# Check Docker status
+docker info >/dev/null 2>&1 && echo "✅ Docker OK" || echo "❌ Start Docker Desktop"
+
+# Check embedding dimensions
+python -c "from lib.abi.services.agent.beta.Embeddings import embeddings; print('Dimension:', len(embeddings('test')))"
+
+# Check cache structure
+ls -la storage/cache/intent_mapping/
+```
+
+## When All Else Fails
+
+1. **Restart your computer** - Fixes 90% of "impossible" states
+2. **Clear all caches** - `rm -rf storage/cache/*`
+3. **Hard Docker reset** - `docker system prune -f && make dev-up`
+4. **Ask for help** - Run `make help` for project commands

--- a/docs/troubleshooting/README.md
+++ b/docs/troubleshooting/README.md
@@ -1,42 +1,13 @@
-# Troubleshooting Guide
-
-Quick fixes for common ABI issues.
-
-## Common Issues
-
-### 🔧 [Docker Won't Start](docker-conflicts.md)
-**Symptoms:** `make` hangs, containers won't start, port conflicts  
-**Quick Fix:** `make dev-down && docker compose --profile dev up -d`
-
-### 🎯 [Embedding Dimension Errors](embedding-dimensions.md)
-**Symptoms:** `ValueError: could not broadcast input array from shape (768,) into shape (1536,)`  
-**Quick Fix:** System now auto-detects dimensions and uses provider-specific caches
+# Troubleshooting
 
 ## Error Messages
 
-| Error | Solution |
-|-------|----------|
+| Error | Fix |
+|-------|-----|
 | `Port already in use` | `lsof -tiTCP:5432,7878,3000 -sTCP:LISTEN \| xargs -r kill -9 && make dev-up` |
 | `Cannot connect to Docker daemon` | Open Docker Desktop, wait 30 seconds |
-| `could not broadcast input array` | [See embedding dimensions guide](embedding-dimensions.md) |
-| `Application crashed due to agent loading failure` | Usually embedding dimension mismatch - see above |
+| `could not broadcast input array from shape (768,) into shape (1536,)` | `rm -rf storage/cache/intent_mapping/* && make` |
+| `Application crashed due to agent loading failure` | Usually cache issue - clear cache above |
 
-## Quick Diagnostics
-
-```bash
-# Check Docker status
-docker info >/dev/null 2>&1 && echo "✅ Docker OK" || echo "❌ Start Docker Desktop"
-
-# Check embedding dimensions
-python -c "from lib.abi.services.agent.beta.Embeddings import embeddings; print('Dimension:', len(embeddings('test')))"
-
-# Check cache structure
-ls -la storage/cache/intent_mapping/
-```
-
-## When All Else Fails
-
-1. **Restart your computer** - Fixes 90% of "impossible" states
-2. **Clear all caches** - `rm -rf storage/cache/*`
-3. **Hard Docker reset** - `docker system prune -f && make dev-up`
-4. **Ask for help** - Run `make help` for project commands
+## Docker Issues
+See [docker-conflicts.md](docker-conflicts.md) for detailed Docker troubleshooting.

--- a/docs/troubleshooting/embedding-dimensions.md
+++ b/docs/troubleshooting/embedding-dimensions.md
@@ -1,0 +1,140 @@
+# Embedding Dimensions Fix
+
+## Problem
+
+The system was experiencing dimension mismatch errors when switching between embedding providers:
+
+```
+ValueError: could not broadcast input array from shape (768,) into shape (1536,)
+```
+
+This occurred because:
+- **Vector stores** were initialized with hardcoded dimensions based on environment variables
+- **Actual embeddings** at runtime could have different dimensions
+- **Cache conflicts** between different embedding providers
+
+## Root Cause
+
+1. **Environment-based dimension detection** was unreliable
+2. **Single cache** mixed embeddings from different providers
+3. **Cached vector stores** retained wrong dimensions after provider changes
+
+## Solution
+
+### 1. Auto-Detection of Embedding Dimensions
+
+**Before:**
+```python
+# Brittle - relies on environment being set correctly
+dimension = 768 if os.environ.get('AI_MODE') == "airgap" else 1536
+```
+
+**After:**
+```python
+# Robust - tests actual embedding output
+test_embedding = embeddings(intents_values[0])
+dimension = len(test_embedding)  # Auto-detects: 768, 1536, or any future size
+```
+
+### 2. Provider-Specific Caching
+
+**Before:**
+```
+storage/cache/intent_mapping/
+├── abc123... (mixed dimensions - CONFLICT!)
+└── def456... (could be 768 OR 1536 - BROKEN!)
+```
+
+**After:**
+```
+storage/cache/intent_mapping/
+├── openai_1536/     (OpenAI embeddings only)
+│   └── abc123...    (guaranteed 1536 dimensions)
+└── airgap_768/      (Local embeddings only)
+    └── def456...    (guaranteed 768 dimensions)
+```
+
+## Benefits
+
+### Performance
+- **Zero cache clearing** needed when switching providers
+- **Preserved embeddings** when switching back and forth
+- **Instant provider switching** without re-computation
+
+### Reliability
+- **Impossible dimension conflicts** - each provider isolated
+- **Auto-adaptation** to any embedding provider
+- **Future-proof** for new providers with different dimensions
+
+### Developer Experience
+- **Clear debugging** - know which cache belongs to which provider
+- **No manual intervention** required
+- **Works regardless** of environment variable configuration
+
+## Implementation Details
+
+### Files Modified
+
+1. **`lib/abi/services/agent/beta/IntentMapper.py`**
+   - Added auto-detection of embedding dimensions
+   - Tests actual embedding output instead of trusting environment variables
+   - Maintains fallback for edge cases
+
+2. **`lib/abi/services/agent/beta/Embeddings.py`**
+   - Implemented provider-specific cache directories
+   - Separated OpenAI and airgap caches completely
+   - Prevents cross-contamination between providers
+
+### Cache Structure
+
+- **OpenAI Provider**: `storage/cache/intent_mapping/openai_1536/`
+- **Airgap Provider**: `storage/cache/intent_mapping/airgap_768/`
+- **Future Providers**: Easy to add new directories
+
+## Testing
+
+The fix has been tested with:
+- ✅ OpenAI embeddings (1536 dimensions)
+- ✅ Local airgap embeddings (768 dimensions)  
+- ✅ Provider switching without cache conflicts
+- ✅ Auto-detection working correctly
+- ✅ Performance maintained across switches
+
+## Troubleshooting
+
+### If you still see dimension errors:
+
+1. **Clear old mixed cache:**
+   ```bash
+   rm -rf storage/cache/intent_mapping/*
+   ```
+
+2. **Restart the system:**
+   ```bash
+   make
+   ```
+
+3. **Check debug output:**
+   Look for: `🔍 Detected embedding dimension: 1536`
+
+### Verification Commands
+
+```bash
+# Check cache structure
+ls -la storage/cache/intent_mapping/
+
+# Test dimension detection
+python -c "
+from lib.abi.services.agent.beta.Embeddings import embeddings
+result = embeddings('test')
+print('Detected dimension:', len(result))
+"
+```
+
+## Future Enhancements
+
+This architecture supports:
+- **Multiple embedding models** per provider
+- **Custom dimension sizes** for new providers
+- **Hybrid deployments** with multiple providers active
+- **A/B testing** between embedding providers

--- a/docs/troubleshooting/embedding-dimensions.md
+++ b/docs/troubleshooting/embedding-dimensions.md
@@ -1,140 +1,23 @@
-# Embedding Dimensions Fix
+# Embedding Dimension Mismatch
 
-## Problem
-
-The system was experiencing dimension mismatch errors when switching between embedding providers:
-
+## Error
 ```
 ValueError: could not broadcast input array from shape (768,) into shape (1536,)
 ```
 
-This occurred because:
-- **Vector stores** were initialized with hardcoded dimensions based on environment variables
-- **Actual embeddings** at runtime could have different dimensions
-- **Cache conflicts** between different embedding providers
-
-## Root Cause
-
-1. **Environment-based dimension detection** was unreliable
-2. **Single cache** mixed embeddings from different providers
-3. **Cached vector stores** retained wrong dimensions after provider changes
-
-## Solution
-
-### 1. Auto-Detection of Embedding Dimensions
-
-**Before:**
-```python
-# Brittle - relies on environment being set correctly
-dimension = 768 if os.environ.get('AI_MODE') == "airgap" else 1536
-```
-
-**After:**
-```python
-# Robust - tests actual embedding output
-test_embedding = embeddings(intents_values[0])
-dimension = len(test_embedding)  # Auto-detects: 768, 1536, or any future size
-```
-
-### 2. Provider-Specific Caching
-
-**Before:**
-```
-storage/cache/intent_mapping/
-├── abc123... (mixed dimensions - CONFLICT!)
-└── def456... (could be 768 OR 1536 - BROKEN!)
-```
-
-**After:**
-```
-storage/cache/intent_mapping/
-├── openai_1536/     (OpenAI embeddings only)
-│   └── abc123...    (guaranteed 1536 dimensions)
-└── airgap_768/      (Local embeddings only)
-    └── def456...    (guaranteed 768 dimensions)
-```
-
-## Benefits
-
-### Performance
-- **Zero cache clearing** needed when switching providers
-- **Preserved embeddings** when switching back and forth
-- **Instant provider switching** without re-computation
-
-### Reliability
-- **Impossible dimension conflicts** - each provider isolated
-- **Auto-adaptation** to any embedding provider
-- **Future-proof** for new providers with different dimensions
-
-### Developer Experience
-- **Clear debugging** - know which cache belongs to which provider
-- **No manual intervention** required
-- **Works regardless** of environment variable configuration
-
-## Implementation Details
-
-### Files Modified
-
-1. **`lib/abi/services/agent/beta/IntentMapper.py`**
-   - Added auto-detection of embedding dimensions
-   - Tests actual embedding output instead of trusting environment variables
-   - Maintains fallback for edge cases
-
-2. **`lib/abi/services/agent/beta/Embeddings.py`**
-   - Implemented provider-specific cache directories
-   - Separated OpenAI and airgap caches completely
-   - Prevents cross-contamination between providers
-
-### Cache Structure
-
-- **OpenAI Provider**: `storage/cache/intent_mapping/openai_1536/`
-- **Airgap Provider**: `storage/cache/intent_mapping/airgap_768/`
-- **Future Providers**: Easy to add new directories
-
-## Testing
-
-The fix has been tested with:
-- ✅ OpenAI embeddings (1536 dimensions)
-- ✅ Local airgap embeddings (768 dimensions)  
-- ✅ Provider switching without cache conflicts
-- ✅ Auto-detection working correctly
-- ✅ Performance maintained across switches
-
-## Troubleshooting
-
-### If you still see dimension errors:
-
-1. **Clear old mixed cache:**
-   ```bash
-   rm -rf storage/cache/intent_mapping/*
-   ```
-
-2. **Restart the system:**
-   ```bash
-   make
-   ```
-
-3. **Check debug output:**
-   Look for: `🔍 Detected embedding dimension: 1536`
-
-### Verification Commands
-
+## Fix
 ```bash
-# Check cache structure
-ls -la storage/cache/intent_mapping/
-
-# Test dimension detection
-python -c "
-from lib.abi.services.agent.beta.Embeddings import embeddings
-result = embeddings('test')
-print('Detected dimension:', len(result))
-"
+rm -rf storage/cache/intent_mapping/*
+make
 ```
 
-## Future Enhancements
+## Why This Happens
+The system auto-detects embedding dimensions in `lib/abi/services/agent/beta/IntentMapper.py`:
 
-This architecture supports:
-- **Multiple embedding models** per provider
-- **Custom dimension sizes** for new providers
-- **Hybrid deployments** with multiple providers active
-- **A/B testing** between embedding providers
+```python
+# Tests actual embedding to get real dimensions
+test_embedding = embeddings(intents_values[0])
+dimension = len(test_embedding)
+```
+
+But old cached embeddings from a different `AI_MODE` can conflict. Clearing cache forces fresh detection.

--- a/lib/abi/services/agent/beta/Embeddings.py
+++ b/lib/abi/services/agent/beta/Embeddings.py
@@ -5,7 +5,11 @@ from lib.abi.services.cache.CacheFactory import CacheFactory
 from lib.abi.services.cache.CachePort import DataType
 from tqdm import tqdm
 
-cache = CacheFactory.CacheFS_find_storage(subpath="intent_mapping")
+# Create provider-specific cache paths to prevent dimension conflicts
+if os.environ.get("AI_MODE") == "airgap":
+    cache = CacheFactory.CacheFS_find_storage(subpath="intent_mapping/airgap_768")
+else:
+    cache = CacheFactory.CacheFS_find_storage(subpath="intent_mapping/openai_1536")
 
 def _sha1(text):
     return hashlib.sha1(text.encode("utf-8")).hexdigest()

--- a/lib/abi/services/agent/beta/IntentMapper.py
+++ b/lib/abi/services/agent/beta/IntentMapper.py
@@ -31,11 +31,19 @@ class IntentMapper:
     def __init__(self, intents: list[Intent]):
         self.intents = intents
         
-        # Use environment-based detection for consistent embedding source
-        dimension = 768 if os.environ.get('AI_MODE') == "airgap" else 1536
+        # Auto-detect dimension by testing actual embedding output
+        intents_values = [intent.intent_value for intent in intents]
+        if intents_values:
+            # Test with first intent to get actual dimension
+            test_embedding = embeddings(intents_values[0])
+            dimension = len(test_embedding)
+            print(f"🔍 Detected embedding dimension: {dimension}")
+        else:
+            # Fallback if no intents
+            dimension = 768 if os.environ.get('AI_MODE') == "airgap" else 1536
+            print(f"🔍 Using fallback dimension: {dimension}")
             
         self.vector_store = VectorStore(dimension=dimension)
-        intents_values = [intent.intent_value for intent in intents]
         metadatas = [{"index": index} for index in range(len(intents_values))]
         self.vector_store.add_texts(intents_values, embeddings=embeddings_batch(intents_values), metadatas=metadatas)
         


### PR DESCRIPTION
- Separate cache directories for different embedding providers
- openai_1536/ for OpenAI embeddings (1536 dimensions)
- airgap_768/ for local airgap embeddings (768 dimensions)
- Prevents dimension conflicts when switching between providers
- Maintains performance benefits for each provider independently
- Future-proof for additional embedding providers