### PR TITLE
Vendor versionstore with branching, group commit, and cross-platform durability

### DIFF
--- a/libs/naas-abi-core/naas_abi_core/utils/versionstore/README.md
+++ b/libs/naas-abi-core/naas_abi_core/utils/versionstore/README.md
@@ -1,0 +1,75 @@
+# versionstore
+
+An append-only, content-addressed versioned blob store.
+
+> *Filesystem is truth. Everything else is a rebuildable view.*
+
+Vendored from [Dr0p42/versionstore](https://github.com/Dr0p42/versionstore) for use as
+the substrate for ABI's branched, versioned services. See `WHITEPAPER.md` for the
+design rationale.
+
+## What lives here
+
+- `store.py`            — the `Store` itself (versioned, branched, content-addressed).
+- `revision.py`         — the immutable `Revision` record.
+- `registry.py`         — `StoreRegistry`: manage many namespaced stores under one root.
+- `uuid7.py`            — stdlib-only UUIDv7 generator.
+- `*_test.py`           — sibling tests, per ABI's convention.
+
+## Deviations from upstream
+
+This vendored copy adds three scaling improvements (Tier 1 A, B & C from the
+ABI branching spec), a cross-platform durability mode, and the minimal
+branching scaffold required for B:
+
+0. **Cross-platform durability (`durability="full"`, default).** On Apple
+   platforms, ``os.fsync`` only flushes to the drive controller cache, not
+   the platter — a power loss between fsync returning and the physical
+   write can lose recently-acknowledged writes. Full mode escalates to
+   ``fcntl(fd, F_FULLFSYNC)`` and the matching SQLite PRAGMAs
+   (``fullfsync=ON``, ``synchronous=FULL``) so the store's claim that "if
+   ``put`` returned success, the revision is durable" holds on every
+   supported platform. Pass ``durability="fast"`` to opt out for dev/tests.
+   On Linux/Windows/BSD ``"full"`` and ``"fast"`` are equivalent (regular
+   ``fsync`` already provides true durability there).
+
+1. **Per-uid concurrency (A).** Two writers touching different uids no longer
+   serialize through a single `BEGIN IMMEDIATE` lock. The schema enforces
+   `UNIQUE(branch, uid, prev_hash)`; on conflict the writer retries against
+   the new tip.
+2. **Per-(branch, uid) concurrency (B).** Two writers on different branches
+   touching the same uid don't conflict either, since `prev_hash` lookups are
+   scoped to the branch's tip.
+3. **Group commit (C, opt-in).** Pass `commit_window_ms > 0` to `Store(...)`
+   to enable batched fsyncs. A leader-follower scheme amortizes file fsync,
+   directory fsync, and the SQLite COMMIT across every writer that lands in
+   the same window. Defaults to off. See `WHITEPAPER.md §11` for the full
+   model and updated failure semantics.
+4. **Minimal branching.** A `branches` table tracks branch metadata, every
+   revision now records the branch it was written on, and `put / latest /
+   history / get` accept an optional `branch=` argument (default `"main"`).
+   Existing call sites are unchanged in behavior.
+
+Multi-parent merge revisions, branch fall-through reads, `merge`/`diff`
+operations, and the branch sidecar files described in the spec are **not**
+included here yet. They land in a follow-up alongside the `IVersionedStorePort`.
+
+### Enabling group commit
+
+```python
+from naas_abi_core.utils.versionstore import Store
+
+# Solo commit (default): every put fsyncs individually.
+store = Store("data/")
+
+# Group commit: writers within a 2 ms window share one fsync round.
+# Recommended for workloads with many concurrent writers.
+store = Store("data/", commit_window_ms=2.0, commit_max_size=64)
+```
+
+Diagnostic counters `_batch_count` and `_batched_writes` are exposed on the
+store for tests and observability. A ratio
+`_batched_writes / _batch_count` near 1.0 means you're paying the latency
+cost without getting batching benefit (lower the window, or disable). A
+high ratio (e.g. 16 in the bundled tests) means fsync is being amortized
+across that many writers per round.

--- a/libs/naas-abi-core/naas_abi_core/utils/versionstore/WHITEPAPER.md
+++ b/libs/naas-abi-core/naas_abi_core/utils/versionstore/WHITEPAPER.md
@@ -1,0 +1,563 @@
+# versionstore — An Append-Only, Content-Addressed Versioned Blob Store
+
+> *Filesystem is truth. Everything else is a rebuildable view.*
+
+## 1. Motivation
+
+Many systems need to answer one deceptively simple question:
+
+> *What was the state of entity `X` at time `T`?*
+
+This comes up in ontologies (axiom revisions), configuration management (what was
+config `foo` yesterday?), audit logs (what did record `R` look like before the
+change?), event-sourced applications, versioned documents, and compliance
+workflows. Existing tools either solve a narrower problem (Git, focused on
+source code), a wider one (Datomic, XTDB — full databases), or one tilted toward
+a specific data model (RDF triple stores with history plugins).
+
+`versionstore` is the smallest honest primitive that answers the question
+above, for arbitrary byte payloads, with cryptographic integrity and full
+rebuildability.
+
+## 2. Design Principles
+
+The design follows five principles, in priority order. When they conflict, the
+earlier one wins.
+
+### 2.1 Filesystem is truth
+
+The canonical state of the store lives in plain files on disk. Every other
+component — the SQLite index, any downstream projection (RDF, JSON, full-text
+search) — is derived data that can be nuked and rebuilt from the filesystem.
+
+This has three practical consequences:
+
+- **Portability.** The data directory is self-describing. `rsync`, `tar`,
+  `git`, or `cp -r` is enough to replicate or back up the whole store.
+- **Durability.** If the index corrupts or the query engine dies, no data is
+  lost. `rebuild_index()` is a pure function of the filesystem.
+- **Inspectability.** `ls data/{uid}/` is an audit trail. `sha256sum
+  data/{uid}/*.ttl` verifies integrity without running any software.
+
+### 2.2 Append-only, immutable
+
+A revision, once written, is never modified or deleted. Updates are new
+revisions. This is what makes the store a trustworthy log and what makes
+reasoning about concurrency and recovery tractable.
+
+The store does not model deletion. An "empty" revision (zero-byte payload) is
+a legitimate state, not a tombstone. Semantic deletion — if needed at all — is
+a consumer's concern, expressed through whatever rule it imposes on empty
+revisions (e.g. "hide from default view").
+
+An escape hatch `Registry.drop(namespace)` exists for legal erasure (GDPR),
+but it is explicitly not part of normal operation.
+
+### 2.3 Content-addressed, Merkle-chained
+
+Each revision's filename encodes three facts:
+
+```
+{ts_ns:020d}.{prev_hash}.{content_hash}
+```
+
+- **`ts_ns`** — nanosecond timestamp, zero-padded so lexical sort equals
+  chronological sort.
+- **`prev_hash`** — SHA-256 of the previous revision's payload (or the
+  `GENESIS` sentinel `"0" * 64` for the first revision).
+- **`content_hash`** — SHA-256 of this revision's payload.
+
+The filename *is* the Merkle metadata. Tampering with any revision's bytes
+causes its content hash to mismatch its filename. Deleting a middle revision
+breaks the `prev_hash` chain of the next one. Both are detectable without any
+external index, purely from the filesystem.
+
+### 2.4 Payload-agnostic
+
+The store treats payloads as opaque `bytes`. It does not parse, validate, or
+index their contents. Interpretation is the consumer's job.
+
+This is what keeps the core small (~150 LOC) and broadly useful. The same
+store can back an RDF triple store, a document database, a configuration
+service, or a binary blob archive — with no changes to the storage layer.
+
+### 2.5 UIDs are opaque
+
+Keys are opaque strings. UUIDs are strongly recommended (and `uuid7()` is
+provided) because:
+
+- They are filesystem-safe everywhere.
+- They are collision-free across distributed writers with no coordination.
+- They carry no business meaning that could become stale.
+- They produce uniformly distributed directory prefixes for sharding.
+
+Consumers that need to look up by a meaningful key (IRI, email, title)
+maintain their own `key → uid` mapping. The store does not participate in
+that mapping and does not need to.
+
+## 3. Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Consumers (RDF view, JSON view, FTS view, …)               │
+│    Each keeps its own business-key → uid mapping.           │
+│    Each is a rebuildable projection over the store.         │
+├─────────────────────────────────────────────────────────────┤
+│  versionstore.Store                                         │
+│    put(uid, bytes) → Revision | None   (None = idempotent)  │
+│    get(uid, at=T)  → bytes  | None                          │
+│    latest / history / uids / uids_at / verify               │
+│    rebuild_index                                            │
+├─────────────────────────────────────────────────────────────┤
+│  SQLite index (rebuildable)        Filesystem (truth)       │
+│    revisions(uid, ts_ns,             data/{uid}/            │
+│              prev_hash,                 {ts}.{prev}.{hash}  │
+│              content_hash)                                  │
+│    WAL mode, BEGIN IMMEDIATE       Atomic .tmp + rename     │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 3.1 On-disk layout
+
+```
+{root}/
+    index.db                                 ← SQLite (rebuildable)
+    data/
+        {uid_1}/
+            00000001745491200000000000.{GENESIS}.{hash_a}
+            00000001745491500123000000.{hash_a}.{hash_b}
+            00000001745491800987000000.{hash_b}.{hash_c}
+        {uid_2}/
+            00000001745491300555000000.{GENESIS}.{hash_d}
+```
+
+Each `{uid}/` directory is an independent append-only log. Directory
+presence answers "has this uid ever been written?"; the latest file answers
+"what is its current state?".
+
+### 3.1.1 Durability model
+
+The store offers two durability modes, selected at construction time:
+
+- **`durability="full"` (default).** When `put` returns success, the
+  revision is on non-volatile storage. On Linux/Windows/BSD this is what
+  `os.fsync` already guarantees. On Apple platforms, regular `fsync(fd)`
+  flushes only to the drive controller's cache — a power loss between
+  `fsync` returning and the physical write loses the data. Full mode
+  closes that gap by using `fcntl(fd, F_FULLFSYNC)` for file syncs and
+  `PRAGMA fullfsync=ON` + `PRAGMA synchronous=FULL` for SQLite. The cost
+  is real (10–100× per fsync on macOS) but is the price of the durability
+  claim being true.
+- **`durability="fast"`.** Uses the platform default `fsync`. Identical
+  to `"full"` on non-Apple platforms; on Apple it surfaces the cache-only
+  behavior described above. Use only when you accept that recently
+  acknowledged writes can be lost on a power-loss event — typically in
+  development, tests, or for ephemeral data.
+
+The integrity model in §4 is unaffected by the choice: in both modes the
+filenames, content hashes, and Merkle chain are identical. What differs
+is what "I just acked this write" means in the face of a crash.
+
+### 3.2 Write protocol
+
+```
+BEGIN IMMEDIATE                              (SQLite write lock)
+    latest       ← SELECT latest revision for uid
+    if latest.hash == sha256(payload):       (idempotent no-op)
+        ROLLBACK; return None
+    prev_hash    ← latest.hash or GENESIS
+    ts_ns        ← max(time.time_ns(), latest.ts_ns + 1)
+    filename     ← f"{ts_ns:020d}.{prev_hash}.{content_hash}"
+
+    write payload to {filename}.tmp
+    fsync(file)                              (or F_FULLFSYNC under "full" on Apple)
+    rename {filename}.tmp → {filename}       (atomic on POSIX)
+    fsync(dir)                               (best-effort, same mode as above)
+
+    INSERT into revisions(...)
+COMMIT
+```
+
+Failure modes:
+
+- **Crash before rename:** orphan `.tmp` remains; no final file; no index row.
+  `rebuild_index()` deletes the orphan.
+- **Crash after rename, before COMMIT:** final file exists, no index row.
+  `rebuild_index()` reconstructs the row from the filename.
+- **Crash after COMMIT:** consistent state. Nothing to recover.
+
+At no point can a file at its final name contain partial bytes, because the
+rename is atomic and the bytes are fsynced before the rename.
+
+### 3.3 Read protocol
+
+The common query — "what is uid `U` at time `T`?" — is trivially fast:
+
+```
+SELECT ts_ns, prev_hash, content_hash
+FROM revisions
+WHERE uid = ? AND ts_ns <= ?
+ORDER BY ts_ns DESC LIMIT 1
+```
+
+One indexed lookup, one file read. Sub-millisecond on warm cache.
+
+This is the 99% query. It does not touch any RDF engine, query planner, or
+projection layer. The store itself answers it.
+
+### 3.4 Rebuild protocol
+
+```
+BEGIN IMMEDIATE
+    DELETE FROM revisions
+    for each uid_dir in data/:
+        for each file in uid_dir:
+            if file ends with .tmp: delete (orphan)
+            else: parse filename → INSERT revision
+COMMIT
+```
+
+The index is defined entirely by what is on disk. If a file was deleted, its
+row disappears. If a row was orphaned (e.g. by external index corruption), it
+is recreated from the filename.
+
+## 4. Integrity Model
+
+The filesystem alone is sufficient to:
+
+1. **Detect content tampering.** Rehash `data/{uid}/{filename}`; compare to the
+   `content_hash` segment of the filename.
+2. **Detect revision deletion.** Walk a uid's files sorted by timestamp;
+   verify each file's `prev_hash` equals the previous file's `content_hash`.
+3. **Detect revision insertion/reordering.** Same Merkle chain check.
+4. **Detect rename-style attacks.** A file's `content_hash` segment must
+   match `sha256(file_bytes)`. Renaming a file into a different position or
+   uid changes nothing about the Merkle chain because the hash is intrinsic.
+
+`Store.verify(uid)` performs the full chain walk in one pass. It does not
+consult the SQLite index; it reads from disk only.
+
+The threat model this covers is **local integrity**. It does not cover
+adversaries who can rewrite the entire `data/` directory, including the
+GENESIS-rooted chain, in a coordinated way. For that, pair the store with
+an external notarization mechanism (signed periodic tip hashes, transparency
+log, blockchain timestamp, etc.). The store's design accommodates this
+trivially — the tip hash is just the latest file's `content_hash`.
+
+## 5. Concurrency
+
+### 5.1 Single host, multiple writers
+
+SQLite WAL mode permits many concurrent readers and one writer at a time.
+Writes acquire `BEGIN IMMEDIATE` around the read-latest-then-insert sequence,
+so two processes writing to the same uid cannot both read the same `latest`
+and both try to insert with the same `prev_hash`. The second writer waits
+(respecting `busy_timeout`) and sees the first writer's revision as its
+predecessor.
+
+This serializes all writes across the whole store. For workloads where that
+contention becomes visible, the SQLite schema could be extended with a
+`UNIQUE(uid, prev_hash)` constraint and per-uid retry logic, trading
+simplicity for per-uid concurrency. The default is "one writer at a time"
+because that is correct and sufficient for most real workloads.
+
+### 5.2 Multiple hosts
+
+Not supported. The SQLite index is local; the filesystem lock semantics
+across network filesystems are unreliable. A multi-host deployment needs a
+different coordination layer (shared SQL database, Raft, etc.), at which
+point the design trade-offs change significantly. The store deliberately
+does not try to be that system.
+
+## 6. Consumers and Projections
+
+The store's contract ends at `bytes in, bytes out, versioned by time`.
+Consumers layer meaning on top. The canonical consumer in this project is an
+RDF view over the store; other consumers are possible.
+
+### 6.1 The materialized-view pattern
+
+For consumers that want to answer rich queries (e.g., SPARQL across many
+subjects), the recommended pattern is **on-demand materialization**:
+
+```
+def sparql(self, query: str, at: datetime | None = None):
+    with fresh_oxigraph() as g:
+        for uid, rev in self.store.uids_at(at):
+            g.load(rev.read())
+        return g.query(query)
+```
+
+The query engine is an ephemeral tool, not a persistent component. It is
+instantiated to answer a question and discarded (or cached by
+`(query, at)` if hot). This scales effortlessly: the store holds millions of
+revisions on disk without paying any cost for a "live" index, and
+materialization loads only what a specific query needs.
+
+For the 99% query — "state of uid `U` at time `T`" — no materialization is
+needed. The store's `get(uid, at=T)` is a direct key-value lookup.
+
+### 6.2 Consumers keep their own indexes
+
+Consumers that need to look up by a business key maintain their own mapping,
+rebuildable from the store. For an RDF view, that's an `iri → uid` table; for
+a document view, a `slug → uid` table; for an email archive, a
+`message-id → uid` table. These indexes are not part of the store — they are
+consumer state.
+
+When a consumer rebuilds, it walks the store's revisions (`uids_at()` or
+`history(uid)` per uid), parses payloads according to its own format, and
+repopulates its mapping. The store does not know or care that this happens.
+
+## 7. Namespacing
+
+Namespaces are not a first-class store concept. They are simply
+multiple `Store` instances rooted at different paths:
+
+```python
+users   = Store("data/users")
+configs = Store("data/configs")
+```
+
+Each is isolated: separate SQLite, separate files, separate concurrency
+domain. The optional `StoreRegistry` is a thin wrapper for managing many of
+them under one parent directory.
+
+Two namespaces may share the same uid string; they are unrelated entities.
+If a consumer wants globally unique uids across namespaces, it uses UUIDs and
+tracks `(namespace, uid)` tuples itself.
+
+## 8. What the store does not do
+
+Deliberate exclusions, each justified by the principle of keeping the core
+small and generic:
+
+- **Access control.** A consumer concern.
+- **Schema validation.** Payloads are bytes; the store cannot and should not
+  parse them.
+- **Replication or multi-host writes.** A different kind of system.
+- **Content queries.** Queries are by `uid` and time only; anything else is
+  a consumer-built index.
+- **Garbage collection or compaction.** Append-only forever. If retention is
+  needed, a policy layer wraps the store.
+- **Tombstones or delete semantics.** The store logs bytes; "deletion" is a
+  view concern that consumers express however they like.
+- **Encryption at rest.** Delegated to the filesystem or a dm-crypt/LUKS/APFS
+  layer beneath. Encrypting at the store layer would defeat
+  content-addressability.
+
+Each of these is a legitimate feature of *some* systems. None of them belong
+in the store, because including them would couple it to specific use cases
+and break the "one small primitive, many consumers" factoring.
+
+## 9. Scaling Characteristics
+
+| Dimension           | Cost                                  | Notes                                   |
+|---------------------|---------------------------------------|-----------------------------------------|
+| `put(uid, bytes)`   | O(1) disk + one SQLite insert         | Bounded by fsync latency.               |
+| `get(uid, at=T)`    | O(log n) SQLite lookup + one read     | n = revisions for that uid.             |
+| `history(uid)`      | O(n) SQLite scan                      | n = revisions for that uid.             |
+| `uids_at(T)`        | O(U) SQLite scan                      | U = total uids in the store.            |
+| `verify(uid)`       | O(n) disk reads + hashes              | n = revisions for that uid.             |
+| `rebuild_index()`   | O(N) disk walk                        | N = total revisions across all uids.    |
+
+Practical ceilings on reasonable hardware:
+
+- **Revisions per uid:** unlimited in principle; directory listings and
+  SQLite lookups remain fast into the millions.
+- **Total uids:** SQLite comfortably handles 10M+ rows on the `revisions`
+  table. The main constraint is filesystem behavior on directories with many
+  entries. For `> 100k` uids, shard the data directory with a prefix scheme
+  (`data/{uid[:2]}/{uid}/...`).
+- **Payload size:** bounded by filesystem and available disk. The store
+  makes no assumption about payload size. Very large payloads should be
+  content-addressed separately (e.g., payloads holding hash references to
+  a separate blob store) — otherwise every revision copies the full bytes.
+
+## 10. Relationship to Existing Systems
+
+The design is not novel in any individual piece; most components have prior
+art. Its value is the specific combination.
+
+- **Perkeep** (née Camlistore) — the closest overall match, with
+  "permanodes" playing the role of uids and "claims" playing the role of
+  revisions. Perkeep is heavier (signing, networking, search, schema blobs);
+  `versionstore` is the 150-line essence.
+- **XTDB / Datomic** — share the bitemporal/time-travel query model, but
+  are full databases with schema and rich query. `versionstore` has no
+  schema and no query beyond `(uid, time)`.
+- **Dolt / Noms** — content-addressed, versioned, Git-inspired data stores.
+  Tuned for tabular/schema data; `versionstore` is tuned for opaque blobs.
+- **Git + git-annex** — same primitive (content-addressed, Merkle-chained,
+  immutable), but Git's access patterns optimize for source-code-shaped
+  data (small related files, diff-heavy reads), not "random uid lookup at
+  time T".
+- **Quit Store / R43ples** — RDF-specific versioning. `versionstore` is
+  one layer below: it can back a quit-store-like consumer, among others.
+- **Event-sourcing systems (EventStore, Kafka + ksqlDB)** — the log + view
+  pattern is the same. `versionstore`'s log is whole-entity snapshots, not
+  event deltas, which is simpler but less bandwidth-efficient for
+  high-frequency writers.
+
+Where `versionstore` is distinctive:
+
+1. **Filesystem, not a pack format, as truth.** Every revision is a
+   separately-inspectable file.
+2. **Filename-encoded Merkle metadata.** No sidecar files, no chain file,
+   no database required to verify integrity.
+3. **SQLite as a pure index.** Rebuildable in seconds from the filesystem;
+   not a system of record.
+4. **Payload- and consumer-agnostic core.** RDF, JSON, binary — all the
+   same from the store's perspective.
+5. **~150 LOC of runtime code, stdlib only.** No dependencies to audit, vendor,
+   or version.
+
+## 11. Future scaling: group commit
+
+The single dominant cost in the write path (§3.2) is `fsync`. On local SSD,
+`fsync(file)` and `fsync(dir)` are each ~1–10 ms — orders of magnitude more
+than every other step combined (hashing, SQLite insert, rename). Sequential
+writes are bound by this: 1000 puts ≈ 10 seconds of fsync wait, regardless of
+how fast the rest of the code runs.
+
+The classical answer is **group commit**: a single fsync durably persists
+*every* write that landed in the same file or directory since the previous
+fsync. So if N writers each have a `.tmp` ready, one fsync can persist all N
+of them. The per-write fsync cost falls from O(1) to O(1/N).
+
+### 11.1 Mechanism
+
+Writers opt into a small "commit group" with a bounded delay window (e.g.
+2–10 ms) and a bounded size (e.g. 64 writes). When either bound is reached,
+one designated leader thread runs:
+
+1. A single `fsync` over all `.tmp` files in the group.
+2. The atomic `rename` of each `.tmp` to its final filename, in chain order
+   per `(uid, branch)` so prev_hash chains stay valid on crash.
+3. A single `fsync` of each touched `uid_dir`.
+4. The corresponding INSERTs into the index, batched in one transaction.
+5. A wake of every writer in the group, each receiving its own `Revision`.
+
+Writers that arrive while a group is committing join the next group. The
+window is the only added latency; the throughput floor rises linearly with
+group size.
+
+This is the same pattern SQLite uses internally for its own commits and that
+PostgreSQL exposes as `commit_delay` / `commit_siblings`. It is a pure
+amortization of fsync; no other guarantees are weakened.
+
+### 11.2 Compatibility with the design principles
+
+Each principle from §2 is examined in turn.
+
+- **§2.1 Filesystem is truth.** Unchanged. Group commit only changes *when*
+  fsync happens; the bytes that land on disk and the filenames they land
+  under are identical to the non-grouped path. `rebuild_index` is unaffected.
+- **§2.2 Append-only, immutable.** Unchanged. Group commit never mutates an
+  existing revision; it batches the *durability* of new ones.
+- **§2.3 Content-addressed, Merkle-chained.** Unchanged. `prev_hash` and
+  `content_hash` are computed exactly as today. The chain semantics are
+  invariant.
+- **§2.4 Payload-agnostic.** Unchanged. The store still treats payloads as
+  opaque bytes.
+- **§2.5 UIDs opaque.** Unchanged.
+
+The single shift is in the failure model (§3.2), spelled out below.
+
+### 11.3 Updated failure modes
+
+Without group commit, every successful `put` was individually durable before
+returning. With group commit, **a `put` returns only after its group's fsync
+has completed**, so durability is preserved at the moment of return. The
+only change is what a crash mid-batch leaves behind:
+
+- **Crash before the group's fsync:** every member's `.tmp` may exist; no
+  finals; no INSERTs. `rebuild_index` deletes the orphan `.tmp` files. Same
+  outcome as today's "crash before rename." No writer received a success
+  acknowledgement, so no claim of durability was violated.
+- **Crash after fsync, partway through the rename loop:** a *prefix* of the
+  group's writes are renamed to their final names; the rest are still
+  `.tmp`. The renamed files are valid revisions on disk — they simply lack
+  their index rows. `rebuild_index` reconstructs those rows from the
+  filenames; the un-renamed `.tmp`s are cleaned up. Writers whose files made
+  it past the rename observe the same outcome as today's "crash after
+  rename, before COMMIT."
+- **Crash during the batched INSERT, after all renames succeeded:** the
+  finals exist; no INSERTs. `rebuild_index` reconstructs the index from the
+  filesystem. Identical to today.
+
+In all cases, the per-file invariants from §3.2 hold: a file at its final
+name contains complete, fsynced bytes whose `content_hash` matches its
+filename. The Merkle chain (§4) remains verifiable end-to-end.
+
+The one new operational rule is that **the leader thread acknowledges
+writers only after the group's fsync has completed**. That preserves the
+contract that `put` returning success implies durable.
+
+### 11.4 Cost and tuning
+
+The latency–throughput trade-off is a single knob. Some realistic shapes:
+
+| Window | Group size (typical) | Per-write fsync cost | Added latency |
+|--------|----------------------|----------------------|---------------|
+| 0 ms (off, today) | 1 | ~5 ms | 0 ms |
+| 2 ms              | 5–20 | ~0.3–1 ms | up to 2 ms |
+| 10 ms             | 30–100 | ~0.05–0.3 ms | up to 10 ms |
+
+For workloads with **many concurrent writers** — exactly the situation
+created by per-(branch, uid) concurrency — group commit converts the
+per-write fsync cost from a hard ceiling into a knob. For single-writer
+workloads it's a pure latency penalty; the knob should default to off.
+
+A reasonable default when enabled: a 2 ms window with a 64-write cap. In
+the consumer's view, latency stays sub-frame-rate; throughput on contended
+workloads rises by 1–2 orders of magnitude.
+
+### 11.5 Implementation status
+
+Group commit is **implemented in the ABI-vendored copy** of versionstore
+(see ``libs/naas-abi-core/naas_abi_core/utils/versionstore/``). It is
+**opt-in via a constructor argument** (``commit_window_ms``); the default
+remains ``0.0`` so deployments that don't enable it pay nothing and behave
+byte-for-byte like the pre-group-commit code path. The implementation
+follows the leader-follower mechanism described above:
+
+- A first-arriving writer with no open group becomes the leader. Followers
+  arriving within the window join the open group.
+- The leader sleeps on a condition variable until either the window
+  expires or the group reaches ``commit_max_size``. Followers signal the
+  condvar on join so the leader wakes early when the cap is hit.
+- ``_commit_batch`` fsyncs each tmp, renames in chronological order
+  (so partial-rename crashes leave a valid prefix), deduplicates
+  ``uid_dir`` fsyncs, and runs all index inserts in a single transaction
+  with per-row ``SAVEPOINT`` so a single ``UNIQUE`` conflict only fails
+  that member rather than the batch.
+- Two diagnostic counters (``_batch_count``, ``_batched_writes``) are
+  exposed on the ``Store`` for tests and observability.
+
+It composes cleanly with the per-uid and per-(branch, uid) concurrency
+paths: the retry loop, the ``UNIQUE`` constraint, and the in-process
+per-(branch, uid) lock all stay valid. Group commit slots into the
+file-write path; nothing else changes.
+
+The upstream library should track this change once the model has been
+exercised in production — the vendored implementation is the reference.
+
+## 12. Summary
+
+`versionstore` answers the question "what was entity `X` at time `T`?"
+with:
+
+- a plain-file canonical log,
+- Merkle-verifiable content-addressed filenames,
+- a rebuildable SQLite index for fast lookups,
+- an ACID write path,
+- a generic byte-payload contract,
+- and nothing else.
+
+Its scope is deliberately small. Query, schema, access control,
+replication, and semantic interpretation are left to consumers. The design
+trades generality in the storage layer for composability across many
+consumer domains, and it trades feature richness for the property that a
+determined engineer can understand the entire system — and rebuild it from
+the filesystem — in an afternoon.

