### PR TITLE
feat: Improve local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,7 @@ help:
 	@echo "  test-ci                  Run basic tests for CI (no external dependencies)"
 	@echo "  test-abi                 Run tests specifically for the abi library"
 	@echo "  test-api                 Run API-specific tests"
+	@echo "  test-local-embedded-core Run no-docker local embedded core e2e test"
 	@echo "  test-integration-core    Run core integration tests (testcontainers)"
 	@echo "  test-api-init            Test API initialization with production secrets"
 	@echo "  test-api-init-container  Test API initialization in containerized environment"
@@ -540,6 +541,11 @@ test: deps
 # Run API-specific tests
 test-api: deps
 	@ uv run python -m pytest libs/naas-abi-core/naas_abi_core/apps/api/api_test.py -v -s
+
+# Run no-docker local embedded stack e2e test
+test-local-embedded-core: deps
+	@ echo "🔍 Running local embedded core e2e test..."
+	@ uv run pytest libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_LocalEmbeddedE2E_test.py -v
 
 # Run core integration tests using testcontainers
 test-integration-core: deps check-docker
@@ -974,4 +980,4 @@ clean:
 # =============================================================================
 # Declare all targets as phony to avoid conflicts with files of the same name
 
-.PHONY: test test-integration-core chat-abi-agent chat-naas-agent chat-ontology-agent chat-support-agent chat-qwen-agent chat-deepseek-agent chat-gemma-agent api sh lock add abi-add help uv oxigraph-up oxigraph-down oxigraph-status local-up local-down container-up container-down model-up model-down model-status airgap dagster-dev dagster-up dagster-down dagster-ui dagster-logs dagster-status dagster-materialize create-module create-agent create-integration create-workflow create-pipeline create-ontology
+.PHONY: test test-local-embedded-core test-integration-core chat-abi-agent chat-naas-agent chat-ontology-agent chat-support-agent chat-qwen-agent chat-deepseek-agent chat-gemma-agent api sh lock add abi-add help uv oxigraph-up oxigraph-down oxigraph-status local-up local-down container-up container-down model-up model-down model-status airgap dagster-dev dagster-up dagster-down dagster-ui dagster-logs dagster-status dagster-materialize create-module create-agent create-integration create-workflow create-pipeline create-ontology

--- a/config.yaml
+++ b/config.yaml
@@ -19,40 +19,41 @@ api:
 global_config:
   ai_mode: "cloud"
 
+default_agent: naas_abi_marketplace.ai.chatgpt ChatGPTAgent
 modules:
-  - module: naas_abi
-    enabled: true
-    config:
-      nexus_config:
-        database_url: "postgresql+asyncpg://{{ secret.POSTGRES_USER }}:{{ secret.POSTGRES_PASSWORD }}@localhost:5432/nexus"
-        redis_url: "redis://localhost:6379/0"
-        cors_origins_str: "http://localhost:3042,http://127.0.0.1:3042"
-
+  # - module: naas_abi
+  #   enabled: true
+  #   config:
+  #     nexus_config:
+  #       database_url: "postgresql+asyncpg://{{ secret.POSTGRES_USER }}:{{ secret.POSTGRES_PASSWORD }}@localhost:5432/nexus"
+  #       redis_url: "redis://localhost:6379/0"
+  #       cors_origins_str: "http://localhost:3042,http://127.0.0.1:3042"
+  #
   - module: naas_abi_marketplace.ai.chatgpt
     enabled: true
     config:
       openai_api_key: "{{ secret.OPENAI_API_KEY }}"
-
-  - module: naas_abi_marketplace.applications.openrouter
-    enabled: true
-    config:
-      openrouter_api_key: "{{ secret.OPENROUTER_API_KEY }}"
-      include_models:
-        - "anthropic/claude-opus-4.6"
-        - "anthropic/claude-sonnet-4.6"
-        - "deepseek/deepseek-v3.2"
-        - "google/gemini-3.1-pro-preview"
-        - "mistralai/mistral-large-2512"
-        - "openai/gpt-4.1"
-        - "openai/gpt-4.1-mini"
-        - "openai/gpt-5.1"
-        - "openai/gpt-5.2"
-        - "perplexity/sonar-pro-search"
-        - "x-ai/grok-4.1-fast"
-
-  - module: naas_abi_marketplace.applications.git
-    enabled: true
-
+  #
+  # - module: naas_abi_marketplace.applications.openrouter
+  #   enabled: true
+  #   config:
+  #     openrouter_api_key: "{{ secret.OPENROUTER_API_KEY }}"
+  #     include_models:
+  #       - "anthropic/claude-opus-4.6"
+  #       - "anthropic/claude-sonnet-4.6"
+  #       - "deepseek/deepseek-v3.2"
+  #       - "google/gemini-3.1-pro-preview"
+  #       - "mistralai/mistral-large-2512"
+  #       - "openai/gpt-4.1"
+  #       - "openai/gpt-4.1-mini"
+  #       - "openai/gpt-5.1"
+  #       - "openai/gpt-5.2"
+  #       - "perplexity/sonar-pro-search"
+  #       - "x-ai/grok-4.1-fast"
+  #
+  # - module: naas_abi_marketplace.applications.git
+  #   enabled: true
+  #
 services:
   secret:
     secret_adapters:
@@ -65,22 +66,27 @@ services:
         base_path: "storage/datastore"
   triple_store:
     triple_store_adapter:
-      adapter: "apache_jena_tdb2"
+      adapter: "oxigraph_embedded"
       config:
-        jena_tdb2_url: "http://admin:{{ secret.FUSEKI_ADMIN_PASSWORD }}@localhost:3030/ds"
+        store_path: "storage/triplestore/oxigraph"
+        graph_base_iri: "http://ontology.naas.ai/graph/default"
   vector_store:
     vector_store_adapter:
-      adapter: "qdrant"
+      adapter: "qdrant_in_memory"
       config:
-        host: "localhost"
-        port: 6333
+        storage_path: "storage/vectorstore/qdrant"
+        timeout: 300
   bus:
     bus_adapter:
-      adapter: "rabbitmq"
+      adapter: "python_queue"
       config:
-        rabbitmq_url: "amqp://{{ secret.RABBITMQ_USER }}:{{ secret.RABBITMQ_PASSWORD }}@localhost:5672"
+        persistence_path: "storage/bus/python_queue.sqlite3"
+        journal_mode: "WAL"
+        busy_timeout_ms: 5000
   kv:
     kv_adapter:
-      adapter: "redis"
+      adapter: "python"
       config:
-        redis_url: "redis://localhost:6379"
+        persistence_path: "storage/kv/python.sqlite3"
+        journal_mode: "WAL"
+        busy_timeout_ms: 5000

--- a/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration.py
@@ -7,6 +7,7 @@ import yaml
 from jinja2 import Template
 from naas_abi_core import logger
 from naas_abi_core.engine.engine_configuration.EngineConfiguration_BusService import (
+    BusAdapterPythonQueueConfiguration,
     BusAdapterConfiguration,
     BusServiceConfiguration,
 )
@@ -14,6 +15,7 @@ from naas_abi_core.engine.engine_configuration.EngineConfiguration_Deploy import
     DeployConfiguration,
 )
 from naas_abi_core.engine.engine_configuration.EngineConfiguration_KeyValueService import (
+    KeyValueAdapterPythonConfiguration,
     KeyValueAdapterConfiguration,
     KeyValueServiceConfiguration,
 )
@@ -29,10 +31,11 @@ from naas_abi_core.engine.engine_configuration.EngineConfiguration_SecretService
 )
 from naas_abi_core.engine.engine_configuration.EngineConfiguration_TripleStoreService import (
     TripleStoreAdapterConfiguration,
-    TripleStoreAdapterFilesystemConfiguration,
+    TripleStoreAdapterOxigraphEmbeddedConfiguration,
     TripleStoreServiceConfiguration,
 )
 from naas_abi_core.engine.engine_configuration.EngineConfiguration_VectorStoreService import (
+    VectorStoreAdapterQdrantInMemoryConfiguration,
     VectorStoreAdapterConfiguration,
     VectorStoreServiceConfiguration,
 )
@@ -56,15 +59,20 @@ class ServicesConfiguration(BaseModel):
     )
     triple_store: TripleStoreServiceConfiguration = TripleStoreServiceConfiguration(
         triple_store_adapter=TripleStoreAdapterConfiguration(
-            adapter="fs",
-            config=TripleStoreAdapterFilesystemConfiguration(
-                store_path="storage/triplestore", triples_path="triples"
+            adapter="oxigraph_embedded",
+            config=TripleStoreAdapterOxigraphEmbeddedConfiguration(
+                store_path="storage/triplestore/oxigraph",
+                graph_base_iri="http://ontology.naas.ai/graph/default",
             ),
         )
     )
     vector_store: VectorStoreServiceConfiguration = VectorStoreServiceConfiguration(
         vector_store_adapter=VectorStoreAdapterConfiguration(
-            adapter="qdrant_in_memory", config={}
+            adapter="qdrant_in_memory",
+            config=VectorStoreAdapterQdrantInMemoryConfiguration(
+                storage_path="storage/vectorstore/qdrant",
+                timeout=300,
+            ).model_dump(),
         )
     )
     secret: SecretServiceConfiguration = SecretServiceConfiguration(
@@ -75,10 +83,26 @@ class ServicesConfiguration(BaseModel):
         ]
     )
     bus: BusServiceConfiguration = BusServiceConfiguration(
-        bus_adapter=BusAdapterConfiguration(adapter="python_queue", config={})
+        bus_adapter=BusAdapterConfiguration(
+            adapter="python_queue",
+            config=BusAdapterPythonQueueConfiguration(
+                persistence_path="storage/bus/python_queue.sqlite3",
+                journal_mode="WAL",
+                busy_timeout_ms=5000,
+                poll_interval_seconds=0.05,
+                lock_timeout_seconds=1.0,
+            ).model_dump(),
+        )
     )  # Provide default if not supplied
     kv: KeyValueServiceConfiguration = KeyValueServiceConfiguration(
-        kv_adapter=KeyValueAdapterConfiguration(adapter="python", config={})
+        kv_adapter=KeyValueAdapterConfiguration(
+            adapter="python",
+            config=KeyValueAdapterPythonConfiguration(
+                persistence_path="storage/kv/python.sqlite3",
+                journal_mode="WAL",
+                busy_timeout_ms=5000,
+            ).model_dump(),
+        )
     )
 
 

--- a/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_BusService.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_BusService.py
@@ -1,9 +1,11 @@
 from typing import Literal
 
-from naas_abi_core.engine.engine_configuration.EngineConfiguration_GenericLoader import \
-    GenericLoader
-from naas_abi_core.engine.engine_configuration.utils.PydanticModelValidator import \
-    pydantic_model_validator
+from naas_abi_core.engine.engine_configuration.EngineConfiguration_GenericLoader import (
+    GenericLoader,
+)
+from naas_abi_core.engine.engine_configuration.utils.PydanticModelValidator import (
+    pydantic_model_validator,
+)
 from naas_abi_core.services.bus.BusPorts import IBusAdapter
 from naas_abi_core.services.bus.BusService import BusService
 from pydantic import BaseModel, ConfigDict, model_validator
@@ -17,9 +19,11 @@ class BusAdapterRabbitMQConfiguration(BaseModel):
       config:
         rabbitmq_url: "{{ secret.RABBITMQ_URL }}"
     """
+
     model_config = ConfigDict(extra="forbid")
 
     rabbitmq_url: str = "amqp://abi:abi@127.0.0.1:5672"
+
 
 class BusAdapterPythonQueueConfiguration(BaseModel):
     """Python queue bus adapter configuration.
