### PR TITLE
chore: update pytest configuration for improved test coverage and dir…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,5 @@ sandbox/
 coverage.xml
 htmlcov/
 secrets.yaml
+cco_merged.py
+coverage-baseline.json

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,21 @@
+import os
+import sys
+
+# Ensure repo root is on sys.path for root-level test discovery
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+# These files use relative imports or depend on package-scoped sys.path
+# manipulation that breaks when pytest collects them from the monorepo root.
+# They are exercised correctly when running pytest from within their package
+# directory (e.g. `uv run pytest libs/naas-abi-core`).
+collect_ignore = [
+    # These use relative imports that only work when pytest is run from within
+    # the package directory (e.g. `uv run pytest libs/naas-abi-core`).
+    "libs/naas-abi-core/naas_abi_core/services/bus/tests/bus__secondary_adapter__generic_test.py",
+    "libs/naas-abi-core/naas_abi_core/services/keyvalue/tests/kv__secondary_adapter__generic_test.py",
+    "libs/naas-abi-core/naas_abi_core/services/vector_store/adapters/QdrantAdapter_test.py",
+    # These require the `testcontainers` package which is only available in the
+    # naas-abi-core dev environment. Run via `make test-integration-core`.
+    "libs/naas-abi-core/naas_abi_core/services/triple_store/adaptors/secondary/ApacheJenaTDB2_integration_test.py",
+    "libs/naas-abi-core/naas_abi_core/services/triple_store/adaptors/secondary/Oxigraph_integration_test.py",
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,8 @@
-[tool:pytest]
-testpaths = tests lib/abi/services src/custom
+[pytest]
+# testpaths: root tests/ directory + packages that have colocated unit tests.
+# Marketplace is excluded — its integrations require external credentials and
+# are not suitable for the default local test run.
+testpaths = tests libs/naas-abi-core libs/naas-abi-cli
 python_files = *test*.py
 python_classes = Test*
 python_functions = test_*
@@ -8,11 +11,20 @@ addopts =
     --strict-config
     --verbose
     --tb=short
-    --cov=lib
+    --cov=naas_abi_core
+    --cov=naas_abi_cli
     --cov-report=term-missing
     --cov-report=html:htmlcov
     --cov-report=xml:coverage.xml
-    --cov-fail-under=30
+    --cov-fail-under=50
+norecursedirs =
+    .venv
+    .git
+    __pycache__
+    node_modules
+    libs/naas-abi-marketplace
+    libs/naas-abi/naas_abi/apps/nexus/apps/web
+    libs/naas-abi-cli/naas_abi_cli/cli/new/templates
 markers =
     integration: marks tests as integration tests (may require external services)
     slow: marks tests as slow (deselect with '-m "not slow"')
@@ -20,4 +32,3 @@ markers =
 filterwarnings =
     ignore::DeprecationWarning
     ignore::PendingDeprecationWarning
-    ignore::PytestUnknownMarkWarning


### PR DESCRIPTION
## Summary

Fixes a silent misconfiguration in `pytest.ini` that caused all test
settings to be ignored, corrects coverage measurement to point at real
packages, and raises the coverage gate from 30% to 50%.

## Root cause

`pytest.ini` used the `[tool:pytest]` section header — the correct format
for `setup.cfg`. In a `pytest.ini` file the required header is `[pytest]`.
Because of this, every setting (`testpaths`, `norecursedirs`, `--cov`,
`--cov-fail-under`) was silently ignored for the entire history of this
file. pytest was running from the repo root with zero configuration.

## Changes

### `pytest.ini`
- `[tool:pytest]` → `[pytest]` — the root fix.
- `testpaths`: removed two phantom legacy paths (`lib/abi/services`,
  `src/custom`); set to `tests libs/naas-abi-core libs/naas-abi-cli`.
  Marketplace excluded — its tests require external credentials and are
  not suitable for default local or CI unit runs.
- `norecursedirs`: added marketplace, nexus web app, and template
  directories to prevent accidental collection.
- `--cov=lib` → `--cov=naas_abi_core --cov=naas_abi_cli`: `lib/` does
  not exist. Now measuring the actual packages that have tests.
- `--cov-fail-under=30` → `50`: measured baseline on the corrected
  paths is **60.79%**. Threshold set conservatively below measured value
  to accommodate infra-dependent tests that require running services.
  Roadmap: raise to 60% as integration tests are properly gated, then
  70% as coverage improves.
- Removed `ignore::PytestUnknownMarkWarning` from `filterwarnings` — not
  a valid built-in warning class; moot with `--strict-markers` active.

### `conftest.py` (new, repo root)
- Documents and excludes 5 known collection-time failures at the root
  conftest level where `collect_ignore` paths are resolved correctly:
  - 3 files using package-relative imports that only work when pytest
    runs from within the package directory.
  - 2 testcontainers integration test files that fail at import time
    before marker filtering can apply.

### `.gitignore`
- Added `cco_merged.py` (generated ontology file) and
  `coverage-baseline.json` (measurement artifact) to prevent accidental
  commits.

## Test plan
- [x] `uv run pytest -m "not integration"` → collects only from correct
  paths, no marketplace collection errors, coverage 60.79% ≥ 50% gate
- [x] `make check` → passes