### PR TITLE
Feature flagging

### DIFF
--- a/config.local.yaml
+++ b/config.local.yaml
@@ -41,6 +41,19 @@ modules:
         frontend_url: "https://{{ secret.PUBLIC_WEB_HOST }}"
         database_url: "postgresql+asyncpg://{{ secret.POSTGRES_USER }}:{{ secret.POSTGRES_PASSWORD }}@postgres:5432/nexus"
         redis_url: "redis://redis:6379/0"
+        feature_flags:
+          enabled_features:
+            - chat
+            - files
+            - agents
+            - knowledge
+            - settings
+          role_baseline:
+            owner: [chat, files, agents, knowledge, settings]
+            admin: [chat, files, agents, knowledge, settings]
+            member: [chat, files]
+            viewer: [chat, files]
+          workspace_overrides: {}
         magic_link_allow_signup: false
         magic_link_email_app_name: "ABI Platform"
         magic_link_email_subject_template: "Your {app_name} sign-in link"

--- a/libs/naas-abi/naas_abi/__init__.py
+++ b/libs/naas-abi/naas_abi/__init__.py
@@ -65,6 +65,28 @@ class ExternalAppConfig(BaseModel):
     icon_emoji: str | None = None
 
 
+FeatureKey = Literal["chat", "files", "agents", "knowledge", "settings"]
+
+
+class FeatureFlagsConfig(BaseModel):
+    """Feature access policy exposed to Nexus frontend."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled_features: list[FeatureKey] = Field(
+        default_factory=lambda: ["chat", "files", "agents", "knowledge", "settings"]
+    )
+    role_baseline: dict[str, list[FeatureKey]] = Field(
+        default_factory=lambda: {
+            "owner": ["chat", "files", "agents", "knowledge", "settings"],
+            "admin": ["chat", "files", "agents", "knowledge", "settings"],
+            "member": ["chat", "files"],
+            "viewer": ["chat", "files"],
+        }
+    )
+    workspace_overrides: dict[str, dict[FeatureKey, bool]] = Field(default_factory=dict)
+
+
 class UserSeedConfig(BaseModel):
     """User definition applied on startup (create by email if missing)."""
 
@@ -214,6 +236,7 @@ class NexusConfig(BaseModel):
     auto_seed_demo_data: bool = True
 
     tenant: TenantConfig = Field(default_factory=TenantConfig)
+    feature_flags: FeatureFlagsConfig = Field(default_factory=FeatureFlagsConfig)
     users: list[UserSeedConfig] = Field(default_factory=list)
     organizations: list[OrganizationSeedConfig] = Field(default_factory=list)
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/config.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/config.py
@@ -61,6 +61,28 @@ class ExternalAppConfig(BaseModel):
     icon_emoji: str | None = None
 
 
+FeatureKey = Literal["chat", "files", "agents", "knowledge", "settings"]
+
+
+class FeatureFlagsConfig(BaseModel):
+    """Feature access policy exposed to Nexus frontend."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled_features: list[FeatureKey] = Field(
+        default_factory=lambda: ["chat", "files", "agents", "knowledge", "settings"]
+    )
+    role_baseline: dict[str, list[FeatureKey]] = Field(
+        default_factory=lambda: {
+            "owner": ["chat", "files", "agents", "knowledge", "settings"],
+            "admin": ["chat", "files", "agents", "knowledge", "settings"],
+            "member": ["chat", "files"],
+            "viewer": ["chat", "files"],
+        }
+    )
+    workspace_overrides: dict[str, dict[FeatureKey, bool]] = Field(default_factory=dict)
+
+
 class UserSeedConfig(BaseModel):
     """User definition applied on startup (create by email if missing)."""
 
@@ -159,6 +181,9 @@ class Settings(BaseSettings):
 
     # Tenant branding (tab title, favicon)
     tenant: TenantConfig = Field(default_factory=TenantConfig)