@@ -28,9 +32,17 @@ class BusAdapterPythonQueueConfiguration(BaseModel):
       adapter: "python_queue"
       config: {}
     """
+
     model_config = ConfigDict(extra="forbid")
 
-    pass
+    persistence_path: str | None = None
+    journal_mode: Literal["DELETE", "TRUNCATE", "PERSIST", "MEMORY", "WAL", "OFF"] = (
+        "WAL"
+    )
+    busy_timeout_ms: int = 5000
+    poll_interval_seconds: float = 0.05
+    lock_timeout_seconds: float = 1.0
+
 
 class BusAdapterConfiguration(GenericLoader):
     adapter: Literal["rabbitmq", "python_queue", "custom"]
@@ -42,11 +54,9 @@ class BusAdapterConfiguration(GenericLoader):
             assert self.config is not None, (
                 "config is required if adapter is not custom"
             )
-        
+
         if self.adapter == "rabbitmq":
-            assert self.config is not None, (
-                "config is required for rabbitmq adapter"
-            )
+            assert self.config is not None, "config is required for rabbitmq adapter"
             pydantic_model_validator(
                 BusAdapterRabbitMQConfiguration,
                 self.config,
@@ -68,15 +78,20 @@ class BusAdapterConfiguration(GenericLoader):
         # Lazy import: only import when actually loading
         if self.adapter == "rabbitmq":
             assert self.config is not None, "config is required for rabbitmq adapter"
-            from naas_abi_core.services.bus.adapters.secondary.RabbitMQAdapter import \
-                RabbitMQAdapter
+            from naas_abi_core.services.bus.adapters.secondary.RabbitMQAdapter import (
+                RabbitMQAdapter,
+            )
 
             return RabbitMQAdapter(**self.config)
         elif self.adapter == "python_queue":
-            from naas_abi_core.services.bus.adapters.secondary.PythonQueueAdapter import \
-                PythonQueueAdapter
+            from naas_abi_core.services.bus.adapters.secondary.PythonQueueAdapter import (
+                PythonQueueAdapter,
+            )
 
-            return PythonQueueAdapter()
+            assert self.config is not None, (
+                "config is required for python_queue adapter"
+            )
+            return PythonQueueAdapter(**self.config)
         elif self.adapter == "custom":
             return super().load()
         else:

--- a/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_BusService_test.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_BusService_test.py
@@ -1,0 +1,21 @@
+from naas_abi_core.engine.engine_configuration.EngineConfiguration_BusService import (
+    BusAdapterConfiguration,
+    BusServiceConfiguration,
+)
+from naas_abi_core.services.bus.BusService import BusService
+from naas_abi_core.services.bus.adapters.secondary.PythonQueueAdapter import (
+    PythonQueueAdapter,
+)
+
+
+def test_bus_service_configuration_python_queue(tmp_path):
+    configuration = BusServiceConfiguration(
+        bus_adapter=BusAdapterConfiguration(
+            adapter="python_queue",
+            config={"persistence_path": str(tmp_path / "bus.sqlite3")},
+        )
+    )
+
+    adapter = configuration.bus_adapter.load()
+    assert isinstance(adapter, PythonQueueAdapter)
+    assert isinstance(configuration.load(), BusService)

--- a/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_KeyValueService.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_KeyValueService.py
@@ -36,7 +36,11 @@ class KeyValueAdapterPythonConfiguration(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    pass
+    persistence_path: str | None = None
+    journal_mode: Literal["DELETE", "TRUNCATE", "PERSIST", "MEMORY", "WAL", "OFF"] = (
+        "WAL"
+    )
+    busy_timeout_ms: int = 5000
 
 
 class KeyValueAdapterConfiguration(GenericLoader):

--- a/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_KeyValueService_test.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_KeyValueService_test.py
@@ -1,0 +1,21 @@
+from naas_abi_core.engine.engine_configuration.EngineConfiguration_KeyValueService import (
+    KeyValueAdapterConfiguration,
+    KeyValueServiceConfiguration,
+)
+from naas_abi_core.services.keyvalue.KeyValueService import KeyValueService
+from naas_abi_core.services.keyvalue.adapters.secondary.PythonAdapter import (
+    PythonAdapter,
+)
+
+
+def test_keyvalue_service_configuration_python_adapter(tmp_path):
+    configuration = KeyValueServiceConfiguration(
+        kv_adapter=KeyValueAdapterConfiguration(
+            adapter="python",
+            config={"persistence_path": str(tmp_path / "kv.sqlite3")},
+        )
+    )
+
+    adapter = configuration.kv_adapter.load()
+    assert isinstance(adapter, PythonAdapter)
+    assert isinstance(configuration.load(), KeyValueService)

--- a/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_LocalEmbeddedE2E_test.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_LocalEmbeddedE2E_test.py
@@ -1,0 +1,145 @@
+import threading
+
+import numpy as np
+import pytest
+from rdflib import Graph, Literal, URIRef
+
+from naas_abi_core.engine.engine_configuration.EngineConfiguration import (
+    EngineConfiguration,
+)
+
+
+def test_local_embedded_services_end_to_end(tmp_path):
+    pytest.importorskip("pyoxigraph")
+    pytest.importorskip("qdrant_client")
+
+    env_path = tmp_path / ".env"
+    env_path.write_text("ENV=local\n", encoding="utf-8")
+
+    config_yaml = f"""
+api:
+  title: "ABI API"
+  description: "API for ABI"
+  logo_path: "assets/logo.png"
+  favicon_path: "assets/favicon.ico"
+  cors_origins:
+    - "http://localhost:9879"
+
+global_config:
+  ai_mode: "cloud"
+
+modules:
+  - module: naas_abi
+    enabled: true
+    config: {{}}
+
+services:
+  secret:
+    secret_adapters:
+      - adapter: "dotenv"
+        config:
+          path: "{env_path.as_posix()}"
+  object_storage:
+    object_storage_adapter:
+      adapter: "fs"
+      config:
+        base_path: "{(tmp_path / "datastore").as_posix()}"
+  triple_store:
+    triple_store_adapter:
+      adapter: "oxigraph_embedded"
+      config:
+        store_path: "{(tmp_path / "triplestore").as_posix()}"
+  vector_store:
+    vector_store_adapter:
+      adapter: "qdrant_in_memory"
+      config:
+        storage_path: "{(tmp_path / "vectorstore").as_posix()}"
+  bus:
+    bus_adapter:
+      adapter: "python_queue"
+      config:
+        persistence_path: "{(tmp_path / "bus.sqlite3").as_posix()}"
+  kv:
+    kv_adapter:
+      adapter: "python"
+      config:
+        persistence_path: "{(tmp_path / "kv.sqlite3").as_posix()}"
+"""
+
+    configuration = EngineConfiguration.from_yaml_content(config_yaml)
+
+    kv = configuration.services.kv.load()
+    kv.set("k", b"v")
+    assert kv.get("k") == b"v"
+
+    bus = configuration.services.bus.load()
+    bus.topic_publish("events", "user.created", b"pending")
+    bus_restarted = configuration.services.bus.load()
+
+    done = threading.Event()
+    seen: list[bytes] = []
+
+    def callback(payload: bytes) -> None:
+        seen.append(payload)
+        done.set()
+        raise StopIteration()
+
+    bus_restarted.topic_consume("events", "user.*", callback)
+    assert done.wait(timeout=3)
+    assert seen == [b"pending"]
+
+    vector_service = configuration.services.vector_store.load()
+    vector_service.ensure_collection("docs", 4)
+    vector_service.add_documents(
+        collection_name="docs",
+        ids=["doc-1"],
+        vectors=[np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32)],
+        metadata=[{"source": "e2e"}],
+        payloads=[{"text": "hello"}],
+    )
+    assert vector_service.get_document("docs", "doc-1") is not None
+    vector_service.adapter.close()
+
+    vector_service_restarted = configuration.services.vector_store.load()
+    assert vector_service_restarted.get_document("docs", "doc-1") is not None
+
+    triple_store = configuration.services.triple_store.load()
+    graph_name = URIRef("http://example.org/graphs/e2e")
+    subject = URIRef("http://example.org/s")
+    predicate = URIRef("http://example.org/p")
+    graph = Graph()
+    graph.add((subject, predicate, Literal("ok")))
+    triple_store.insert(graph, graph_name)
+
+    result = list(
+        triple_store.query(
+            f"""
+            SELECT ?o WHERE {{
+                GRAPH <{graph_name}> {{
+                    <{subject}> <{predicate}> ?o .
+                }}
+            }}
+            """
+        )
+    )
+    assert len(result) == 1
+    assert str(result[0].o) == "ok"
+
+    triple_store_restarted = configuration.services.triple_store.load()
+    result_restarted = list(
+        triple_store_restarted.query(
+            f"""
+            SELECT ?o WHERE {{
+                GRAPH <{graph_name}> {{
+                    <{subject}> <{predicate}> ?o .
+                }}
+            }}
+            """
+        )
+    )
+    assert len(result_restarted) == 1
+
+    object_storage = configuration.services.object_storage.load()
+    object_storage.put_object("e2e", "file.txt", b"content")
+    object_storage_restarted = configuration.services.object_storage.load()
+    assert object_storage_restarted.get_object("e2e", "file.txt") == b"content"

--- a/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_TripleStoreService.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_TripleStoreService.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Literal, Union
+from typing import TYPE_CHECKING, Any, Literal, Union
 
 from naas_abi_core.engine.engine_configuration.EngineConfiguration_GenericLoader import (
     GenericLoader,
@@ -111,6 +111,22 @@ class TripleStoreAdapterFilesystemConfiguration(BaseModel):
     triples_path: str = "triples"
 
 
+class TripleStoreAdapterOxigraphEmbeddedConfiguration(BaseModel):
+    """Embedded Oxigraph adapter configuration.
+
+    triple_store_adapter:
+      adapter: "oxigraph_embedded"
+      config:
+        store_path: "storage/triplestore/oxigraph"
+        graph_base_iri: "http://ontology.naas.ai/graph/default"
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    store_path: str
+    graph_base_iri: str = "http://ontology.naas.ai/graph/default"
+
+
 class TripleStoreAdapterObjectStorageConfiguration(BaseModel):
     """Object storage adapter configuration.
 
@@ -134,6 +150,7 @@ class TripleStoreAdapterConfiguration(GenericLoader):
         "aws_neptune_sshtunnel",
         "aws_neptune",
         "fs",
+        "oxigraph_embedded",
         "object_storage",
         "custom",
     ]
@@ -144,6 +161,7 @@ class TripleStoreAdapterConfiguration(GenericLoader):
             AWSNeptuneAdapterConfiguration,
             AWSNeptuneSSHTunnelAdapterConfiguration,
             TripleStoreAdapterFilesystemConfiguration,
+            TripleStoreAdapterOxigraphEmbeddedConfiguration,
             TripleStoreAdapterObjectStorageConfiguration,
             dict,
         ]
@@ -152,42 +170,88 @@ class TripleStoreAdapterConfiguration(GenericLoader):
 
     @model_validator(mode="after")
     def validate_adapter(self) -> Self:
+        config_value = self.config
+        payload: dict[str, Any] | None
+        if isinstance(config_value, BaseModel):
+            payload = config_value.model_dump()
+        elif isinstance(config_value, dict):
+            payload = config_value
+        else:
+            payload = None
+
+        def _payload_for(model: type[BaseModel]) -> dict | None:
+            if payload is None:
+                return None
+            if not isinstance(payload, dict):
+                return payload
+            allowed_fields = set(model.model_fields.keys())
+            return {
+                key: value for key, value in payload.items() if key in allowed_fields
+            }
+
         if self.adapter != "custom":
-            assert self.config is not None, (
-                "config is required if adapter is not custom"
-            )
+            assert payload is not None, "config is required if adapter is not custom"
 
         if self.adapter == "fs":
+            self.config = TripleStoreAdapterFilesystemConfiguration.model_validate(
+                _payload_for(TripleStoreAdapterFilesystemConfiguration)
+            )
             pydantic_model_validator(
                 TripleStoreAdapterFilesystemConfiguration,
                 self.config,
                 "Invalid configuration for services.triple_store.triple_store_adapter 'fs' adapter",
             )
         if self.adapter == "object_storage":
+            self.config = TripleStoreAdapterObjectStorageConfiguration.model_validate(
+                _payload_for(TripleStoreAdapterObjectStorageConfiguration)
+            )
             pydantic_model_validator(
                 TripleStoreAdapterObjectStorageConfiguration,
                 self.config,
                 "Invalid configuration for services.triple_store.triple_store_adapter 'object_storage' adapter",
             )
+        if self.adapter == "oxigraph_embedded":
+            self.config = (
+                TripleStoreAdapterOxigraphEmbeddedConfiguration.model_validate(
+                    _payload_for(TripleStoreAdapterOxigraphEmbeddedConfiguration)
+                )
+            )
+            pydantic_model_validator(
+                TripleStoreAdapterOxigraphEmbeddedConfiguration,
+                self.config,
+                "Invalid configuration for services.triple_store.triple_store_adapter 'oxigraph_embedded' adapter",
+            )
         if self.adapter == "oxigraph":
+            self.config = OxigraphAdapterConfiguration.model_validate(
+                _payload_for(OxigraphAdapterConfiguration)
+            )
             pydantic_model_validator(
                 OxigraphAdapterConfiguration,
                 self.config,
                 "Invalid configuration for services.triple_store.triple_store_adapter 'oxigraph' adapter",
             )
         if self.adapter == "apache_jena_tdb2":
+            self.config = ApacheJenaTDB2AdapterConfiguration.model_validate(
+                _payload_for(ApacheJenaTDB2AdapterConfiguration)
+            )
             pydantic_model_validator(
                 ApacheJenaTDB2AdapterConfiguration,
                 self.config,
                 "Invalid configuration for services.triple_store.triple_store_adapter 'apache_jena_tdb2' adapter",
             )
         if self.adapter == "aws_neptune":
+            self.config = AWSNeptuneAdapterConfiguration.model_validate(
+                _payload_for(AWSNeptuneAdapterConfiguration)
+            )
             pydantic_model_validator(
                 AWSNeptuneAdapterConfiguration,
                 self.config,
                 "Invalid configuration for services.triple_store.triple_store_adapter 'aws_neptune' adapter",
             )
         if self.adapter == "aws_neptune_sshtunnel":
+            self.config = AWSNeptuneSSHTunnelAdapterConfiguration.model_validate(
+                _payload_for(AWSNeptuneSSHTunnelAdapterConfiguration)
+            )
             pydantic_model_validator(
                 AWSNeptuneSSHTunnelAdapterConfiguration,
                 self.config,
@@ -247,6 +311,18 @@ class TripleStoreAdapterConfiguration(GenericLoader):
                 TripleStoreAdapterFilesystemConfiguration.model_validate(arguments)
 
                 return TripleStoreService__SecondaryAdaptor__Filesystem(**arguments)
+            elif self.adapter == "oxigraph_embedded":
+                from naas_abi_core.services.triple_store.adaptors.secondary.TripleStoreService__SecondaryAdaptor__OxigraphEmbedded import (
+                    TripleStoreService__SecondaryAdaptor__OxigraphEmbedded,
+                )
+
+                TripleStoreAdapterOxigraphEmbeddedConfiguration.model_validate(
+                    arguments
+                )
+
+                return TripleStoreService__SecondaryAdaptor__OxigraphEmbedded(
+                    **arguments
+                )
             elif self.adapter == "object_storage":
                 from naas_abi_core.services.triple_store.adaptors.secondary.TripleStoreService__SecondaryAdaptor__ObjectStorage import (
                     TripleStoreService__SecondaryAdaptor__ObjectStorage,

--- a/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_TripleStoreService_test.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_TripleStoreService_test.py
@@ -1,8 +1,11 @@
+import pytest
+
 from naas_abi_core.engine.engine_configuration.EngineConfiguration_TripleStoreService import (
     ApacheJenaTDB2AdapterConfiguration,
     AWSNeptuneSSHTunnelAdapterConfiguration,
     OxigraphAdapterConfiguration,
     TripleStoreAdapterConfiguration,
+    TripleStoreAdapterOxigraphEmbeddedConfiguration,
     TripleStoreAdapterFilesystemConfiguration,
     TripleStoreServiceConfiguration,
 )
@@ -152,3 +155,29 @@ def test_triple_store_service_configuration_apache_jena_tdb2():
 
         assert triple_store_service is not None
         assert isinstance(triple_store_service, TripleStoreService)
+
+
+def test_triple_store_service_configuration_oxigraph_embedded(tmp_path):
+    pytest.importorskip("pyoxigraph")
+
+    from naas_abi_core.services.triple_store.adaptors.secondary.TripleStoreService__SecondaryAdaptor__OxigraphEmbedded import (
+        TripleStoreService__SecondaryAdaptor__OxigraphEmbedded,
+    )
+
+    configuration = TripleStoreServiceConfiguration(
+        triple_store_adapter=TripleStoreAdapterConfiguration(
+            adapter="oxigraph_embedded",
+            config=TripleStoreAdapterOxigraphEmbeddedConfiguration(
+                store_path=str(tmp_path / "oxigraph"),
+            ),
+        )
+    )
+
+    triple_store_adapter = configuration.triple_store_adapter.load()
+
+    assert triple_store_adapter is not None
+    assert isinstance(triple_store_adapter, ITripleStorePort)
+    assert isinstance(
+        triple_store_adapter,
+        TripleStoreService__SecondaryAdaptor__OxigraphEmbedded,
+    )

--- a/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_VectorStoreService.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_VectorStoreService.py
@@ -1,13 +1,13 @@
 from typing import Literal
 
-from naas_abi_core.engine.engine_configuration.EngineConfiguration_GenericLoader import \
-    GenericLoader
-from naas_abi_core.engine.engine_configuration.utils.PydanticModelValidator import \
-    pydantic_model_validator
-from naas_abi_core.services.vector_store.IVectorStorePort import \
-    IVectorStorePort
-from naas_abi_core.services.vector_store.VectorStoreService import \
-    VectorStoreService
+from naas_abi_core.engine.engine_configuration.EngineConfiguration_GenericLoader import (
+    GenericLoader,
+)
+from naas_abi_core.engine.engine_configuration.utils.PydanticModelValidator import (
+    pydantic_model_validator,
+)
+from naas_abi_core.services.vector_store.IVectorStorePort import IVectorStorePort
+from naas_abi_core.services.vector_store.VectorStoreService import VectorStoreService
 from pydantic import BaseModel, ConfigDict, model_validator
 
 
@@ -23,6 +23,7 @@ class VectorStoreAdapterQdrantConfiguration(BaseModel):
         https: "{{ secret.QDRANT_HTTPS }}"
         timeout: "{{ secret.QDRANT_TIMEOUT }}"
     """