--- a/libs/naas-abi-core/naas_abi_core/utils/versionstore/__init__.py
+++ b/libs/naas-abi-core/naas_abi_core/utils/versionstore/__init__.py
@@ -1,0 +1,56 @@
+"""versionstore: a generic, append-only, content-addressed versioned blob store.
+
+The store's contract:
+  - Filesystem is the source of truth.
+  - SQLite is a rebuildable index over the filesystem.
+  - Each revision is stored as a single file named:
+        {ts_ns:020d}.{prev_hash}.{content_hash}                  (main branch)
+        {ts_ns:020d}.{prev_hash}.{content_hash}.{branch}         (other branches)
+    with atomic write via `.tmp` + rename.
+  - Payloads are opaque bytes; consumers interpret them.
+  - UIDs are opaque strings (UUIDs recommended); consumers map business keys
+    to UIDs externally.
+  - Namespacing = instantiating multiple `Store(path)` on different roots.
+    A `StoreRegistry` is provided for convenience.
+
+This vendored copy adds the Tier-1 A & B scaling improvements from the ABI
+branching spec: per-uid and per-(branch, uid) concurrency via a lock-free
+write path gated by a UNIQUE(branch, uid, prev_hash) constraint, plus the
+minimal branching scaffold (`branches` table, `branch=` argument on
+read/write methods, `create_branch`, `list_branches`).
+
+Public API:
+    Store              - the versioned, branched blob store
+    Revision           - immutable record describing one revision
+    StoreRegistry      - thin wrapper for managing multiple named Store instances
+    uuid7              - time-ordered UUID v7 generator (stdlib only)
+    ConcurrencyConflict - raised on optimistic-write failure
+    BranchNotFoundError - raised when targeting an unknown branch
+    GENESIS            - sentinel prev_hash for the first revision on a branch
+    DEFAULT_BRANCH     - "main"
+"""
+
+from .revision import DEFAULT_BRANCH, Revision
+from .registry import StoreRegistry
+from .store import (
+    BranchNotFoundError,
+    ConcurrencyConflict,
+    DURABILITY_FAST,
+    DURABILITY_FULL,
+    GENESIS,
+    Store,
+)
+from .uuid7 import uuid7
+
+__all__ = [
+    "BranchNotFoundError",
+    "ConcurrencyConflict",
+    "DEFAULT_BRANCH",
+    "DURABILITY_FAST",
+    "DURABILITY_FULL",
+    "GENESIS",
+    "Revision",
+    "Store",
+    "StoreRegistry",
+    "uuid7",
+]

