### PR TITLE
fix: remove cli rerun

### DIFF
--- a/libs/naas-abi-cli/README.md
+++ b/libs/naas-abi-cli/README.md
@@ -198,7 +198,7 @@ The CLI is built using:
 - **naas-abi-marketplace**: Marketplace modules and agents
 - **naas-abi**: Main ABI package
 
-The CLI automatically detects if it's being run from within an ABI project (by checking for `pyproject.toml` with `naas-abi-cli` dependency) and uses `uv run` to ensure proper environment isolation.
+The CLI runs directly in the current environment and does not automatically re-run itself via `uv run`.
 
 ## Project Structure
 
@@ -230,4 +230,3 @@ The CLI integrates seamlessly with the ABI ecosystem:
 - [ABI Main README](../../../README.md) - Complete ABI framework documentation
 - [naas-abi-core](../naas-abi-core/) - Core engine documentation
 - [naas-abi-marketplace](../naas-abi-marketplace/) - Marketplace modules documentation
-

--- a/libs/naas-abi-cli/naas_abi_cli/cli/__init__.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/__init__.py
@@ -1,7 +1,3 @@
-import os
-import subprocess
-import sys
-
 import click
 
 from .agent import agent
@@ -45,26 +41,6 @@ def main():
         return
     ran = True
 
-    # Check how the project is being runned.
-    if os.getenv("LOCAL_UV_RAN") is None:
-        if "pyproject.toml" in os.listdir(os.getcwd()):
-            with open("pyproject.toml", "r") as file:
-                if "naas-abi-cli" in file.read():
-                    arguments = (
-                        "uv run --active python -m naas_abi_cli.cli".split(" ")
-                        + sys.argv[1:]
-                    )
-                    try:
-                        subprocess.run(
-                            arguments,
-                            cwd=os.getcwd(),
-                            env={**os.environ, "LOCAL_UV_RAN": "true"},
-                            check=True,
-                        )
-                    except Exception:
-                        pass
-
-                    return
     _main()
 
 


### PR DESCRIPTION
 Summary
- Removed automatic CLI self re-execution through `uv run` in `naas-abi-cli`.
- Simplified the CLI entrypoint by deleting `LOCAL_UV_RAN`/subprocess bootstrap logic.
- Updated documentation to reflect that the CLI now runs directly in the current environment.
 Why
The previous implicit re-run behavior introduced hidden execution flow and environment coupling. Running directly in the active environment makes CLI behavior explicit and predictable.
 Changes
- **Code:** Deleted bootstrap logic in `libs/naas-abi-cli/naas_abi_cli/cli/__init__.py` that detected `pyproject.toml` and re-invoked `python -m naas_abi_cli.cli` with `uv run`.
- **Docs:** Updated `libs/naas-abi-cli/README.md` to describe direct execution behavior.
 Impact
- **Behavior change:** `abi` no longer automatically switches to a `uv`-managed execution path.
- Users should invoke `abi` from the intended Python environment.
 Validation
- Verified CLI module import/entrypoint loads and exposes expected commands.
- Confirmed no recursive re-launch path remains in the CLI bootstrap.