+
     model_config = ConfigDict(extra="forbid")
 
     host: str = "localhost"
@@ -31,6 +32,7 @@ class VectorStoreAdapterQdrantConfiguration(BaseModel):
     https: bool = False
     timeout: int = 30
 
+
 class VectorStoreAdapterQdrantInMemoryConfiguration(BaseModel):
     """Qdrant in memory vector store adapter configuration.
 
@@ -38,9 +40,12 @@ class VectorStoreAdapterQdrantInMemoryConfiguration(BaseModel):
       adapter: "qdrant_in_memory"
       config: {}
     """
+
     model_config = ConfigDict(extra="forbid")
 
-    pass
+    storage_path: str = ":memory:"
+    timeout: int = 300
+
 
 class VectorStoreAdapterConfiguration(GenericLoader):
     adapter: Literal["qdrant", "qdrant_in_memory", "custom"]
@@ -77,13 +82,15 @@ class VectorStoreAdapterConfiguration(GenericLoader):
 
             # Lazy import: only import when actually loading
             if self.adapter == "qdrant":
-                from naas_abi_core.services.vector_store.adapters.QdrantAdapter import \
-                    QdrantAdapter
+                from naas_abi_core.services.vector_store.adapters.QdrantAdapter import (
+                    QdrantAdapter,
+                )
 
                 return QdrantAdapter(**self.config)
             elif self.adapter == "qdrant_in_memory":
-                from naas_abi_core.services.vector_store.adapters.QdrantInMemoryAdapter import \
-                    QdrantInMemoryAdapter
+                from naas_abi_core.services.vector_store.adapters.QdrantInMemoryAdapter import (
+                    QdrantInMemoryAdapter,
+                )
 
                 return QdrantInMemoryAdapter(**self.config)
             else:

--- a/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_VectorStoreService_test.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_VectorStoreService_test.py
@@ -31,3 +31,20 @@ def test_vector_store_service_configuration():
 
     assert vector_store_service is not None
     assert isinstance(vector_store_service, VectorStoreService)
+
+
+def test_vector_store_service_configuration_qdrant_in_memory(tmp_path):
+    from naas_abi_core.services.vector_store.adapters.QdrantInMemoryAdapter import (
+        QdrantInMemoryAdapter,
+    )
+
+    configuration = VectorStoreServiceConfiguration(
+        vector_store_adapter=VectorStoreAdapterConfiguration(
+            adapter="qdrant_in_memory",
+            config={"storage_path": str(tmp_path / "qdrant-local")},
+        )
+    )
+
+    vector_store_adapter = configuration.vector_store_adapter.load()
+    assert isinstance(vector_store_adapter, IVectorStorePort)
+    assert isinstance(vector_store_adapter, QdrantInMemoryAdapter)

--- a/libs/naas-abi-core/naas_abi_core/services/agent/SqliteCheckpointSaver.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/SqliteCheckpointSaver.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import os
+import pickle
+import sqlite3
+import threading
+import time
+from collections import defaultdict
+from typing import Any
+
+from langgraph.checkpoint.base import (
+    ChannelVersions,
+    Checkpoint,
+    CheckpointMetadata,
+    CheckpointTuple,
+    RunnableConfig,
+)
+from langgraph.checkpoint.memory import InMemorySaver
+
+
+class SqliteCheckpointSaver(InMemorySaver):
+    """SQLite-backed checkpoint saver for local persistence.
+
+    This saver extends LangGraph's in-memory saver and persists its internal
+    structures after each write/delete operation.
+    """
+
+    def __init__(
+        self,
+        path: str,
+        journal_mode: str = "WAL",
+        busy_timeout_ms: int = 5000,
+    ) -> None:
+        super().__init__()
+        self._lock = threading.RLock()
+        self._path = path
+
+        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+        self._conn = sqlite3.connect(
+            path,
+            timeout=max(0.0, busy_timeout_ms / 1000),
+            check_same_thread=False,
+        )
+        self._conn.execute(f"PRAGMA journal_mode={journal_mode}")
+        self._conn.execute(f"PRAGMA busy_timeout={busy_timeout_ms}")
+        self._conn.execute("PRAGMA synchronous=NORMAL")
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS checkpoint_state (
+                id INTEGER PRIMARY KEY CHECK(id = 1),
+                storage BLOB NOT NULL,
+                writes BLOB NOT NULL,
+                blobs BLOB NOT NULL,
+                updated_at REAL NOT NULL
+            )
+            """
+        )
+        self._conn.commit()
+        self._load_state()
+
+    def _serialize_storage(self) -> dict[str, dict[str, dict[str, tuple[Any, ...]]]]:
+        return {
+            thread_id: {
+                checkpoint_ns: dict(checkpoints)
+                for checkpoint_ns, checkpoints in namespaces.items()
+            }
+            for thread_id, namespaces in self.storage.items()
+        }
+
+    def _load_state(self) -> None:
+        row = self._conn.execute(
+            "SELECT storage, writes, blobs FROM checkpoint_state WHERE id = 1"
+        ).fetchone()
+        if row is None:
+            return
+
+        raw_storage = pickle.loads(row[0])
+        raw_writes = pickle.loads(row[1])
+        raw_blobs = pickle.loads(row[2])
+
+        storage: defaultdict[
+            str,
+            dict[
+                str, dict[str, tuple[tuple[str, bytes], tuple[str, bytes], str | None]]
+            ],
+        ] = defaultdict(lambda: defaultdict(dict))
+        for thread_id, namespaces in raw_storage.items():
+            for checkpoint_ns, checkpoints in namespaces.items():
+                storage[thread_id][checkpoint_ns].update(checkpoints)
+
+        writes: defaultdict[
+            tuple[str, str, str],
+            dict[tuple[str, int], tuple[str, str, tuple[str, bytes], str]],
+        ] = defaultdict(dict)
+        for key, value in raw_writes.items():
+            writes[key] = value
+
+        self.storage = storage
+        self.writes = writes
+        self.blobs = raw_blobs
+
+    def _persist_state(self) -> None:
+        self._conn.execute(
+            """
+            INSERT INTO checkpoint_state(id, storage, writes, blobs, updated_at)
+            VALUES(1, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                storage=excluded.storage,
+                writes=excluded.writes,
+                blobs=excluded.blobs,
+                updated_at=excluded.updated_at
+            """,
+            (
+                pickle.dumps(
+                    self._serialize_storage(), protocol=pickle.HIGHEST_PROTOCOL
+                ),
+                pickle.dumps(dict(self.writes), protocol=pickle.HIGHEST_PROTOCOL),
+                pickle.dumps(dict(self.blobs), protocol=pickle.HIGHEST_PROTOCOL),
+                time.time(),
+            ),
+        )
+        self._conn.commit()
+
+    def get_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:
+        with self._lock:
+            return super().get_tuple(config)
+
+    def list(
+        self,
+        config: RunnableConfig | None,
+        *,
+        filter: dict[str, Any] | None = None,
+        before: RunnableConfig | None = None,
+        limit: int | None = None,
+    ):
+        with self._lock:
+            yield from super().list(config, filter=filter, before=before, limit=limit)
+
+    def put(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+    ) -> RunnableConfig:
+        with self._lock:
+            updated_config = super().put(config, checkpoint, metadata, new_versions)
+            self._persist_state()
+            return updated_config
+
+    def put_writes(
+        self,
+        config: RunnableConfig,
+        writes,
+        task_id: str,
+        task_path: str = "",
+    ) -> None:
+        with self._lock:
+            super().put_writes(config, writes, task_id, task_path)
+            self._persist_state()
+
+    def delete_thread(self, thread_id: str) -> None:
+        with self._lock:
+            super().delete_thread(thread_id)
+            self._persist_state()
+
+    def close(self) -> None:
+        with self._lock:
+            self._conn.close()

--- a/libs/naas-abi-core/naas_abi_core/services/bus/adapters/secondary/PythonQueueAdapter.py
+++ b/libs/naas-abi-core/naas_abi_core/services/bus/adapters/secondary/PythonQueueAdapter.py
@@ -1,65 +1,149 @@
-from dataclasses import dataclass
-from queue import Queue
-from threading import RLock, Thread
-from typing import Callable, Dict, List
+import os
+import sqlite3
+import time
+import threading
+from threading import Event, Thread
+from typing import Callable
 
 from naas_abi_core.services.bus.BusPorts import IBusAdapter
 
 
-@dataclass(frozen=True)
-class _Subscriber:
-    routing_key: str
-    queue: Queue
-
-
 class PythonQueueAdapter(IBusAdapter):
-    """Process-local bus using stdlib queues (no external deps)."""
+    """Process-local durable queue using sqlite.
 
-    _lock: RLock
-    _subscribers: Dict[str, List[_Subscriber]]
-    
-    def __init__(self) -> None:
-        self._lock = RLock()
-        self._subscribers: Dict[str, List[_Subscriber]] = {}
+    The adapter provides at-least-once delivery semantics. Messages are persisted
+    before publish returns and are replayed after restart when using a file path.
+    """
+
+    _SHARED_IN_MEMORY_URI = "file:python_queue_adapter?mode=memory&cache=shared"
+
+    def __init__(
+        self,
+        persistence_path: str | None = None,
+        journal_mode: str = "WAL",
+        busy_timeout_ms: int = 5000,
+        poll_interval_seconds: float = 0.05,
+        lock_timeout_seconds: float = 1.0,
+    ) -> None:
+        self._poll_interval_seconds = poll_interval_seconds
+        self._lock_timeout_seconds = lock_timeout_seconds
+
+        if persistence_path is None:
+            db_target = self._SHARED_IN_MEMORY_URI
+            uri = True
+        else:
+            os.makedirs(os.path.dirname(persistence_path) or ".", exist_ok=True)
+            db_target = persistence_path
+            uri = False
+
+        self._conn = sqlite3.connect(
+            db_target,
+            uri=uri,
+            timeout=max(0.0, busy_timeout_ms / 1000),
+            check_same_thread=False,
+        )
+        self._conn.execute(f"PRAGMA busy_timeout={busy_timeout_ms}")
+        self._conn.execute(f"PRAGMA journal_mode={journal_mode}")
+        self._conn.execute("PRAGMA synchronous=NORMAL")
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS bus_messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                topic TEXT NOT NULL,
+                routing_key TEXT NOT NULL,
+                payload BLOB NOT NULL,
+                locked_until REAL,
+                attempts INTEGER NOT NULL DEFAULT 0,
+                created_at REAL NOT NULL
+            )
+            """
+        )
+        self._conn.commit()
+        self._db_lock = threading.RLock()
 
     def topic_publish(self, topic: str, routing_key: str, payload: bytes) -> None:
-        with self._lock:
-            subscribers = [
-                subscriber
-                for topic_pattern, topic_subscribers in self._subscribers.items()
-                if self._match_routing_key(topic_pattern, topic)
-                for subscriber in topic_subscribers
-            ]
+        with self._db_lock:
+            self._conn.execute(
+                "INSERT INTO bus_messages(topic, routing_key, payload, created_at) VALUES(?, ?, ?, ?)",
+                (topic, routing_key, payload, time.time()),
+            )
+            self._conn.commit()
 
-        for subscriber in subscribers:
-            if self._match_routing_key(subscriber.routing_key, routing_key):
-                subscriber.queue.put(payload)
+    def _claim_next(self, topic: str, routing_key: str) -> tuple[int, bytes] | None:
+        now = time.time()
+        lease_until = now + self._lock_timeout_seconds
+
+        with self._db_lock:
+            rows = self._conn.execute(
+                """
+                SELECT id, topic, routing_key, payload
+                FROM bus_messages
+                WHERE locked_until IS NULL OR locked_until <= ?
+                ORDER BY id ASC
+                """,
+                (now,),
+            ).fetchall()
+
+            for row in rows:
+                message_id = int(row[0])
+                message_topic = str(row[1])
+                message_routing_key = str(row[2])
+                message_payload = bytes(row[3])
+
+                if not self._match_routing_key(topic, message_topic):
+                    continue
+                if not self._match_routing_key(routing_key, message_routing_key):
+                    continue
+
+                updated = self._conn.execute(
+                    """
+                    UPDATE bus_messages
+                    SET locked_until = ?, attempts = attempts + 1
+                    WHERE id = ? AND (locked_until IS NULL OR locked_until <= ?)
+                    """,
+                    (lease_until, message_id, now),
+                )
+                if updated.rowcount > 0:
+                    self._conn.commit()
+                    return message_id, message_payload
+
+            return None
+
+    def _ack(self, message_id: int) -> None:
+        with self._db_lock:
+            self._conn.execute("DELETE FROM bus_messages WHERE id = ?", (message_id,))
+            self._conn.commit()
+
+    def _release(self, message_id: int) -> None:
+        with self._db_lock:
+            self._conn.execute(
+                "UPDATE bus_messages SET locked_until = NULL WHERE id = ?",
+                (message_id,),
+            )
+            self._conn.commit()
 
     def topic_consume(
         self, topic: str, routing_key: str, callback: Callable[[bytes], None]
     ) -> Thread:
-        subscriber = _Subscriber(routing_key=routing_key, queue=Queue())
-        with self._lock:
-            self._subscribers.setdefault(topic, []).append(subscriber)
+        stop_event = Event()
 
         def _consume_loop() -> None:
-            try:
-                while True:
-                    payload = subscriber.queue.get()
-                    try:
-                        callback(payload)
-                    except StopIteration:
-                        break
-                    except Exception:
-                        subscriber.queue.put(payload)
-                        raise
-            finally:
-                with self._lock:
-                    subscribers = self._subscribers.get(topic, [])
-                    if subscriber in subscribers:
-                        subscribers.remove(subscriber)
-                    if not subscribers and topic in self._subscribers:
-                        del self._subscribers[topic]
+            while not stop_event.is_set():
+                claimed = self._claim_next(topic=topic, routing_key=routing_key)
+                if claimed is None:
+                    time.sleep(self._poll_interval_seconds)
+                    continue
+
+                message_id, payload = claimed
+                try:
+                    callback(payload)
+                    self._ack(message_id)
+                except StopIteration:
+                    self._ack(message_id)
+                    stop_event.set()
+                except Exception:
+                    self._release(message_id)
+                    raise
 
         thread = Thread(target=_consume_loop, daemon=True)
         thread.start()

--- a/libs/naas-abi-core/naas_abi_core/services/bus/adapters/secondary/PythonQueueAdapter_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/bus/adapters/secondary/PythonQueueAdapter_test.py
@@ -1,40 +1,18 @@
 import threading
-import time
+from concurrent.futures import ThreadPoolExecutor
 
-from naas_abi_core.services.bus.adapters.secondary.PythonQueueAdapter import \
-    PythonQueueAdapter
-
-
-def _clear_subscribers() -> None:
-    with PythonQueueAdapter._lock:
-        PythonQueueAdapter._subscribers.clear()
+from naas_abi_core.services.bus.adapters.secondary.PythonQueueAdapter import (
+    PythonQueueAdapter,
+)
 
 
-def _wait_for_subscriber(topic: str) -> None:
-    for _ in range(50):
-        with PythonQueueAdapter._lock:
-            if PythonQueueAdapter._subscribers.get(topic):
-                return
-        time.sleep(0.01)
-    raise AssertionError("subscriber not registered")
-
-
-def _wait_for_unsubscribe(topic: str) -> None:
-    for _ in range(50):
-        with PythonQueueAdapter._lock:
-            if not PythonQueueAdapter._subscribers.get(topic):
-                return
-        time.sleep(0.01)
-    raise AssertionError("subscriber not removed")
-
-
-def test_publish_across_instances() -> None:
-    _clear_subscribers()
-    received = []
+def test_publish_across_instances(tmp_path) -> None:
+    received: list[bytes] = []
     done = threading.Event()
 
-    consumer = PythonQueueAdapter()
-    publisher = PythonQueueAdapter()
+    db_path = str(tmp_path / "bus-basic.sqlite3")
+    consumer = PythonQueueAdapter(persistence_path=db_path)
+    publisher = PythonQueueAdapter(persistence_path=db_path)
 
     def callback(payload: bytes) -> None:
         received.append(payload)
@@ -42,47 +20,40 @@ def test_publish_across_instances() -> None:
         raise StopIteration()
 
     consumer.topic_consume("events", "user.*", callback)
-    _wait_for_subscriber("events")
-
     publisher.topic_publish("events", "user.created", b"ok")
 
-    assert done.wait(timeout=1)
-    _wait_for_unsubscribe("events")
+    assert done.wait(timeout=2)
     assert received == [b"ok"]
 
 
-def test_routing_key_mismatch_is_ignored() -> None:
-    _clear_subscribers()
-    received = []
+def test_routing_key_mismatch_is_ignored(tmp_path) -> None:
+    received: list[bytes] = []
     done = threading.Event()
 
-    consumer = PythonQueueAdapter()
-    publisher = PythonQueueAdapter()
+    db_path = str(tmp_path / "bus-routing.sqlite3")
+    consumer = PythonQueueAdapter(persistence_path=db_path)
+    publisher = PythonQueueAdapter(persistence_path=db_path)
 
     def callback(payload: bytes) -> None:
         received.append(payload)
-        if payload == b"match":
-            done.set()
-            raise StopIteration()
+        done.set()
+        raise StopIteration()
 
     consumer.topic_consume("events", "system.#", callback)
-    _wait_for_subscriber("events")
-
     publisher.topic_publish("events", "user.created", b"nope")
     publisher.topic_publish("events", "system.alerts.high", b"match")
 
-    assert done.wait(timeout=1)
-    _wait_for_unsubscribe("events")
+    assert done.wait(timeout=2)
     assert received == [b"match"]
 
 
-def test_topic_pattern_matches_publish_topic() -> None:
-    _clear_subscribers()
-    received = []
+def test_topic_pattern_matches_publish_topic(tmp_path) -> None:
+    received: list[bytes] = []
     done = threading.Event()
 
-    consumer = PythonQueueAdapter()
-    publisher = PythonQueueAdapter()
+    db_path = str(tmp_path / "bus-topic.sqlite3")
+    consumer = PythonQueueAdapter(persistence_path=db_path)
+    publisher = PythonQueueAdapter(persistence_path=db_path)
 
     def callback(payload: bytes) -> None:
         received.append(payload)
@@ -90,10 +61,58 @@ def test_topic_pattern_matches_publish_topic() -> None:
         raise StopIteration()
 
     consumer.topic_consume("events.#", "user.*", callback)
-    _wait_for_subscriber("events.#")
-
     publisher.topic_publish("events.system.alerts", "user.created", b"ok")
 
-    assert done.wait(timeout=1)
-    _wait_for_unsubscribe("events.#")
+    assert done.wait(timeout=2)
     assert received == [b"ok"]
+
+
+def test_pending_messages_replayed_after_restart(tmp_path) -> None:
+    db_path = tmp_path / "bus.sqlite3"
+    publisher = PythonQueueAdapter(persistence_path=str(db_path))
+    publisher.topic_publish("events", "user.created", b"before-consumer")
+
+    done = threading.Event()
+    received: list[bytes] = []
+    consumer = PythonQueueAdapter(persistence_path=str(db_path))
+
+    def callback(payload: bytes) -> None:
+        received.append(payload)
+        done.set()
+        raise StopIteration()
+
+    consumer.topic_consume("events", "user.*", callback)
+
+    assert done.wait(timeout=2)
+    assert received == [b"before-consumer"]
+
+
+def test_concurrent_publish_and_consume(tmp_path) -> None:
+    db_path = tmp_path / "bus-concurrency.sqlite3"
+    publisher = PythonQueueAdapter(persistence_path=str(db_path))
+    consumer = PythonQueueAdapter(persistence_path=str(db_path))
+
+    total = 50
+    received: list[bytes] = []
+    done = threading.Event()
+    lock = threading.Lock()
+
+    def callback(payload: bytes) -> None:
+        with lock:
+            received.append(payload)
+            if len(received) >= total:
+                done.set()
+                raise StopIteration()
+
+    consumer.topic_consume("events", "user.*", callback)
+
+    def publish_one(index: int) -> None:
+        publisher.topic_publish(
+            "events", "user.created", f"msg-{index}".encode("utf-8")
+        )
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        list(executor.map(publish_one, range(total)))
+
+    assert done.wait(timeout=5)
+    assert len(received) == total

--- a/libs/naas-abi-core/naas_abi_core/services/cache/adapters/secondary/CacheFSAdapter.py
+++ b/libs/naas-abi-core/naas_abi_core/services/cache/adapters/secondary/CacheFSAdapter.py
@@ -1,6 +1,8 @@
 import hashlib
 import json
 import os
