### PR TITLE
fix: make favicon & title persistant

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/contexts/tenant-context.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/contexts/tenant-context.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { usePathname } from 'next/navigation';
 import { createContext, useContext, useEffect, useState } from 'react';
 import { getApiUrl } from '@/lib/config';
 
@@ -76,6 +77,7 @@ function applyFavicon(url: string) {
 }
 
 export function TenantProvider({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
   const [tenant, setTenant] = useState<TenantConfig>(DEFAULT_TENANT);
 
   useEffect(() => {
@@ -85,15 +87,20 @@ export function TenantProvider({ children }: { children: React.ReactNode }) {
       .then((data: TenantConfig | null) => {
         if (!data) return;
         setTenant(data);
-        document.title = data.tab_title;
-        if (data.favicon_url) {
-          applyFavicon(data.favicon_url);
-        }
       })
       .catch(() => {
         // Tenant endpoint unavailable — keep defaults
       });
   }, []);
+
+  // Re-apply tenant title and favicon on every navigation so they persist
+  // over route-level metadata (e.g. auth layout "Sign In").
+  useEffect(() => {
+    document.title = tenant.tab_title;
+    if (tenant.favicon_url) {
+      applyFavicon(tenant.favicon_url);
+    }
+  }, [tenant.tab_title, tenant.favicon_url, pathname]);
 
   return (
     <TenantContext.Provider value={tenant}>{children}</TenantContext.Provider>


### PR DESCRIPTION
### Summary
This PR addresses the issue of favicon and tab title not persisting across route changes in the application.

### Changes:
- Removed the immediate setting of document title and favicon inside the tenant data fetch.
- Added a new effect hook that listens to changes in tenant tab title, favicon URL, and the current pathname.
- This effect re-applies the document title and favicon on every navigation, ensuring persistence over route-level metadata changes.

### Impact
This change ensures consistent branding by maintaining the tenant's tab title and favicon throughout navigation, improving user experience.

### Files changed:
- `libs/naas-abi/naas_abi/apps/nexus/apps/web/src/contexts/tenant-context.tsx`