+
+    # Feature access policy consumed by workspace bootstrap responses
+    feature_flags: FeatureFlagsConfig = Field(default_factory=FeatureFlagsConfig)
 
     # User seed configs (upserted by email on startup)
     users: list[UserSeedConfig] = Field(default_factory=list)

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/feature_flags.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/feature_flags.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from naas_abi.apps.nexus.apps.api.app.core.config import FeatureFlagsConfig
+
+KNOWN_FEATURE_KEYS: tuple[str, ...] = (
+    "chat",
+    "files",
+    "agents",
+    "knowledge",
+    "settings",
+)
+
+
+def build_feature_flags(
+    *,
+    role: str,
+    feature_flags_config: FeatureFlagsConfig,
+    workspace_slug: str | None,
+    workspace_id: str | None,
+) -> dict[str, bool]:
+    """Build effective feature flags for a workspace user."""
+    enabled_catalog = _resolve_enabled_catalog(feature_flags_config.enabled_features)
+    baseline = {
+        key for key in feature_flags_config.role_baseline.get(role, []) if key in enabled_catalog
+    }
+    flags: dict[str, bool] = {key: (key in baseline) for key in KNOWN_FEATURE_KEYS}
+
+    overrides = _resolve_workspace_overrides(
+        workspace_overrides=feature_flags_config.workspace_overrides,
+        workspace_slug=workspace_slug,
+        workspace_id=workspace_id,
+    )
+    for key, value in overrides.items():
+        if key in enabled_catalog:
+            flags[key] = bool(value)
+
+    for key in KNOWN_FEATURE_KEYS:
+        if key not in enabled_catalog:
+            flags[key] = False
+
+    return flags
+
+
+def _resolve_enabled_catalog(enabled_features: list[str]) -> set[str]:
+    known = {key for key in enabled_features if key in KNOWN_FEATURE_KEYS}
+    if known:
+        return known
+    return set(KNOWN_FEATURE_KEYS)
+
+
+def _resolve_workspace_overrides(
+    *,
+    workspace_overrides: Mapping[str, Mapping[str, bool]],
+    workspace_slug: str | None,
+    workspace_id: str | None,
+) -> Mapping[str, bool]:
+    if workspace_slug and workspace_slug in workspace_overrides:
+        return workspace_overrides[workspace_slug]
+    if workspace_id and workspace_id in workspace_overrides:
+        return workspace_overrides[workspace_id]
+    return {}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/feature_flags_test.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/feature_flags_test.py
@@ -1,0 +1,55 @@
+from naas_abi.apps.nexus.apps.api.app.core.config import FeatureFlagsConfig
+from naas_abi.apps.nexus.apps.api.app.core.feature_flags import build_feature_flags
+
+
+class TestBuildFeatureFlags:
+    def test_member_role_defaults_to_chat_and_files_only(self) -> None:
+        config = FeatureFlagsConfig()
+
+        flags = build_feature_flags(
+            role="member",
+            feature_flags_config=config,
+            workspace_slug="demo",
+            workspace_id="ws-1",
+        )
+
+        assert flags == {
+            "chat": True,
+            "files": True,
+            "agents": False,
+            "knowledge": False,
+            "settings": False,
+        }
+
+    def test_workspace_overrides_apply_on_top_of_role_baseline(self) -> None:
+        config = FeatureFlagsConfig(
+            workspace_overrides={
+                "demo": {
+                    "knowledge": True,
+                    "chat": False,
+                }
+            }
+        )
+
+        flags = build_feature_flags(
+            role="member",
+            feature_flags_config=config,
+            workspace_slug="demo",
+            workspace_id="ws-1",
+        )
+
+        assert flags["knowledge"] is True
+        assert flags["chat"] is False
+        assert flags["files"] is True
+
+    def test_unknown_role_denies_all_features(self) -> None:
+        config = FeatureFlagsConfig()
+
+        flags = build_feature_flags(
+            role="unknown-role",
+            feature_flags_config=config,
+            workspace_slug="demo",
+            workspace_id="ws-1",
+        )
+
+        assert all(value is False for value in flags.values())

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/workspaces/adapters/primary/workspaces__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/workspaces/adapters/primary/workspaces__primary_adapter__FastAPI.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import os
 from datetime import datetime
 from pathlib import Path
@@ -13,7 +14,9 @@ from naas_abi.apps.nexus.apps.api.app.api.endpoints.auth import (
     require_workspace_access,
 )
 from naas_abi.apps.nexus.apps.api.app.api.endpoints.secrets import deprecated_encrypt
+from naas_abi.apps.nexus.apps.api.app.core.config import settings
 from naas_abi.apps.nexus.apps.api.app.core.database import get_db