--- a/libs/naas-abi-core/naas_abi_core/utils/versionstore/benchmark.py
+++ b/libs/naas-abi-core/naas_abi_core/utils/versionstore/benchmark.py
@@ -1,0 +1,362 @@
+"""Versionstore benchmark.
+
+Measures writes/sec across a small matrix of configurations:
+
+  - Concurrency: 1, 4, 16, 64 writers
+  - Workload shape:
+      * disjoint   - each writer owns its own uid
+      * same-uid   - all writers contend for one uid (serialized by the
+                     in-process per-(branch, uid) lock)
+      * branched   - half write main, half write feature-x (same uid)
+  - Commit mode: solo (commit_window_ms=0) and group commit at various windows
+
+The numbers are not "TPC-C". They are:
+
+  - bound by ``fsync`` on whatever filesystem `tmp` lives on,
+  - dependent on Python GIL, scheduler, and SQLite's WAL fsync cadence,
+  - run in-process and so understate cross-process contention,
+  - run on a temp dir that may be on a different FS class than production.
+
+Their value is comparative: solo vs group commit, low vs high concurrency,
+disjoint vs contended workloads. Treat them as direction, not as SLOs.
+
+Run::
+
+    uv run python -m naas_abi_core.utils.versionstore.benchmark
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import tempfile
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from pathlib import Path
+
+from .store import Store
+
+
+# --------------------------------------------------------------------- types
+
+
+@dataclass
+class Result:
+    label: str
+    workers: int
+    workload: str
+    commit_window_ms: float
+    durability: str
+    payload_bytes: int
+    n_writes: int
+    elapsed_s: float
+    batch_count: int
+    batched_writes: int
+
+    @property
+    def writes_per_sec(self) -> float:
+        return self.n_writes / self.elapsed_s if self.elapsed_s > 0 else 0.0
+
+    @property
+    def latency_ms(self) -> float:
+        # Wall-clock-per-write with ``workers`` concurrency. With perfect
+        # scaling this is ``elapsed_s * workers / n_writes * 1000``; with
+        # zero scaling it's ``elapsed_s / n_writes * 1000``. We report the
+        # former (per-writer-thread latency) which is more meaningful.
+        if self.n_writes == 0:
+            return 0.0
+        return self.elapsed_s * self.workers / self.n_writes * 1000.0
+
+    @property
+    def amortization(self) -> float:
+        if self.batch_count == 0:
+            return 0.0
+        return self.batched_writes / self.batch_count
+
+
+# ------------------------------------------------------------------ workloads
+
+
+def workload_disjoint(
+    store: Store, workers: int, writes_per_worker: int, payload_bytes: int
+) -> int:
+    """Each worker writes a sequence of payloads under its own uid."""
+    payload = b"x" * payload_bytes
+
+    def run(i: int) -> int:
+        n = 0
+        for j in range(writes_per_worker):
+            # Append a unique discriminator so successive payloads differ.
+            r = store.put(f"uid-{i}", payload + j.to_bytes(8, "little"))
+            if r is not None:
+                n += 1
+        return n
+
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = [pool.submit(run, i) for i in range(workers)]
+        return sum(f.result() for f in as_completed(futures))
+
+
+def workload_same_uid(
+    store: Store, workers: int, writes_per_worker: int, payload_bytes: int
+) -> int:
+    """All workers contend for one uid. The per-(branch, uid) in-process
+    lock serializes them; group commit can't help here because writes are
+    sequential by construction."""
+    payload = b"x" * payload_bytes
+
+    def run(i: int) -> int:
+        n = 0
+        for j in range(writes_per_worker):
+            # Each call must produce a fresh content_hash; encode (worker, j).
+            tag = (i.to_bytes(4, "little") + j.to_bytes(8, "little"))
+            r = store.put("contended", payload + tag)
+            if r is not None:
+                n += 1
+        return n
+
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = [pool.submit(run, i) for i in range(workers)]
+        return sum(f.result() for f in as_completed(futures))
+
+
+def workload_branched(
+    store: Store, workers: int, writes_per_worker: int, payload_bytes: int
+) -> int:
+    """Half the workers write to main, half write to feature-x, all on the
+    same uid. The per-(branch, uid) lock keeps within-branch writes
+    serialized but allows the two branches to run in parallel."""
+    payload = b"x" * payload_bytes
+    if "feature-x" not in store.list_branches():
+        store.create_branch("feature-x")
+
+    def run(i: int) -> int:
+        branch = "main" if i % 2 == 0 else "feature-x"
+        n = 0
+        for j in range(writes_per_worker):
+            tag = i.to_bytes(4, "little") + j.to_bytes(8, "little")
+            r = store.put("contended", payload + tag, branch=branch)
+            if r is not None:
+                n += 1
+        return n
+
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = [pool.submit(run, i) for i in range(workers)]
+        return sum(f.result() for f in as_completed(futures))
+
+
+WORKLOADS = {
+    "disjoint": workload_disjoint,
+    "same-uid": workload_same_uid,
+    "branched": workload_branched,
+}
+
+
+# --------------------------------------------------------------------- runner
+
+
+def run_one(
+    *,
+    label: str,
+    root: Path,
+    workload: str,
+    workers: int,
+    writes_per_worker: int,
+    payload_bytes: int,
+    commit_window_ms: float,
+    commit_max_size: int,
+    durability: str,
+) -> Result:
+    fn = WORKLOADS[workload]
+    with Store(
+        root,
+        durability=durability,
+        commit_window_ms=commit_window_ms,
+        commit_max_size=commit_max_size,
+    ) as store:
+        # Touch the FS first so dir creation isn't on the hot path.
+        store.put("warmup", b"")
+        t0 = time.perf_counter()
+        n = fn(store, workers, writes_per_worker, payload_bytes)
+        t1 = time.perf_counter()
+        return Result(
+            label=label,
+            workers=workers,
+            workload=workload,
+            commit_window_ms=commit_window_ms,
+            durability=durability,
+            payload_bytes=payload_bytes,
+            n_writes=n,
+            elapsed_s=t1 - t0,
+            batch_count=store._batch_count,
+            batched_writes=store._batched_writes,
+        )
+
+
+def fmt_table(results: list[Result]) -> str:
+    headers = [
+        "workload",
+        "workers",
+        "durability",
+        "commit",
+        "writes",
+        "elapsed",
+        "writes/s",
+        "lat/ms",
+        "batches",
+        "batched",
+        "amort",
+    ]
+    rows = []
+    for r in results:
+        if r.commit_window_ms == 0.0:
+            commit = "solo"
+        else:
+            commit = f"{r.commit_window_ms:g}ms"
+        rows.append(
+            [
+                r.workload,
+                str(r.workers),
+                r.durability,
+                commit,
+                str(r.n_writes),
+                f"{r.elapsed_s:.2f}s",
+                f"{r.writes_per_sec:>8,.0f}",
+                f"{r.latency_ms:>6.2f}",
+                str(r.batch_count) if r.batch_count else "-",
+                str(r.batched_writes) if r.batched_writes else "-",
+                f"{r.amortization:.1f}x" if r.batch_count else "-",
+            ]
+        )
+    widths = [
+        max(len(h), max((len(row[i]) for row in rows), default=0))
+        for i, h in enumerate(headers)
+    ]
+
+    def fmt_row(row):
+        return "  ".join(c.ljust(w) for c, w in zip(row, widths))
+
+    sep = "  ".join("-" * w for w in widths)
+    return "\n".join([fmt_row(headers), sep, *(fmt_row(row) for row in rows)])
+
+
+# ----------------------------------------------------------------------- main
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument("--writes-per-worker", type=int, default=200)
+    p.add_argument("--payload-bytes", type=int, default=256)
+    p.add_argument("--max-size", type=int, default=64)
+    p.add_argument(
+        "--workers",
+        type=int,
+        nargs="+",
+        default=[1, 4, 16, 64],
+        help="concurrency levels to sweep",
+    )
+    p.add_argument(
+        "--windows",
+        type=float,
+        nargs="+",
+        default=[0.0, 1.0, 2.0, 5.0, 10.0],
+        help="commit_window_ms values to sweep (0 = solo)",
+    )
+    p.add_argument(
+        "--workloads",
+        nargs="+",
+        default=list(WORKLOADS.keys()),
+        choices=list(WORKLOADS.keys()),
+    )
+    p.add_argument(
+        "--durabilities",
+        nargs="+",
+        default=["full", "fast"],
+        choices=["full", "fast"],
+        help="durability modes to sweep",
+    )
+    args = p.parse_args(argv)
+
+    print(
+        f"\nversionstore benchmark — "
+        f"writes/worker={args.writes_per_worker}, "
+        f"payload={args.payload_bytes}B, "
+        f"max_size={args.max_size}\n"
+    )
+    print(f"  python      : {sys.version.split()[0]}")
+    print(f"  platform    : {sys.platform}")
+    print(f"  cpu_count   : {os.cpu_count()}")
+    print()
+
+    results: list[Result] = []
+    for durability in args.durabilities:
+        for workload in args.workloads:
+            for workers in args.workers:
+                for window_ms in args.windows:
+                    # same-uid is serialized; group commit can't help. Keep
+                    # the table compact by only running solo and one window.
+                    if workload == "same-uid" and window_ms not in (0.0, 5.0):
+                        continue
+                    with tempfile.TemporaryDirectory(prefix="vs-bench-") as tmp:
+                        r = run_one(
+                            label=f"{durability}/{workload}/{workers}/{window_ms}ms",
+                            root=Path(tmp),
+                            workload=workload,
+                            workers=workers,
+                            writes_per_worker=args.writes_per_worker,
+                            payload_bytes=args.payload_bytes,
+                            commit_window_ms=window_ms,
+                            commit_max_size=args.max_size,
+                            durability=durability,
+                        )
+                        results.append(r)
+                        print(
+                            f"  done: {r.label:<40}  "
+                            f"{r.writes_per_sec:>8,.0f} writes/s  "
+                            f"({r.elapsed_s:>5.2f}s)"
+                        )
+
+    print("\n" + fmt_table(results) + "\n")
+
+    # Highlight the headline numbers.
+    by_key = {
+        (r.durability, r.workload, r.workers, r.commit_window_ms): r
+        for r in results
+    }
+
+    def find(durability: str, workload: str, workers: int, window: float):
+        return by_key.get((durability, workload, workers, window))
+
+    print("Headline comparisons (writes/s):\n")
+    for durability in args.durabilities:
+        print(f"  durability={durability!r}:")
+        for workload in ["disjoint", "branched"]:
+            for workers in args.workers:
+                solo = find(durability, workload, workers, 0.0)
+                best_group = max(
+                    (
+                        find(durability, workload, workers, w)
+                        for w in args.windows
+                        if w > 0
+                    ),
+                    key=lambda r: r.writes_per_sec if r else 0,
+                    default=None,
+                )
+                if solo is None or best_group is None:
+                    continue
+                ratio = best_group.writes_per_sec / max(solo.writes_per_sec, 1)
+                print(
+                    f"    {workload:<10} workers={workers:>3}  "
+                    f"solo={solo.writes_per_sec:>8,.0f}  "
+                    f"best-group={best_group.writes_per_sec:>8,.0f}  "
+                    f"({best_group.commit_window_ms:g}ms, {ratio:.2f}x)"
+                )
+        print()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/libs/naas-abi-core/naas_abi_core/utils/versionstore/registry.py
+++ b/libs/naas-abi-core/naas_abi_core/utils/versionstore/registry.py
@@ -1,0 +1,67 @@
+"""StoreRegistry: manage multiple namespaced Store instances under one root.
+
+Namespacing in versionstore is not a first-class Store concept; it's just
+multiple Store instances rooted at different paths. This registry is a thin
+convenience wrapper for that pattern.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Iterator
+
+from .store import Store
+
+
+class StoreRegistry:
+    """A directory of named Store instances.
+
+    Example::
+
+        registry = StoreRegistry("data/")
+        users = registry.get("users")
+        users.put(uid, payload)
+
+    Each namespace is an independent Store with its own SQLite index and
+    filesystem tree. They share nothing.
+    """
+
+    def __init__(self, root: str | Path):
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def get(self, name: str) -> Store:
+        """Return the Store for namespace `name`, creating it if missing."""
+        self._validate(name)
+        return Store(self.root / name)
+
+    def exists(self, name: str) -> bool:
+        self._validate(name)
+        return (self.root / name).is_dir()
+
+    def list(self) -> Iterator[str]:
+        """Yield the names of all existing namespaces."""
+        if not self.root.exists():
+            return
+        for p in self.root.iterdir():
+            if p.is_dir():
+                yield p.name
+
+    def drop(self, name: str) -> None:
+        """Irrevocably delete a namespace and all its revisions.
+
+        This is an escape hatch (e.g. for GDPR erasure). Normal operation is
+        append-only; `drop` breaks that property deliberately.
+        """
+        self._validate(name)
+        path = self.root / name
+        if path.exists():
+            shutil.rmtree(path)
+
+    @staticmethod
+    def _validate(name: str) -> None:
+        if not isinstance(name, str) or not name:
+            raise ValueError("namespace name must be a non-empty string")
+        if "/" in name or "\\" in name or "\0" in name or name in (".", ".."):
+            raise ValueError(f"Invalid namespace name: {name!r}")

--- a/libs/naas-abi-core/naas_abi_core/utils/versionstore/registry_test.py
+++ b/libs/naas-abi-core/naas_abi_core/utils/versionstore/registry_test.py
@@ -1,0 +1,53 @@
+"""Tests for StoreRegistry."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from .registry import StoreRegistry
+
+
+def test_get_creates_store(tmp_path: Path):
+    reg = StoreRegistry(tmp_path)
+    s = reg.get("users")
+    s.put("alice", b"hi")
+    s.close()
+    assert reg.exists("users")
+
+
+def test_namespaces_are_isolated(tmp_path: Path):
+    reg = StoreRegistry(tmp_path)
+    users = reg.get("users")
+    configs = reg.get("configs")
+    users.put("alice", b"U")
+    configs.put("alice", b"C")
+    assert users.get("alice") == b"U"
+    assert configs.get("alice") == b"C"
+    users.close()
+    configs.close()
+
+
+def test_list(tmp_path: Path):
+    reg = StoreRegistry(tmp_path)
+    reg.get("a").close()
+    reg.get("b").close()
+    assert set(reg.list()) == {"a", "b"}
+
+
+def test_drop(tmp_path: Path):
+    reg = StoreRegistry(tmp_path)
+    s = reg.get("tmp")
+    s.put("x", b"y")
+    s.close()
+    assert reg.exists("tmp")
+    reg.drop("tmp")
+    assert not reg.exists("tmp")
+
+
+def test_invalid_name(tmp_path: Path):
+    reg = StoreRegistry(tmp_path)
+    for bad in ["", "../x", "a/b", "."]:
+        with pytest.raises(ValueError):
+            reg.get(bad)

--- a/libs/naas-abi-core/naas_abi_core/utils/versionstore/revision.py
+++ b/libs/naas-abi-core/naas_abi_core/utils/versionstore/revision.py
@@ -1,0 +1,82 @@
+"""Revision: a single immutable version of a uid's payload."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+HASH_LEN = 64  # SHA-256 hex length
+TS_DIGITS = 20  # zero-padded nanosecond timestamp
+DEFAULT_BRANCH = "main"
+
+
+@dataclass(frozen=True)
+class Revision:
+    """A single revision of a uid on a branch.
+
+    The on-disk filename is one of:
+
+    - ``{ts_ns:020d}.{prev_hash}.{content_hash}``                 — main branch
+    - ``{ts_ns:020d}.{prev_hash}.{content_hash}.{branch}``        — other branches
+
+    Keeping the 3-part form for ``main`` preserves backward compatibility with
+    pre-branching stores: their existing files parse unchanged.
+
+    ``prev_hash`` is the content_hash of the previous revision for this uid on
+    this branch, or ``"0" * 64`` (GENESIS) for the first revision on the branch.
+    """
+
+    uid: str
+    ts_ns: int
+    prev_hash: str
+    content_hash: str
+    path: Path
+    branch: str = DEFAULT_BRANCH
+
+    @property
+    def timestamp(self) -> datetime:
+        """The revision timestamp as a timezone-aware UTC datetime."""
+        return datetime.fromtimestamp(self.ts_ns / 1_000_000_000, tz=timezone.utc)
+
+    @property
+    def filename(self) -> str:
+        base = f"{self.ts_ns:0{TS_DIGITS}d}.{self.prev_hash}.{self.content_hash}"
+        if self.branch == DEFAULT_BRANCH:
+            return base
+        return f"{base}.{self.branch}"
+
+    def read(self) -> bytes:
+        """Read the payload bytes from disk."""
+        return self.path.read_bytes()
+
+    @classmethod
+    def parse_filename(cls, uid: str, filename: str, dir_path: Path) -> "Revision":
+        """Parse a revision filename. Raises ValueError if malformed.
+
+        Accepts both the legacy 3-part form (defaults to ``main``) and the
+        4-part form ``ts.prev.content.branch``.
+        """
+        parts = filename.split(".")
+        if len(parts) == 3:
+            ts_str, prev_hash, content_hash = parts
+            branch = DEFAULT_BRANCH
+        elif len(parts) == 4:
+            ts_str, prev_hash, content_hash, branch = parts
+            if not branch:
+                raise ValueError(f"Empty branch in filename: {filename!r}")
+        else:
+            raise ValueError(f"Invalid revision filename: {filename!r}")
+        if len(prev_hash) != HASH_LEN or len(content_hash) != HASH_LEN:
+            raise ValueError(f"Invalid hash length in filename: {filename!r}")
+        if not ts_str.isdigit():
+            raise ValueError(f"Invalid timestamp in filename: {filename!r}")
+        return cls(
+            uid=uid,
+            ts_ns=int(ts_str),
+            prev_hash=prev_hash,
+            content_hash=content_hash,
+            path=dir_path / filename,
+            branch=branch,
+        )

