### PR TITLE
feat: get object metadata

### DIFF
--- a/libs/naas-abi-core/naas_abi_core/services/object_storage/ObjectStoragePort.py
+++ b/libs/naas-abi-core/naas_abi_core/services/object_storage/ObjectStoragePort.py
@@ -1,6 +1,9 @@
 from abc import ABC, abstractmethod
+from datetime import datetime
 from queue import Queue
 from typing import Optional
+
+from pydantic import BaseModel
 
 
 class Exceptions:
@@ -9,6 +12,18 @@ class Exceptions:
 
     class ObjectAlreadyExists(Exception):
         pass
+
+
+class ObjectMetaData(BaseModel):
+    file_path: str
+    file_name: str
+    file_size_bytes: int
+    created_time: Optional[datetime]
+    modified_time: Optional[datetime]
+    accessed_time: Optional[datetime]
+    permissions: Optional[str]
+    mime_type: Optional[str]
+    encoding: Optional[str]
 
 
 class IObjectStorageAdapter(ABC):
@@ -28,6 +43,10 @@ class IObjectStorageAdapter(ABC):
     def list_objects(self, prefix: str, queue: Optional[Queue] = None) -> list[str]:
         pass
 
+    @abstractmethod
+    def get_object_metadata(self, prefix: str, key: str) -> ObjectMetaData:
+        pass
+
 
 class IObjectStorageDomain(ABC):
     @abstractmethod
@@ -44,4 +63,8 @@ class IObjectStorageDomain(ABC):
 
     @abstractmethod
     def list_objects(self, prefix: str, queue: Optional[Queue] = None) -> list[str]:
+        pass
+
+    @abstractmethod
+    def get_object_metadata(self, prefix: str, key: str) -> ObjectMetaData:
         pass

--- a/libs/naas-abi-core/naas_abi_core/services/object_storage/ObjectStorageService.py
+++ b/libs/naas-abi-core/naas_abi_core/services/object_storage/ObjectStorageService.py
@@ -2,7 +2,10 @@ from queue import Queue
 from typing import Optional
 
 from naas_abi_core.services.object_storage.ObjectStoragePort import (
-    IObjectStorageAdapter, IObjectStorageDomain)
+    IObjectStorageAdapter,
+    IObjectStorageDomain,
+    ObjectMetaData,
+)
 from naas_abi_core.services.ServiceBase import ServiceBase
 
 
@@ -39,3 +42,6 @@ class ObjectStorageService(ServiceBase, IObjectStorageDomain):
             prefix = ""
 
         return self.adapter.list_objects(prefix, queue)
+
+    def get_object_metadata(self, prefix: str, key: str) -> ObjectMetaData:
+        return self.adapter.get_object_metadata(prefix, key)

--- a/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterFS.py
+++ b/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterFS.py
@@ -1,4 +1,3 @@
-import hashlib
 import mimetypes
 import os
 import stat
@@ -91,5 +90,5 @@ class ObjectStorageSecondaryAdapterFS(IObjectStorageAdapter):
             accessed_time=datetime.fromtimestamp(stat_info.st_atime),
             permissions=stat.filemode(stat_info.st_mode),
             mime_type=mime_type,
-            encoding=encoding
+            encoding=encoding,
         )

--- a/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterFS.py
+++ b/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterFS.py
@@ -1,12 +1,17 @@
+import hashlib
+import mimetypes
 import os
-from queue import Queue
+import stat
 import tempfile
 import threading
+from datetime import datetime
+from queue import Queue
 from typing import Optional
 
 from naas_abi_core.services.object_storage.ObjectStoragePort import (
     Exceptions,
     IObjectStorageAdapter,
+    ObjectMetaData,
 )
 
 
@@ -60,7 +65,31 @@ class ObjectStorageSecondaryAdapterFS(IObjectStorageAdapter):
     def list_objects(self, prefix: str, queue: Optional[Queue] = None) -> list[str]:
         with self._lock:
             self.__path_exists(prefix)
-            return [
+            objects = [
                 os.path.join(prefix, f)
                 for f in os.listdir(os.path.join(self.base_path, prefix))
             ]
+            if queue:
+                for obj in objects:
+                    queue.put(obj)
+            return objects
+
+    def get_object_metadata(self, prefix: str, key: str) -> ObjectMetaData:
+        self.__path_exists(prefix, key)
+
+        file_path = os.path.join(self.base_path, prefix, key)
+        stat_info = os.stat(file_path)
+
+        mime_type, encoding = mimetypes.guess_type(file_path)
+
+        return ObjectMetaData(
+            file_path=os.path.abspath(file_path),
+            file_name=os.path.basename(file_path),
+            file_size_bytes=stat_info.st_size,
+            created_time=datetime.fromtimestamp(stat_info.st_ctime),
+            modified_time=datetime.fromtimestamp(stat_info.st_mtime),
+            accessed_time=datetime.fromtimestamp(stat_info.st_atime),
+            permissions=stat.filemode(stat_info.st_mode),
+            mime_type=mime_type,
+            encoding=encoding
+        )

--- a/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterNaas.py
+++ b/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterNaas.py
@@ -13,6 +13,7 @@ from naas_abi_core.services.object_storage.adapters.secondary.ObjectStorageSecon
 )
 from naas_abi_core.services.object_storage.ObjectStoragePort import (
     IObjectStorageAdapter,
+    ObjectMetaData,
 )
 
 NAAS_API_URL = "https://api.naas.ai/"
@@ -129,3 +130,10 @@ class ObjectStorageSecondaryAdapterNaas(IObjectStorageAdapter):
         assert self.__s3_adapter is not None
 
         return self.__s3_adapter.list_objects(prefix, queue)
