### PR TITLE
feat: Add api example in new abi module creation

### DIFF
--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/module/__init__.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/module/__init__.py
@@ -1,3 +1,4 @@
+from fastapi import FastAPI
 from naas_abi_core.module.Module import (
     BaseModule,
     ModuleConfiguration,
@@ -39,3 +40,17 @@ class ABIModule(BaseModule):
     # You can see it as the constructor of the module.
     def on_load(self):
         super().on_load()
+
+    # Optional FastAPI integration hook.
+    # This mirrors how `naas_abi` wires API settings and services into app.state.
+    # Override and adapt to your module if you expose HTTP routes.
+    def api(self, app: FastAPI) -> None:
+        # Example: expose services to your API layer.
+        # app.state.object_storage = self.engine.services.object_storage
+        # app.state.secret_service = self.engine.services.secret
+        # app.state.triple_store = self.engine.services.triple_store
+
+        # Example: mount your FastAPI routes/app factory.
+        # from your_module.apps.api.app.main import create_app
+        # create_app(app)
+        pass


### PR DESCRIPTION
Summary
- Extend the module scaffold template to include an optional api(self, app: FastAPI) -> None hook.
- Add FastAPI import in the template so generated modules can expose API wiring points out of the box.
- Include inline examples showing how to attach services to app.state and how to mount module routes/app factories.

Why
- Makes new modules API-ready by default without forcing implementation.
- Reduces friction for developers who want to expose HTTP endpoints from a generated module.
- Aligns generated module structure with the existing BaseModule.api(...) extension point.

Notes
- No behavioral change for existing modules.
- The default implementation remains a no-op (pass) until overridden by the module author.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the module scaffold template used by `naas-abi-cli`, adding an optional no-op method and import with no runtime behavior changes unless newly generated modules override it.
> 
> **Overview**
> New modules generated from the `naas-abi-cli` template are now *API-ready by default*: the scaffold imports `FastAPI` and includes an optional `ABIModule.api(self, app: FastAPI)` hook.
> 
> The new `api` method is a no-op with inline examples showing how to attach engine services to `app.state` and how to mount module routes/app factories when a module chooses to expose HTTP endpoints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 735931ee331b57fec791dbede5949e5d019654b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->