+import tempfile
+import threading
 
 from naas_abi_core.services.cache.CachePort import (
     CachedData,
@@ -12,28 +14,48 @@ from naas_abi_core.services.cache.CachePort import (
 class CacheFSAdapter(ICacheAdapter):
     def __init__(self, cache_dir: str):
         self.cache_dir = cache_dir
+        self._lock = threading.RLock()
 
         if not os.path.exists(self.cache_dir):
             os.makedirs(self.cache_dir)
+
+    def __entry_path(self, key: str) -> str:
+        return os.path.join(self.cache_dir, self.__key_to_sha256(key))
 
     def __key_to_sha256(self, key: str) -> str:
         return hashlib.sha256(key.encode()).hexdigest()
 
     def get(self, key: str) -> CachedData:
-        if not os.path.exists(os.path.join(self.cache_dir, self.__key_to_sha256(key))):
-            raise CacheNotFoundError(f"Cache file not found: {key}")
+        path = self.__entry_path(key)
+        with self._lock:
+            if not os.path.exists(path):
+                raise CacheNotFoundError(f"Cache file not found: {key}")
 
-        with open(os.path.join(self.cache_dir, self.__key_to_sha256(key)), "r") as f:
-            return CachedData(**json.load(f))
+            with open(path, "r", encoding="utf-8") as f:
+                return CachedData(**json.load(f))
 
     def set(self, key: str, value: CachedData) -> None:
-        with open(os.path.join(self.cache_dir, self.__key_to_sha256(key)), "w") as f:
-            json.dump(value.model_dump(), f, indent=4)
+        path = self.__entry_path(key)
+        payload = json.dumps(value.model_dump(), indent=4)
+        with self._lock:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=self.cache_dir,
+                delete=False,
+            ) as temp_file:
+                temp_file.write(payload)
+                temp_path = temp_file.name
+            os.replace(temp_path, path)
 
     def delete(self, key: str) -> None:
-        if not os.path.exists(os.path.join(self.cache_dir, self.__key_to_sha256(key))):
-            raise CacheNotFoundError(f"Cache file not found: {key}")
-        os.remove(os.path.join(self.cache_dir, self.__key_to_sha256(key)))
+        path = self.__entry_path(key)
+        with self._lock:
+            if not os.path.exists(path):
+                raise CacheNotFoundError(f"Cache file not found: {key}")
+            os.remove(path)
 
     def exists(self, key: str) -> bool:
-        return os.path.exists(os.path.join(self.cache_dir, self.__key_to_sha256(key)))
+        path = self.__entry_path(key)
+        with self._lock:
+            return os.path.exists(path)

--- a/libs/naas-abi-core/naas_abi_core/services/cache/adapters/secondary/CacheFSAdapter_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/cache/adapters/secondary/CacheFSAdapter_test.py
@@ -1,0 +1,30 @@
+from concurrent.futures import ThreadPoolExecutor
+
+from naas_abi_core.services.cache.CachePort import CachedData, DataType
+from naas_abi_core.services.cache.adapters.secondary.CacheFSAdapter import (
+    CacheFSAdapter,
+)
+
+
+def test_persistence_across_restart(tmp_path):
+    adapter = CacheFSAdapter(str(tmp_path / "cache"))
+    adapter.set("k", CachedData(key="k", data="v", data_type=DataType.TEXT))
+
+    restarted = CacheFSAdapter(str(tmp_path / "cache"))
+    assert restarted.get("k").data == "v"
+
+
+def test_atomic_concurrent_writes(tmp_path):
+    adapter = CacheFSAdapter(str(tmp_path / "cache"))
+
+    def _write(i: int) -> None:
+        adapter.set(
+            "k",
+            CachedData(key="k", data=f"v-{i}", data_type=DataType.TEXT),
+        )
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        list(executor.map(_write, range(20)))
+
+    result = adapter.get("k")
+    assert result.data.startswith("v-")

--- a/libs/naas-abi-core/naas_abi_core/services/keyvalue/adapters/secondary/PythonAdapter.py
+++ b/libs/naas-abi-core/naas_abi_core/services/keyvalue/adapters/secondary/PythonAdapter.py
@@ -1,7 +1,9 @@
+import os
+import sqlite3
 import threading
-import time
 from dataclasses import dataclass
 from typing import Optional
+import time
 
 from naas_abi_core.services.keyvalue.KeyValuePorts import (
     IKeyValueAdapter,
@@ -17,11 +19,37 @@ class _Entry:
 
 class PythonAdapter(IKeyValueAdapter):
     _store: dict[str, _Entry]
-    _lock: threading.Lock
+    _lock: threading.RLock
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        persistence_path: str | None = None,
+        journal_mode: str = "WAL",
+        busy_timeout_ms: int = 5000,
+    ) -> None:
         self._store: dict[str, _Entry] = {}
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
+        self._conn: sqlite3.Connection | None = None
+
+        if persistence_path is not None:
+            os.makedirs(os.path.dirname(persistence_path) or ".", exist_ok=True)
+            self._conn = sqlite3.connect(
+                persistence_path,
+                timeout=max(0.0, busy_timeout_ms / 1000),
+                check_same_thread=False,
+            )
+            self._conn.execute(f"PRAGMA journal_mode={journal_mode}")
+            self._conn.execute("PRAGMA synchronous=NORMAL")
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS kv_store (
+                    key TEXT PRIMARY KEY,
+                    value BLOB NOT NULL,
+                    expires_at REAL
+                )
+                """
+            )
+            self._conn.commit()
 
     @staticmethod
     def _normalize_value(value: bytes | str) -> bytes:
@@ -35,18 +63,38 @@ class PythonAdapter(IKeyValueAdapter):
     def _compute_expiration(ttl: int | None) -> Optional[float]:
         if ttl is None:
             return None
-        return time.monotonic() + ttl
+        return time.time() + ttl
+
+    @staticmethod
+    def _now() -> float:
+        return time.time()
 
     def _purge_if_expired(self, key: str) -> None:
+        if self._conn is not None:
+            self._conn.execute(
+                "DELETE FROM kv_store WHERE key = ? AND expires_at IS NOT NULL AND expires_at <= ?",
+                (key, self._now()),
+            )
+            return
+
         entry = self._store.get(key)
         if entry is None:
             return
-        if entry.expires_at is not None and entry.expires_at <= time.monotonic():
+        if entry.expires_at is not None and entry.expires_at <= self._now():
             del self._store[key]
 
     def get(self, key: str) -> bytes:
         with self._lock:
             self._purge_if_expired(key)
+            if self._conn is not None:
+                row = self._conn.execute(
+                    "SELECT value FROM kv_store WHERE key = ?",
+                    (key,),
+                ).fetchone()
+                if row is None:
+                    raise KVNotFoundError(f"Key not found: {key}")
+                return bytes(row[0])
+
             entry = self._store.get(key)
             if entry is None:
                 raise KVNotFoundError(f"Key not found: {key}")
@@ -56,6 +104,13 @@ class PythonAdapter(IKeyValueAdapter):
         normalized = self._normalize_value(value)
         expires_at = self._compute_expiration(ttl)
         with self._lock:
+            if self._conn is not None:
+                self._conn.execute(
+                    "INSERT OR REPLACE INTO kv_store(key, value, expires_at) VALUES(?, ?, ?)",
+                    (key, normalized, expires_at),
+                )
+                self._conn.commit()
+                return
             self._store[key] = _Entry(value=normalized, expires_at=expires_at)
 
     def set_if_not_exists(
@@ -68,6 +123,13 @@ class PythonAdapter(IKeyValueAdapter):
         expires_at = self._compute_expiration(ttl)
         with self._lock:
             self._purge_if_expired(key)
+            if self._conn is not None:
+                cursor = self._conn.execute(
+                    "INSERT OR IGNORE INTO kv_store(key, value, expires_at) VALUES(?, ?, ?)",
+                    (key, normalized, expires_at),
+                )
+                self._conn.commit()
+                return cursor.rowcount > 0
             if key in self._store:
                 return False
             self._store[key] = _Entry(value=normalized, expires_at=expires_at)
@@ -76,6 +138,15 @@ class PythonAdapter(IKeyValueAdapter):
     def delete(self, key: str) -> None:
         with self._lock:
             self._purge_if_expired(key)
+            if self._conn is not None:
+                cursor = self._conn.execute(
+                    "DELETE FROM kv_store WHERE key = ?",
+                    (key,),
+                )
+                self._conn.commit()
+                if cursor.rowcount == 0:
+                    raise KVNotFoundError(f"Key not found: {key}")
+                return
             if key not in self._store:
                 raise KVNotFoundError(f"Key not found: {key}")
             del self._store[key]
@@ -84,6 +155,13 @@ class PythonAdapter(IKeyValueAdapter):
         normalized = self._normalize_value(value)
         with self._lock:
             self._purge_if_expired(key)
+            if self._conn is not None:
+                cursor = self._conn.execute(
+                    "DELETE FROM kv_store WHERE key = ? AND value = ?",
+                    (key, normalized),
+                )
+                self._conn.commit()
+                return cursor.rowcount > 0
             entry = self._store.get(key)
             if entry is None:
                 return False
@@ -95,4 +173,10 @@ class PythonAdapter(IKeyValueAdapter):
     def exists(self, key: str) -> bool:
         with self._lock:
             self._purge_if_expired(key)
+            if self._conn is not None:
+                row = self._conn.execute(
+                    "SELECT 1 FROM kv_store WHERE key = ? LIMIT 1",
+                    (key,),
+                ).fetchone()
+                return row is not None
             return key in self._store

--- a/libs/naas-abi-core/naas_abi_core/services/keyvalue/adapters/secondary/PythonAdapter_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/keyvalue/adapters/secondary/PythonAdapter_test.py
@@ -1,4 +1,5 @@
 import time
+from concurrent.futures import ThreadPoolExecutor
 from uuid import uuid4
 
 import pytest
@@ -82,3 +83,43 @@ class TestPythonAdapter(GenericKVSecondaryAdapterTest):
         assert adapter.exists(key) is True
         assert adapter.delete_if_value_matches(key, token) is True
         assert adapter.exists(key) is False
+
+    def test_persistence_across_restart(self, tmp_path):
+        db_path = tmp_path / "kv.sqlite3"
+        key = f"naas-abi-core:kv:persist:{uuid4()}"
+
+        first = PythonAdapter(persistence_path=str(db_path))
+        first.set(key, b"persisted")
+
+        second = PythonAdapter(persistence_path=str(db_path))
+        assert second.get(key) == b"persisted"
+
+    def test_ttl_survives_restart(self, tmp_path):
+        db_path = tmp_path / "kv-ttl.sqlite3"
+        key = f"naas-abi-core:kv:persist-ttl:{uuid4()}"
+
+        first = PythonAdapter(persistence_path=str(db_path))
+        first.set(key, b"ttl", ttl=1)
+
+        second = PythonAdapter(persistence_path=str(db_path))
+        assert second.exists(key) is True
+
+        deadline = time.monotonic() + 3
+        while time.monotonic() < deadline and second.exists(key):
+            time.sleep(0.05)
+
+        assert second.exists(key) is False
+
+    def test_concurrent_writes_are_safe(self, tmp_path):
+        db_path = tmp_path / "kv-concurrency.sqlite3"
+        adapter = PythonAdapter(persistence_path=str(db_path))
+        key = f"naas-abi-core:kv:conc:{uuid4()}"
+
+        def _writer(value: bytes) -> None:
+            adapter.set(key, value)
+
+        values = [f"value-{i}".encode("utf-8") for i in range(20)]
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            list(executor.map(_writer, values))
+
+        assert adapter.get(key) in values

--- a/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterFS.py
+++ b/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterFS.py
@@ -1,5 +1,7 @@
 import os
 from queue import Queue
+import tempfile
+import threading
 from typing import Optional
 
 from naas_abi_core.services.object_storage.ObjectStoragePort import (
@@ -11,6 +13,7 @@ from naas_abi_core.services.object_storage.ObjectStoragePort import (
 class ObjectStorageSecondaryAdapterFS(IObjectStorageAdapter):
     def __init__(self, base_path: str):
         self.base_path = base_path
+        self._lock = threading.RLock()
         self.__create_path(base_path)
 
     def __create_path(self, prefix: str) -> None:
@@ -28,25 +31,36 @@ class ObjectStorageSecondaryAdapterFS(IObjectStorageAdapter):
         return exists
 
     def get_object(self, prefix: str, key: str) -> bytes:
-        self.__path_exists(prefix, key)
+        with self._lock:
+            self.__path_exists(prefix, key)
 
-        with open(os.path.join(self.base_path, prefix, key), "rb") as f:
-            return f.read()
+            with open(os.path.join(self.base_path, prefix, key), "rb") as f:
+                return f.read()
 
     def put_object(self, prefix: str, key: str, content: bytes) -> None:
-        self.__create_path(prefix)
+        with self._lock:
+            self.__create_path(prefix)
+            target_path = os.path.join(self.base_path, prefix, key)
+            with tempfile.NamedTemporaryFile(
+                mode="wb",
+                dir=os.path.join(self.base_path, prefix),
+                delete=False,
+            ) as temp_file:
+                temp_file.write(content)
+                temp_path = temp_file.name
 
-        with open(os.path.join(self.base_path, prefix, key), "wb") as f:
-            f.write(content)
+            os.replace(temp_path, target_path)
 
     def delete_object(self, prefix: str, key: str) -> None:
-        self.__path_exists(prefix, key)
+        with self._lock:
+            self.__path_exists(prefix, key)
 
-        os.remove(os.path.join(self.base_path, prefix, key))
+            os.remove(os.path.join(self.base_path, prefix, key))
 
     def list_objects(self, prefix: str, queue: Optional[Queue] = None) -> list[str]:
-        self.__path_exists(prefix)
-        return [
-            os.path.join(prefix, f)
-            for f in os.listdir(os.path.join(self.base_path, prefix))
-        ]
+        with self._lock:
+            self.__path_exists(prefix)
+            return [
+                os.path.join(prefix, f)
+                for f in os.listdir(os.path.join(self.base_path, prefix))
+            ]

--- a/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterFS_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterFS_test.py
@@ -1,0 +1,27 @@
+from concurrent.futures import ThreadPoolExecutor
+
+from naas_abi_core.services.object_storage.adapters.secondary.ObjectStorageSecondaryAdapterFS import (
+    ObjectStorageSecondaryAdapterFS,
+)
+
+
+def test_persistence_across_restart(tmp_path):
+    base_path = str(tmp_path / "storage")
+    adapter = ObjectStorageSecondaryAdapterFS(base_path=base_path)
+    adapter.put_object("objects", "k.txt", b"hello")
+
+    restarted = ObjectStorageSecondaryAdapterFS(base_path=base_path)
+    assert restarted.get_object("objects", "k.txt") == b"hello"
+
+
+def test_atomic_concurrent_put(tmp_path):
+    adapter = ObjectStorageSecondaryAdapterFS(base_path=str(tmp_path / "storage"))
+
+    def _put(i: int) -> None:
+        adapter.put_object("objects", "k.bin", f"value-{i}".encode("utf-8"))
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        list(executor.map(_put, range(30)))
+
+    data = adapter.get_object("objects", "k.bin")
+    assert data.startswith(b"value-")

--- a/libs/naas-abi-core/naas_abi_core/services/triple_store/TripleStoreFactory.py
+++ b/libs/naas-abi-core/naas_abi_core/services/triple_store/TripleStoreFactory.py
@@ -13,6 +13,9 @@ from naas_abi_core.services.triple_store.adaptors.secondary.Oxigraph import Oxig
 from naas_abi_core.services.triple_store.adaptors.secondary.TripleStoreService__SecondaryAdaptor__Filesystem import (
     TripleStoreService__SecondaryAdaptor__Filesystem,
 )
+from naas_abi_core.services.triple_store.adaptors.secondary.TripleStoreService__SecondaryAdaptor__OxigraphEmbedded import (
+    TripleStoreService__SecondaryAdaptor__OxigraphEmbedded,
+)
 from naas_abi_core.services.triple_store.adaptors.secondary.TripleStoreService__SecondaryAdaptor__ObjectStorage import (
     TripleStoreService__SecondaryAdaptor__ObjectStorage,
 )
@@ -137,5 +140,17 @@ class TripleStoreFactory:
         return TripleStoreService(
             ApacheJenaTDB2(
                 jena_tdb2_url=jena_tdb2_url,
+            )
+        )
+
+    @staticmethod
+    def TripleStoreServiceOxigraphEmbedded(
+        store_path: str,
+        graph_base_iri: str = "http://ontology.naas.ai/graph/default",
+    ) -> TripleStoreService:
+        return TripleStoreService(
+            TripleStoreService__SecondaryAdaptor__OxigraphEmbedded(
+                store_path=store_path,
+                graph_base_iri=graph_base_iri,
             )
         )

--- a/libs/naas-abi-core/naas_abi_core/services/triple_store/adaptors/secondary/TripleStoreService__SecondaryAdaptor__Filesystem.py
+++ b/libs/naas-abi-core/naas_abi_core/services/triple_store/adaptors/secondary/TripleStoreService__SecondaryAdaptor__Filesystem.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 from threading import Lock
 from typing import Any, Dict, List, Tuple
 
@@ -47,6 +48,21 @@ class TripleStoreService__SecondaryAdaptor__Filesystem(
             f"{hash_value}.ttl" if not hash_value.endswith(".ttl") else hash_value,
         )
 
+    def __serialize_atomic(self, graph: Graph, destination: str) -> None:
+        directory = os.path.dirname(destination)
+        os.makedirs(directory, exist_ok=True)
+
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=directory,
+            delete=False,
+        ) as temp_file:
+            temp_path = temp_file.name
+
+        graph.serialize(destination=temp_path, format="turtle")
+        os.replace(temp_path, destination)
+
     ## File System Methods
 
     def insert(self, triples: Graph, graph_name: URIRef | None = None):
@@ -76,9 +92,7 @@ class TripleStoreService__SecondaryAdaptor__Filesystem(
                 for p, o in triples_by_subject[subject]:
                     graph.add((subject, p, o))
 
-                graph.serialize(
-                    destination=self.hash_triples_path(subject_hash), format="turtle"
-                )
+                self.__serialize_atomic(graph, self.hash_triples_path(subject_hash))
 
             for prefix, namespace in triples.namespaces():
                 self.__live_graph.bind(prefix, namespace)
@@ -108,10 +122,7 @@ class TripleStoreService__SecondaryAdaptor__Filesystem(
                     for p, o in triples_by_subject[subject]:
                         graph.remove((subject, p, o))
 
-                    graph.serialize(
-                        destination=self.hash_triples_path(subject_hash),
-                        format="turtle",
-                    )
+                    self.__serialize_atomic(graph, self.hash_triples_path(subject_hash))
 
             # Update the live graph
             self.__live_graph -= triples
@@ -234,7 +245,7 @@ class TripleStoreService__SecondaryAdaptor__Filesystem(
 
     def create_graph(self, graph_name: URIRef) -> None:
         """Create a named graph.
-        
+
         Not supported by filesystem adapter.
         """
         raise NotImplementedError(
@@ -243,7 +254,7 @@ class TripleStoreService__SecondaryAdaptor__Filesystem(
 
     def clear_graph(self, graph_name: URIRef | None = None) -> None:
         """Clear triples from a graph.
-        
+
         Not supported by filesystem adapter.
         """
         raise NotImplementedError(
@@ -252,7 +263,7 @@ class TripleStoreService__SecondaryAdaptor__Filesystem(
 
     def drop_graph(self, graph_name: URIRef) -> None:
         """Drop a graph.
-        
+
         Not supported by filesystem adapter.
         """
         raise NotImplementedError(
@@ -261,7 +272,7 @@ class TripleStoreService__SecondaryAdaptor__Filesystem(
 
     def list_graphs(self) -> list[URIRef]:
         """List all named graphs.
-        
+
         Not supported by filesystem adapter - returns empty list.
         """
         return []

--- a/libs/naas-abi-core/naas_abi_core/services/triple_store/adaptors/secondary/TripleStoreService__SecondaryAdaptor__Filesystem_concurrency_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/triple_store/adaptors/secondary/TripleStoreService__SecondaryAdaptor__Filesystem_concurrency_test.py
@@ -1,0 +1,46 @@
+from concurrent.futures import ThreadPoolExecutor
+
+from rdflib import Graph, Literal, URIRef
+
+from naas_abi_core.services.triple_store.adaptors.secondary.TripleStoreService__SecondaryAdaptor__Filesystem import (
+    TripleStoreService__SecondaryAdaptor__Filesystem,
+)
+
+
+def _build_graph(subject: URIRef, index: int) -> Graph:
+    graph = Graph()
+    graph.add((subject, URIRef("http://example.org/p"), Literal(f"v-{index}")))
+    return graph
+
+
+def test_filesystem_adapter_persistence_across_restart(tmp_path):
+    adapter = TripleStoreService__SecondaryAdaptor__Filesystem(
+        store_path=str(tmp_path / "triplestore"),
+        triples_path="triples",
+    )
+    subject = URIRef("http://example.org/s1")
+    adapter.insert(_build_graph(subject, 1))
+
+    restarted = TripleStoreService__SecondaryAdaptor__Filesystem(
+        store_path=str(tmp_path / "triplestore"),
+        triples_path="triples",
+    )
+    subject_graph = restarted.get_subject_graph(subject, "default")
+    assert len(list(subject_graph.triples((subject, None, None)))) == 1
+
+
+def test_filesystem_adapter_concurrent_insert(tmp_path):
+    adapter = TripleStoreService__SecondaryAdaptor__Filesystem(
+        store_path=str(tmp_path / "triplestore"),
+        triples_path="triples",
+    )
+    subject = URIRef("http://example.org/shared")
+
+    def _insert(i: int) -> None:
+        adapter.insert(_build_graph(subject, i))
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        list(executor.map(_insert, range(20)))
+
+    subject_graph = adapter.get_subject_graph(subject, "default")
+    assert len(list(subject_graph.triples((subject, None, None)))) == 20

--- a/libs/naas-abi-core/naas_abi_core/services/triple_store/adaptors/secondary/TripleStoreService__SecondaryAdaptor__OxigraphEmbedded.py
+++ b/libs/naas-abi-core/naas_abi_core/services/triple_store/adaptors/secondary/TripleStoreService__SecondaryAdaptor__OxigraphEmbedded.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import threading
+from io import BytesIO
+from typing import Any, Tuple
+
+import rdflib
+from naas_abi_core.services.triple_store.TripleStorePorts import (
+    Exceptions,
+    ITripleStorePort,
+    OntologyEvent,
+)
+from rdflib import Graph, URIRef
+from rdflib.plugins.sparql.results.jsonresults import JSONResultParser
+
+
+class TripleStoreService__SecondaryAdaptor__OxigraphEmbedded(ITripleStorePort):
+    _stores: dict[str, Any] = {}
+    _stores_lock = threading.Lock()
+
+    def __init__(
+        self,
+        store_path: str,
+        graph_base_iri: str = "http://ontology.naas.ai/graph/default",
+    ) -> None:
+        try:
+            from pyoxigraph import Store
+        except ImportError as exc:
+            raise ImportError(
+                "oxigraph_embedded adapter requires pyoxigraph. "
+                "Install with: uv pip install pyoxigraph"
+            ) from exc
+
+        with self._stores_lock:
+            existing = self._stores.get(store_path)
+            if existing is None:
+                existing = Store(path=store_path)
+                self._stores[store_path] = existing
+
+        self._store: Any = existing
+        self._default_graph_iri = URIRef(graph_base_iri)
+        self._lock = threading.RLock()
+
+    def _graph_iri(self, graph_name: URIRef | None) -> URIRef:
+        return self._default_graph_iri if graph_name is None else graph_name
+
+    def _graph_node(self, graph_name: URIRef | None):
+        from pyoxigraph import NamedNode
+
+        return NamedNode(str(self._graph_iri(graph_name)))
+
+    def insert(self, triples: Graph, graph_name: URIRef | None = None):
+        if len(triples) == 0:
+            return
+
+        from pyoxigraph import RdfFormat
+
+        with self._lock:
+            self._store.load(
+                input=triples.serialize(format="nt").encode("utf-8"),
+                format=RdfFormat.N_TRIPLES,
+                to_graph=self._graph_node(graph_name),
+            )
+
+    def remove(self, triples: Graph, graph_name: URIRef | None = None):
+        if len(triples) == 0:
+            return
+
+        triples_nt = triples.serialize(format="nt")
+        delete_query = f"DELETE DATA {{ GRAPH <{self._graph_iri(graph_name)}> {{ {triples_nt} }} }}"
+        with self._lock:
+            self._store.update(delete_query)
+
+    def get(self) -> Graph:
+        query = """
+        CONSTRUCT { ?s ?p ?o }
+        WHERE {
+            { ?s ?p ?o }
+            UNION
+            { GRAPH ?g { ?s ?p ?o } }
+        }
+        """
+        result = self.query(query)
+        assert isinstance(result, Graph)
+        return result
+
+    def get_subject_graph(self, subject: URIRef, graph_name: str | URIRef) -> Graph:
+        if graph_name == "*":
+            query = f"""
+            CONSTRUCT {{ <{subject}> ?p ?o }}
+            WHERE {{
+                {{ <{subject}> ?p ?o }}
+                UNION
+                {{ GRAPH ?g {{ <{subject}> ?p ?o }} }}
+            }}
+            """
+        else:
+            query = f"""
+            CONSTRUCT {{ <{subject}> ?p ?o }}
+            WHERE {{ GRAPH <{graph_name}> {{ <{subject}> ?p ?o }} }}
+            """
+
+        result = self.query(query)
+        assert isinstance(result, Graph)
+        if len(result) == 0:
+            raise Exceptions.SubjectNotFoundError(f"Subject {subject} not found")
+        return result
+
+    def query(self, query: str) -> Any:
+        from pyoxigraph import (
+            QueryBoolean,
+            QueryResultsFormat,
+            QuerySolutions,
+            QueryTriples,
+        )
+        from pyoxigraph import RdfFormat
+
+        with self._lock:
+            result = self._store.query(query)
+
+        if isinstance(result, QueryTriples):
+            serialized = result.serialize(format=RdfFormat.N_TRIPLES)
+            if serialized is None:
+                raise ValueError("Oxigraph returned no bytes for triple query result")
+            return Graph().parse(
+                data=serialized.decode("utf-8"),
+                format="nt",
+            )
+
+        if isinstance(result, QuerySolutions):
+            serialized = result.serialize(format=QueryResultsFormat.JSON)
+            if serialized is None:
+                raise ValueError("Oxigraph returned no bytes for solution query result")
+            return JSONResultParser().parse(BytesIO(serialized))
+
+        if isinstance(result, QueryBoolean):
+            serialized = result.serialize(format=QueryResultsFormat.JSON)
+            if serialized is None:
+                raise ValueError("Oxigraph returned no bytes for boolean query result")
+            return JSONResultParser().parse(BytesIO(serialized))
+
+        raise ValueError(f"Unsupported query result type: {type(result)}")
+
+    def query_view(self, view: str, query: str) -> rdflib.query.Result:
+        return self.query(query)
+
+    def handle_view_event(
+        self,
+        view: Tuple[URIRef | None, URIRef | None, URIRef | None],
+        event: OntologyEvent,
+        triple: Tuple[URIRef | None, URIRef | None, URIRef | None],
+    ):
+        return None
+
+    def create_graph(self, graph_name: URIRef):
+        with self._lock:
+            if self._store.contains_named_graph(self._graph_node(graph_name)):
+                raise Exceptions.GraphAlreadyExistsError(
+                    f"Graph {graph_name} already exists"
+                )
+            self._store.add_graph(self._graph_node(graph_name))
+
+    def clear_graph(self, graph_name: URIRef):
+        with self._lock:
+            if not self._store.contains_named_graph(self._graph_node(graph_name)):
+                raise Exceptions.GraphNotFoundError(f"Graph {graph_name} not found")
+            self._store.clear_graph(self._graph_node(graph_name))
+
+    def drop_graph(self, graph_name: URIRef):
+        with self._lock:
+            if not self._store.contains_named_graph(self._graph_node(graph_name)):
+                raise Exceptions.GraphNotFoundError(f"Graph {graph_name} not found")
+            self._store.remove_graph(self._graph_node(graph_name))
+
+    def list_graphs(self) -> list[URIRef]:
+        with self._lock:
+            return [URIRef(graph.value) for graph in self._store.named_graphs()]

--- a/libs/naas-abi-core/naas_abi_core/services/triple_store/adaptors/secondary/TripleStoreService__SecondaryAdaptor__OxigraphEmbedded_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/triple_store/adaptors/secondary/TripleStoreService__SecondaryAdaptor__OxigraphEmbedded_test.py
@@ -1,0 +1,70 @@
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+from rdflib import Graph, Literal, URIRef
+
+from naas_abi_core.services.triple_store.adaptors.secondary.TripleStoreService__SecondaryAdaptor__OxigraphEmbedded import (
+    TripleStoreService__SecondaryAdaptor__OxigraphEmbedded,
+)
+from naas_abi_core.services.triple_store.tests.triple_store__secondary_adapter__generic_test import (
+    GenericTripleStoreSecondaryAdapterTest,
+)
+
+
+def _build_graph(subject: URIRef, index: int) -> Graph:
+    graph = Graph()
+    graph.add((subject, URIRef("http://example.org/p"), Literal(f"v-{index}")))
+    return graph
+
+
+class TestTripleStoreServiceSecondaryAdaptorOxigraphEmbedded(
+    GenericTripleStoreSecondaryAdapterTest
+):
+    @pytest.fixture
+    def adapter(self, tmp_path):
+        pytest.importorskip("pyoxigraph")
+        return TripleStoreService__SecondaryAdaptor__OxigraphEmbedded(
+            store_path=str(tmp_path / "oxigraph"),
+        )
+
+    @pytest.fixture
+    def supports_named_graphs(self) -> bool:
+        return True
+
+    @pytest.fixture
+    def supports_graph_management(self) -> bool:
+        return True
+
+
+def test_oxigraph_embedded_persistence_across_restart(tmp_path):
+    pytest.importorskip("pyoxigraph")
+
+    path = str(tmp_path / "oxigraph")
+    subject = URIRef("http://example.org/persist/s1")
+    graph_name = URIRef("http://example.org/graph/persist")
+
+    adapter = TripleStoreService__SecondaryAdaptor__OxigraphEmbedded(path)
+    adapter.insert(_build_graph(subject, 1), graph_name)
+
+    restarted = TripleStoreService__SecondaryAdaptor__OxigraphEmbedded(path)
+    subject_graph = restarted.get_subject_graph(subject, graph_name)
+    assert len(list(subject_graph.triples((subject, None, None)))) == 1
+
+
+def test_oxigraph_embedded_concurrent_insert(tmp_path):
+    pytest.importorskip("pyoxigraph")
+
+    adapter = TripleStoreService__SecondaryAdaptor__OxigraphEmbedded(
+        store_path=str(tmp_path / "oxigraph"),
+    )
+    subject = URIRef("http://example.org/shared")
+    graph_name = URIRef("http://example.org/graph/concurrency")
+
+    def _insert(i: int) -> None:
+        adapter.insert(_build_graph(subject, i), graph_name)
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        list(executor.map(_insert, range(20)))
+
+    subject_graph = adapter.get_subject_graph(subject, graph_name)
+    assert len(list(subject_graph.triples((subject, None, None)))) == 20

--- a/libs/naas-abi-core/naas_abi_core/services/vector_store/adapters/QdrantInMemoryAdapter.py
+++ b/libs/naas-abi-core/naas_abi_core/services/vector_store/adapters/QdrantInMemoryAdapter.py
@@ -1,86 +1,77 @@
 import logging
-from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+import os
+import threading
+from typing import Any, Dict, List, Optional, Union, cast
+import uuid
+from uuid import UUID
 
 import numpy as np
+from qdrant_client import QdrantClient
+from qdrant_client.models import (
+    Distance,
+    FieldCondition,
+    Filter,
+    MatchValue,
+    PointIdsList,
+    PointStruct,
+    PointVectors,
+    UpdateStatus,
+    VectorParams,
+)
 
 from ..IVectorStorePort import IVectorStorePort, SearchResult, VectorDocument
 
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class _InMemoryCollection:
-    dimension: int
-    distance_metric: str
-    documents: Dict[str, VectorDocument] = field(default_factory=dict)
-
-
 class QdrantInMemoryAdapter(IVectorStorePort):
-    def __init__(self) -> None:
-        self._collections: Dict[str, _InMemoryCollection] = {}
-        self._initialized = False
+    """Local Qdrant adapter.
+
+    Uses embedded Qdrant mode for both ephemeral (`:memory:`) and durable
+    filesystem-backed persistence.
+    """
+
+    def __init__(
+        self,
+        storage_path: str = ":memory:",
+        timeout: int = 300,
+    ) -> None:
+        self.storage_path = storage_path
+        self.timeout = timeout
+        self.client: Optional[QdrantClient] = None
+        self._lock = threading.RLock()
 
     def initialize(self) -> None:
-        self._initialized = True
-        logger.info("Initialized QdrantInMemoryAdapter")
+        with self._lock:
+            if self.client is not None:
+                return
 
-    def _require_initialized(self) -> None:
-        if not self._initialized:
+            if self.storage_path == ":memory:":
+                self.client = QdrantClient(location=":memory:", timeout=self.timeout)
+                logger.info("Initialized in-memory local Qdrant")
+                return
+
+            os.makedirs(self.storage_path, exist_ok=True)
+            self.client = QdrantClient(path=self.storage_path, timeout=self.timeout)
+            logger.info("Initialized local Qdrant at %s", self.storage_path)
+
+    def _require_initialized(self) -> QdrantClient:
+        if self.client is None:
             raise RuntimeError("Adapter not initialized")
+        return self.client
 
-    def _get_collection(self, collection_name: str) -> _InMemoryCollection:
-        collection = self._collections.get(collection_name)
-        if collection is None:
-            raise KeyError(f"Collection not found: {collection_name}")
-        return collection
+    @staticmethod
+    def _point_id(vector_id: str) -> str:
+        return str(uuid.uuid5(uuid.NAMESPACE_URL, vector_id))
 
-    def _to_vector(self, vector: np.ndarray) -> np.ndarray:
-        array = np.asarray(vector, dtype=float)
-        if array.ndim != 1:
-            array = array.reshape(-1)
-        return array
-
-    def _validate_dimension(
-        self, collection: _InMemoryCollection, vector: np.ndarray
-    ) -> None:
-        if vector.size != collection.dimension:
-            raise ValueError(
-                "Vector dimension mismatch. "
-                f"Expected {collection.dimension}, got {vector.size}"
-            )
-
-    def _score(
-        self, metric: str, query_vector: np.ndarray, candidate_vector: np.ndarray
-    ) -> float:
-        metric_key = metric.lower()
-        if metric_key == "euclidean":
-            return float(-np.linalg.norm(query_vector - candidate_vector))
-        if metric_key == "dot":
-            return float(np.dot(query_vector, candidate_vector))
-
-        query_norm = np.linalg.norm(query_vector)
-        candidate_norm = np.linalg.norm(candidate_vector)
-        if query_norm == 0.0 or candidate_norm == 0.0:
-            return 0.0
-        return float(np.dot(query_vector, candidate_vector) / (query_norm * candidate_norm))
-
-    def _matches_filter(
-        self, document: VectorDocument, filter: Optional[Dict[str, Any]]
-    ) -> bool:
-        if not filter:
-            return True
-
-        payload: Dict[str, Any] = {}
-        if document.metadata:
-            payload.update(document.metadata)
-        if document.payload is not None:
-            payload["payload"] = document.payload
-
-        for key, value in filter.items():
-            if key not in payload or payload[key] != value:
-                return False
-        return True
+    @staticmethod
+    def _get_distance_metric(metric: str) -> Distance:
+        metric_map = {
+            "cosine": Distance.COSINE,
+            "euclidean": Distance.EUCLID,
+            "dot": Distance.DOT,
+        }
+        return metric_map.get(metric.lower(), Distance.COSINE)
 
     def create_collection(
         self,
@@ -89,49 +80,55 @@ class QdrantInMemoryAdapter(IVectorStorePort):
         distance_metric: str = "cosine",
         **kwargs,
     ) -> None:
-        self._require_initialized()
-
-        if collection_name in self._collections:
-            raise RuntimeError(f"Collection already exists: {collection_name}")
-
-        self._collections[collection_name] = _InMemoryCollection(
-            dimension=dimension, distance_metric=distance_metric
-        )
-        logger.info(f"Created collection: {collection_name}")
+        with self._lock:
+            client = self._require_initialized()
+            client.create_collection(
+                collection_name=collection_name,
+                vectors_config=VectorParams(
+                    size=dimension, distance=self._get_distance_metric(distance_metric)
+                ),
+                **kwargs,
+            )
 
     def delete_collection(self, collection_name: str) -> None:
-        self._require_initialized()
-
-        if collection_name in self._collections:
-            del self._collections[collection_name]
-            logger.info(f"Deleted collection: {collection_name}")
-            return
-
-        raise KeyError(f"Collection not found: {collection_name}")
+        with self._lock:
+            client = self._require_initialized()
+            client.delete_collection(collection_name=collection_name)
 
     def list_collections(self) -> List[str]:
-        self._require_initialized()
-        return list(self._collections.keys())
+        with self._lock:
+            client = self._require_initialized()
+            collections = client.get_collections()
+            return [c.name for c in collections.collections]
 
     def store_vectors(
         self, collection_name: str, documents: List[VectorDocument]
     ) -> None:
-        self._require_initialized()
+        with self._lock:
+            client = self._require_initialized()
+            points = []
+            for doc in documents:
+                payload = {}
+                if doc.metadata:
+                    payload.update(doc.metadata)
+                if doc.payload:
+                    payload["payload"] = doc.payload
+                payload["_abi_id"] = doc.id
+                payload["_abi_vector"] = doc.vector.tolist()
 
-        collection = self._get_collection(collection_name)
+                points.append(
+                    PointStruct(
+                        id=self._point_id(doc.id),
+                        vector=doc.vector.tolist(),
+                        payload=payload,
+                    )
+                )
 
-        for doc in documents:
-            vector = self._to_vector(doc.vector)
-            self._validate_dimension(collection, vector)
-
-            collection.documents[doc.id] = VectorDocument(
-                id=doc.id,
-                vector=vector.copy(),
-                metadata=dict(doc.metadata) if doc.metadata else {},
-                payload=dict(doc.payload) if doc.payload is not None else None,
+            operation_info = client.upsert(
+                collection_name=collection_name, points=points
             )
-
-        logger.debug(f"Stored {len(documents)} vectors in {collection_name}")
+            if operation_info.status != UpdateStatus.COMPLETED:
+                raise RuntimeError(f"Failed to store vectors: {operation_info}")
 
     def search(
         self,
@@ -142,51 +139,94 @@ class QdrantInMemoryAdapter(IVectorStorePort):
         include_vectors: bool = False,
         include_metadata: bool = True,
     ) -> List[SearchResult]:
-        self._require_initialized()
+        with self._lock:
+            client = self._require_initialized()
 
-        collection = self._get_collection(collection_name)
-        query_array = self._to_vector(query_vector)
-        self._validate_dimension(collection, query_array)
+            search_filter = None
+            if filter:
+                conditions = [
+                    FieldCondition(key=key, match=MatchValue(value=value))
+                    for key, value in filter.items()
+                ]
+                if conditions:
+                    search_filter = Filter(must=cast(Any, conditions))
 
-        results: List[SearchResult] = []
-        for doc in collection.documents.values():
-            if not self._matches_filter(doc, filter):
-                continue
-
-            score = self._score(collection.distance_metric, query_array, doc.vector)
-            results.append(
-                SearchResult(
-                    id=doc.id,
-                    score=score,
-                    vector=doc.vector.copy() if include_vectors else None,
-                    metadata=dict(doc.metadata) if include_metadata else None,
-                    payload=(
-                        dict(doc.payload)
-                        if include_metadata and doc.payload is not None
-                        else None
-                    ),
-                )
+            search_result = client.query_points(
+                collection_name=collection_name,
+                query=query_vector.tolist(),
+                limit=k,
+                query_filter=search_filter,
+                with_vectors=include_vectors,
+                with_payload=include_metadata,
             )
 
-        results.sort(key=lambda item: item.score, reverse=True)
-        return results[:k]
+            return [
+                SearchResult(
+                    id=str(hit.payload.get("_abi_id", hit.id))
+                    if hit.payload
+                    else str(hit.id),
+                    score=hit.score,
+                    vector=(
+                        np.array(hit.payload["_abi_vector"])
+                        if include_vectors
+                        and hit.payload
+                        and "_abi_vector" in hit.payload
+                        else (
+                            np.array(hit.vector)
+                            if include_vectors and hit.vector is not None
+                            else None
+                        )
+                    ),
+                    metadata={
+                        k: v
+                        for k, v in dict(hit.payload).items()
+                        if k not in {"payload", "_abi_id", "_abi_vector"}
+                    }
+                    if hit.payload and include_metadata
+                    else None,
+                    payload=hit.payload.get("payload")
+                    if hit.payload and "payload" in hit.payload
+                    else None,
+                )
+                for hit in search_result.points
+            ]
 
     def get_vector(
         self, collection_name: str, vector_id: str, include_vector: bool = True
     ) -> Optional[VectorDocument]:
-        self._require_initialized()
+        with self._lock:
+            client = self._require_initialized()
+            points = client.retrieve(
+                collection_name=collection_name,
+                ids=[self._point_id(vector_id)],
+                with_vectors=include_vector,
+                with_payload=True,
+            )
 
-        collection = self._get_collection(collection_name)
-        doc = collection.documents.get(vector_id)
-        if doc is None:
-            return None
+            if not points:
+                return None
 
-        return VectorDocument(
-            id=doc.id,
-            vector=doc.vector.copy() if include_vector else np.array([]),
-            metadata=dict(doc.metadata) if doc.metadata else {},
-            payload=dict(doc.payload) if doc.payload is not None else None,
-        )
+            point = points[0]
+            payload = dict(point.payload) if point.payload else {}
+            vector_array = (
+                np.array(payload["_abi_vector"])
+                if include_vector and "_abi_vector" in payload
+                else (
+                    np.array(point.vector)
+                    if include_vector and point.vector is not None
+                    else np.array([])
+                )
+            )
+            return VectorDocument(
+                id=str(payload.get("_abi_id", vector_id)),
+                vector=vector_array,
+                metadata={
+                    k: v
+                    for k, v in payload.items()
+                    if k not in {"payload", "_abi_id", "_abi_vector"}
+                },
+                payload=payload.get("payload"),
+            )
 
     def update_vector(
         self,
@@ -196,38 +236,56 @@ class QdrantInMemoryAdapter(IVectorStorePort):
         metadata: Optional[Dict[str, Any]] = None,
         payload: Optional[Dict[str, Any]] = None,
     ) -> None:
-        self._require_initialized()
+        with self._lock:
+            client = self._require_initialized()
 
-        collection = self._get_collection(collection_name)
-        doc = collection.documents.get(vector_id)
-        if doc is None:
-            raise KeyError(f"Vector not found: {vector_id}")
+            if vector is not None:
+                client.update_vectors(
+                    collection_name=collection_name,
+                    points=[
+                        PointVectors(
+                            id=self._point_id(vector_id),
+                            vector=vector.tolist(),
+                        )
+                    ],
+                )
 
-        if vector is not None:
-            new_vector = self._to_vector(vector)
-            self._validate_dimension(collection, new_vector)
-            doc.vector = new_vector.copy()
+            if metadata is not None or payload is not None or vector is not None:
+                new_payload = {}
+                if metadata:
+                    new_payload.update(metadata)
+                if payload:
+                    new_payload["payload"] = payload
+                new_payload["_abi_id"] = vector_id
+                if vector is not None:
+                    new_payload["_abi_vector"] = vector.tolist()
 
-        if metadata is not None:
-            doc.metadata = dict(metadata)
+                client.set_payload(
+                    collection_name=collection_name,
+                    payload=new_payload,
+                    points=[self._point_id(vector_id)],
+                )
 
-        if payload is not None:
-            doc.payload = dict(payload)
-
-    def delete_vectors(self, collection_name: str, vector_ids: List) -> None:
-        self._require_initialized()
-
-        collection = self._get_collection(collection_name)
-        for vector_id in vector_ids:
-            collection.documents.pop(vector_id, None)
-
-        logger.debug(f"Deleted {len(vector_ids)} vectors from {collection_name}")
+    def delete_vectors(self, collection_name: str, vector_ids: List[str]) -> None:
+        with self._lock:
+            client = self._require_initialized()
+            point_ids = cast(
+                List[Union[int, str, UUID]],
+                [self._point_id(vector_id) for vector_id in vector_ids],
+            )
+            client.delete(
+                collection_name=collection_name,
+                points_selector=PointIdsList(points=point_ids),
+            )
 
     def count_vectors(self, collection_name: str) -> int:
-        self._require_initialized()
-        collection = self._get_collection(collection_name)
-        return len(collection.documents)
+        with self._lock:
+            client = self._require_initialized()
+            collection_info = client.get_collection(collection_name=collection_name)
+            return collection_info.points_count or 0
 
     def close(self) -> None:
-        self._initialized = False
-        logger.info("Closed QdrantInMemoryAdapter")
+        with self._lock:
+            if self.client is not None:
+                self.client.close()
+                self.client = None

--- a/libs/naas-abi-core/naas_abi_core/services/vector_store/adapters/QdrantInMemoryAdapter_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/vector_store/adapters/QdrantInMemoryAdapter_test.py
@@ -1,0 +1,78 @@
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+import pytest
+
+from naas_abi_core.services.vector_store.IVectorStorePort import VectorDocument
+from naas_abi_core.services.vector_store.IVectorStorePort_test import (
+    GenericVectorStoreAdapterTest,
+)
+from naas_abi_core.services.vector_store.adapters.QdrantInMemoryAdapter import (
+    QdrantInMemoryAdapter,
+)
+
+
+class TestQdrantInMemoryAdapter(GenericVectorStoreAdapterTest):
+    @pytest.fixture
+    def adapter(self):
+        adapter = QdrantInMemoryAdapter(storage_path=":memory:")
+        adapter.initialize()
+        yield adapter
+        adapter.close()
+
+    def test_persistence_across_restart(self, tmp_path):
+        storage_path = str(tmp_path / "qdrant-local")
+
+        adapter = QdrantInMemoryAdapter(storage_path=storage_path)
+        adapter.initialize()
+        adapter.create_collection("persist", 4)
+        adapter.store_vectors(
+            "persist",
+            [
+                VectorDocument(
+                    id="doc-1",
+                    vector=np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float32),
+                    metadata={"kind": "test"},
+                    payload={"v": 1},
+                )
+            ],
+        )
+        adapter.close()
+
+        restarted = QdrantInMemoryAdapter(storage_path=storage_path)
+        restarted.initialize()
+        assert "persist" in restarted.list_collections()
+        result = restarted.get_vector("persist", "doc-1")
+        assert result is not None
+        assert result.metadata["kind"] == "test"
+        restarted.close()
+
+    def test_concurrent_upsert_and_search(self, tmp_path):
+        adapter = QdrantInMemoryAdapter(
+            storage_path=str(tmp_path / "qdrant-concurrency")
+        )
+        adapter.initialize()
+        adapter.create_collection("conc", 8)
+
+        def _upsert(i: int) -> None:
+            vector = np.ones(8, dtype=np.float32) * i
+            adapter.store_vectors(
+                "conc",
+                [
+                    VectorDocument(
+                        id=f"doc-{i}",
+                        vector=vector,
+                        metadata={"i": i},
+                        payload={"i": i},
+                    )
+                ],
+            )
+
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            list(executor.map(_upsert, range(30)))
+
+        query = np.ones(8, dtype=np.float32) * 29
+        results = adapter.search("conc", query, k=5)
+        assert len(results) > 0
+        assert adapter.count_vectors("conc") == 30
+        adapter.close()

--- a/libs/naas-abi-core/pyproject.toml
+++ b/libs/naas-abi-core/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "dagster-webserver>=1.11.12",
     "dagster-postgres>=0.27.12",
     "dagster-aws>=0.27.12",
+    "pyoxigraph>=0.5.5",
 ]
 license = { text = "MIT License" }
 


### PR DESCRIPTION
## Summary

This PR adds a local embedded runtime path for `naas-abi-core` so core services can run end-to-end without Docker-managed infrastructure. It introduces durable local persistence for previously in-memory adapters and wires these defaults through engine configuration.

## What changed

- Added a new `make test-local-embedded-core` target and help entry to run a no-Docker local embedded core E2E test.
- Updated `config.yaml` defaults to local embedded-friendly adapters:
  - triple store: `oxigraph_embedded`
  - vector store: `qdrant_in_memory` with local storage path/timeout
  - bus: `python_queue` with SQLite persistence settings
  - key-value: `python` adapter with SQLite persistence settings
  - set `default_agent` and commented optional marketplace modules for slimmer local setup.
- Extended engine configuration models to accept and validate richer adapter config for:
  - `python_queue` bus adapter
  - `python` key-value adapter
  - `qdrant_in_memory` vector adapter
  - new `oxigraph_embedded` triple-store adapter.
- Implemented and integrated a new embedded triple-store adapter:
  - `TripleStoreService__SecondaryAdaptor__OxigraphEmbedded`
  - factory/configuration wiring and dedicated tests.
- Refactored local adapters for durable, concurrent-safe behavior with persistence options:
  - `PythonQueueAdapter` moved to SQLite-backed at-least-once delivery semantics
  - `PythonAdapter` (KV), `CacheFSAdapter`, `ObjectStorageSecondaryAdapterFS`, and filesystem triple-store paths received persistence/concurrency improvements with added tests.
- Improved `QdrantInMemoryAdapter` to support local persistent storage behavior and added targeted tests.
- Added `SqliteCheckpointSaver` for SQLite-backed checkpoint persistence in agent workflows.
- Added/updated focused tests across engine configuration and adapters, plus a full local embedded E2E test covering bus, KV, vector store, triple store, and object storage restart behavior.
- Added required dependency updates in `libs/naas-abi-core/pyproject.toml`.

## Why

The goal is to make local development and validation more reliable and self-contained by removing mandatory Docker dependencies for core flows, while preserving restart durability and improving deterministic behavior under concurrency.

## Impact

- Developers can run an embedded core stack locally with persisted state.
- Configuration defaults are now more local-first.
- Adapter-level behavior is more resilient across process restarts and concurrent access.

## Validation

- Added unit/integration-style tests for each updated adapter/configuration path.
- Added `EngineConfiguration_LocalEmbeddedE2E_test.py` to validate cross-service embedded operation and restart persistence.
- Added a dedicated `make` target: `test-local-embedded-core`.

## Notes

- This is a substantial infra-oriented change (~29 files) centered on local embedded runtime and persistence.
- Some optional marketplace modules are intentionally commented out in root `config.yaml` for local-focused defaults.

This pull request resolves https://github.com/jupyter-naas/abi/issues/792