+
+    def get_object_metadata(self, prefix: str, key: str) -> ObjectMetaData:
+        self.ensure_credentials()
+
+        assert self.__s3_adapter is not None
+
+        return self.__s3_adapter.get_object_metadata(prefix, key)

--- a/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterS3.py
+++ b/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterS3.py
@@ -1,4 +1,3 @@
-import hashlib
 from datetime import datetime
 from queue import Queue
 from typing import Optional

--- a/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterS3.py
+++ b/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterS3.py
@@ -1,3 +1,5 @@
+import hashlib
+from datetime import datetime
 from queue import Queue
 from typing import Optional
 
@@ -6,6 +8,7 @@ from botocore.exceptions import ClientError
 from naas_abi_core.services.object_storage.ObjectStoragePort import (
     Exceptions,
     IObjectStorageAdapter,
+    ObjectMetaData,
 )
 
 
@@ -192,3 +195,52 @@ class ObjectStorageSecondaryAdapterS3(IObjectStorageAdapter):
                         if queue:
                             queue.put(prefix_key)
         return objects
+
+    def get_object_metadata(self, prefix: str, key: str) -> ObjectMetaData:
+        """Get object metadata from S3.
+
+        Args:
+            prefix (str): Prefix/folder path
+            key (str): Object key name
+
+        Returns:
+            Dict[str, Any]: Object metadata including size and modified date
+        """
+        self.__object_exists(prefix, key)
+
+        # Fields returned by the head_object method
+        # ContentLength → Size of the object in bytes
+        # LastModified → When the object was last updated
+        # ETag → Usually the MD5 hash (not always for multipart uploads)
+        # ContentType → MIME type (e.g., image/png, text/plain)
+        # Metadata → Custom user-defined metadata
+        # StorageClass → Storage tier (STANDARD, GLACIER, etc.)
+        # VersionId → Present if versioning is enabled
+        # ServerSideEncryption → Encryption type used
+        response = self.s3_client.head_object(
+            Bucket=self.bucket_name, Key=self.__get_full_key(prefix, key)
+        )
+
+        last_modified = response.get("LastModified")
+        last_modified_date = (
+            datetime.fromisoformat(last_modified.isoformat()) if last_modified else None
+        )
+
+        full_key = self.__get_full_key(prefix, key)
+        file_path = (
+            f"s3://{self.bucket_name}/{full_key}"
+            if full_key
+            else f"s3://{self.bucket_name}"
+        )
+
+        return ObjectMetaData(
+            file_path=file_path,
+            file_name=key.split("/")[-1] if key else "",
+            file_size_bytes=response.get("ContentLength", 0),
+            created_time=None,
+            modified_time=last_modified_date,
+            accessed_time=None,
+            permissions=None,
+            mime_type=response.get("ContentType", "") or None,
+            encoding=None,
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -3693,7 +3693,7 @@ wheels = [
 
 [[package]]
 name = "naas-abi"
-version = "1.16.2"
+version = "1.17.0"
 source = { editable = "libs/naas-abi" }
 dependencies = [
     { name = "alembic" },
@@ -3767,7 +3767,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-cli"
-version = "1.24.0"
+version = "1.24.1"
 source = { editable = "libs/naas-abi-cli" }
 dependencies = [
     { name = "naas-abi" },
@@ -3793,7 +3793,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-core"
-version = "1.21.6"
+version = "1.22.0"
 source = { editable = "libs/naas-abi-core" }
 dependencies = [
     { name = "click" },
@@ -3920,7 +3920,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-marketplace"
-version = "1.8.1"
+version = "1.9.0"
 source = { editable = "libs/naas-abi-marketplace" }
 dependencies = [
     { name = "naas-abi-core" },


### PR DESCRIPTION
This pull request resolves #object-metadata                                                                           
                                                                                                                       
 ### Summary                                                                                                           
                                                                                                                       
 This PR introduces a new feature to retrieve and handle metadata for objects stored in various storage backends. It   
 adds a new `ObjectMetaData` model and extends the existing object storage interfaces and adapters to support fetching 
 metadata.                                                                                                             
                                                                                                                       
 ### Changes                                                                                                           
                                                                                                                       
 - Added `ObjectMetaData` Pydantic model to represent metadata attributes such as file path, name, size, timestamps,   
 permissions, MIME type, and encoding.                                                                                 
 - Extended `IObjectStorageAdapter` and `IObjectStorageDomain` interfaces with a new method `get_object_metadata`.     
 - Implemented `get_object_metadata` in the `ObjectStorageService` to delegate to the adapter.                         
 - Implemented `get_object_metadata` in the following adapters:                                                        
   - `ObjectStorageSecondaryAdapterFS`: Retrieves file system metadata using `os.stat` and `mimetypes`.                
   - `ObjectStorageSecondaryAdapterNaas`: Delegates metadata retrieval to the underlying S3 adapter.                   
   - `ObjectStorageSecondaryAdapterS3`: Uses AWS S3 `head_object` API to fetch metadata and maps it to `ObjectMetaData 
                                                                                                                       
 ### Benefits                                                                                                          
                                                                                                                       
 - Provides a unified way to access detailed metadata about stored objects across different storage backends.          
 - Enables clients to obtain file size, timestamps, permissions, and content type information.                         
                                                                                                                       
 ### Notes                                                                                                             
                                                                                                                       
 - The `created_time` and `accessed_time` fields are not available for S3 and are set to `None`.                       
 - Permissions are only available for filesystem storage.                                                              
                                                                                                                       
 This enhancement improves the observability and management capabilities of the object storage service.  