+from naas_abi.apps.nexus.apps.api.app.core.feature_flags import build_feature_flags
 from naas_abi.apps.nexus.apps.api.app.services.workspaces.adapters.secondary.postgres import (
     WorkspaceSecondaryAdapterPostgres,
 )
@@ -54,6 +57,8 @@ class Workspace(BaseModel):
     updated_at: datetime | None = None
     organization_logo_url: str | None = None
     organization_logo_rectangle_url: str | None = None
+    current_user_role: str | None = None
+    feature_flags: dict[str, bool] = Field(default_factory=dict)
 
 
 class WorkspaceCreate(BaseModel):
@@ -131,7 +136,8 @@ class InferenceServerUpdate(BaseModel):
     models_path: str | None = None
 
 
-def _to_schema(record: WorkspaceRecord) -> Workspace:
+def _to_schema(record: WorkspaceRecord, current_user_role: str | None) -> Workspace:
+    role = current_user_role or "member"
     return Workspace(
         id=record.id,
         name=record.name,
@@ -149,6 +155,13 @@ def _to_schema(record: WorkspaceRecord) -> Workspace:
         updated_at=record.updated_at,
         organization_logo_url=record.organization_logo_url,
         organization_logo_rectangle_url=record.organization_logo_rectangle_url,
+        current_user_role=current_user_role,
+        feature_flags=build_feature_flags(
+            role=role,
+            feature_flags_config=settings.feature_flags,
+            workspace_slug=record.slug,
+            workspace_id=record.id,
+        ),
     )
 
 
@@ -158,7 +171,10 @@ async def list_workspaces(
     service: WorkspaceService = Depends(get_workspace_service),
 ) -> list[Workspace]:
     rows = await service.list_workspaces(user_id=current_user.id)
-    return [_to_schema(row) for row in rows]
+    roles = await asyncio.gather(
+        *[service.get_workspace_role(user_id=current_user.id, workspace_id=row.id) for row in rows]
+    )
+    return [_to_schema(row, role) for row, role in zip(rows, roles, strict=False)]
 
 
 @router.get("/{workspace_id}")
@@ -167,11 +183,11 @@ async def get_workspace(
     current_user: User = Depends(get_current_user_required),
     service: WorkspaceService = Depends(get_workspace_service),
 ) -> Workspace:
-    await require_workspace_access(current_user.id, workspace_id)
+    role = await require_workspace_access(current_user.id, workspace_id)
     row = await service.get_workspace(workspace_id=workspace_id)
     if row is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
-    return _to_schema(row)
+    return _to_schema(row, role)
 
 
 @router.get("/slug/{slug}")