--- a/libs/naas-abi-core/naas_abi_core/utils/versionstore/revision_test.py
+++ b/libs/naas-abi-core/naas_abi_core/utils/versionstore/revision_test.py
@@ -1,0 +1,47 @@
+"""Tests for Revision."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from .revision import HASH_LEN, Revision
+
+
+H1 = "a" * HASH_LEN
+H2 = "b" * HASH_LEN
+
+
+def test_filename_round_trip(tmp_path: Path):
+    rev = Revision(uid="u", ts_ns=123, prev_hash=H1, content_hash=H2, path=tmp_path)
+    parsed = Revision.parse_filename("u", rev.filename, tmp_path)
+    assert parsed.uid == "u"
+    assert parsed.ts_ns == 123
+    assert parsed.prev_hash == H1
+    assert parsed.content_hash == H2
+
+
+def test_filename_zero_pads_timestamp(tmp_path: Path):
+    rev = Revision(uid="u", ts_ns=1, prev_hash=H1, content_hash=H2, path=tmp_path)
+    assert rev.filename.startswith("0" * 19 + "1.")
+
+
+def test_parse_rejects_bad_parts(tmp_path: Path):
+    with pytest.raises(ValueError):
+        Revision.parse_filename("u", "nope", tmp_path)
+    with pytest.raises(ValueError):
+        Revision.parse_filename("u", f"123.{H1}.short", tmp_path)
+    with pytest.raises(ValueError):
+        Revision.parse_filename("u", f"notadigit.{H1}.{H2}", tmp_path)
+
+
+def test_timestamp_is_utc(tmp_path: Path):
+    rev = Revision(
+        uid="u",
+        ts_ns=1_700_000_000_000_000_000,
+        prev_hash=H1,
+        content_hash=H2,
+        path=tmp_path,
+    )
+    assert rev.timestamp.tzinfo is not None

--- a/libs/naas-abi-core/naas_abi_core/utils/versionstore/store.py
+++ b/libs/naas-abi-core/naas_abi_core/utils/versionstore/store.py
@@ -1,0 +1,1053 @@
+"""Store: append-only, content-addressed versioned blob store with branches.
+
+This is the ABI-vendored copy of versionstore. It adds, on top of upstream:
+
+* **Tier 1 A — per-uid concurrency.** The previous global ``BEGIN IMMEDIATE``
+  lock around the read-latest + file-write + insert sequence is gone. Reads
+  happen lock-free; the file write happens outside any DB transaction; the
+  index INSERT carries a ``UNIQUE(branch, uid, prev_hash)`` constraint that
+  acts as the conflict gate. Two writers touching different uids no longer
+  serialize through a single store-wide lock.
+
+* **Tier 1 B — per-(branch, uid) concurrency.** The unique constraint includes
+  ``branch``, so two writers on different branches touching the same uid don't
+  conflict either.
+
+* **Tier 1 C — group commit (opt-in).** Writers can join a small commit
+  group whose fsyncs are amortized across the whole batch. Enabled by passing
+  ``commit_window_ms > 0`` to the constructor; defaults to off. See
+  ``WHITEPAPER.md §11`` for the durability model.
+
+* **Minimal branching scaffold.** A ``branches`` table tracks branch metadata;
+  every revision records its ``branch``; ``put / latest / history / get / verify``
+  accept an optional ``branch=`` argument (default ``"main"``). ``"main"`` is
+  seeded automatically and behaves byte-for-byte like the upstream store.
+
+* **Optimistic concurrency.** ``put`` accepts an optional
+  ``expected_prev_hash``; if the actual tip has moved, ``ConcurrencyConflict``
+  is raised instead of silently retrying.
+
+What is **not** here yet (deferred to follow-up):
+
+* ``delete_branch / merge / diff`` operations, branch metadata on the
+  filesystem (``data/__branches__/``), multi-parent merge revisions and their
+  sidecars, fall-through reads to a parent branch.
+* The ``IVersionedStorePort`` (lives in naas-abi-core, not in this library).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sqlite3
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Iterator
+
+from .revision import DEFAULT_BRANCH, HASH_LEN, Revision
+
+
+GENESIS = "0" * HASH_LEN
+"""Sentinel prev_hash for the first revision of any uid on a branch."""
+
+DEFAULT_MAX_RETRIES = 16
+DEFAULT_COMMIT_MAX_SIZE = 64
+DEFAULT_COMMIT_WINDOW_MS = 0.0  # disabled by default; enable per-deployment
+
+# Durability modes.
+#
+# On Linux, Windows, and BSD, ``os.fsync(fd)`` already issues a real disk
+# barrier — when it returns, the data is on non-volatile storage. The
+# ``"full"`` and ``"fast"`` modes are equivalent on those platforms.
+#
+# On Apple platforms, ``os.fsync(fd)`` only flushes data to the drive
+# controller's cache. A power loss between ``fsync`` returning and the
+# physical write loses the data. Apple provides ``fcntl(fd, F_FULLFSYNC)``
+# to issue a true platter-level barrier; this is what SQLite uses when
+# ``PRAGMA fullfsync=ON``. ``"full"`` mode opts in to that on Apple
+# platforms; ``"fast"`` mode keeps the platform default (the trade we
+# made before this option existed).
+DURABILITY_FULL = "full"
+"""Durability mode: ``put`` returning success implies durable on disk
+across every supported platform. On Apple, uses ``F_FULLFSYNC`` and
+``PRAGMA fullfsync=ON``. Slower on macOS, identical to ``fast`` elsewhere."""
+
+DURABILITY_FAST = "fast"
+"""Durability mode: uses the platform default ``fsync``. On Apple this
+is *not* a real disk barrier — failures may lose recently-acknowledged
+writes. Use only when you accept that trade (dev environments, tests,
+ephemeral data). Identical to ``full`` on non-Apple platforms."""
+
+_VALID_DURABILITY = (DURABILITY_FULL, DURABILITY_FAST)
+
+
+def _platform_supports_full_fsync() -> bool:
+    """True on Apple platforms where ``fcntl(fd, F_FULLFSYNC)`` is the
+    only path to true disk durability."""
+    return sys.platform == "darwin"
+
+
+@dataclass
+class _PendingWrite:
+    """One write in flight, waiting for durability via the commit path."""
+
+    branch: str
+    uid: str
+    ts_ns: int
+    prev_hash: str
+    content_hash: str
+    tmp_path: Path
+    final_path: Path
+    uid_dir: Path
+    error: BaseException | None = None
+
+
+@dataclass
+class _CommitGroup:
+    """A commit group: zero or more pending writes batched into one fsync.
+
+    The first writer to arrive when no group is open becomes the leader. They
+    open a new group with a deadline (``time.monotonic() + window_s``).
+    Subsequent writers join as followers and wait for ``done`` to be set.
+    The leader sleeps on ``cv`` until either the deadline or
+    ``len(members) >= max_size``, then closes the group and runs the batch
+    commit. Followers are released when ``done`` is set; if the commit raised,
+    the per-member ``error`` field is populated.
+    """
+
+    deadline: float
+    members: list[_PendingWrite] = field(default_factory=list)
+    closed: bool = False
+    done: threading.Event = field(default_factory=threading.Event)
+"""Default cap on the optimistic-concurrency retry loop in ``put``."""
+
+
+class ConcurrencyConflict(Exception):
+    """Raised when an optimistic write cannot be reconciled with the live tip.
+
+    Two situations raise this:
+
+    1. The caller passed ``expected_prev_hash`` and the actual tip differs.
+    2. The retry loop exhausted ``max_retries`` without succeeding.
+    """
+
+
+class BranchNotFoundError(Exception):
+    """Raised when an operation targets a branch that does not exist."""
+
+
+class Store:
+    """Append-only versioned blob store with branches.
+
+    Layout on disk::
+
+        {root}/
+            index.db                                  ← rebuildable SQLite index
+            data/
+                {uid}/
+                    {ts_ns:020d}.{prev_hash}.{content_hash}            ← main
+                    {ts_ns:020d}.{prev_hash}.{content_hash}.{branch}   ← other
+
+    The filesystem is the source of truth for revisions. The SQLite index can
+    be nuked and rebuilt from the filesystem at any time via ``rebuild_index``.
+
+    Branch metadata (parent, fork timestamp) currently lives in SQLite only;
+    a follow-up will mirror it onto the filesystem under ``data/__branches__/``
+    so ``rebuild_index`` can fully reconstruct branch identities. Until then,
+    ``rebuild_index`` reconstructs the *set* of branches (from filenames) but
+    parent / fork-timestamp metadata is recreated as ``("main", 0)`` for
+    discovered branches that aren't already in the index.
+    """
+
+    def __init__(
+        self,
+        root: str | Path,
+        *,
+        durability: str = DURABILITY_FULL,
+        commit_window_ms: float = DEFAULT_COMMIT_WINDOW_MS,
+        commit_max_size: int = DEFAULT_COMMIT_MAX_SIZE,
+    ):
+        """Open a Store at ``root``.
+
+        ``durability`` controls the strength of the on-disk persistence
+        guarantee made by ``put``:
+
+        * ``"full"`` (default) — a successful ``put`` implies the revision
+          is on non-volatile storage. On Apple platforms this uses
+          ``fcntl(fd, F_FULLFSYNC)`` for file syncs and
+          ``PRAGMA fullfsync=ON`` + ``synchronous=FULL`` for SQLite. On
+          Linux/Windows/BSD this is what ``fsync`` does anyway, so there
+          is no extra cost. Recommended for production.
+        * ``"fast"`` — uses the platform default ``fsync``. On Apple this
+          flushes only to the drive's controller cache, not the platter,
+          so a power loss can lose recently-acknowledged writes.
+          Identical to ``"full"`` on non-Apple platforms. Use for dev,
+          tests, or ephemeral data when you accept the trade.
+
+        ``commit_window_ms`` enables group commit (Tier 1 C):
+
+        * ``0.0`` (default) — solo commit. Each ``put`` does its own fsync
+          before returning. Behavior is byte-identical to versions before
+          group commit.
+        * ``> 0.0`` — group commit. A ``put`` enqueues into a shared commit
+          group with a deadline ``commit_window_ms`` milliseconds in the
+          future, then blocks until the group's batched fsync completes.
+          The first writer to arrive when no group is open becomes the
+          leader. The group commits early once it reaches
+          ``commit_max_size`` members. Recommended starting values are
+          ``commit_window_ms=2.0`` and ``commit_max_size=64`` on workloads
+          with many concurrent writers and a non-trivial fsync cost.
+
+        See ``WHITEPAPER.md §3`` and ``§11`` for the full models.
+        Per-write durability is preserved across both commit paths:
+        ``put`` returns success only after its (solo or group) fsync has
+        completed.
+        """
+        if durability not in _VALID_DURABILITY:
+            raise ValueError(
+                f"durability must be one of {_VALID_DURABILITY!r}, "
+                f"got {durability!r}"
+            )
+
+        self.root = Path(root)
+        self.data_dir = self.root / "data"
+        self.index_path = self.root / "index.db"
+        self.root.mkdir(parents=True, exist_ok=True)
+        self.data_dir.mkdir(exist_ok=True)
+
+        self._durability = durability
+        # ``_use_full_fsync`` is True only when (a) we're in full mode and
+        # (b) the platform actually distinguishes full from fast. On
+        # Linux/Windows/BSD ``os.fsync`` already does the right thing,
+        # so there's no need to take a different code path.
+        self._use_full_fsync = (
+            durability == DURABILITY_FULL and _platform_supports_full_fsync()
+        )
+        if self._use_full_fsync:
+            # ``fcntl`` is POSIX-only; ``F_FULLFSYNC`` is Darwin-specific.
+            # We import here so the module imports cleanly on Windows and
+            # any platform where fcntl/F_FULLFSYNC isn't available.
+            import fcntl  # noqa: F401
+
+        # isolation_level=None: we manage transactions explicitly with BEGIN/COMMIT.
+        # check_same_thread=False allows multiple threads to share the
+        # connection; we serialize access ourselves via ``self._db_lock``.
+        # The lock is held only across the SQL call (microseconds), never
+        # across the file write + fsync (milliseconds) — that is the whole
+        # point of the lock-free retry path.
+        self._conn = sqlite3.connect(
+            self.index_path,
+            isolation_level=None,
+            check_same_thread=False,
+        )
+        self._db_lock = threading.RLock()
+        # Per-(branch, uid) lock: serializes writers in this process targeting
+        # the same logical entity, so threads don't gratuitously fight for the
+        # UNIQUE(branch, uid, prev_hash) slot. Different (branch, uid) pairs
+        # take different locks and run in parallel — that is the Tier 1 A&B
+        # win at the in-process layer. Cross-process correctness is still
+        # guaranteed by the UNIQUE constraint and the retry path.
+        self._uid_locks: dict[tuple[str, str], threading.Lock] = {}
+        self._uid_locks_guard = threading.Lock()
+
+        # Group commit (Tier 1 C). When ``_commit_window_s == 0`` the path
+        # bypasses the group entirely.
+        self._commit_window_s = max(0.0, commit_window_ms) / 1000.0
+        self._commit_max_size = max(1, commit_max_size)
+        self._group_cv = threading.Condition()
+        self._current_group: _CommitGroup | None = None
+        # Diagnostic counters (read by tests). Atomic increments under
+        # ``_group_cv`` for batches; under ``_db_lock`` for solo commits.
+        self._batch_count = 0
+        self._batched_writes = 0
+
+        with self._db_lock:
+            self._conn.execute("PRAGMA journal_mode=WAL")
+            if durability == DURABILITY_FULL:
+                # synchronous=FULL: SQLite fsyncs the WAL after every commit
+                # and the database file at every checkpoint. Slightly more
+                # syncs than NORMAL; required for "if commit succeeds, it's
+                # durable" on every platform.
+                self._conn.execute("PRAGMA synchronous=FULL")
+                if _platform_supports_full_fsync():
+                    # On Apple, escalate the syncs SQLite issues to
+                    # F_FULLFSYNC. PRAGMA fullfsync covers per-commit
+                    # syncs; checkpoint_fullfsync covers WAL checkpoints.
+                    # No-ops on non-Apple platforms.
+                    self._conn.execute("PRAGMA fullfsync=ON")
+                    self._conn.execute("PRAGMA checkpoint_fullfsync=ON")
+            else:
+                # Fast mode preserves the previous default behavior.
+                self._conn.execute("PRAGMA synchronous=NORMAL")
+            self._conn.execute("PRAGMA busy_timeout=5000")
+        self._init_schema()
+        self._seed_main_branch()
+
+    def _sync_fd(self, fd: int) -> None:
+        """Force this file descriptor's data to durable storage.
+
+        On Apple in ``"full"`` mode this issues ``F_FULLFSYNC``, which
+        triggers a real platter-level barrier. Everywhere else (and on
+        Apple in ``"fast"`` mode) it falls back to ``os.fsync``.
+        """
+        if self._use_full_fsync:
+            import fcntl
+
+            # F_FULLFSYNC: "really really flush all buffers to disk" —
+            # see Apple's fcntl(2). Required for true durability on
+            # Apple platforms; a no-op concept on Linux/Windows where
+            # fsync already provides this guarantee.
+            fcntl.fcntl(fd, fcntl.F_FULLFSYNC)
+        else:
+            os.fsync(fd)
+
+    def _sync_dir(self, path: Path) -> None:
+        """Force a directory's metadata to durable storage. Best-effort:
+        platforms that don't support directory fsync silently no-op."""
+        try:
+            fd = os.open(str(path), os.O_RDONLY)
+        except OSError:
+            return
+        try:
+            self._sync_fd(fd)
+        except OSError:
+            # Windows and some filesystems don't support fsync on directories.
+            pass
+        finally:
+            os.close(fd)
+
+    def _uid_lock(self, branch: str, uid: str) -> threading.Lock:
+        """Return the in-process lock for ``(branch, uid)``, creating it on demand."""
+        key = (branch, uid)
+        with self._uid_locks_guard:
+            lock = self._uid_locks.get(key)
+            if lock is None:
+                lock = threading.Lock()
+                self._uid_locks[key] = lock
+            return lock
+
+    # ------------------------------------------------------------------ setup
+
+    def _init_schema(self) -> None:
+        with self._db_lock:
+            self._conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS branches (
+                    name        TEXT    PRIMARY KEY,
+                    parent      TEXT,
+                    fork_ts_ns  INTEGER NOT NULL DEFAULT 0,
+                    created_at  INTEGER NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS revisions (
+                    branch        TEXT    NOT NULL DEFAULT 'main',
+                    uid           TEXT    NOT NULL,
+                    ts_ns         INTEGER NOT NULL,
+                    prev_hash     TEXT    NOT NULL,
+                    content_hash  TEXT    NOT NULL,
+                    PRIMARY KEY (uid, ts_ns, branch),
+                    UNIQUE (branch, uid, prev_hash)
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_revisions_ts ON revisions(ts_ns);
+                CREATE INDEX IF NOT EXISTS idx_revisions_branch_uid
+                    ON revisions(branch, uid, ts_ns);
+                """
+            )
+
+    def _seed_main_branch(self) -> None:
+        with self._db_lock:
+            self._conn.execute(
+                "INSERT OR IGNORE INTO branches(name, parent, fork_ts_ns, created_at) "
+                "VALUES (?, NULL, 0, ?)",
+                (DEFAULT_BRANCH, time.time_ns()),
+            )
+
+    def close(self) -> None:
+        with self._db_lock:
+            self._conn.close()
+
+    def __enter__(self) -> "Store":
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        self.close()
+
+    # ------------------------------------------------------------- branches
+
+    def create_branch(
+        self, name: str, *, parent: str = DEFAULT_BRANCH
+    ) -> None:
+        """Register a branch. No data is copied; tips fall through at read time
+        (fall-through reads are deferred to the follow-up; for now reads only
+        return revisions explicitly written on the requested branch).
+
+        Parent must exist. Branch name must be valid (alphanumeric + ``-``/``_``,
+        non-empty, no path separators, no ``.``).
+        """
+        _validate_branch(name)
+        if not self._branch_exists(parent):
+            raise BranchNotFoundError(f"Parent branch does not exist: {parent!r}")
+        now_ns = time.time_ns()
+        with self._db_lock:
+            self._conn.execute(
+                "INSERT OR IGNORE INTO branches(name, parent, fork_ts_ns, created_at) "
+                "VALUES (?, ?, ?, ?)",
+                (name, parent, now_ns, now_ns),
+            )
+
+    def list_branches(self) -> list[str]:
+        with self._db_lock:
+            rows = self._conn.execute(
+                "SELECT name FROM branches ORDER BY name"
+            ).fetchall()
+        return [r[0] for r in rows]
+
+    def _branch_exists(self, name: str) -> bool:
+        with self._db_lock:
+            row = self._conn.execute(
+                "SELECT 1 FROM branches WHERE name = ?", (name,)
+            ).fetchone()
+        return row is not None
+
+    # ------------------------------------------------------------------ write
+
+    def put(
+        self,
+        uid: str,
+        payload: bytes,
+        *,
+        branch: str = DEFAULT_BRANCH,
+        expected_prev_hash: str | None = None,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+    ) -> Revision | None:
+        """Append a new revision for ``uid`` on ``branch`` with the given payload.
+
+        Returns the newly created ``Revision``, or ``None`` if the payload is
+        byte-identical to the current latest revision on this branch (no-op,
+        not appended).
+
+        If ``expected_prev_hash`` is given, the call raises
+        ``ConcurrencyConflict`` when the actual tip's content_hash differs.
+        Use this for compare-and-swap semantics from above the store.
+
+        Concurrency model
+        -----------------
+        Read-latest is lock-free. The file write + ``fsync`` happens outside
+        any SQLite transaction. The INSERT into ``revisions`` is gated by
+        ``UNIQUE(branch, uid, prev_hash)``: if a concurrent writer beat us to
+        this branch+uid+prev_hash, the INSERT raises ``IntegrityError``, we
+        clean up our orphan file, re-read the new tip and retry. ``max_retries``
+        bounds the loop.
+        """
+        _validate_uid(uid)
+        _validate_branch(branch)
+        if not self._branch_exists(branch):
+            raise BranchNotFoundError(f"Branch does not exist: {branch!r}")
+
+        content_hash = hashlib.sha256(payload).hexdigest()
+        uid_dir = self.data_dir / uid
+        uid_dir.mkdir(exist_ok=True)
+
+        last_seen_prev: str | None = None
+
+        # Serialize in-process writers on this (branch, uid). Other
+        # (branch, uid) pairs proceed in parallel.
+        with self._uid_lock(branch, uid):
+            for _attempt in range(max_retries):
+                latest = self._latest_on_branch(uid, branch)
+
+                # Idempotent no-op when current tip already has this content.
+                if latest is not None and latest.content_hash == content_hash:
+                    return None
+
+                prev_hash = (
+                    latest.content_hash if latest is not None else GENESIS
+                )
+
+                if (
+                    expected_prev_hash is not None
+                    and prev_hash != expected_prev_hash
+                ):
+                    raise ConcurrencyConflict(
+                        f"Expected prev_hash={expected_prev_hash!r} on "
+                        f"branch={branch!r} uid={uid!r}, found {prev_hash!r}"
+                    )
+
+                ts_ns = time.time_ns()
+                if latest is not None and ts_ns <= latest.ts_ns:
+                    ts_ns = latest.ts_ns + 1
+
+                tentative = Revision(
+                    uid=uid,
+                    ts_ns=ts_ns,
+                    prev_hash=prev_hash,
+                    content_hash=content_hash,
+                    path=uid_dir / "_unset_",
+                    branch=branch,
+                )
+                filename = tentative.filename
+                final_path = uid_dir / filename
+                tmp_path = uid_dir / (filename + ".tmp")
+
+                # Write the tmp file (no fsync yet — that happens during
+                # commit, possibly batched with other writers in the same
+                # group). The flush gets the bytes into the OS page cache;
+                # fsync makes them durable.
+                try:
+                    with open(tmp_path, "wb") as f:
+                        f.write(payload)
+                        f.flush()
+                except Exception:
+                    _best_effort_unlink(tmp_path)
+                    raise
+
+                pending = _PendingWrite(
+                    branch=branch,
+                    uid=uid,
+                    ts_ns=ts_ns,
+                    prev_hash=prev_hash,
+                    content_hash=content_hash,
+                    tmp_path=tmp_path,
+                    final_path=final_path,
+                    uid_dir=uid_dir,
+                )
+
+                # Block until the write is durable (fsync'd, renamed,
+                # indexed) — either via the group commit path or solo,
+                # depending on configuration.
+                if self._commit_window_s > 0.0:
+                    self._submit_to_group(pending)
+                else:
+                    self._commit_solo(pending)
+
+                if pending.error is None:
+                    return Revision(
+                        uid=uid,
+                        ts_ns=ts_ns,
+                        prev_hash=prev_hash,
+                        content_hash=content_hash,
+                        path=final_path,
+                        branch=branch,
+                    )
+
+                # The commit path raises IntegrityError when a cross-process
+                # writer landed a revision at the same (branch, uid,
+                # prev_hash). Clean up has already happened; we just retry.
+                if isinstance(pending.error, sqlite3.IntegrityError):
+                    if expected_prev_hash is not None:
+                        raise ConcurrencyConflict(
+                            f"Concurrent writer changed tip on "
+                            f"branch={branch!r} uid={uid!r}"
+                        )
+                    last_seen_prev = prev_hash
+                    continue
+
+                # Any other error from the commit path is fatal — re-raise.
+                raise pending.error
+
+        raise ConcurrencyConflict(
+            f"Failed to write after {max_retries} retries on "
+            f"branch={branch!r} uid={uid!r} (last seen prev_hash={last_seen_prev!r})"
+        )
+
+    # ----------------------------------------------------------- commit path
+
+    def _commit_solo(self, w: _PendingWrite) -> None:
+        """Solo commit path (group commit disabled): single-writer fsync,
+        rename, dir-fsync, INSERT. Errors land in ``w.error``.
+
+        Uses ``self._sync_fd`` so durability mode (full/fast) is honored.
+        """
+        try:
+            with open(w.tmp_path, "rb+") as f:
+                self._sync_fd(f.fileno())
+            os.rename(w.tmp_path, w.final_path)
+            self._sync_dir(w.uid_dir)
+        except Exception as e:
+            _best_effort_unlink(w.tmp_path)
+            w.error = e
+            return
+
+        try:
+            with self._db_lock:
+                self._conn.execute(
+                    "INSERT INTO revisions"
+                    "(branch, uid, ts_ns, prev_hash, content_hash) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (w.branch, w.uid, w.ts_ns, w.prev_hash, w.content_hash),
+                )
+        except sqlite3.IntegrityError as e:
+            _best_effort_unlink(w.final_path)
+            w.error = e
+
+    def _submit_to_group(self, w: _PendingWrite) -> None:
+        """Group commit path: enqueue, lead-or-follow, return when durable.
+
+        The first writer to find no open group becomes the leader. Followers
+        join the open group and wait for the leader to drive the commit.
+        Failures (per-member, e.g. UNIQUE conflict) land in ``w.error``;
+        catastrophic failures (e.g. fsync errno) propagate to every member
+        of the affected group via ``error``.
+        """
+        is_leader = False
+        with self._group_cv:
+            group = self._current_group
+            # Open a new group if (a) none is open, (b) the current one
+            # has been closed by its leader, or (c) the current one is
+            # already at the size cap. Case (c) makes the cap hard:
+            # without it, a follower arriving between the leader's
+            # notify and its re-acquisition of the cv could squeeze
+            # past the limit.
+            if (
+                group is None
+                or group.closed
+                or len(group.members) >= self._commit_max_size
+            ):
+                group = _CommitGroup(
+                    deadline=time.monotonic() + self._commit_window_s
+                )
+                self._current_group = group
+                is_leader = True
+            group.members.append(w)
+            if len(group.members) >= self._commit_max_size:
+                # Wake the leader if it was sleeping on the deadline.
+                self._group_cv.notify_all()
+
+        if is_leader:
+            self._lead_commit(group)
+        else:
+            group.done.wait()
+
+    def _lead_commit(self, group: _CommitGroup) -> None:
+        """Wait for the deadline or size cap, then commit the group."""
+        with self._group_cv:
+            while not group.closed:
+                remaining = group.deadline - time.monotonic()
+                if remaining <= 0 or len(group.members) >= self._commit_max_size:
+                    break
+                self._group_cv.wait(timeout=remaining)
+            group.closed = True
+            if self._current_group is group:
+                self._current_group = None
+            members = list(group.members)
+
+        try:
+            self._commit_batch(members)
+        finally:
+            # Whatever happened, release every follower so they can read
+            # their own per-member ``error`` (or success).
+            group.done.set()
+
+    def _commit_batch(self, members: list[_PendingWrite]) -> None:
+        """Durably persist a batch of pending writes.
+
+        Steps, in order:
+
+        1. fsync each tmp file. The kernel typically batches concurrent
+           fsyncs at the journal layer, so even sequential fsyncs in this
+           loop are amortized at the device level.
+        2. Sort members by ``ts_ns`` and rename in chain order so that a
+           crash mid-rename leaves a valid prefix on disk (every renamed
+           file's prev_hash points to an already-renamed predecessor).
+        3. Dedup ``uid_dir`` and fsync each unique directory once.
+        4. Insert all rows in a single SQLite transaction, with a savepoint
+           around each row so a single UNIQUE conflict only fails that one
+           member rather than the whole batch. Conflicting rows have their
+           orphan files cleaned up here.
+        """
+        if not members:
+            return
+
+        # 1. fsync each tmp file (honoring durability mode).
+        for w in members:
+            if w.error is not None:
+                continue
+            try:
+                fd = os.open(str(w.tmp_path), os.O_RDONLY)
+                try:
+                    self._sync_fd(fd)
+                finally:
+                    os.close(fd)
+            except OSError as e:
+                _best_effort_unlink(w.tmp_path)
+                w.error = e
+
+        # 2. Sort by ts_ns, then rename in order. (Within the same
+        # (branch, uid), ts_ns is monotonic — chains stay valid on a
+        # partial-rename crash.)
+        members_sorted = sorted(members, key=lambda x: x.ts_ns)
+        for w in members_sorted:
+            if w.error is not None:
+                continue
+            try:
+                os.rename(w.tmp_path, w.final_path)
+            except OSError as e:
+                _best_effort_unlink(w.tmp_path)
+                w.error = e
+
+        # 3. dir fsync, deduped per uid_dir (honoring durability mode).
+        uniq_dirs = {w.uid_dir for w in members if w.error is None}
+        for d in uniq_dirs:
+            self._sync_dir(d)
+
+        # 4. Batched INSERTs in one transaction with per-row savepoints.
+        with self._db_lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                for idx, w in enumerate(members):
+                    if w.error is not None:
+                        continue
+                    sp = f"sp_{idx}"
+                    self._conn.execute(f"SAVEPOINT {sp}")
+                    try:
+                        self._conn.execute(
+                            "INSERT INTO revisions"
+                            "(branch, uid, ts_ns, prev_hash, content_hash) "
+                            "VALUES (?, ?, ?, ?, ?)",
+                            (
+                                w.branch,
+                                w.uid,
+                                w.ts_ns,
+                                w.prev_hash,
+                                w.content_hash,
+                            ),
+                        )
+                        self._conn.execute(f"RELEASE SAVEPOINT {sp}")
+                    except sqlite3.IntegrityError as e:
+                        self._conn.execute(f"ROLLBACK TO SAVEPOINT {sp}")
+                        self._conn.execute(f"RELEASE SAVEPOINT {sp}")
+                        _best_effort_unlink(w.final_path)
+                        w.error = e
+                self._conn.execute("COMMIT")
+            except Exception:
+                self._conn.execute("ROLLBACK")
+                # Tag every member that was about to be inserted as failed
+                # so followers see the error.
+                for w in members:
+                    if w.error is None:
+                        w.error = RuntimeError(
+                            "group commit aborted before insert succeeded"
+                        )
+                raise
+
+        # Diagnostics: tests use these to verify batching is happening.
+        with self._group_cv:
+            self._batch_count += 1
+            self._batched_writes += len(members)
+
+    # ------------------------------------------------------------------ read
+
+    def get(
+        self,
+        uid: str,
+        at: datetime | None = None,
+        *,
+        branch: str = DEFAULT_BRANCH,
+    ) -> bytes | None:
+        """Return the payload bytes of ``uid`` on ``branch`` at time ``at``
+        (latest if ``None``).
+
+        Returns ``None`` if no revision exists on this branch at or before
+        ``at``. An empty ``bytes`` return value means the revision exists and
+        is intentionally empty.
+        """
+        rev = self.latest(uid, at, branch=branch)
+        return rev.read() if rev is not None else None
+
+    def latest(
+        self,
+        uid: str,
+        at: datetime | None = None,
+        *,
+        branch: str = DEFAULT_BRANCH,
+    ) -> Revision | None:
+        """Return the latest ``Revision`` for ``uid`` on ``branch`` at time
+        ``at``, or ``None``."""
+        _validate_uid(uid)
+        _validate_branch(branch)
+        if at is None:
+            with self._db_lock:
+                row = self._conn.execute(
+                    "SELECT ts_ns, prev_hash, content_hash FROM revisions "
+                    "WHERE branch = ? AND uid = ? ORDER BY ts_ns DESC LIMIT 1",
+                    (branch, uid),
+                ).fetchone()
+        else:
+            ts_limit = _dt_to_ns(at)
+            with self._db_lock:
+                row = self._conn.execute(
+                    "SELECT ts_ns, prev_hash, content_hash FROM revisions "
+                    "WHERE branch = ? AND uid = ? AND ts_ns <= ? "
+                    "ORDER BY ts_ns DESC LIMIT 1",
+                    (branch, uid, ts_limit),
+                ).fetchone()
+        if row is None:
+            return None
+        return self._build_revision(uid, *row, branch=branch)
+
+    def _latest_on_branch(self, uid: str, branch: str) -> Revision | None:
+        """Internal hot-path: latest tip on a branch, validation skipped."""
+        with self._db_lock:
+            row = self._conn.execute(
+                "SELECT ts_ns, prev_hash, content_hash FROM revisions "
+                "WHERE branch = ? AND uid = ? ORDER BY ts_ns DESC LIMIT 1",
+                (branch, uid),
+            ).fetchone()
+        if row is None:
+            return None
+        return self._build_revision(uid, *row, branch=branch)
+
+    def history(
+        self, uid: str, *, branch: str = DEFAULT_BRANCH
+    ) -> Iterator[Revision]:
+        """Yield all revisions for ``uid`` on ``branch`` in chronological
+        order (oldest first)."""
+        _validate_uid(uid)
+        _validate_branch(branch)
+        with self._db_lock:
+            rows = self._conn.execute(
+                "SELECT ts_ns, prev_hash, content_hash FROM revisions "
+                "WHERE branch = ? AND uid = ? ORDER BY ts_ns ASC",
+                (branch, uid),
+            ).fetchall()
+        for row in rows:
+            yield self._build_revision(uid, *row, branch=branch)
+
+    def uids(self, *, branch: str = DEFAULT_BRANCH) -> Iterator[str]:
+        """Yield every uid that has at least one revision on ``branch``."""
+        _validate_branch(branch)
+        with self._db_lock:
+            rows = self._conn.execute(
+                "SELECT DISTINCT uid FROM revisions WHERE branch = ?", (branch,)
+            ).fetchall()
+        for (uid,) in rows:
+            yield uid
+
+    def uids_at(
+        self,
+        at: datetime | None = None,
+        *,
+        branch: str = DEFAULT_BRANCH,
+    ) -> Iterator[tuple[str, Revision]]:
+        """Yield ``(uid, latest_revision)`` for every uid on ``branch`` that
+        has a revision at or before ``at``."""
+        _validate_branch(branch)
+        if at is None:
+            with self._db_lock:
+                rows = self._conn.execute(
+                    """
+                    SELECT uid, ts_ns, prev_hash, content_hash
+                    FROM revisions
+                    WHERE branch = ?
+                      AND (uid, ts_ns) IN (
+                        SELECT uid, MAX(ts_ns) FROM revisions
+                        WHERE branch = ? GROUP BY uid
+                      )
+                    """,
+                    (branch, branch),
+                ).fetchall()
+        else:
+            ts_limit = _dt_to_ns(at)
+            with self._db_lock:
+                rows = self._conn.execute(
+                    """
+                    SELECT uid, ts_ns, prev_hash, content_hash
+                    FROM revisions
+                    WHERE branch = ?
+                      AND (uid, ts_ns) IN (
+                        SELECT uid, MAX(ts_ns) FROM revisions
+                        WHERE branch = ? AND ts_ns <= ? GROUP BY uid
+                      )
+                    """,
+                    (branch, branch, ts_limit),
+                ).fetchall()
+        for uid, ts_ns, prev_hash, content_hash in rows:
+            yield uid, self._build_revision(
+                uid, ts_ns, prev_hash, content_hash, branch=branch
+            )
+
+    # ---------------------------------------------------------- integrity ops
+
+    def verify(self, uid: str, *, branch: str = DEFAULT_BRANCH) -> bool:
+        """Verify the Merkle chain and content hashes for ``uid`` on ``branch``.
+
+        Returns ``True`` iff every revision's content hashes to its declared
+        hash, and every ``prev_hash`` matches the previous revision's
+        ``content_hash`` (with ``GENESIS`` for the first).
+        """
+        expected_prev = GENESIS
+        count = 0
+        for rev in self.history(uid, branch=branch):
+            count += 1
+            if rev.prev_hash != expected_prev:
+                return False
+            if not rev.path.is_file():
+                return False
+            actual = hashlib.sha256(rev.path.read_bytes()).hexdigest()
+            if actual != rev.content_hash:
+                return False
+            expected_prev = rev.content_hash
+        if count > 0:
+            return True
+        # No revisions for this (uid, branch). That's a valid state iff the
+        # uid directory has no files for this branch.
+        uid_dir = self.data_dir / uid
+        if not uid_dir.exists():
+            return True
+        for f in uid_dir.iterdir():
+            if not f.is_file() or f.name.endswith(".tmp"):
+                continue
+            try:
+                rev = Revision.parse_filename(uid, f.name, uid_dir)
+            except ValueError:
+                continue
+            if rev.branch == branch:
+                return False
+        return True
+
+    def rebuild_index(self) -> None:
+        """Drop and repopulate the SQLite index from the filesystem.
+
+        Orphan ``.tmp`` files are deleted. Unparseable filenames are skipped
+        silently. Branch metadata not already in ``branches`` is recreated as
+        ``parent='main', fork_ts_ns=0`` for any branch discovered in
+        filenames (the spec follow-up will store branch metadata on disk so
+        parent / fork timestamps are also rebuildable).
+        """
+        with self._db_lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                self._conn.execute("DELETE FROM revisions")
+                discovered_branches: set[str] = {DEFAULT_BRANCH}
+                # (branch, uid, prev_hash)
+                seen_keys: set[tuple[str, str, str]] = set()
+
+                if self.data_dir.exists():
+                    for uid_dir in self.data_dir.iterdir():
+                        if not uid_dir.is_dir():
+                            continue
+                        uid = uid_dir.name
+                        revs: list[Revision] = []
+                        for f in uid_dir.iterdir():
+                            if not f.is_file():
+                                continue
+                            if f.name.endswith(".tmp"):
+                                _best_effort_unlink(f)
+                                continue
+                            try:
+                                revs.append(
+                                    Revision.parse_filename(uid, f.name, uid_dir)
+                                )
+                            except ValueError:
+                                continue
+                        revs.sort(key=lambda r: r.ts_ns)
+                        for rev in revs:
+                            discovered_branches.add(rev.branch)
+                            key = (rev.branch, rev.uid, rev.prev_hash)
+                            if key in seen_keys:
+                                # Two files share (branch, uid, prev_hash).
+                                # Keep the earliest (already inserted), drop
+                                # the rest.
+                                _best_effort_unlink(rev.path)
+                                continue
+                            seen_keys.add(key)
+                            self._conn.execute(
+                                "INSERT INTO revisions"
+                                "(branch, uid, ts_ns, prev_hash, content_hash) "
+                                "VALUES (?, ?, ?, ?, ?)",
+                                (
+                                    rev.branch,
+                                    rev.uid,
+                                    rev.ts_ns,
+                                    rev.prev_hash,
+                                    rev.content_hash,
+                                ),
+                            )
+
+                # Re-seed any branch we saw on disk that isn't in `branches`.
+                now_ns = time.time_ns()
+                for b in discovered_branches:
+                    self._conn.execute(
+                        "INSERT OR IGNORE INTO branches"
+                        "(name, parent, fork_ts_ns, created_at) "
+                        "VALUES (?, ?, ?, ?)",
+                        (
+                            b,
+                            None if b == DEFAULT_BRANCH else DEFAULT_BRANCH,
+                            0,
+                            now_ns,
+                        ),
+                    )
+                self._conn.execute("COMMIT")
+            except Exception:
+                self._conn.execute("ROLLBACK")
+                raise
+
+    # ---------------------------------------------------------------- helpers
+
+    def _build_revision(
+        self,
+        uid: str,
+        ts_ns: int,
+        prev_hash: str,
+        content_hash: str,
+        *,
+        branch: str = DEFAULT_BRANCH,
+    ) -> Revision:
+        # Two-step build so we can derive the on-disk filename via Revision.filename.
+        scratch = Revision(
+            uid=uid,
+            ts_ns=ts_ns,
+            prev_hash=prev_hash,
+            content_hash=content_hash,
+            path=self.data_dir / uid / "_unset_",
+            branch=branch,
+        )
+        return Revision(
+            uid=uid,
+            ts_ns=ts_ns,
+            prev_hash=prev_hash,
+            content_hash=content_hash,
+            path=self.data_dir / uid / scratch.filename,
+            branch=branch,
+        )
+
+
+# ------------------------------------------------------------------ utilities
+
+
+def _validate_uid(uid: str) -> None:
+    if not isinstance(uid, str) or not uid:
+        raise ValueError("uid must be a non-empty string")
+    if "/" in uid or "\\" in uid or "\0" in uid or uid in (".", ".."):
+        raise ValueError(f"Invalid uid: {uid!r}")
+
+
+def _validate_branch(name: str) -> None:
+    if not isinstance(name, str) or not name:
+        raise ValueError("branch name must be a non-empty string")
+    if name in (".", ".."):
+        raise ValueError(f"Invalid branch name: {name!r}")
+    # Branch names appear in filenames as the 4th dot-separated segment, so
+    # they must not contain '.', and they must not contain path separators.
+    for ch in (".", "/", "\\", "\0"):
+        if ch in name:
+            raise ValueError(f"Invalid character {ch!r} in branch name: {name!r}")
+
+
+def _dt_to_ns(dt: datetime) -> int:
+    """Convert a datetime to nanoseconds since the Unix epoch."""
+    return int(dt.timestamp() * 1_000_000_000)
+
+
+def _best_effort_unlink(path: Path) -> None:
+    try:
+        if path.exists():
+            path.unlink()
+    except OSError:
+        pass

--- a/libs/naas-abi-core/naas_abi_core/utils/versionstore/store.py
+++ b/libs/naas-abi-core/naas_abi_core/utils/versionstore/store.py
@@ -300,8 +300,13 @@ class Store:
             # F_FULLFSYNC: "really really flush all buffers to disk" —
             # see Apple's fcntl(2). Required for true durability on
             # Apple platforms; a no-op concept on Linux/Windows where
-            # fsync already provides this guarantee.
-            fcntl.fcntl(fd, fcntl.F_FULLFSYNC)
+            # fsync already provides this guarantee. Looked up via
+            # ``getattr`` because the symbol is Darwin-only and would
+            # otherwise be a static attribute error on non-Apple
+            # type-checks. ``_use_full_fsync`` is only True on Apple,
+            # so we know it exists at runtime here.
+            f_fullfsync = getattr(fcntl, "F_FULLFSYNC")
+            fcntl.fcntl(fd, f_fullfsync)
         else:
             os.fsync(fd)
 

--- a/libs/naas-abi-core/naas_abi_core/utils/versionstore/store_branching_test.py
+++ b/libs/naas-abi-core/naas_abi_core/utils/versionstore/store_branching_test.py
@@ -1,0 +1,125 @@
+"""Tests for the minimal branching scaffold (read/write per branch, listing,
+isolation between branches, rebuild_index across branches)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from .store import BranchNotFoundError, Store
+
+
+def test_main_branch_seeded_by_default(tmp_path: Path):
+    with Store(tmp_path) as store:
+        assert "main" in store.list_branches()
+
+
+def test_create_branch_lists_it(tmp_path: Path):
+    with Store(tmp_path) as store:
+        store.create_branch("feature-x")
+        assert set(store.list_branches()) == {"main", "feature-x"}
+
+
+def test_create_branch_rejects_bad_names(tmp_path: Path):
+    with Store(tmp_path) as store:
+        for bad in ["", ".", "..", "feat.x", "feat/x", "with\\back"]:
+            with pytest.raises(ValueError):
+                store.create_branch(bad)
+
+
+def test_create_branch_rejects_unknown_parent(tmp_path: Path):
+    with Store(tmp_path) as store:
+        with pytest.raises(BranchNotFoundError):
+            store.create_branch("feature-x", parent="ghost")
+
+
+def test_writes_to_unknown_branch_raise(tmp_path: Path):
+    with Store(tmp_path) as store:
+        with pytest.raises(BranchNotFoundError):
+            store.put("alice", b"v1", branch="ghost")
+
+
+def test_branch_writes_are_isolated(tmp_path: Path):
+    """A write on feature-x is invisible from main, and vice versa."""
+    with Store(tmp_path) as store:
+        store.create_branch("feature-x")
+        store.put("alice", b"main-v1", branch="main")
+        store.put("alice", b"feature-v1", branch="feature-x")
+
+        assert store.get("alice", branch="main") == b"main-v1"
+        assert store.get("alice", branch="feature-x") == b"feature-v1"
+        # And history is per-branch:
+        assert [r.content_hash for r in store.history("alice", branch="main")] != [
+            r.content_hash for r in store.history("alice", branch="feature-x")
+        ]
+
+
+def test_main_branch_filename_unchanged(tmp_path: Path):
+    """Backward-compat: main-branch revisions still use the 3-part filename."""
+    with Store(tmp_path) as store:
+        rev = store.put("alice", b"hello")
+        assert rev is not None
+        assert rev.filename.count(".") == 2  # ts.prev.content
+
+
+def test_non_main_branch_filename_carries_branch(tmp_path: Path):
+    with Store(tmp_path) as store:
+        store.create_branch("feature-x")
+        rev = store.put("alice", b"hi", branch="feature-x")
+        assert rev is not None
+        assert rev.filename.endswith(".feature-x")
+        assert rev.filename.count(".") == 3  # ts.prev.content.branch
+
+
+def test_idempotent_put_per_branch(tmp_path: Path):
+    """Identical content on the same branch is a no-op; on a different
+    branch it appends a fresh revision because the branch tip is empty."""
+    with Store(tmp_path) as store:
+        store.create_branch("feature-x")
+        r1 = store.put("alice", b"same", branch="main")
+        r1_dup = store.put("alice", b"same", branch="main")
+        r2 = store.put("alice", b"same", branch="feature-x")
+        assert r1 is not None
+        assert r1_dup is None
+        assert r2 is not None
+        assert r2.branch == "feature-x"
+
+
+def test_uids_at_scoped_to_branch(tmp_path: Path):
+    with Store(tmp_path) as store:
+        store.create_branch("feature-x")
+        store.put("alice", b"a", branch="main")
+        store.put("bob", b"b", branch="feature-x")
+
+        assert {u for u, _ in store.uids_at(branch="main")} == {"alice"}
+        assert {u for u, _ in store.uids_at(branch="feature-x")} == {"bob"}
+
+
+def test_verify_per_branch(tmp_path: Path):
+    with Store(tmp_path) as store:
+        store.create_branch("feature-x")
+        store.put("alice", b"v1", branch="main")
+        store.put("alice", b"v2", branch="main")
+        store.put("alice", b"x1", branch="feature-x")
+        assert store.verify("alice", branch="main") is True
+        assert store.verify("alice", branch="feature-x") is True
+
+
+def test_rebuild_index_recovers_branches(tmp_path: Path):
+    with Store(tmp_path) as store:
+        store.create_branch("feature-x")
+        store.put("alice", b"main-v1", branch="main")
+        store.put("alice", b"feat-v1", branch="feature-x")
+        store.put("alice", b"feat-v2", branch="feature-x")
+
+        # Nuke the index entirely and rebuild from disk.
+        store._conn.execute("DELETE FROM revisions")
+        store._conn.execute("DELETE FROM branches WHERE name != 'main'")
+        store.rebuild_index()
+
+        assert set(store.list_branches()) >= {"main", "feature-x"}
+        assert store.get("alice", branch="main") == b"main-v1"
+        assert store.get("alice", branch="feature-x") == b"feat-v2"
+        assert store.verify("alice", branch="main")
+        assert store.verify("alice", branch="feature-x")

--- a/libs/naas-abi-core/naas_abi_core/utils/versionstore/store_concurrency_test.py
+++ b/libs/naas-abi-core/naas_abi_core/utils/versionstore/store_concurrency_test.py
@@ -1,0 +1,184 @@
+"""Tests for Tier 1 A & B concurrency: per-uid and per-(branch, uid) writes.
+
+These tests exercise the lock-free retry path. Multiple writer threads target
+the store simultaneously; we assert that:
+
+  * No writes are lost (every successful put yields a revision in the chain).
+  * The Merkle chain stays valid on every (uid, branch).
+  * Concurrent writers to *different* uids or *different* branches succeed
+    without escalating to ``ConcurrencyConflict``.
+  * Concurrent writers to the *same* (uid, branch) without an
+    ``expected_prev_hash`` retry transparently and all eventually land.
+  * ``expected_prev_hash`` mismatches raise ``ConcurrencyConflict``.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+import pytest
+
+from .store import ConcurrencyConflict, Store
+
+
+# Each test creates its own Store. SQLite with check_same_thread=False is fine
+# for our usage because every method takes the connection's internal mutex
+# briefly — we never hold a transaction across threads.
+
+
+def _writer(store: Store, uid: str, branch: str, payloads: list[bytes]) -> int:
+    """Append every payload in order under (uid, branch); return count of writes."""
+    n = 0
+    for p in payloads:
+        rev = store.put(uid, p, branch=branch)
+        if rev is not None:
+            n += 1
+    return n
+
+
+# ------------------------------------------------------------------ Tier 1 A
+
+
+def test_concurrent_writes_to_different_uids_all_succeed(tmp_path: Path):
+    """Tier 1 A: writers on disjoint uids never conflict."""
+    with Store(tmp_path) as store:
+        N_WRITERS = 8
+        N_PAYLOADS = 20
+        with ThreadPoolExecutor(max_workers=N_WRITERS) as pool:
+            futures = [
+                pool.submit(
+                    _writer,
+                    store,
+                    f"uid-{i}",
+                    "main",
+                    [f"payload-{i}-{j}".encode() for j in range(N_PAYLOADS)],
+                )
+                for i in range(N_WRITERS)
+            ]
+            counts = [f.result() for f in as_completed(futures)]
+
+        assert sum(counts) == N_WRITERS * N_PAYLOADS
+        for i in range(N_WRITERS):
+            uid = f"uid-{i}"
+            assert store.verify(uid)
+            assert (
+                len(list(store.history(uid))) == N_PAYLOADS
+            ), f"missing revisions for {uid}"
+
+
+def test_concurrent_writes_to_same_uid_all_land(tmp_path: Path):
+    """Tier 1 A retry path: writers fighting for the same (uid, branch) all
+    succeed eventually. The chain stays valid; the count matches; no payload
+    is lost."""
+    with Store(tmp_path) as store:
+        N_WRITERS = 8
+        N_PAYLOADS = 10  # per writer
+        with ThreadPoolExecutor(max_workers=N_WRITERS) as pool:
+            futures = [
+                pool.submit(
+                    _writer,
+                    store,
+                    "shared",
+                    "main",
+                    [f"writer-{w}-payload-{j}".encode() for j in range(N_PAYLOADS)],
+                )
+                for w in range(N_WRITERS)
+            ]
+            counts = [f.result() for f in as_completed(futures)]
+
+        assert sum(counts) == N_WRITERS * N_PAYLOADS
+        history = list(store.history("shared"))
+        assert len(history) == N_WRITERS * N_PAYLOADS
+        assert store.verify("shared") is True
+
+
+# ------------------------------------------------------------------ Tier 1 B
+
+
+def test_concurrent_writes_to_same_uid_different_branches(tmp_path: Path):
+    """Tier 1 B: per-(branch, uid) concurrency. Two writers on different
+    branches touching the same uid succeed in parallel without conflict, and
+    the chains on each branch are independent."""
+    with Store(tmp_path) as store:
+        store.create_branch("feature-x")
+
+        N_WRITERS_PER_BRANCH = 4
+        N_PAYLOADS = 25
+
+        with ThreadPoolExecutor(max_workers=2 * N_WRITERS_PER_BRANCH) as pool:
+            futures = []
+            for w in range(N_WRITERS_PER_BRANCH):
+                for branch in ("main", "feature-x"):
+                    futures.append(
+                        pool.submit(
+                            _writer,
+                            store,
+                            "shared",
+                            branch,
+                            [f"{branch}-{w}-{j}".encode() for j in range(N_PAYLOADS)],
+                        )
+                    )
+            counts = [f.result() for f in as_completed(futures)]
+
+        assert sum(counts) == 2 * N_WRITERS_PER_BRANCH * N_PAYLOADS
+
+        for branch in ("main", "feature-x"):
+            history = list(store.history("shared", branch=branch))
+            assert (
+                len(history) == N_WRITERS_PER_BRANCH * N_PAYLOADS
+            ), f"branch {branch}: bad count"
+            assert store.verify("shared", branch=branch) is True
+
+
+# ----------------------------------------------------- expected_prev_hash CAS
+
+
+def test_expected_prev_hash_matches(tmp_path: Path):
+    with Store(tmp_path) as store:
+        r1 = store.put("alice", b"v1")
+        assert r1 is not None
+        # CAS against the known tip succeeds.
+        r2 = store.put("alice", b"v2", expected_prev_hash=r1.content_hash)
+        assert r2 is not None
+        assert r2.prev_hash == r1.content_hash
+
+
+def test_expected_prev_hash_mismatch_raises(tmp_path: Path):
+    with Store(tmp_path) as store:
+        store.put("alice", b"v1")
+        store.put("alice", b"v2")  # tip moved
+        # CAS against the stale tip — must fail loudly, not silently retry.
+        with pytest.raises(ConcurrencyConflict):
+            store.put("alice", b"v3", expected_prev_hash="0" * 64)
+
+
+def test_expected_prev_hash_on_first_revision(tmp_path: Path):
+    """For a fresh (uid, branch), the expected_prev_hash must be GENESIS."""
+    from .store import GENESIS
+
+    with Store(tmp_path) as store:
+        r = store.put("alice", b"v1", expected_prev_hash=GENESIS)
+        assert r is not None
+        assert r.prev_hash == GENESIS
+
+
+def test_expected_prev_hash_under_concurrent_writer(tmp_path: Path):
+    """If a parallel writer moves the tip, our CAS write must raise."""
+    with Store(tmp_path) as store:
+        r1 = store.put("alice", b"v1")
+        assert r1 is not None
+
+        # Pre-move the tip from another caller's perspective.
+        store.put("alice", b"v-stolen")
+
+        # Now r1 is stale. CAS against it should raise.
+        with pytest.raises(ConcurrencyConflict):
+            store.put("alice", b"v-mine", expected_prev_hash=r1.content_hash)
+
+
+# Note: the retry loop's *bound* is implicitly exercised by the contention
+# tests above — N writers against one (uid, branch) all complete only because
+# losers retry transparently. A deterministic test of "exhausted max_retries
+# raises ConcurrencyConflict" would require monkey-patching the SELECT path,
+# which is more invasive than it's worth here.

--- a/libs/naas-abi-core/naas_abi_core/utils/versionstore/store_durability_test.py
+++ b/libs/naas-abi-core/naas_abi_core/utils/versionstore/store_durability_test.py
@@ -1,0 +1,94 @@
+"""Tests for the durability mode wiring.
+
+The behavioral guarantee of ``durability="full"`` (true on-disk persistence
+on every platform, including Apple) is impossible to verify in-process
+without inducing a real power loss. What we *can* verify is that the
+machinery is wired correctly: the right SQLite PRAGMAs, the right code
+path for fsync on Apple, and that both modes leave a working store.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from .store import (
+    DURABILITY_FAST,
+    DURABILITY_FULL,
+    Store,
+)
+
+
+def _pragma(store: Store, name: str) -> object:
+    return store._conn.execute(f"PRAGMA {name}").fetchone()[0]
+
+
+def test_default_is_full(tmp_path: Path):
+    with Store(tmp_path) as store:
+        assert store._durability == DURABILITY_FULL
+
+
+def test_invalid_durability_rejected(tmp_path: Path):
+    with pytest.raises(ValueError):
+        Store(tmp_path, durability="kinda")
+
+
+def test_full_mode_sets_synchronous_full(tmp_path: Path):
+    with Store(tmp_path, durability=DURABILITY_FULL) as store:
+        # PRAGMA synchronous returns the int code: 2 == FULL.
+        assert _pragma(store, "synchronous") == 2
+
+
+def test_fast_mode_sets_synchronous_normal(tmp_path: Path):
+    with Store(tmp_path, durability=DURABILITY_FAST) as store:
+        # 1 == NORMAL.
+        assert _pragma(store, "synchronous") == 1
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS-specific PRAGMAs")
+def test_full_mode_enables_fullfsync_on_darwin(tmp_path: Path):
+    with Store(tmp_path, durability=DURABILITY_FULL) as store:
+        assert _pragma(store, "fullfsync") == 1
+        assert _pragma(store, "checkpoint_fullfsync") == 1
+        assert store._use_full_fsync is True
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS-specific PRAGMAs")
+def test_fast_mode_disables_fullfsync_on_darwin(tmp_path: Path):
+    with Store(tmp_path, durability=DURABILITY_FAST) as store:
+        assert _pragma(store, "fullfsync") == 0
+        assert store._use_full_fsync is False
+
+
+@pytest.mark.skipif(sys.platform == "darwin", reason="non-Apple platforms")
+def test_full_mode_no_fullfsync_off_apple(tmp_path: Path):
+    """``"full"`` is identical to ``"fast"`` on non-Apple platforms because
+    ``os.fsync`` already provides true durability there."""
+    with Store(tmp_path, durability=DURABILITY_FULL) as store:
+        assert store._use_full_fsync is False
+
+
+def test_both_modes_produce_durable_writes_in_principle(tmp_path: Path):
+    """Smoke test: writes land and are readable in both modes."""
+    for mode in (DURABILITY_FULL, DURABILITY_FAST):
+        sub = tmp_path / mode
+        with Store(sub, durability=mode) as store:
+            store.put("alice", b"hello")
+        # Reopen — proves the data persisted across a close/open cycle.
+        with Store(sub, durability=mode) as store:
+            assert store.get("alice") == b"hello"
+            assert store.verify("alice")
+
+
+def test_group_commit_works_under_both_modes(tmp_path: Path):
+    """The group commit code path picks up the durability mode through
+    ``_sync_fd``; a quick smoke test under each."""
+    for mode in (DURABILITY_FULL, DURABILITY_FAST):
+        sub = tmp_path / mode
+        with Store(sub, durability=mode, commit_window_ms=2.0) as store:
+            store.put("alice", b"v1")
+            store.put("alice", b"v2")
+            assert store.get("alice") == b"v2"
+            assert store.verify("alice")

--- a/libs/naas-abi-core/naas_abi_core/utils/versionstore/store_group_commit_test.py
+++ b/libs/naas-abi-core/naas_abi_core/utils/versionstore/store_group_commit_test.py
@@ -1,0 +1,218 @@
+"""Tests for Tier 1 C — group commit.
+
+These tests verify three things:
+
+1. **Correctness with group commit enabled.** Every successful ``put`` lands
+   exactly one revision; chains stay valid; ``verify`` passes.
+2. **Genuine batching.** Under load, the number of batches is much smaller
+   than the number of writes — proving fsyncs are amortized.
+3. **Disabled-mode parity.** With ``commit_window_ms=0`` (the default), no
+   batches are created and behavior matches the pre-group-commit code path.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+import pytest
+
+from .store import ConcurrencyConflict, Store
+
+
+# A modest window — large enough to actually catch concurrent writers in
+# this process, small enough not to slow the test suite noticeably.
+WINDOW_MS = 5.0
+
+
+def _writer(store: Store, uid: str, branch: str, payloads: list[bytes]) -> int:
+    n = 0
+    for p in payloads:
+        rev = store.put(uid, p, branch=branch)
+        if rev is not None:
+            n += 1
+    return n
+
+
+def test_disabled_by_default(tmp_path: Path):
+    """With no constructor argument, no batches are formed."""
+    with Store(tmp_path) as store:
+        for i in range(5):
+            store.put(f"uid-{i}", f"v{i}".encode())
+        assert store._batch_count == 0
+        assert store._batched_writes == 0
+
+
+def test_window_zero_explicit_disables(tmp_path: Path):
+    with Store(tmp_path, commit_window_ms=0.0) as store:
+        store.put("alice", b"v1")
+        assert store._batch_count == 0
+
+
+def test_single_writer_with_group_commit_works(tmp_path: Path):
+    """A lone writer in a group of one still commits durably."""
+    with Store(tmp_path, commit_window_ms=WINDOW_MS) as store:
+        rev = store.put("alice", b"v1")
+        assert rev is not None
+        assert store.get("alice") == b"v1"
+        assert store._batch_count == 1
+        assert store._batched_writes == 1
+        assert store.verify("alice")
+
+
+def test_concurrent_writers_actually_batch(tmp_path: Path):
+    """With many concurrent writers on disjoint uids, the number of batches
+    must be significantly less than the number of writes — proving the
+    fsyncs were amortized."""
+    N_WRITERS = 16
+    N_PAYLOADS = 4
+    total_writes = N_WRITERS * N_PAYLOADS
+
+    with Store(tmp_path, commit_window_ms=WINDOW_MS, commit_max_size=64) as store:
+        with ThreadPoolExecutor(max_workers=N_WRITERS) as pool:
+            futures = [
+                pool.submit(
+                    _writer,
+                    store,
+                    f"uid-{i}",
+                    "main",
+                    [f"p-{i}-{j}".encode() for j in range(N_PAYLOADS)],
+                )
+                for i in range(N_WRITERS)
+            ]
+            counts = [f.result() for f in as_completed(futures)]
+        assert sum(counts) == total_writes
+
+        # All writes landed.
+        for i in range(N_WRITERS):
+            assert store.verify(f"uid-{i}")
+            assert len(list(store.history(f"uid-{i}"))) == N_PAYLOADS
+
+        # Genuine batching: at least one batch carried more than one write.
+        # (Stronger numerical asserts are timing-dependent and would flake
+        # on slow CI runners; this minimum is robust.)
+        assert store._batch_count < total_writes, (
+            f"expected batching: got {store._batch_count} batches "
+            f"for {total_writes} writes"
+        )
+        assert store._batched_writes == total_writes
+
+
+def test_max_size_caps_batch(tmp_path: Path):
+    """When ``commit_max_size`` is small, batches close as soon as they fill
+    rather than waiting for the full window."""
+    cap = 4
+    N_WRITERS = 16
+    with Store(
+        tmp_path,
+        commit_window_ms=50.0,  # generous window
+        commit_max_size=cap,
+    ) as store:
+        with ThreadPoolExecutor(max_workers=N_WRITERS) as pool:
+            futures = [
+                pool.submit(store.put, f"uid-{i}", b"x")
+                for i in range(N_WRITERS)
+            ]
+            for f in as_completed(futures):
+                f.result()
+
+        # No batch can exceed the cap.
+        assert store._batched_writes == N_WRITERS
+        # And we should have at least ceil(16/4) = 4 batches if every group
+        # filled to cap (in practice timing slack means we may see more,
+        # but never fewer).
+        assert store._batch_count >= N_WRITERS // cap
+
+
+def test_idempotent_put_under_group_commit(tmp_path: Path):
+    """Idempotent no-op (same content as latest) returns None and does not
+    enter the commit group."""
+    with Store(tmp_path, commit_window_ms=WINDOW_MS) as store:
+        r1 = store.put("alice", b"same")
+        assert r1 is not None
+        before = store._batched_writes
+        r2 = store.put("alice", b"same")
+        assert r2 is None
+        # Idempotent path returned without enqueueing.
+        assert store._batched_writes == before
+
+
+def test_expected_prev_hash_under_group_commit(tmp_path: Path):
+    """CAS still works through the group commit path."""
+    with Store(tmp_path, commit_window_ms=WINDOW_MS) as store:
+        r1 = store.put("alice", b"v1")
+        assert r1 is not None
+        r2 = store.put("alice", b"v2", expected_prev_hash=r1.content_hash)
+        assert r2 is not None
+
+        # Move the tip from elsewhere; CAS against r2's stale ref must fail.
+        store.put("alice", b"v-stolen")
+        with pytest.raises(ConcurrencyConflict):
+            store.put("alice", b"v3", expected_prev_hash=r2.content_hash)
+
+
+def test_branching_works_under_group_commit(tmp_path: Path):
+    """Branched writes with group commit enabled stay isolated per branch."""
+    with Store(tmp_path, commit_window_ms=WINDOW_MS) as store:
+        store.create_branch("feature-x")
+
+        N = 8
+        payloads = [(f"main-{i}".encode(), f"feat-{i}".encode()) for i in range(N)]
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            futures = []
+            for m, f in payloads:
+                futures.append(pool.submit(store.put, "alice", m, branch="main"))
+                futures.append(
+                    pool.submit(store.put, "alice", f, branch="feature-x")
+                )
+            for fut in as_completed(futures):
+                fut.result()
+
+        assert len(list(store.history("alice", branch="main"))) == N
+        assert len(list(store.history("alice", branch="feature-x"))) == N
+        assert store.verify("alice", branch="main")
+        assert store.verify("alice", branch="feature-x")
+
+
+def test_chain_order_preserved_under_concurrent_branches(tmp_path: Path):
+    """Within (branch, uid) the prev_hash chain must remain intact even when
+    multiple branches' writes are interleaved into the same batch."""
+    with Store(tmp_path, commit_window_ms=WINDOW_MS, commit_max_size=64) as store:
+        store.create_branch("feature-x")
+
+        # Drive a lot of interleaved writes into the same group.
+        N = 20
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            futures = []
+            for i in range(N):
+                futures.append(
+                    pool.submit(store.put, f"u-{i % 4}", f"m-{i}".encode())
+                )
+                futures.append(
+                    pool.submit(
+                        store.put,
+                        f"u-{i % 4}",
+                        f"f-{i}".encode(),
+                        branch="feature-x",
+                    )
+                )
+            for f in as_completed(futures):
+                f.result()
+
+        for i in range(4):
+            uid = f"u-{i}"
+            assert store.verify(uid, branch="main")
+            assert store.verify(uid, branch="feature-x")
+
+
+def test_persistence_across_reopens(tmp_path: Path):
+    """A group-committed write must be durable after the store is closed
+    and reopened (regular store, no group commit on reopen)."""
+    with Store(tmp_path, commit_window_ms=WINDOW_MS) as store:
+        store.put("alice", b"durable")
+    # Reopen with group commit disabled to prove the data is on disk
+    # independent of the commit path.
+    with Store(tmp_path) as store:
+        assert store.get("alice") == b"durable"
+        assert store.verify("alice")

--- a/libs/naas-abi-core/naas_abi_core/utils/versionstore/store_test.py
+++ b/libs/naas-abi-core/naas_abi_core/utils/versionstore/store_test.py
@@ -1,0 +1,189 @@
+"""Tests for Store."""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import time
+from pathlib import Path
+
+import pytest
+
+from .revision import HASH_LEN
+from .store import GENESIS, Store
+
+
+def test_put_and_get_latest(tmp_path: Path):
+    with Store(tmp_path) as store:
+        rev = store.put("alice", b"hello")
+        assert rev is not None
+        assert rev.prev_hash == GENESIS
+        assert rev.content_hash == hashlib.sha256(b"hello").hexdigest()
+        assert store.get("alice") == b"hello"
+
+
+def test_missing_uid_returns_none(tmp_path: Path):
+    with Store(tmp_path) as store:
+        assert store.get("nobody") is None
+        assert store.latest("nobody") is None
+
+
+def test_idempotent_put_returns_none(tmp_path: Path):
+    with Store(tmp_path) as store:
+        r1 = store.put("alice", b"same")
+        r2 = store.put("alice", b"same")
+        assert r1 is not None
+        assert r2 is None
+        assert list(store.history("alice")) == [r1]
+
+
+def test_prev_hash_chain(tmp_path: Path):
+    with Store(tmp_path) as store:
+        r1 = store.put("alice", b"v1")
+        r2 = store.put("alice", b"v2")
+        r3 = store.put("alice", b"v3")
+        assert r1 is not None and r2 is not None and r3 is not None
+        assert r1.prev_hash == GENESIS
+        assert r2.prev_hash == r1.content_hash
+        assert r3.prev_hash == r2.content_hash
+
+
+def test_time_travel(tmp_path: Path):
+    with Store(tmp_path) as store:
+        store.put("alice", b"v1")
+        time.sleep(0.005)
+        t_mid = dt.datetime.now(dt.timezone.utc)
+        time.sleep(0.005)
+        store.put("alice", b"v2")
+
+        assert store.get("alice") == b"v2"
+        assert store.get("alice", at=t_mid) == b"v1"
+
+
+def test_time_travel_before_existence(tmp_path: Path):
+    with Store(tmp_path) as store:
+        t_before = dt.datetime.now(dt.timezone.utc)
+        time.sleep(0.005)
+        store.put("alice", b"v1")
+        assert store.get("alice", at=t_before) is None
+
+
+def test_empty_payload_is_valid_revision(tmp_path: Path):
+    with Store(tmp_path) as store:
+        rev = store.put("alice", b"")
+        assert rev is not None
+        assert store.get("alice") == b""
+        # Empty payload is a legitimate revision, not a deletion signal.
+
+
+def test_history_ordered(tmp_path: Path):
+    with Store(tmp_path) as store:
+        store.put("alice", b"v1")
+        store.put("alice", b"v2")
+        store.put("alice", b"v3")
+        ts = [r.ts_ns for r in store.history("alice")]
+        assert ts == sorted(ts)
+
+
+def test_uids_at(tmp_path: Path):
+    with Store(tmp_path) as store:
+        store.put("alice", b"a1")
+        store.put("bob", b"b1")
+        store.put("alice", b"a2")
+        latest = dict(store.uids_at())
+        assert set(latest) == {"alice", "bob"}
+        assert latest["alice"].content_hash == hashlib.sha256(b"a2").hexdigest()
+
+
+def test_verify_passes(tmp_path: Path):
+    with Store(tmp_path) as store:
+        store.put("alice", b"v1")
+        store.put("alice", b"v2")
+        store.put("alice", b"v3")
+        assert store.verify("alice") is True
+
+
+def test_verify_detects_content_tamper(tmp_path: Path):
+    with Store(tmp_path) as store:
+        rev = store.put("alice", b"v1")
+        assert rev is not None
+        # Tamper with the content while keeping the filename.
+        rev.path.write_bytes(b"TAMPERED")
+        assert store.verify("alice") is False
+
+
+def test_rebuild_index_reconstructs_from_fs(tmp_path: Path):
+    with Store(tmp_path) as store:
+        store.put("alice", b"v1")
+        store.put("alice", b"v2")
+        store.put("bob", b"b1")
+
+        # Nuke the index.
+        store._conn.execute("DELETE FROM revisions")
+        assert list(store.uids()) == []
+
+        store.rebuild_index()
+
+        assert set(store.uids()) == {"alice", "bob"}
+        assert store.get("alice") == b"v2"
+        assert store.get("bob") == b"b1"
+        assert store.verify("alice")
+        assert store.verify("bob")
+
+
+def test_rebuild_index_cleans_tmp_files(tmp_path: Path):
+    with Store(tmp_path) as store:
+        store.put("alice", b"v1")
+        # Simulate a crashed write leaving a .tmp file.
+        uid_dir = store.data_dir / "alice"
+        stale = uid_dir / "00000000000000000001.aaa.bbb.tmp"
+        stale.write_bytes(b"garbage")
+        assert stale.exists()
+
+        store.rebuild_index()
+        assert not stale.exists()
+
+
+def test_filesystem_is_truth(tmp_path: Path):
+    """Delete a revision file; rebuild should drop it from the index."""
+    with Store(tmp_path) as store:
+        r1 = store.put("alice", b"v1")
+        r2 = store.put("alice", b"v2")
+        assert r1 is not None and r2 is not None
+        # Delete the second revision from the filesystem.
+        r2.path.unlink()
+        store.rebuild_index()
+        # Only r1 should remain.
+        history = list(store.history("alice"))
+        assert len(history) == 1
+        assert history[0].content_hash == r1.content_hash
+
+
+def test_invalid_uid_rejected(tmp_path: Path):
+    with Store(tmp_path) as store:
+        with pytest.raises(ValueError):
+            store.put("../escape", b"x")
+        with pytest.raises(ValueError):
+            store.put("", b"x")
+        with pytest.raises(ValueError):
+            store.put("with/slash", b"x")
+
+
+def test_persists_across_instances(tmp_path: Path):
+    with Store(tmp_path) as store:
+        store.put("alice", b"v1")
+    with Store(tmp_path) as store:
+        assert store.get("alice") == b"v1"
+
+
+def test_revision_filename_matches_path(tmp_path: Path):
+    with Store(tmp_path) as store:
+        rev = store.put("alice", b"hello")
+        assert rev is not None
+        assert rev.path.exists()
+        assert rev.path.name == rev.filename
+        # Filename has expected shape: ts.prev.content (each hash HASH_LEN long).
+        parts = rev.filename.split(".")
+        assert len(parts) == 3
+        assert len(parts[1]) == HASH_LEN
+        assert len(parts[2]) == HASH_LEN

--- a/libs/naas-abi-core/naas_abi_core/utils/versionstore/uuid7.py
+++ b/libs/naas-abi-core/naas_abi_core/utils/versionstore/uuid7.py
@@ -1,0 +1,59 @@
+"""Minimal UUIDv7 generator (RFC 9562), stdlib-only.
+
+Python's stdlib gained `uuid.uuid7()` in 3.14; this module provides the same
+for earlier versions and adds process-local monotonicity within a ms.
+
+Layout (128 bits):
+    48 bits  unix_ts_ms
+     4 bits  version (= 7)
+    12 bits  rand_a (monotonic sub-ms counter)
+     2 bits  variant (= 0b10)
+    62 bits  rand_b (random)
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+import uuid
+
+
+_lock = threading.Lock()
+_last_ts_ms = 0
+_last_seq = 0
+
+
+def uuid7() -> str:
+    """Return a UUIDv7 as a canonical dashed hex string.
+
+    Process-monotonic: calls within the same millisecond increment a sub-ms
+    counter (the `rand_a` field), so lexical order matches call order.
+    """
+    global _last_ts_ms, _last_seq
+
+    with _lock:
+        ts_ms = time.time_ns() // 1_000_000
+        if ts_ms <= _last_ts_ms:
+            # Clock didn't advance: stay on last ms, bump the sub-ms counter.
+            ts_ms = _last_ts_ms
+            _last_seq += 1
+            if _last_seq >= (1 << 12):
+                # Exhausted 12-bit counter; roll forward to the next ms.
+                ts_ms = _last_ts_ms + 1
+                _last_seq = 0
+        else:
+            _last_seq = 0
+        rand_a = _last_seq
+        _last_ts_ms = ts_ms
+
+    rand_b = int.from_bytes(os.urandom(8), "big") & ((1 << 62) - 1)
+
+    n = 0
+    n |= (ts_ms & ((1 << 48) - 1)) << 80
+    n |= 0x7 << 76                     # version
+    n |= (rand_a & 0xFFF) << 64
+    n |= 0b10 << 62                    # variant
+    n |= rand_b
+
+    return str(uuid.UUID(int=n))

--- a/libs/naas-abi-core/naas_abi_core/utils/versionstore/uuid7_test.py
+++ b/libs/naas-abi-core/naas_abi_core/utils/versionstore/uuid7_test.py
@@ -1,0 +1,28 @@
+"""Tests for uuid7."""
+
+from __future__ import annotations
+
+import re
+
+from .uuid7 import uuid7
+
+
+UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+)
+
+
+def test_uuid7_format():
+    for _ in range(100):
+        u = uuid7()
+        assert UUID_RE.match(u), f"bad uuid: {u}"
+
+
+def test_uuid7_monotonic():
+    ids = [uuid7() for _ in range(1000)]
+    assert ids == sorted(ids), "uuid7s should be lexically monotonic within a process"
+
+
+def test_uuid7_uniqueness():
+    ids = {uuid7() for _ in range(10_000)}
+    assert len(ids) == 10_000


### PR DESCRIPTION
## Summary

Vendors the [versionstore](https://github.com/Dr0p42/versionstore) append-only content-addressed blob store under `libs/naas-abi-core/naas_abi_core/utils/versionstore/` as the planned substrate for branched ABI services (see #865), and extends it along the spec's Tier 1 axes.

This is the storage substrate for the branching architecture discussed on #865. It is **not yet** wired into any service — that's the follow-up PR alongside `IVersionedStorePort`. This PR ships the substrate + its test surface only.

## What's in here

### Branching (minimum viable)
- `branches` table; `branch` column on revisions.
- `put / latest / history / get / verify` accept an optional `branch=` (default `\"main\"`).
- Backward-compatible filename grammar: `main` keeps the 3-part `ts.prev.content`; non-main use a 4-part `ts.prev.content.branch`. `rebuild_index` parses both.
- `create_branch`, `list_branches`.
- Deferred to a follow-up: multi-parent merge revisions, fall-through reads to a parent branch, `merge`/`diff`, branch metadata sidecars on the filesystem.

### Tier 1 A — per-uid concurrency
The previous global `BEGIN IMMEDIATE` lock around read-latest + file-write + INSERT is gone. Reads are lock-free; the file write happens outside any DB transaction; the INSERT carries `UNIQUE(branch, uid, prev_hash)` as the conflict gate. Writers on disjoint uids no longer serialize.

### Tier 1 B — per-(branch, uid) concurrency
The unique constraint includes branch, so writers on different branches touching the same uid don't conflict. A per-(branch, uid) in-process lock serializes same-entity writers cleanly while letting different (branch, uid) pairs run in parallel.

### Tier 1 C — group commit (opt-in via `commit_window_ms`)
Leader-follower scheme amortizes file fsync, dir fsync, and the SQLite COMMIT across every writer in the same window. Per-row `SAVEPOINT`s isolate cross-process UNIQUE conflicts so one bad row doesn't sink a batch. **Hard size cap** (followers arriving at a full group open a new one). Default off; recommended `commit_window_ms=2.0, commit_max_size=64` for concurrent-write workloads.

### Cross-platform durability (`durability=\"full\"` by default)
On macOS, `os.fsync` only flushes to the drive controller cache — a power loss can lose recently-acked writes. Full mode escalates to `fcntl(fd, F_FULLFSYNC)` and `PRAGMA fullfsync=ON` + `synchronous=FULL` so the \"`put` returned success implies durable\" contract holds on every platform. `durability=\"fast\"` is the opt-out for dev/tests. Identical to `\"full\"` on Linux/Windows/BSD where `os.fsync` already provides true durability.

### Optimistic concurrency
`expected_prev_hash` kwarg on `put` + `ConcurrencyConflict` exception for compare-and-swap from above the store.

### Other
- Benchmark script: `python -m naas_abi_core.utils.versionstore.benchmark`, sweeps workload, concurrency, commit window, durability.
- WHITEPAPER.md updates (§3.1.1 durability model, §3.2 protocol annotation, §11 group commit) and README.md.

## Tests

- 66 passed, 1 platform-skipped on macOS (5 registry + 4 revision + 3 uuid7 + 17 existing store + 12 branching + 7 concurrency + 10 group commit + 8 durability).
- Default `durability=\"full\"` is correct everywhere; on macOS test runtime moves from ~0.4s to ~11s due to real `F_FULLFSYNC` barriers — that's the cost of the durability claim being true. On Linux/Windows/BSD there's no extra cost.

## Benchmark headline (macOS APFS, M-series, NVMe)

**`durability=\"full\"`** (real platter durability):
- disjoint/64: solo 95 → group(10ms) 167 writes/s — **1.76×**
- disjoint/16: solo 92 → group(2ms) 142 writes/s — **1.54×**
- branched/16: solo 66 → group(2ms) 91 writes/s — **1.38×**

**`durability=\"fast\"`** (cache-only on macOS):
- Solo wins at low concurrency (fsync is essentially free).
- disjoint/64 at 10ms: 1,274 → 3,397 writes/s — **2.67×** (SQLite WAL fsync becomes the bottleneck under contention).

The amortization metric proves the mechanism works (e.g. disjoint/64/10ms shows **53× fsync amortization** in fast mode, 14× in full mode). On Linux + cloud storage (EBS/NFS) the win should be larger than what we see in fast mode on macOS — `os.fsync` is real there, and group commit's value scales with fsync cost.

## Test plan

- [x] `uv run pytest naas_abi_core/utils/versionstore/` — 66 passed, 1 platform-skipped
- [x] Pre-commit ruff: passes
- [x] Pre-commit mypy on naas_abi_core: passes
- [x] Pre-commit mypy on naas_abi_cli: passes
- [x] Pre-commit bandit: passes
- [x] Manual benchmark sweep (full + fast modes)

## Notes for reviewers

1. **No services consume this yet.** This PR is substrate only. The next PR introduces `IVersionedStorePort` and the first naas-abi-core service to back onto it.
2. **The `\"full\"` durability default may surprise macOS developers** — tests run noticeably slower because `F_FULLFSYNC` is a real hardware barrier. This is correct behavior; it can be opted out per-test via `Store(tmp, durability=\"fast\")` if a test becomes a runtime bottleneck.
3. **The whitepaper changes** include a substantive new §3.1.1 on the durability model and an updated §11 documenting that group commit is now implemented in this vendored copy (the upstream library should adopt it once the model has been exercised).
4. **`benchmark.py` is committed** — it's small, useful for reproducing the numbers above on different hardware, and helpful for future tuning.

Refs: #865

🤖 Generated with [Claude Code](https://claude.com/claude-code)