### PR TITLE
fix(nexus): remove duplicate socket field in WebSocketContextType

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/contexts/websocket-context.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/contexts/websocket-context.tsx
@@ -30,7 +30,6 @@ interface WebSocketContextType {
   startTyping: (workspaceId: string, conversationId: string) => void;
   stopTyping: (workspaceId: string, conversationId: string) => void;
   onMessage: (callback: (data: any) => void) => () => void;
-  socket: Socket | null;
 }
 
 const WebSocketContext = createContext<WebSocketContextType | null>(null);


### PR DESCRIPTION
## Summary
- Fixes the nexus Docker build that was failing on `pnpm build` with a TS2300 "Duplicate identifier 'socket'" error.
- The `WebSocketContextType` interface in `libs/naas-abi/naas_abi/apps/nexus/apps/web/src/contexts/websocket-context.tsx` declared `socket: Socket | null;` twice (lines 24 and 33). Removed the redundant second declaration.

## Why
The duplicate field broke the build pipeline (see [failing run](https://github.com/jupyter-naas/abi/actions/runs/24830168115/job/72676333902)). All other usage of `socket` (state, provider value) is unaffected by this change.

## Test plan
- [ ] CI build (`pnpm build` in nexus image) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)