@@ -183,8 +199,8 @@ async def get_workspace_by_slug(
     row = await service.get_workspace_by_slug(slug=slug)
     if row is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
-    await require_workspace_access(current_user.id, row.id)
-    return _to_schema(row)
+    role = await require_workspace_access(current_user.id, row.id)
+    return _to_schema(row, role)
 
 
 @router.post("")
@@ -211,7 +227,7 @@ async def create_workspace(
         )
     except WorkspaceSlugAlreadyExistsError as exc:
         raise HTTPException(status_code=400, detail="Slug already exists") from exc
-    return _to_schema(record)
+    return _to_schema(record, "owner")
 
 
 @router.delete("/{workspace_id}")
@@ -248,7 +264,7 @@ async def update_workspace(
     )
     if record is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
-    return _to_schema(record)
+    return _to_schema(record, role)
 
 
 @router.get("/{workspace_id}/stats")

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/workspaces/adapters/primary/workspaces__primary_adapter__FastAPI_test.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/workspaces/adapters/primary/workspaces__primary_adapter__FastAPI_test.py
@@ -1,0 +1,40 @@
+from datetime import UTC, datetime
+
+from naas_abi.apps.nexus.apps.api.app.core.config import FeatureFlagsConfig, settings
+from naas_abi.apps.nexus.apps.api.app.services.workspaces.adapters.primary.workspaces__primary_adapter__FastAPI import (
+    _to_schema,
+)
+from naas_abi.apps.nexus.apps.api.app.services.workspaces.port import WorkspaceRecord
+
+
+def test_to_schema_includes_role_and_feature_flags_for_member() -> None:
+    previous_config = settings.feature_flags
+    settings.feature_flags = FeatureFlagsConfig(
+        workspace_overrides={
+            "demo": {
+                "knowledge": True,
+            }
+        }
+    )
+    try:
+        record = WorkspaceRecord(
+            id="ws-1",
+            name="Demo",
+            slug="demo",
+            owner_id="user-1",
+            created_at=datetime.now(tz=UTC),
+            updated_at=datetime.now(tz=UTC),
+        )
+
+        schema = _to_schema(record, "member")
+
+        assert schema.current_user_role == "member"
+        assert schema.feature_flags == {
+            "chat": True,
+            "files": True,
+            "agents": False,
+            "knowledge": True,
+            "settings": False,
+        }
+    finally:
+        settings.feature_flags = previous_config

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/tests/test_workspaces.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/tests/test_workspaces.py
@@ -124,3 +124,24 @@ class TestWorkspaceLogoUpload:
         assert workspace_data["logo_url"] == payload["logo_url"]
 
         Path("uploads/logos", payload["filename"]).unlink(missing_ok=True)
+
+
+class TestWorkspaceFeatureFlags:
+    async def test_workspace_payload_contains_role_and_feature_flags(
+        self, client, test_user, test_workspace
+    ):
+        response = await client.get(
+            f"/api/workspaces/{test_workspace['id']}",
+            headers=test_user["headers"],
+        )
+        assert response.status_code == 200
+        payload = response.json()
+
+        assert payload["current_user_role"] in {"owner", "admin", "member", "viewer"}
+        assert payload["feature_flags"] == {
+            "chat": True,
+            "files": True,
+            "agents": True,
+            "knowledge": True,
+            "settings": True,
+        }

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/layout.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/layout.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { Component, useEffect, useState } from 'react';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams, usePathname, useRouter } from 'next/navigation';
+import { isWorkspacePathAllowed } from '@/lib/feature-access';
 import { WorkspaceLayout } from '@/components/shell/workspace-layout';
 import { useWorkspaceStore } from '@/stores/workspace';
 import { useAuthStore } from '@/stores/auth';
