### PR TITLE
fix: Make the key cache building for intentagent more robust to model/dimension switch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,7 @@ chat-qwen-agent: deps
 
 # Generate pull request description using AI agent
 pull-request-description: deps
-	@ LOG_LEVEL=ERROR uv run python -m src.cli PullRequestDescriptionAgent
+	@ echo "generate the pull request description please." | LOG_LEVEL=ERROR uv run python -m src.cli PullRequestDescriptionAgent
 
 # Naas platform integration agent
 chat-naas-agent: deps

--- a/lib/abi/services/agent/beta/Embeddings.py
+++ b/lib/abi/services/agent/beta/Embeddings.py
@@ -7,33 +7,108 @@ from tqdm import tqdm
 
 cache = CacheFactory.CacheFS_find_storage(subpath="intent_mapping")
 
-def _sha1(text):
-    return hashlib.sha1(text.encode("utf-8")).hexdigest()
+EMBEDDINGS_MODELS_DIMENSIONS_MAP = {
+    "ai/embeddinggemma": 768,
+    "text-embedding-ada-002": 1536,
+}
 
-def _sha1s(texts):
-    key = ""
-    
-    for text in texts:
-        key += _sha1(text)
-    
-    return _sha1(key)
-    
+def __get_safe_model(model: str):
+    """
+    Returns a sanitized version of the model name suitable for use in cache keys.
+
+    Args:
+        model (str): The model name to sanitize.
+
+    Returns:
+        str: The sanitized model name.
+
+    Raises:
+        AssertionError: If the model is not in the EMBEDDINGS_MODELS_DIMENSIONS_MAP.
+    """
+    assert model in EMBEDDINGS_MODELS_DIMENSIONS_MAP, f"Model {model} not supported. You need to add it to the EMBEDDINGS_MODELS_DIMENSIONS_MAP in Embeddings.py"
+    return "".join([c if c.isalnum() or c in ('-', '_') else '_' for c in model])
+
+def __compute_key(safe_model: str, dimensions: int, text: str):
+    """
+    Computes a unique cache key for a given model and text.
+
+    Args:
+        safe_model (str): The sanitized model name.
+        text (str): The input text.
+
+    Returns:
+        str: The computed cache key.
+    """
+    return f'{safe_model}_{dimensions}_{hashlib.sha1(text.encode("utf-8")).hexdigest()}'
+
+def _sha1s(model: str):
+    """
+    Returns a function that computes a combined cache key for a list of texts for a given model.
+
+    Args:
+        model (str): The model name.
+
+    Returns:
+        Callable[[list[str]], str]: A function that takes a list of texts and returns a combined cache key.
+    """
+    safe_model = __get_safe_model(model)
+
+    def func(texts):
+        """
+        Computes a combined cache key for a list of texts.
+
+        Args:
+            texts (list[str]): The list of input texts.
+
+        Returns:
+            str: The combined cache key.
+        """
+        key = ""
+        for text in texts:
+            key += __compute_key(safe_model, EMBEDDINGS_MODELS_DIMENSIONS_MAP[model], text)
+        return key
+
+    return func
+
+def _sha1(model: str):  
+    """
+    Returns a function that computes a cache key for a single text for a given model.
+
+    Args:
+        model (str): The model name.
+
+    Returns:
+        Callable[[str], str]: A function that takes a text and returns a cache key.
+    """
+    safe_model = __get_safe_model(model)
+
+    def func(text):
+        """
+        Computes a cache key for a single text.
+
+        Args:
+            text (str): The input text.
+
+        Returns:
+            str: The cache key.
+        """
+        return __compute_key(safe_model, EMBEDDINGS_MODELS_DIMENSIONS_MAP[model], text)
+
+    return func
 
 if os.environ.get("AI_MODE") == "airgap":
     import requests
-
-
-    @cache(lambda text: _sha1(text), cache_type=DataType.PICKLE)
+        
+    @cache(_sha1("ai/embeddinggemma"), cache_type=DataType.PICKLE)
     def embeddings(text) -> list[float]:
         res = requests.post("http://localhost:12434/engines/llama.cpp/v1/embeddings", json={
             "model": "ai/embeddinggemma",
             "input": text 
         })
         res.raise_for_status()
-        
         return res.json()["data"][0]["embedding"]
         
-    @cache(lambda texts: _sha1s(texts), cache_type=DataType.PICKLE)
+    @cache(_sha1s("ai/embeddinggemma"), cache_type=DataType.PICKLE)
     def embeddings_batch(texts) -> list[list[float]]:
         ret = []
         
@@ -54,12 +129,12 @@ else:
             _embeddings_model = OpenAIEmbeddings(model="text-embedding-ada-002")
         return _embeddings_model
 
-    @cache(lambda texts: _sha1s(texts), cache_type=DataType.PICKLE)
+    @cache(_sha1s("text-embedding-ada-002"), cache_type=DataType.PICKLE)
     def embeddings_batch(texts):
         for e in tqdm([texts], "Embedding intents"):
             return _get_embeddings_model().embed_documents(e)
     
-    @cache(lambda text: _sha1(text), cache_type=DataType.PICKLE)
+    @cache(_sha1("text-embedding-ada-002"), cache_type=DataType.PICKLE)
     def embeddings(text):
         """Generate embeddings for text using OpenAI's embedding model.
         


### PR DESCRIPTION
This pull request resolves [#dimensions](https://github.com/jupyter-naas/abi/issues/618)

## Summary
This pull request introduces several enhancements and refactorings to the `Embeddings.py` module and updates the `Makefile` to improve the generation of pull request descriptions.

## Changes

1. **Makefile Update**:
   - Modified the `pull-request-description` target to echo a command for generating pull request descriptions using the AI agent.

2. **Embeddings.py Enhancements**:
   - Introduced a dictionary `EMBEDDINGS_MODELS_DIMENSIONS_MAP` to map embedding models to their respective dimensions.
   - Added functions `__get_safe_model` and `__compute_key` to sanitize model names and compute unique cache keys.
   - Refactored `_sha1` and `_sha1s` functions to return functions that compute cache keys for single and multiple texts, respectively, based on the model.
   - Updated the `embeddings` and `embeddings_batch` functions to use the new cache key computation methods.

## Rationale
These changes aim to improve the maintainability and scalability of the embeddings service by:
- Ensuring that model names are safely used in cache keys.
- Allowing easy addition of new models and their dimensions.
- Enhancing the clarity and reusability of the cache key computation logic.

## Testing
- Verified that the updated `embeddings` and `embeddings_batch` functions correctly generate and cache embeddings for both single and batch text inputs.
- Ensured that the Makefile target for pull request description generation works as expected.