### PR TITLE
fix: Use our own github runner

### DIFF
--- a/.github/workflows/build_abi_container.yml
+++ b/.github/workflows/build_abi_container.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   build:
     # if: startsWith(github.event.release.tag_name, 'naas-abi-v')
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build_nexus_web_container.yml
+++ b/.github/workflows/build_nexus_web_container.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   build:
     if: startsWith(github.event.release.tag_name, 'naas-abi-v')
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 30
     steps:
       - name: Checkout repository
@@ -187,7 +187,7 @@ jobs:
           exit 1
 
   streamlit-demo:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 10
     env:
       REGISTRY_NAME: ${{ github.event.repository.name }}-demo-streamlit
@@ -262,7 +262,7 @@ jobs:
            || naas-python space update --name=${{ env.REGISTRY_NAME }} --image=$URI@sha256:$IMAGE_SHA --port=8501 --cpu=1 --memory=1Gi --env "$ENV_CONFIG"
 
   mcp-server:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 10
     needs: build  # Wait for API to be deployed first
     env:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v4
 
@@ -48,7 +48,7 @@ jobs:
           echo "🚨🚨🚨🚨🚨🚨🚨🚨🚨 Skipping API initialization tests (disabled) WE NEED TO REMEDIATE THIS 🚨🚨🚨🚨🚨🚨🚨🚨🚨"
           
   container-scan:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
 
   release:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     concurrency:
       group: ${{ github.workflow }}-release-${{ github.ref_name }}
       cancel-in-progress: false


### PR DESCRIPTION
## Summary
- Migrate GitHub Actions jobs from GitHub-hosted `ubuntu-latest` runners to self-hosted Linux x64 runners.
- Keep existing workflow logic unchanged while standardizing runner selection across build, deploy, pull request, and release pipelines.

## What Changed
- Updated `runs-on` from `ubuntu-latest` to `[self-hosted, Linux, X64]` in:
  - `.github/workflows/build_abi_container.yml`
  - `.github/workflows/build_nexus_web_container.yml`
  - `.github/workflows/deploy_api.yml`
  - `.github/workflows/pull_request.yml`
  - `.github/workflows/release.yml`

## Why
- Use organization-managed self-hosted runners for CI/CD execution.
- Enable environment consistency and infrastructure control across all key workflows.

## Validation
- Configuration-only change; no application code paths were modified.
- Verified the diff to ensure runner label updates are applied consistently to all affected jobs.