@@ -107,12 +108,14 @@ export default function WorkspaceIdLayout({
   children: React.ReactNode;
 }) {
   const params = useParams();
+  const pathname = usePathname();
   const router = useRouter();
   const workspaceId = params.workspaceId as string;
   
   const { workspaces, currentWorkspaceId, setCurrentWorkspace, syncWorkspaceConversations } = useWorkspaceStore();
-  const { isAuthenticated, token } = useAuthStore();
+  const { token } = useAuthStore();
   const [authReady, setAuthReady] = useState(false);
+  const currentWorkspace = workspaces.find((w) => w.id === workspaceId);
 
   // Wait for auth store to rehydrate from localStorage before doing anything
   useEffect(() => {
@@ -155,6 +158,27 @@ export default function WorkspaceIdLayout({
       void syncWorkspaceConversations(workspaceId);
     }
   }, [workspaceId, syncWorkspaceConversations]);
+
+  useEffect(() => {
+    if (!authReady || !token || !workspaceId || !pathname || !currentWorkspace) {
+      return;
+    }
+
+    const allowed = isWorkspacePathAllowed({
+      pathname,
+      role: currentWorkspace.currentUserRole,
+      workspaceFlags: currentWorkspace.featureFlags,
+    });
+    if (allowed) {
+      return;
+    }
+
+    const blockedPath = encodeURIComponent(pathname);
+    const notAvailablePath = `/workspace/${workspaceId}/not-available?from=${blockedPath}`;
+    if (notAvailablePath !== pathname) {
+      router.replace(notAvailablePath);
+    }
+  }, [authReady, token, workspaceId, pathname, currentWorkspace, router]);
 
   // Show nothing while checking auth
   if (!authReady || !token) {

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/not-available/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/not-available/page.tsx
@@ -1,0 +1,41 @@
+import Link from 'next/link';
+
+type NotAvailablePageProps = {
+  params: {
+    workspaceId: string;
+  };
+  searchParams?: {
+    from?: string;
+  };
+};
+
+export default function WorkspaceFeatureNotAvailablePage({
+  params,
+  searchParams,
+}: NotAvailablePageProps) {
+  const fallbackPath = `/workspace/${params.workspaceId}/chat`;
+
+  const blockedPath = searchParams?.from ? decodeURIComponent(searchParams.from) : null;
+
+  return (
+    <div className="flex h-full w-full items-center justify-center bg-background p-6">
+      <div className="w-full max-w-lg rounded-xl border border-border bg-card p-8 shadow-sm">
+        <h1 className="text-2xl font-semibold text-foreground">Feature not available</h1>
+        <p className="mt-3 text-sm text-muted-foreground">
+          Your workspace role does not grant access to this section yet.
+        </p>
+        {blockedPath ? (
+          <p className="mt-2 text-xs text-muted-foreground">Blocked path: {blockedPath}</p>
+        ) : null}
+        <div className="mt-6">
+          <Link
+            href={fallbackPath}
+            className="inline-flex items-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90"
+          >
+            Go to an available section
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/index.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/index.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from 'react';
 import { Check, ChevronsUpDown, PanelLeft } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { cn } from '@/lib/utils';
+import { useFeature } from '@/hooks/use-feature';
 import { useWorkspaceStore } from '@/stores/workspace';
 import { useFilesStore } from '@/stores/files';
 import { useOntologyStore } from '@/stores/ontology';
@@ -35,12 +36,21 @@ export function Sidebar() {
   const { fetchFiles, fetchLabFiles } = useFilesStore();
   const { fetchItems: fetchOntology } = useOntologyStore();
 
+  const canChat = useFeature('chat');
+  const canFiles = useFeature('files');
+  const canAgents = useFeature('agents');
+  const canKnowledge = useFeature('knowledge');
+
   useEffect(() => {
     setMounted(true);
-    fetchFiles();
-    fetchLabFiles();
-    fetchOntology();
-  }, [fetchFiles, fetchLabFiles, fetchOntology]);
+    if (canFiles) {
+      fetchFiles();
+      fetchLabFiles();
+    }
+    if (canKnowledge) {
+      fetchOntology();
+    }
+  }, [canFiles, canKnowledge, fetchFiles, fetchLabFiles, fetchOntology]);
 
   // Close workspace menu on click outside
   useEffect(() => {
@@ -176,13 +186,13 @@ export function Sidebar() {
 
       {/* Navigation Sections */}
       <nav className="flex-1 space-y-1 overflow-y-auto p-2">
-        <SearchSection collapsed={collapsed} />
-        <ChatSection collapsed={collapsed} />
-        <OntologySection collapsed={collapsed} />
-        <KnowledgeGraphSection collapsed={collapsed} />
-        <FilesSection collapsed={collapsed} />
-        <LabSection collapsed={collapsed} />
-        <AppsSection collapsed={collapsed} />
+        {canKnowledge && <SearchSection collapsed={collapsed} />}
+        {canChat && <ChatSection collapsed={collapsed} />}
+        {canKnowledge && <OntologySection collapsed={collapsed} />}
+        {canKnowledge && <KnowledgeGraphSection collapsed={collapsed} />}
+        {canFiles && <FilesSection collapsed={collapsed} />}
+        {canAgents && <LabSection collapsed={collapsed} />}
+        {canAgents && <AppsSection collapsed={collapsed} />}
       </nav>
     </aside>
   );

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/hooks/use-feature.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/hooks/use-feature.ts
@@ -1,0 +1,13 @@
+'use client';
+
+import { isFeatureEnabled, type FeatureKey } from '@/lib/feature-access';
+import { useWorkspaceStore } from '@/stores/workspace';
+
+export function useFeature(feature: FeatureKey): boolean {
+  const currentWorkspace = useWorkspaceStore((state) => state.getCurrentWorkspace());
+  return isFeatureEnabled({
+    feature,
+    role: currentWorkspace?.currentUserRole,
+    workspaceFlags: currentWorkspace?.featureFlags,
+  });
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/feature-access.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/feature-access.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  getFeatureForWorkspacePath,
+  getFirstAllowedWorkspacePath,
+  isWorkspacePathAllowed,
+  mergeFeatureFlags,
+} from './feature-access';
+
+test('mergeFeatureFlags keeps member defaults', () => {
+  const flags = mergeFeatureFlags('member');
+
+  assert.equal(flags.chat, true);
+  assert.equal(flags.files, true);
+  assert.equal(flags.agents, false);
+  assert.equal(flags.knowledge, false);
+  assert.equal(flags.settings, false);
+});
+
+test('mergeFeatureFlags applies workspace overrides', () => {
+  const flags = mergeFeatureFlags('member', { knowledge: true, chat: false });
+
+  assert.equal(flags.chat, false);
+  assert.equal(flags.files, true);
+  assert.equal(flags.knowledge, true);
+});
+
+test('guard maps workspace paths to features', () => {
+  assert.equal(getFeatureForWorkspacePath('/workspace/ws1/chat'), 'chat');
+  assert.equal(getFeatureForWorkspacePath('/workspace/ws1/graph'), 'knowledge');
+  assert.equal(getFeatureForWorkspacePath('/workspace/ws1/settings/agents'), 'agents');
+  assert.equal(getFeatureForWorkspacePath('/workspace/ws1/help'), 'settings');
+});
+
+test('guard supports org-scoped rewritten routes', () => {
+  assert.equal(getFeatureForWorkspacePath('/org/acme/workspace/ws1/chat'), 'chat');
+  assert.equal(getFeatureForWorkspacePath('/org/acme/workspace/ws1/lab'), 'agents');
+});
+
+test('isWorkspacePathAllowed blocks disabled routes', () => {
+  const allowedChat = isWorkspacePathAllowed({
+    pathname: '/workspace/ws1/chat',
+    role: 'member',
+  });
+  const blockedGraph = isWorkspacePathAllowed({
+    pathname: '/workspace/ws1/graph',
+    role: 'member',
+  });
+
+  assert.equal(allowedChat, true);
+  assert.equal(blockedGraph, false);
+});
+
+test('getFirstAllowedWorkspacePath returns first enabled route', () => {
+  const path = getFirstAllowedWorkspacePath({
+    workspaceId: 'ws1',
+    role: 'member',
+  });
+
+  assert.equal(path, '/workspace/ws1/chat');
+});

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/feature-access.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/feature-access.ts
@@ -1,0 +1,114 @@
+export type FeatureKey = 'chat' | 'files' | 'agents' | 'knowledge' | 'settings';
+
+export type WorkspaceFeatureFlags = Partial<Record<FeatureKey, boolean>>;
+
+export const FEATURE_KEYS: FeatureKey[] = ['chat', 'files', 'agents', 'knowledge', 'settings'];
+
+const DEFAULT_ROLE_BASELINE: Record<string, FeatureKey[]> = {
+  owner: [...FEATURE_KEYS],
+  admin: [...FEATURE_KEYS],
+  member: ['chat', 'files'],
+  viewer: ['chat', 'files'],
+};
+
+const FEATURE_FALLBACK_ROUTE: Record<FeatureKey, string> = {
+  chat: '/chat',
+  files: '/files',
+  agents: '/lab',
+  knowledge: '/search',
+  settings: '/settings',
+};
+
+export function mergeFeatureFlags(role?: string, workspaceFlags?: WorkspaceFeatureFlags): Record<FeatureKey, boolean> {
+  const baseline = new Set(DEFAULT_ROLE_BASELINE[role || ''] || []);
+  const resolved = Object.fromEntries(
+    FEATURE_KEYS.map((feature) => [feature, baseline.has(feature)])
+  ) as Record<FeatureKey, boolean>;
+
+  if (!workspaceFlags) {
+    return resolved;
+  }
+
+  for (const feature of FEATURE_KEYS) {
+    if (typeof workspaceFlags[feature] === 'boolean') {
+      resolved[feature] = Boolean(workspaceFlags[feature]);
+    }
+  }
+  return resolved;
+}
+
+export function isFeatureEnabled(params: {
+  feature: FeatureKey;
+  role?: string;
+  workspaceFlags?: WorkspaceFeatureFlags;
+}): boolean {
+  if (!FEATURE_KEYS.includes(params.feature)) {
+    return false;
+  }
+  const resolved = mergeFeatureFlags(params.role, params.workspaceFlags);
+  return resolved[params.feature] === true;
+}
+
+export function getFeatureForWorkspacePath(pathname: string): FeatureKey | null {
+  const parts = pathname.split('/').filter(Boolean);
+  const workspaceIndex = parts.indexOf('workspace');
+  if (workspaceIndex < 0 || parts.length <= workspaceIndex + 2) {
+    return null;
+  }
+
+  const firstSegment = parts[workspaceIndex + 2];
+  if (firstSegment === 'chat') {
+    return 'chat';
+  }
+  if (firstSegment === 'files') {
+    return 'files';
+  }
+  if (firstSegment === 'search' || firstSegment === 'ontology' || firstSegment === 'graph') {
+    return 'knowledge';
+  }
+  if (
+    firstSegment === 'lab' ||
+    firstSegment === 'apps' ||
+    (firstSegment === 'settings' && parts[workspaceIndex + 3] === 'agents')
+  ) {
+    return 'agents';
+  }
+  if (firstSegment === 'settings' || firstSegment === 'organization' || firstSegment === 'help') {
+    return 'settings';
+  }
+
+  return null;
+}
+
+export function isWorkspacePathAllowed(params: {
+  pathname: string;
+  role?: string;
+  workspaceFlags?: WorkspaceFeatureFlags;
+}): boolean {
+  const feature = getFeatureForWorkspacePath(params.pathname);
+  if (!feature) {
+    return true;
+  }
+  return isFeatureEnabled({
+    feature,
+    role: params.role,
+    workspaceFlags: params.workspaceFlags,
+  });
+}
+
+export function getFirstAllowedWorkspacePath(params: {
+  workspaceId: string;
+  role?: string;
+  workspaceFlags?: WorkspaceFeatureFlags;
+}): string {
+  const resolved = mergeFeatureFlags(params.role, params.workspaceFlags);
+  const priority: FeatureKey[] = ['chat', 'files', 'knowledge', 'agents', 'settings'];
+
+  for (const feature of priority) {
+    if (resolved[feature]) {
+      return `/workspace/${params.workspaceId}${FEATURE_FALLBACK_ROUTE[feature]}`;
+    }
+  }
+
+  return `/workspace/${params.workspaceId}/chat`;
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
+import type { WorkspaceFeatureFlags } from '@/lib/feature-access';
 import { useAuthStore } from './auth';
 import { getApiUrl } from '@/lib/config';
 
@@ -133,6 +134,8 @@ export interface Workspace {
   currentBranchId: string;
   createdAt: Date;
   updatedAt: Date;
+  currentUserRole?: string;
+  featureFlags?: WorkspaceFeatureFlags;
   isDemo?: boolean;
 }
 
@@ -739,6 +742,8 @@ export const useWorkspaceStore = create<WorkspaceState>()(
         currentBranchId: `branch-main-${ws.id}`,
         createdAt: new Date(ws.created_at || Date.now()),
         updatedAt: new Date(ws.updated_at || Date.now()),
+        currentUserRole: ws.current_user_role,
+        featureFlags: ws.feature_flags,
       }));
       
       set({ workspaces });


### PR DESCRIPTION
## Summary

- Add Nexus feature-flagging support with a centralized backend policy (`enabled_features`, `role_baseline`, `workspace_overrides`) and expose resolved flags on workspace responses.
- Enforce feature access in the frontend workspace shell by computing effective flags from role + workspace overrides, hiding unavailable navigation items, and redirecting users away from disallowed routes.
- Add fallback UX for unavailable features with a dedicated `not-available` page and first-allowed-route resolution.

## Main Changes

- Backend:
  - Add `FeatureFlagsConfig` to Nexus API settings.
  - Implement feature flag resolution logic in `feature_flags.py`.
  - Include `feature_flags` in workspace payloads returned by the FastAPI workspace adapter.
  - Add API/unit tests for feature flag resolution and workspace responses.
- Frontend:
  - Add feature access helpers (`feature-access.ts`) and tests.
  - Add `use-feature` hook.
  - Update workspace layout and sidebar to enforce and reflect feature access.
  - Add `/workspace/[workspaceId]/not-available` page.
- Configuration:
  - Add default `feature_flags` policy in `config.local.yaml`.

## Testing

- Added backend tests for feature flag computation and workspace API behavior.
- Added frontend tests for feature-to-route mapping and access resolution.
- Full test suite not run as part of this PR description generation.

## ADR Check

- `docs/adr/` exists and was reviewed against this change.
- No new architecture-level boundary/ownership/cross-domain decision is introduced; this is a feature-policy implementation within existing Nexus API + web app patterns.
- Decision: no ADR update/new ADR required for this PR.
