### PR TITLE
feat(nexus): expand file previews to office docs and plain-text formats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -567,7 +567,7 @@ test-api-init-container: build
 		abi:latest uv run --no-dev python -m naas_abi_core.apps.api.test_init
 
 # TTL_FILES := $(wildcard src/*/*/ontologies/*.ttl src/marketplace/*/*/ontologies/*.ttl)
-TTL_FILES := $(shell find src -name '*.ttl')
+TTL_FILES := $(shell find src -name '*.ttl' 2>/dev/null)
 PY_FILES := $(patsubst %.ttl, %.py, $(TTL_FILES))
 
 onto2py-force: onto2py-clean $(PY_FILES) onto2py-ruff-fix
@@ -596,7 +596,7 @@ hello:
 # =============================================================================
 
 # Master check target - runs all code quality checks
-check: deps .venv/lib/python$(python_version)/site-packages/abi check-core check-marketplace
+check: deps check-core check-marketplace
 
 # Code quality checks for core modules
 check-core: deps

--- a/docker/images/Dockerfile
+++ b/docker/images/Dockerfile
@@ -1,8 +1,19 @@
 FROM python:3.11
 WORKDIR /app
 
-# Install CA certificates
-RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificates
+# Install CA certificates and LibreOffice (headless) for office-document
+# preview conversion (docx/xlsx/pptx -> PDF) used by the Nexus files API.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libreoffice-core \
+        libreoffice-writer \
+        libreoffice-calc \
+        libreoffice-impress \
+        fonts-dejavu \
+        fonts-liberation \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN pip install uv
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/files/service.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/files/service.py
@@ -235,11 +235,20 @@ class FilesService:
             content_type=content_type or "application/octet-stream",
         )
 
+    # Office-style formats LibreOffice can render to PDF for preview.
+    PDF_PREVIEW_EXTENSIONS: frozenset[str] = frozenset({
+        ".ppt", ".pptx", ".odp",
+        ".doc", ".docx", ".odt", ".rtf",
+        ".xls", ".xlsx", ".xlsm", ".xlsb", ".ods",
+    })
+
     def preview_file_as_pdf(self, path: str) -> PdfPreviewData:
         normalized_path = self.normalize_relative_path(path)
         ext = PurePosixPath(normalized_path).suffix.lower()
-        if ext not in {".ppt", ".pptx"}:
-            raise UnsupportedPreviewError("Only PPT/PPTX preview is supported")
+        if ext not in self.PDF_PREVIEW_EXTENSIONS:
+            raise UnsupportedPreviewError(
+                "PDF preview is not supported for this file type"
+            )
         if self._is_directory(normalized_path):
             raise IsDirectoryError("Cannot preview a directory")
 
@@ -251,10 +260,10 @@ class FilesService:
         soffice = shutil.which("soffice") or shutil.which("libreoffice")
         if not soffice:
             raise PreviewUnavailableError(
-                "PPTX preview is unavailable: LibreOffice is not installed on the API service."
+                "Office preview is unavailable: LibreOffice is not installed on the API service."
             )
 
-        with tempfile.TemporaryDirectory(prefix="nexus-ppt-preview-") as tmp_dir:
+        with tempfile.TemporaryDirectory(prefix="nexus-office-preview-") as tmp_dir:
             input_path = Path(tmp_dir) / PurePosixPath(normalized_path).name
             output_name = f"{PurePosixPath(normalized_path).stem}.pdf"
             output_path = Path(tmp_dir) / output_name

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/package.json
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/package.json
@@ -13,6 +13,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@embedpdf/snippet": "^2.14.1",
     "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-avatar": "^1.0.4",
     "@radix-ui/react-dialog": "^1.0.5",

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/files/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/files/page.tsx
@@ -34,6 +34,7 @@ import { cn } from '@/lib/utils';
 import { useFilesStore, type FileInfo } from '@/stores/files';
 import { authFetch } from '@/stores/auth';
 import { usePrompt, useConfirm } from '@/components/ui/dialogs';
+import { PdfViewer } from '@/components/files/pdf-viewer';
 
 export default function FilesPage() {
   const router = useRouter();
@@ -77,10 +78,11 @@ export default function FilesPage() {
   const [imageViewerUrl, setImageViewerUrl] = useState<string | null>(null);
   const [imageViewerLoading, setImageViewerLoading] = useState(false);
   const [imageViewerError, setImageViewerError] = useState<string | null>(null);
-  const [markdownViewerFileName, setMarkdownViewerFileName] = useState<string | null>(null);
-  const [markdownViewerContent, setMarkdownViewerContent] = useState<string>('');
-  const [markdownViewerLoading, setMarkdownViewerLoading] = useState(false);
-  const [markdownViewerError, setMarkdownViewerError] = useState<string | null>(null);
+  const [textViewerFileName, setTextViewerFileName] = useState<string | null>(null);
+  const [textViewerContent, setTextViewerContent] = useState<string>('');
+  const [textViewerMode, setTextViewerMode] = useState<'markdown' | 'code'>('code');
+  const [textViewerLoading, setTextViewerLoading] = useState(false);
+  const [textViewerError, setTextViewerError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   
   // Helper to open file in Lab
@@ -117,6 +119,10 @@ export default function FilesPage() {
   // Check if we're viewing a synced local folder
   const activeSyncedFolder = syncedFolders.find((f) => f.id === activeSource);
   const isLocalFolder = !!activeSyncedFolder;
+  // Source-aware scope param to match how file ops are routed in the store.
+  const filesScope: 'workspace' | 'my_drive' =
+    activeSource === 'my-drive' ? 'my_drive' : 'workspace';
+  const fileQueryParams = `workspace_id=${encodeURIComponent(workspaceId)}&scope=${filesScope}`;
 
   useEffect(() => {
     // Clear any previous errors
@@ -340,14 +346,75 @@ export default function FilesPage() {
     return (
       lowerName.endsWith('.md') ||
       lowerName.endsWith('.markdown') ||
+      lowerName.endsWith('.mdx') ||
       file.content_type === 'text/markdown'
     );
   };
 
-  const isPresentationFile = (file: FileInfo) => {
+  // Extensions that are reliably plain text. Markdown is detected separately
+  // so it can be rendered with ReactMarkdown instead of as raw source.
+  const TEXT_EXTENSIONS = new Set([
+    'txt', 'log', 'rst', 'tex', 'csv', 'tsv',
+    'json', 'jsonc', 'json5', 'ndjson', 'geojson',
+    'yaml', 'yml', 'toml', 'ini', 'cfg', 'conf', 'properties', 'env',
+    'xml', 'plist', 'svg', 'gql', 'graphql', 'proto',
+    'html', 'htm', 'css', 'scss', 'sass', 'less', 'styl',
+    'js', 'jsx', 'mjs', 'cjs', 'ts', 'tsx', 'vue', 'svelte', 'astro',
+    'py', 'pyi', 'rb', 'go', 'rs', 'java', 'kt', 'kts', 'swift',
+    'c', 'h', 'cc', 'cpp', 'hpp', 'cs', 'm', 'mm',
+    'php', 'lua', 'r', 'jl', 'dart', 'sql', 'pl', 'pm',
+    'sh', 'bash', 'zsh', 'fish', 'ps1', 'bat', 'cmd',
+    'patch', 'diff', 'gitignore', 'gitattributes', 'editorconfig',
+    'lock', 'in', 'mk',
+  ]);
+
+  // Filenames (no extension or special) that we know are text.
+  const TEXT_FILENAMES = new Set([
+    'dockerfile', 'makefile', 'rakefile', 'gemfile', 'procfile',
+    'license', 'readme', 'changelog', 'authors', 'contributors', 'notice',
+    '.gitignore', '.gitattributes', '.editorconfig', '.env', '.npmrc', '.nvmrc',
+  ]);
+
+  const isTextFile = (file: FileInfo) => {
     if (file.type !== 'file') return false;
+    if (isMarkdownFile(file)) return true;
+    const lowerName = file.name.toLowerCase();
+    if (TEXT_FILENAMES.has(lowerName)) return true;
     const ext = getFileExtension(file.name);
-    return ['ppt', 'pptx', 'key'].includes(ext);
+    if (ext && TEXT_EXTENSIONS.has(ext)) return true;
+    const ct = file.content_type?.toLowerCase() || '';
+    if (ct.startsWith('text/')) return true;
+    if (
+      ct === 'application/json' ||
+      ct === 'application/xml' ||
+      ct === 'application/javascript' ||
+      ct === 'application/x-yaml' ||
+      ct === 'application/x-sh' ||
+      ct.endsWith('+json') ||
+      ct.endsWith('+xml')
+    ) {
+      return true;
+    }
+    return false;
+  };
+
+  // Office formats we render via server-side LibreOffice → PDF conversion.
+  const OFFICE_PREVIEW_EXTENSIONS = new Set([
+    'ppt', 'pptx', 'odp', 'key',
+    'doc', 'docx', 'odt', 'rtf',
+    'xls', 'xlsx', 'xlsm', 'xlsb', 'ods',
+  ]);
+
+  const isOfficeFile = (file: FileInfo) => {
+    if (file.type !== 'file') return false;
+    return OFFICE_PREVIEW_EXTENSIONS.has(getFileExtension(file.name));
+  };
+
+  const officeKindLabel = (file: FileInfo): string => {
+    const ext = getFileExtension(file.name);
+    if (['doc', 'docx', 'odt', 'rtf'].includes(ext)) return 'Document';
+    if (['xls', 'xlsx', 'xlsm', 'xlsb', 'ods'].includes(ext)) return 'Spreadsheet';
+    return 'Presentation';
   };
 
   const openPdfViewer = async (file: FileInfo) => {
@@ -365,7 +432,7 @@ export default function FilesPage() {
     try {
       const encodedPath = file.path.split('/').map(encodeURIComponent).join('/');
       const response = await authFetch(
-        `/api/files/raw/${encodedPath}?workspace_id=${encodeURIComponent(workspaceId)}`
+        `/api/files/raw/${encodedPath}?${fileQueryParams}`
       );
       if (!response.ok) {
         throw new Error('Failed to load PDF preview');
@@ -393,8 +460,8 @@ export default function FilesPage() {
     setPdfViewerLoading(false);
   };
 
-  const openPresentationPreview = async (file: FileInfo) => {
-    if (!isPresentationFile(file)) return;
+  const openOfficePreview = async (file: FileInfo) => {
+    if (!isOfficeFile(file)) return;
     setPdfViewerError(null);
     setPdfViewerLoading(true);
     setPdfViewerFileName(`${file.name} (PDF preview)`);
@@ -408,10 +475,10 @@ export default function FilesPage() {
     try {
       const encodedPath = file.path.split('/').map(encodeURIComponent).join('/');
       const response = await authFetch(
-        `/api/files/preview/pdf/${encodedPath}?workspace_id=${encodeURIComponent(workspaceId)}`
+        `/api/files/preview/pdf/${encodedPath}?${fileQueryParams}`
       );
       if (!response.ok) {
-        throw new Error('PPTX preview unavailable right now');
+        throw new Error(`${officeKindLabel(file)} preview unavailable right now`);
       }
       const blob = await response.blob();
       const blobUrl = URL.createObjectURL(
@@ -444,7 +511,7 @@ export default function FilesPage() {
     try {
       const encodedPath = file.path.split('/').map(encodeURIComponent).join('/');
       const response = await authFetch(
-        `/api/files/raw/${encodedPath}?workspace_id=${encodeURIComponent(workspaceId)}`
+        `/api/files/raw/${encodedPath}?${fileQueryParams}`
       );
       if (!response.ok) {
         throw new Error('Failed to load image preview');
@@ -469,35 +536,40 @@ export default function FilesPage() {
     setImageViewerLoading(false);
   };
 
-  const openMarkdownViewer = async (file: FileInfo) => {
-    if (!isMarkdownFile(file)) return;
-    setMarkdownViewerError(null);
-    setMarkdownViewerLoading(true);
-    setMarkdownViewerFileName(file.name);
-    setMarkdownViewerContent('');
+  const openTextViewer = async (file: FileInfo) => {
+    if (!isTextFile(file)) return;
+    const mode: 'markdown' | 'code' = isMarkdownFile(file) ? 'markdown' : 'code';
+    setTextViewerError(null);
+    setTextViewerLoading(true);
+    setTextViewerFileName(file.name);
+    setTextViewerMode(mode);
+    setTextViewerContent('');
 
     try {
       const encodedPath = file.path.split('/').map(encodeURIComponent).join('/');
       const response = await authFetch(
-        `/api/files/${encodedPath}?workspace_id=${encodeURIComponent(workspaceId)}`
+        `/api/files/${encodedPath}?${fileQueryParams}`
       );
       if (!response.ok) {
-        throw new Error('Failed to load markdown preview');
+        if (response.status === 415 || response.status === 422) {
+          throw new Error('This file is not a UTF-8 text file.');
+        }
+        throw new Error('Failed to load preview');
       }
       const data = await response.json();
-      setMarkdownViewerContent(typeof data.content === 'string' ? data.content : '');
+      setTextViewerContent(typeof data.content === 'string' ? data.content : '');
     } catch (error) {
-      setMarkdownViewerError(error instanceof Error ? error.message : 'Failed to load markdown preview');
+      setTextViewerError(error instanceof Error ? error.message : 'Failed to load preview');
     } finally {
-      setMarkdownViewerLoading(false);
+      setTextViewerLoading(false);
     }
   };
 
-  const closeMarkdownViewer = () => {
-    setMarkdownViewerFileName(null);
-    setMarkdownViewerContent('');
-    setMarkdownViewerError(null);
-    setMarkdownViewerLoading(false);
+  const closeTextViewer = () => {
+    setTextViewerFileName(null);
+    setTextViewerContent('');
+    setTextViewerError(null);
+    setTextViewerLoading(false);
   };
 
   const downloadFileToDesktop = async (file: FileInfo) => {
@@ -505,7 +577,7 @@ export default function FilesPage() {
     try {
       const encodedPath = file.path.split('/').map(encodeURIComponent).join('/');
       const response = await authFetch(
-        `/api/files/raw/${encodedPath}?workspace_id=${encodeURIComponent(workspaceId)}`
+        `/api/files/raw/${encodedPath}?${fileQueryParams}`
       );
       if (!response.ok) {
         throw new Error('Failed to download file');
@@ -778,14 +850,14 @@ export default function FilesPage() {
                             } else {
                               fetchFiles(file.path);
                             }
-                          } else if (isPresentationFile(file)) {
-                            openPresentationPreview(file);
+                          } else if (isOfficeFile(file)) {
+                            openOfficePreview(file);
                           } else if (isImageFile(file)) {
                             openImageViewer(file);
-                          } else if (isMarkdownFile(file)) {
-                            openMarkdownViewer(file);
                           } else if (isPdfFile(file)) {
                             openPdfViewer(file);
+                          } else if (isTextFile(file)) {
+                            openTextViewer(file);
                           } else {
                             openFile(file.path);
                           }
@@ -840,17 +912,17 @@ export default function FilesPage() {
                                 Open in Lab
                               </button>
                             )}
-                            {isPresentationFile(file) && (
+                            {isOfficeFile(file) && (
                               <button
                                 onClick={(e) => {
                                   e.stopPropagation();
                                   setActiveContextMenu(null);
-                                  openPresentationPreview(file);
+                                  openOfficePreview(file);
                                 }}
                                 className="flex w-full items-center gap-2 px-3 py-1.5 text-xs hover:bg-muted"
                               >
                                 <Eye size={12} />
-                                Preview PPTX
+                                Preview {officeKindLabel(file)}
                               </button>
                             )}
                             {isPdfFile(file) && (
@@ -879,17 +951,17 @@ export default function FilesPage() {
                                 View Image
                               </button>
                             )}
-                            {isMarkdownFile(file) && (
+                            {isTextFile(file) && !isPdfFile(file) && !isImageFile(file) && !isOfficeFile(file) && (
                               <button
                                 onClick={(e) => {
                                   e.stopPropagation();
                                   setActiveContextMenu(null);
-                                  openMarkdownViewer(file);
+                                  openTextViewer(file);
                                 }}
                                 className="flex w-full items-center gap-2 px-3 py-1.5 text-xs hover:bg-muted"
                               >
                                 <Eye size={12} />
-                                View Markdown
+                                {isMarkdownFile(file) ? 'View Markdown' : 'Preview'}
                               </button>
                             )}
                             {file.type === 'file' && (
@@ -946,14 +1018,14 @@ export default function FilesPage() {
                         } else {
                           fetchFiles(file.path);
                         }
-                      } else if (isPresentationFile(file)) {
-                        openPresentationPreview(file);
+                      } else if (isOfficeFile(file)) {
+                        openOfficePreview(file);
                       } else if (isImageFile(file)) {
                         openImageViewer(file);
-                      } else if (isMarkdownFile(file)) {
-                        openMarkdownViewer(file);
                       } else if (isPdfFile(file)) {
                         openPdfViewer(file);
+                      } else if (isTextFile(file)) {
+                        openTextViewer(file);
                       } else {
                         openFile(file.path);
                       }
@@ -1019,11 +1091,7 @@ export default function FilesPage() {
                 </div>
               )}
               {pdfViewerUrl && !pdfViewerLoading && !pdfViewerError && (
-                <iframe
-                  src={pdfViewerUrl}
-                  title={pdfViewerFileName}
-                  className="h-full w-full border-0"
-                />
+                <PdfViewer src={pdfViewerUrl} className="h-full w-full" />
               )}
             </div>
           </div>
@@ -1066,36 +1134,41 @@ export default function FilesPage() {
           </div>
         </div>
       )}
-      {markdownViewerFileName && (
+      {textViewerFileName && (
         <div className="fixed inset-0 z-[100] bg-black/60 p-4 backdrop-blur-sm">
           <div className="flex h-full flex-col overflow-hidden rounded-xl border bg-background shadow-2xl">
             <div className="flex items-center justify-between border-b px-4 py-2">
-              <div className="truncate text-sm font-medium">{markdownViewerFileName}</div>
+              <div className="truncate text-sm font-medium">{textViewerFileName}</div>
               <button
-                onClick={closeMarkdownViewer}
+                onClick={closeTextViewer}
                 className="flex h-8 w-8 items-center justify-center rounded-md hover:bg-muted"
-                aria-label="Close markdown viewer"
+                aria-label="Close text viewer"
               >
                 <X size={16} />
               </button>
             </div>
-            <div className="relative flex-1 overflow-auto bg-background p-6">
-              {markdownViewerLoading && (
+            <div className="relative flex-1 overflow-auto bg-background">
+              {textViewerLoading && (
                 <div className="absolute inset-0 flex items-center justify-center text-sm text-muted-foreground">
-                  Loading markdown preview...
+                  Loading preview...
                 </div>
               )}
-              {markdownViewerError && !markdownViewerLoading && (
+              {textViewerError && !textViewerLoading && (
                 <div className="absolute inset-0 flex items-center justify-center p-6 text-sm text-destructive">
-                  {markdownViewerError}
+                  {textViewerError}
                 </div>
               )}
-              {!markdownViewerLoading && !markdownViewerError && (
-                <div className="prose prose-sm max-w-none dark:prose-invert">
+              {!textViewerLoading && !textViewerError && textViewerMode === 'markdown' && (
+                <div className="prose prose-sm max-w-none p-6 dark:prose-invert">
                   <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                    {markdownViewerContent}
+                    {textViewerContent}
                   </ReactMarkdown>
                 </div>
+              )}
+              {!textViewerLoading && !textViewerError && textViewerMode === 'code' && (
+                <pre className="m-0 h-full overflow-auto whitespace-pre p-4 font-mono text-xs leading-relaxed text-foreground">
+                  {textViewerContent}
+                </pre>
               )}
             </div>
           </div>

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/files/pdf-viewer.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/files/pdf-viewer.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useTheme } from 'next-themes';
+
+type SnippetModule = typeof import('@embedpdf/snippet');
+
+interface PdfViewerProps {
+  src: string;
+  className?: string;
+}
+
+// Mounts the @embedpdf/snippet web-component viewer (PDFium WASM under the hood)
+// inside a host div. We dynamically import the module so the ~MB-class WASM/JS
+// payload is only fetched when a PDF is actually opened.
+export function PdfViewer({ src, className }: PdfViewerProps) {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const containerRef = useRef<Element | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const { resolvedTheme } = useTheme();
+
+  // Suppress the harmless "ResizeObserver loop completed with undelivered
+  // notifications" warning that the viewer's internal layout observers can
+  // emit. Next.js's dev error overlay otherwise turns it into a toast.
+  useEffect(() => {
+    const RESIZE_MSG = 'ResizeObserver loop completed with undelivered notifications';
+    const onError = (e: ErrorEvent) => {
+      if (e.message?.includes(RESIZE_MSG)) {
+        e.stopImmediatePropagation();
+        e.preventDefault();
+      }
+    };
+    window.addEventListener('error', onError);
+    return () => window.removeEventListener('error', onError);
+  }, []);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host || !src) return;
+
+    let cancelled = false;
+    setLoadError(null);
+
+    (async () => {
+      try {
+        const mod: SnippetModule = await import('@embedpdf/snippet');
+        if (cancelled || !hostRef.current) return;
+
+        // Tear down any prior instance before mounting a new one.
+        host.replaceChildren();
+
+        const instance = mod.default.init({
+          type: 'container',
+          target: host,
+          src,
+          theme: { preference: resolvedTheme === 'dark' ? 'dark' : 'light' },
+        });
+        containerRef.current = instance ?? null;
+
+        // The snippet mounts an <embedpdf-container> custom element; by default
+        // custom elements are display:inline and don't fill their parent,
+        // which leaves the inner scroll viewport unbounded. Force it to fill
+        // the host so the viewer's own scrolling/zoom can work.
+        if (instance instanceof HTMLElement) {
+          instance.style.position = 'absolute';
+          instance.style.inset = '0';
+          instance.style.display = 'block';
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setLoadError(err instanceof Error ? err.message : 'Failed to load PDF viewer');
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      // Removing children triggers the web-component's disconnectedCallback,
+      // which disposes the engine and releases the WASM document.
+      host.replaceChildren();
+      containerRef.current = null;
+    };
+  }, [src, resolvedTheme]);
+
+  return (
+    <div
+      className={className}
+      style={{ position: 'relative', height: '100%', width: '100%', minHeight: 0 }}
+    >
+      {/* Absolute fill guarantees a concrete pixel height for the snippet's
+          internal scroll viewport, regardless of the surrounding flex chain. */}
+      <div
+        ref={hostRef}
+        style={{ position: 'absolute', inset: 0, overflow: 'hidden' }}
+      />
+      {loadError && (
+        <div className="absolute inset-0 flex items-center justify-center p-6 text-sm text-destructive">
+          {loadError}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/pnpm-lock.yaml
+++ b/libs/naas-abi/naas_abi/apps/nexus/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@embedpdf/snippet':
+        specifier: ^2.14.1
+        version: 2.14.1(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@18.3.1)(react@18.3.1)
@@ -134,6 +137,32 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
     dev: true
+
+  /@babel/helper-string-parser@7.27.1:
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+    dev: false
+
+  /@babel/helper-validator-identifier@7.28.5:
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+    dev: false
+
+  /@babel/parser@7.29.2:
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.29.0
+    dev: false
+
+  /@babel/types@7.29.0:
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+    dev: false
 
   /@cloudflare/kv-asset-handler@0.4.2:
     resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==}
@@ -287,6 +316,737 @@ packages:
     engines: {node: '>=0.8.0'}
     dependencies:
       '@types/hammerjs': 2.0.46
+    dev: false
+
+  /@embedpdf/core@2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33):
+    resolution: {integrity: sha512-L0lNn5WGnGDPaI1q2wnavVF6C6haRtvPGbMfqhZrjr7V+e0GExeoTO0VjK1DwH4IIBHOuD6nsQFYI89+nY/sJA==}
+    peerDependencies:
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+    dependencies:
+      '@embedpdf/engines': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/models': 2.14.1
+      preact: 10.29.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      svelte: 5.55.5
+      vue: 3.5.33(typescript@5.9.3)
+    dev: false
+
+  /@embedpdf/engines@2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33):
+    resolution: {integrity: sha512-k+HHuhj7dPKZC+8wUvMbpEUbNfi6F5r96Ky2XbNhBxiMQSWlVljBQVfZWcq9Jy3TLslwn5m2BbrvvHw+UVqe3w==}
+    peerDependencies:
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+    dependencies:
+      '@embedpdf/fonts-arabic': 1.0.0
+      '@embedpdf/fonts-hebrew': 1.0.0
+      '@embedpdf/fonts-jp': 1.0.0
+      '@embedpdf/fonts-kr': 1.0.0
+      '@embedpdf/fonts-latin': 1.0.0
+      '@embedpdf/fonts-sc': 1.0.0
+      '@embedpdf/fonts-tc': 1.0.0
+      '@embedpdf/models': 2.14.1
+      '@embedpdf/pdfium': 2.14.1
+      preact: 10.29.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      svelte: 5.55.5
+      vue: 3.5.33(typescript@5.9.3)
+    dev: false
+
+  /@embedpdf/fonts-arabic@1.0.0:
+    resolution: {integrity: sha512-SnGvQb+LwPZQO2WjjvlmXrJZolJUfLYbLZQSaYUw1vrQyMyJKT4LewvJGG+hZ+Yz2fz7OMIQ+4Gc98mGODZtOg==}
+    dev: false
+
+  /@embedpdf/fonts-hebrew@1.0.0:
+    resolution: {integrity: sha512-5HVAKGL7VqPeTxxADDrSqAFBxfmAXdP8fIqrPwJIKkqdK2643bOer8CqnnpO3/nPoFhkzxhttWMB9BGiqSW62w==}
+    dev: false
+
+  /@embedpdf/fonts-jp@1.0.0:
+    resolution: {integrity: sha512-BY2tv/mcICUUKf+M/bizf3RU65PMqKClJ/e5o9mgMibxyML0OQvEDwYMRPODQkKgJKXCO3ScHmVvcmXp6kt+fA==}
+    dev: false
+
+  /@embedpdf/fonts-kr@1.0.0:
+    resolution: {integrity: sha512-bh88HXSvOBS581kgmihWY7Ijp9hBsvlmXogFG5LSNx9UBAobRcakZiFMGieRBc06hUSkpo7WhjaFM/z/SfQ8dQ==}
+    dev: false
+
+  /@embedpdf/fonts-latin@1.0.0:
+    resolution: {integrity: sha512-LLYysdr8O6sRNzhmW3PbF3AeA8xnqvOi4XLFfIfNlW5uEZ+qsJdcfd78Q78sFJMhlaOAYFMziMMsnOzmx463rA==}
+    dev: false
+
+  /@embedpdf/fonts-sc@1.0.0:
+    resolution: {integrity: sha512-ETXl7XCwaQLSSvMO3EUDwMNqtL64kX2LlFxarTRi/NsIGGOIxUurGfKtrkmtnKHrWy1jAJSt6oxK2uJhvdvQIw==}
+    dev: false
+
+  /@embedpdf/fonts-tc@1.0.0:
+    resolution: {integrity: sha512-rGZJbVD6DYS5BbXdpEMnWkpVF0Knar+bsiyb2o3+YRx7O8eyFubEBQUSUInirQk69HA6fc3GhYCg7TyC/oD76Q==}
+    dev: false
+
+  /@embedpdf/models@2.14.1:
+    resolution: {integrity: sha512-jbuoXKv4jW8F1o8EzCmPIB5U/yVC5DWlWhxL9ZfvBiBgW2HIy68ydcu+AykqOG75eAvCfxqcvF2HzSDsV3+K0A==}
+    dev: false
+
+  /@embedpdf/pdfium@2.14.1:
+    resolution: {integrity: sha512-4FKhpeb7CYfkZ1k0WyDTq8i2FlIO5MaR0ywIDJ0goxOjenKkYOgHQ4747B5evxRzNEC2H5V3Rk6Dunf7TlIYBQ==}
+    dev: false
+
+  /@embedpdf/plugin-annotation@2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-history@2.14.1)(@embedpdf/plugin-interaction-manager@2.14.1)(@embedpdf/plugin-scroll@2.14.1)(@embedpdf/plugin-selection@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33):
+    resolution: {integrity: sha512-YGe/DLL5r9HsF54QYgNnsc82W4E2jXRaX6D4WzR38argBhiSLf3IhTJmFXVR2WlPK4VwW6DA0p7WqKcEYUOyDg==}
+    peerDependencies:
+      '@embedpdf/core': 2.14.1
+      '@embedpdf/plugin-history': 2.14.1
+      '@embedpdf/plugin-interaction-manager': 2.14.1
+      '@embedpdf/plugin-scroll': 2.14.1
+      '@embedpdf/plugin-selection': 2.14.1
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+    dependencies:
+      '@embedpdf/core': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/models': 2.14.1
+      '@embedpdf/plugin-history': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-interaction-manager': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-scroll': 2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-viewport@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-selection': 2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-interaction-manager@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/utils': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      preact: 10.29.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      svelte: 5.55.5
+      vue: 3.5.33(typescript@5.9.3)
+    dev: false
+
+  /@embedpdf/plugin-attachment@2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33):
+    resolution: {integrity: sha512-RdR43Kp/t15/KcvAiN8VEMxhqJcTfK2ZeU95PbPHr8zZ1rDatRltVGmKQ4fcaBXQMv15VLTEPZNbGFbfRgdF8g==}
+    peerDependencies:
+      '@embedpdf/core': 2.14.1
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+    dependencies:
+      '@embedpdf/core': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/models': 2.14.1
+      preact: 10.29.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      svelte: 5.55.5
+      vue: 3.5.33(typescript@5.9.3)
+    dev: false
+
+  /@embedpdf/plugin-bookmark@2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33):
+    resolution: {integrity: sha512-ur5tEu4OaVec8T6qF9c18W9hfMNqg0g6dkVqcuh+qaLUYznJpyxMSsNTMJmw/h607bsVLfA1QCwk4l2vORwNmQ==}
+    peerDependencies:
+      '@embedpdf/core': 2.14.1
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+    dependencies:
+      '@embedpdf/core': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/models': 2.14.1
+      preact: 10.29.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      svelte: 5.55.5
+      vue: 3.5.33(typescript@5.9.3)
+    dev: false
+
+  /@embedpdf/plugin-capture@2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-interaction-manager@2.14.1)(@embedpdf/plugin-render@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33):
+    resolution: {integrity: sha512-Rgykj6DANjKACdpS2KIceJlQ9j+oHquiUnIiIFplN7ajMX8CBfe+eAkQZVfIHmFI1cEFJezf1lLWz04gZcTz2g==}
+    peerDependencies:
+      '@embedpdf/core': 2.14.1
+      '@embedpdf/plugin-interaction-manager': 2.14.1
+      '@embedpdf/plugin-render': 2.14.1
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+    dependencies:
+      '@embedpdf/core': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/models': 2.14.1
+      '@embedpdf/plugin-interaction-manager': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-render': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      preact: 10.29.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      svelte: 5.55.5
+      vue: 3.5.33(typescript@5.9.3)
+    dev: false
+
+  /@embedpdf/plugin-commands@2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33):
+    resolution: {integrity: sha512-3ekSwdn9i8SSi5ywaGe/l8aBlsivF0Dy/L9PZt6ypG64Iu4h6SprEgJcLscmJtRMTYhr5qibLSPLHKDePq5/NQ==}
+    peerDependencies:
+      '@embedpdf/core': 2.14.1
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+    dependencies:
+      '@embedpdf/core': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/models': 2.14.1
+      preact: 10.29.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      svelte: 5.55.5
+      vue: 3.5.33(typescript@5.9.3)
+    dev: false
+
+  /@embedpdf/plugin-document-manager@2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33):
+    resolution: {integrity: sha512-Qdj6Xkmpyt0aLHCkqZbOsOK5xzwI4IjaV8C2ihPiggB/iPDhoyXPklJb3wXmJfxjTIl+aw+FZmmPkmr4IpYn7w==}
+    peerDependencies:
+      '@embedpdf/core': 2.14.1
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+    dependencies:
+      '@embedpdf/core': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/models': 2.14.1
+      preact: 10.29.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      svelte: 5.55.5
+      vue: 3.5.33(typescript@5.9.3)
+    dev: false
+
+  /@embedpdf/plugin-export@2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33):
+    resolution: {integrity: sha512-O52WPexZD7dbUJQnjp3ikhNg7D3PmGZJowJmXVcmJ2YlTkBabN799LBppC+FYP7nXrtbwy7UmG6vdGWha1b/NQ==}
+    peerDependencies:
+      '@embedpdf/core': 2.14.1
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+    dependencies:
+      '@embedpdf/core': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/models': 2.14.1
+      preact: 10.29.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      svelte: 5.55.5
+      vue: 3.5.33(typescript@5.9.3)
+    dev: false
+
+  /@embedpdf/plugin-form@2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-annotation@2.14.1)(@embedpdf/plugin-history@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33):
+    resolution: {integrity: sha512-dZTp63433/U8YSzWe+dZFK1+AtSQuDibPCMjNhWipy7zlTku4oX5gPOE9Xt9avTGPUVWEqhAWju3uySLDaSjag==}
+    peerDependencies:
+      '@embedpdf/core': 2.14.1
+      '@embedpdf/plugin-annotation': 2.14.1
+      '@embedpdf/plugin-history': 2.14.1
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+    dependencies:
+      '@embedpdf/core': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/models': 2.14.1
+      '@embedpdf/plugin-annotation': 2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-history@2.14.1)(@embedpdf/plugin-interaction-manager@2.14.1)(@embedpdf/plugin-scroll@2.14.1)(@embedpdf/plugin-selection@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-history': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/utils': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      preact: 10.29.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      svelte: 5.55.5
+      vue: 3.5.33(typescript@5.9.3)
+    dev: false
+
+  /@embedpdf/plugin-fullscreen@2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33):
+    resolution: {integrity: sha512-O8JZc3RnveaoZYVRRj8uOvBZbmXZpOd2Q1WFIiZ5NweYquQCzlYDdfBKC5Bgny81/+Uslglk5/8SPokCkp3NfA==}
+    peerDependencies:
+      '@embedpdf/core': 2.14.1
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+    dependencies:
+      '@embedpdf/core': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/models': 2.14.1
+      preact: 10.29.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      svelte: 5.55.5
+      vue: 3.5.33(typescript@5.9.3)
+    dev: false
+
+  /@embedpdf/plugin-history@2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33):
+    resolution: {integrity: sha512-mJUKNO69b8Cf0zpE3zJRM5in/AsVRLZq4bRbuAfK9c5+YG2Z59fYEjfRNSwDefxatzFTgy3mlZ5/fSfZsAZz0w==}
+    peerDependencies:
+      '@embedpdf/core': 2.14.1
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+    dependencies:
+      '@embedpdf/core': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/models': 2.14.1
+      preact: 10.29.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      svelte: 5.55.5
+      vue: 3.5.33(typescript@5.9.3)
+    dev: false
+
+  /@embedpdf/plugin-i18n@2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33):
+    resolution: {integrity: sha512-CtVEcoY/BQmk4YX06MDuaIbVDsb3553ncXjYLR9UwPmv/eCJXYokcgY2/f7twFR3mg5O4Xgc/0O4DtuJrv87Gw==}
+    peerDependencies:
+      '@embedpdf/core': 2.14.1
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+    dependencies:
+      '@embedpdf/core': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/models': 2.14.1
+      preact: 10.29.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      svelte: 5.55.5
+      vue: 3.5.33(typescript@5.9.3)
+    dev: false
+
+  /@embedpdf/plugin-interaction-manager@2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33):
+    resolution: {integrity: sha512-eyH45cF3vHeZ5BlcgIjH212EtUhi20FvKSRZeLWZW72noOn6saXRDScLy/XGbtfGFjJoTrzkNA553hvrRpqVKA==}
+    peerDependencies:
+      '@embedpdf/core': 2.14.1
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+    dependencies:
+      '@embedpdf/core': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/models': 2.14.1
+      preact: 10.29.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      svelte: 5.55.5
+      vue: 3.5.33(typescript@5.9.3)
+    dev: false
+
+  /@embedpdf/plugin-pan@2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-interaction-manager@2.14.1)(@embedpdf/plugin-viewport@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33):
+    resolution: {integrity: sha512-sHc9gjfoWQhfMcJ2JULsTzH9Sg9z6wX76Qvr5cujSPoOVV5bZ4QCB0kF1vgLFFzA1ia7vIBveGtDHIGkQQjsxA==}
+    peerDependencies:
+      '@embedpdf/core': 2.14.1
+      '@embedpdf/plugin-interaction-manager': 2.14.1
+      '@embedpdf/plugin-viewport': 2.14.1
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+    dependencies:
+      '@embedpdf/core': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/models': 2.14.1
+      '@embedpdf/plugin-interaction-manager': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-viewport': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      preact: 10.29.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      svelte: 5.55.5
+      vue: 3.5.33(typescript@5.9.3)
+    dev: false
+
+  /@embedpdf/plugin-print@2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33):
+    resolution: {integrity: sha512-wYuGuxuBhau7l2BfTlD5oohboRdseOn9/v0uVNGwKDuLHUTrv2WnkpzibBYIjv73gttyMBxTXdB3PZfnWOo8VA==}
+    peerDependencies:
+      '@embedpdf/core': 2.14.1
+      preact: ^10.26.4
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+    dependencies:
+      '@embedpdf/core': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/models': 2.14.1
+      preact: 10.29.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      svelte: 5.55.5
+      vue: 3.5.33(typescript@5.9.3)
+    dev: false
+
+  /@embedpdf/plugin-redaction@2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-annotation@2.14.1)(@embedpdf/plugin-history@2.14.1)(@embedpdf/plugin-interaction-manager@2.14.1)(@embedpdf/plugin-selection@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33):
+    resolution: {integrity: sha512-xlcOgYDNqIKp9u7exT95RtfDGCkW1b+knGikpTNZEA5OJgtYO9RxquTkEZ4rdVZbgIWxs0xiMg6b0mhr33z4JQ==}
+    peerDependencies:
+      '@embedpdf/core': 2.14.1
+      '@embedpdf/plugin-annotation': 2.14.1
+      '@embedpdf/plugin-history': 2.14.1
+      '@embedpdf/plugin-interaction-manager': 2.14.1
+      '@embedpdf/plugin-selection': 2.14.1
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+    dependencies:
+      '@embedpdf/core': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/models': 2.14.1
+      '@embedpdf/plugin-annotation': 2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-history@2.14.1)(@embedpdf/plugin-interaction-manager@2.14.1)(@embedpdf/plugin-scroll@2.14.1)(@embedpdf/plugin-selection@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-history': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-interaction-manager': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-selection': 2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-interaction-manager@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/utils': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      preact: 10.29.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      svelte: 5.55.5
+      vue: 3.5.33(typescript@5.9.3)
+    dev: false
+
+  /@embedpdf/plugin-render@2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33):
+    resolution: {integrity: sha512-KRjeSZeQRrg6fuyUgSU43yE6bOrRredpEiAfPI/FUCGgniO9nokTHjnFYg5G3UtVteJdnzdnKwzBl5sY++NQkg==}
+    peerDependencies:
+      '@embedpdf/core': 2.14.1
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+    dependencies:
+      '@embedpdf/core': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/models': 2.14.1
+      preact: 10.29.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      svelte: 5.55.5
+      vue: 3.5.33(typescript@5.9.3)
+    dev: false
+
+  /@embedpdf/plugin-rotate@2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33):
+    resolution: {integrity: sha512-ILu0Y6bXzLQg63cj9pAJ0ime5m5HVDOSBOyTT/Nb47hBfDLSbTWQuvAHZXwxPhGOjM5Pn6gHssKWZjW2WiXkBQ==}
+    peerDependencies:
+      '@embedpdf/core': 2.14.1
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+    dependencies:
+      '@embedpdf/core': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/models': 2.14.1
+      preact: 10.29.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      svelte: 5.55.5
+      vue: 3.5.33(typescript@5.9.3)
+    dev: false
+
+  /@embedpdf/plugin-scroll@2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-viewport@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33):
+    resolution: {integrity: sha512-ppnP4t43EVNiXr2coEwybQ7BYucbUEpdTGlcEBm38DhLywgseVVySrcIMx7rHdM7ZylsW7uwS84hCFndTpPezg==}
+    peerDependencies:
+      '@embedpdf/core': 2.14.1
+      '@embedpdf/plugin-viewport': 2.14.1
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+    dependencies:
+      '@embedpdf/core': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/models': 2.14.1
+      '@embedpdf/plugin-viewport': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      preact: 10.29.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      svelte: 5.55.5
+      vue: 3.5.33(typescript@5.9.3)
+    dev: false
+
+  /@embedpdf/plugin-search@2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33):
+    resolution: {integrity: sha512-dAX4aIc4WeO+bUImbcHVm4c32UADYelpTeJA0It2eq6agZVND20B25kyDYpJiWKTl9NaVcJbNic+wreudl6vsQ==}
+    peerDependencies:
+      '@embedpdf/core': 2.14.1
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+    dependencies:
+      '@embedpdf/core': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/models': 2.14.1
+      preact: 10.29.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      svelte: 5.55.5
+      vue: 3.5.33(typescript@5.9.3)
+    dev: false
+
+  /@embedpdf/plugin-selection@2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-interaction-manager@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33):
+    resolution: {integrity: sha512-M+omnIDqgME+QgYX3nW3ypjzRvvz2IrSWpx7vP7vUhfd12R4ZJnTkS9AkKbXgHBVwWrxnbibKlZduiiehRLeKg==}
+    peerDependencies:
+      '@embedpdf/core': 2.14.1
+      '@embedpdf/plugin-interaction-manager': 2.14.1
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+    dependencies:
+      '@embedpdf/core': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/models': 2.14.1
+      '@embedpdf/plugin-interaction-manager': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/utils': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      preact: 10.29.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      svelte: 5.55.5
+      vue: 3.5.33(typescript@5.9.3)
+    dev: false
+
+  /@embedpdf/plugin-signature@2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-annotation@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33):
+    resolution: {integrity: sha512-G2cXSkxbX5YUUWD8nSXoI2qsYKfuLhIL8/bwHWvmJ+SafhCtLmpQ3Q1TRVhleD+Ncl2fTcOPBx9C48aZXPNnQA==}
+    peerDependencies:
+      '@embedpdf/core': 2.14.1
+      '@embedpdf/plugin-annotation': 2.14.1
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+    dependencies:
+      '@embedpdf/core': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/models': 2.14.1
+      '@embedpdf/plugin-annotation': 2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-history@2.14.1)(@embedpdf/plugin-interaction-manager@2.14.1)(@embedpdf/plugin-scroll@2.14.1)(@embedpdf/plugin-selection@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      preact: 10.29.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      svelte: 5.55.5
+      vue: 3.5.33(typescript@5.9.3)
+    dev: false
+
+  /@embedpdf/plugin-spread@2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33):
+    resolution: {integrity: sha512-MychoG54eYqjB+8/1/ArKYF+4eonULtBuGPqU72MO9t/Nadl8nNThaPrOW/eKQr3zQu1Af3KO7ng6tm6Umz4rA==}
+    peerDependencies:
+      '@embedpdf/core': 2.14.1
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+    dependencies:
+      '@embedpdf/core': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/models': 2.14.1
+      preact: 10.29.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      svelte: 5.55.5
+      vue: 3.5.33(typescript@5.9.3)
+    dev: false
+
+  /@embedpdf/plugin-stamp@2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-annotation@2.14.1)(@embedpdf/plugin-i18n@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33):
+    resolution: {integrity: sha512-5g09thywttSWOmWDk6S/6o7IFZp9DdYo2ejg5J46MJz1P6xwsJVAw9k8MzJjnHMBPD+z1yoajfpienC/EqzG0g==}
+    peerDependencies:
+      '@embedpdf/core': 2.14.1
+      '@embedpdf/plugin-annotation': 2.14.1
+      '@embedpdf/plugin-i18n': 2.14.1
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+    dependencies:
+      '@embedpdf/core': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/models': 2.14.1
+      '@embedpdf/plugin-annotation': 2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-history@2.14.1)(@embedpdf/plugin-interaction-manager@2.14.1)(@embedpdf/plugin-scroll@2.14.1)(@embedpdf/plugin-selection@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-i18n': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      preact: 10.29.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      svelte: 5.55.5
+      vue: 3.5.33(typescript@5.9.3)
+    dev: false
+
+  /@embedpdf/plugin-thumbnail@2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-render@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33):
+    resolution: {integrity: sha512-NOaFve83gbD6BUiANSSbiREjUJ1qpNyQrHl2RdMDNLyDaSUARweUu5zC5vfFRd9I+jUf3XGsCa3GNFlzQt+C9A==}
+    peerDependencies:
+      '@embedpdf/core': 2.14.1
+      '@embedpdf/plugin-render': 2.14.1
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+    dependencies:
+      '@embedpdf/core': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/models': 2.14.1
+      '@embedpdf/plugin-render': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      preact: 10.29.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      svelte: 5.55.5
+      vue: 3.5.33(typescript@5.9.3)
+    dev: false
+
+  /@embedpdf/plugin-tiling@2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-render@2.14.1)(@embedpdf/plugin-scroll@2.14.1)(@embedpdf/plugin-viewport@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33):
+    resolution: {integrity: sha512-tvs3pPT6wVh0MjMN7Dp8R1XeoTjguH30j/ToWz9ziTKkwXADfJXdyjqYGhagiamMMTwQeUF9py+yDTMP23QV7Q==}
+    peerDependencies:
+      '@embedpdf/core': 2.14.1
+      '@embedpdf/plugin-render': 2.14.1
+      '@embedpdf/plugin-scroll': 2.14.1
+      '@embedpdf/plugin-viewport': 2.14.1
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+    dependencies:
+      '@embedpdf/core': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/models': 2.14.1
+      '@embedpdf/plugin-render': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-scroll': 2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-viewport@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-viewport': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      preact: 10.29.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      svelte: 5.55.5
+      vue: 3.5.33(typescript@5.9.3)
+    dev: false
+
+  /@embedpdf/plugin-ui@2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-render@2.14.1)(@embedpdf/plugin-scroll@2.14.1)(@embedpdf/plugin-viewport@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33):
+    resolution: {integrity: sha512-aQVJeaLv17fVzTW3LuxUgTiFbz/K3O9II9hBt7sLORUAyuIdlExqhlVru7ANbn4JcLqhe/pYSjD5Jt5KRNqGOQ==}
+    peerDependencies:
+      '@embedpdf/core': 2.14.1
+      '@embedpdf/plugin-render': 2.14.1
+      '@embedpdf/plugin-scroll': 2.14.1
+      '@embedpdf/plugin-viewport': 2.14.1
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+    dependencies:
+      '@embedpdf/core': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/models': 2.14.1
+      '@embedpdf/plugin-render': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-scroll': 2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-viewport@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-viewport': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      preact: 10.29.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      svelte: 5.55.5
+      vue: 3.5.33(typescript@5.9.3)
+    dev: false
+
+  /@embedpdf/plugin-viewport@2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33):
+    resolution: {integrity: sha512-U45B46XoaAFxC3yKnVhBO8Z5Wa+ca17UW7esJC/yWneJ2dNfSnvRAR7309KKP/RpZfDmn/lfJDVOFGCDbR3hvw==}
+    peerDependencies:
+      '@embedpdf/core': 2.14.1
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+    dependencies:
+      '@embedpdf/core': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/models': 2.14.1
+      preact: 10.29.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      svelte: 5.55.5
+      vue: 3.5.33(typescript@5.9.3)
+    dev: false
+
+  /@embedpdf/plugin-zoom@2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-scroll@2.14.1)(@embedpdf/plugin-viewport@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33):
+    resolution: {integrity: sha512-rVah7XgrWiNe9kT7VGRhNp5mCImf3eMk4cGO9kXIidQWka+yFqBANJw6Rj+FJdtWqz6pamZNWXTDZ1jvQkMKZg==}
+    peerDependencies:
+      '@embedpdf/core': 2.14.1
+      '@embedpdf/plugin-scroll': 2.14.1
+      '@embedpdf/plugin-viewport': 2.14.1
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+    dependencies:
+      '@embedpdf/core': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/models': 2.14.1
+      '@embedpdf/plugin-scroll': 2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-viewport@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-viewport': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      preact: 10.29.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      svelte: 5.55.5
+      vue: 3.5.33(typescript@5.9.3)
+    dev: false
+
+  /@embedpdf/snippet@2.14.1(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33):
+    resolution: {integrity: sha512-EGWyQmFfOzuVU7y3qQ+89dmN9Jh+Opno5Is4rvB/TGsEVp6MQKB/qSAdPcw+6faIJ0W8LqSQLpBlwSbdnbIHeg==}
+    dependencies:
+      '@embedpdf/core': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/engines': 2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/models': 2.14.1
+      '@embedpdf/pdfium': 2.14.1
+      '@embedpdf/plugin-annotation': 2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-history@2.14.1)(@embedpdf/plugin-interaction-manager@2.14.1)(@embedpdf/plugin-scroll@2.14.1)(@embedpdf/plugin-selection@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-attachment': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-bookmark': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-capture': 2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-interaction-manager@2.14.1)(@embedpdf/plugin-render@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-commands': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-document-manager': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-export': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-form': 2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-annotation@2.14.1)(@embedpdf/plugin-history@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-fullscreen': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-history': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-i18n': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-interaction-manager': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-pan': 2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-interaction-manager@2.14.1)(@embedpdf/plugin-viewport@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-print': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-redaction': 2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-annotation@2.14.1)(@embedpdf/plugin-history@2.14.1)(@embedpdf/plugin-interaction-manager@2.14.1)(@embedpdf/plugin-selection@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-render': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-rotate': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-scroll': 2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-viewport@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-search': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-selection': 2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-interaction-manager@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-signature': 2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-annotation@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-spread': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-stamp': 2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-annotation@2.14.1)(@embedpdf/plugin-i18n@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-thumbnail': 2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-render@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-tiling': 2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-render@2.14.1)(@embedpdf/plugin-scroll@2.14.1)(@embedpdf/plugin-viewport@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-ui': 2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-render@2.14.1)(@embedpdf/plugin-scroll@2.14.1)(@embedpdf/plugin-viewport@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-viewport': 2.14.1(@embedpdf/core@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      '@embedpdf/plugin-zoom': 2.14.1(@embedpdf/core@2.14.1)(@embedpdf/plugin-scroll@2.14.1)(@embedpdf/plugin-viewport@2.14.1)(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33)
+      preact: 10.29.1
+      tailwind-merge: 3.5.0
+    transitivePeerDependencies:
+      - react
+      - react-dom
+      - svelte
+      - vue
+    dev: false
+
+  /@embedpdf/utils@2.14.1(preact@10.29.1)(react-dom@18.3.1)(react@18.3.1)(svelte@5.55.5)(vue@3.5.33):
+    resolution: {integrity: sha512-TlJBT+SgRgcSMKH2EX3WBXIm/a/LEtgG2IiZ7hXPhT3t2e1HOeXjkvreJi6wcnvkMt4eYtJh3nocetto5gNclw==}
+    peerDependencies:
+      preact: ^10.26.4
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      svelte: '>=5 <6'
+      vue: '>=3.2.0'
+    dependencies:
+      preact: 10.29.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      svelte: 5.55.5
+      vue: 3.5.33(typescript@5.9.3)
     dev: false
 
   /@emnapi/core@1.8.1:
@@ -705,6 +1465,7 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -713,6 +1474,7 @@ packages:
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -721,6 +1483,7 @@ packages:
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -729,6 +1492,7 @@ packages:
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -737,6 +1501,7 @@ packages:
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -745,6 +1510,7 @@ packages:
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -753,6 +1519,7 @@ packages:
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: true
     optional: true
@@ -761,6 +1528,7 @@ packages:
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: true
     optional: true
@@ -770,6 +1538,7 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     optionalDependencies:
       '@img/sharp-libvips-linux-arm64': 1.2.4
@@ -781,6 +1550,7 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     optionalDependencies:
       '@img/sharp-libvips-linux-arm': 1.2.4
@@ -792,6 +1562,7 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     optionalDependencies:
       '@img/sharp-libvips-linux-ppc64': 1.2.4
@@ -803,6 +1574,7 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     optionalDependencies:
       '@img/sharp-libvips-linux-riscv64': 1.2.4
@@ -814,6 +1586,7 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     optionalDependencies:
       '@img/sharp-libvips-linux-s390x': 1.2.4
@@ -825,6 +1598,7 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     optionalDependencies:
       '@img/sharp-libvips-linux-x64': 1.2.4
@@ -836,6 +1610,7 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
@@ -847,6 +1622,7 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.2.4
@@ -907,23 +1683,26 @@ packages:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.31
-    dev: true
+
+  /@jridgewell/remapping@2.3.5:
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+    dev: false
 
   /@jridgewell/resolve-uri@3.1.2:
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
-    dev: true
 
   /@jridgewell/sourcemap-codec@1.5.5:
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
-    dev: true
 
   /@jridgewell/trace-mapping@0.3.31:
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
-    dev: true
 
   /@jridgewell/trace-mapping@0.3.9:
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
@@ -991,6 +1770,7 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     optional: true
 
@@ -999,6 +1779,7 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     optional: true
 
@@ -1007,6 +1788,7 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     optional: true
 
@@ -1015,6 +1797,7 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     optional: true
 
@@ -1826,6 +2609,14 @@ packages:
     resolution: {integrity: sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==}
     dev: true
 
+  /@sveltejs/acorn-typescript@1.0.9(acorn@8.15.0):
+    resolution: {integrity: sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==}
+    peerDependencies:
+      acorn: ^8.9.0
+    dependencies:
+      acorn: 8.15.0
+    dev: false
+
   /@swc/helpers@0.5.2:
     resolution: {integrity: sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==}
     dependencies:
@@ -1905,7 +2696,6 @@ packages:
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
     requiresBuild: true
     dev: false
-    optional: true
 
   /@types/unist@2.0.11:
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -2042,6 +2832,7 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -2050,6 +2841,7 @@ packages:
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: true
     optional: true
@@ -2058,6 +2850,7 @@ packages:
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -2066,6 +2859,7 @@ packages:
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -2074,6 +2868,7 @@ packages:
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: true
     optional: true
@@ -2082,6 +2877,7 @@ packages:
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -2090,6 +2886,7 @@ packages:
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -2098,6 +2895,7 @@ packages:
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: true
     optional: true
@@ -2136,6 +2934,80 @@ packages:
     dev: true
     optional: true
 
+  /@vue/compiler-core@3.5.33:
+    resolution: {integrity: sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw==}
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@vue/shared': 3.5.33
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+    dev: false
+
+  /@vue/compiler-dom@3.5.33:
+    resolution: {integrity: sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==}
+    dependencies:
+      '@vue/compiler-core': 3.5.33
+      '@vue/shared': 3.5.33
+    dev: false
+
+  /@vue/compiler-sfc@3.5.33:
+    resolution: {integrity: sha512-UTUvRO9cY+rROrx/pvN9P5Z7FgA6QGfokUCfhQE4EnmUj3rVnK+CHI0LsEO1pg+I7//iRYMUfcNcCPe7tg0CoA==}
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@vue/compiler-core': 3.5.33
+      '@vue/compiler-dom': 3.5.33
+      '@vue/compiler-ssr': 3.5.33
+      '@vue/shared': 3.5.33
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.12
+      source-map-js: 1.2.1
+    dev: false
+
+  /@vue/compiler-ssr@3.5.33:
+    resolution: {integrity: sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A==}
+    dependencies:
+      '@vue/compiler-dom': 3.5.33
+      '@vue/shared': 3.5.33
+    dev: false
+
+  /@vue/reactivity@3.5.33:
+    resolution: {integrity: sha512-p8UfIqyIhb0rYGlSgSBV+lPhF2iUSBcRy7enhTmPqKWadHy9kcOFYF1AejYBP9P+avnd3OBbD49DU4pLWX/94A==}
+    dependencies:
+      '@vue/shared': 3.5.33
+    dev: false
+
+  /@vue/runtime-core@3.5.33:
+    resolution: {integrity: sha512-UpFF45RI9//a7rvq7RdOQblb4tup7hHG9QsmIrxkFQLzQ7R8/iNQ5LE15NhLZ1/WcHMU2b47u6P33CPUelHyIQ==}
+    dependencies:
+      '@vue/reactivity': 3.5.33
+      '@vue/shared': 3.5.33
+    dev: false
+
+  /@vue/runtime-dom@3.5.33:
+    resolution: {integrity: sha512-IOxMsAOwquhfITgmOgaPYl7/j8gKUxUFoflRc+u4LxyD3+783xne8vNta1PONVCvCV9A0w7hkyEepINDqfO0tw==}
+    dependencies:
+      '@vue/reactivity': 3.5.33
+      '@vue/runtime-core': 3.5.33
+      '@vue/shared': 3.5.33
+      csstype: 3.2.3
+    dev: false
+
+  /@vue/server-renderer@3.5.33(vue@3.5.33):
+    resolution: {integrity: sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==}
+    peerDependencies:
+      vue: 3.5.33
+    dependencies:
+      '@vue/compiler-ssr': 3.5.33
+      '@vue/shared': 3.5.33
+      vue: 3.5.33(typescript@5.9.3)
+    dev: false
+
+  /@vue/shared@3.5.33:
+    resolution: {integrity: sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ==}
+    dev: false
+
   /acorn-jsx@5.3.2(acorn@8.15.0):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -2159,7 +3031,6 @@ packages:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-    dev: true
 
   /ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
@@ -2217,6 +3088,11 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       tslib: 2.8.1
+    dev: false
+
+  /aria-query@5.3.1:
+    resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
+    engines: {node: '>= 0.4'}
     dev: false
 
   /aria-query@5.3.2:
@@ -2372,7 +3248,6 @@ packages:
   /axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -2701,6 +3576,10 @@ packages:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
     dev: false
 
+  /devalue@5.7.1:
+    resolution: {integrity: sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==}
+    dev: false
+
   /devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
     dependencies:
@@ -2784,6 +3663,11 @@ packages:
   /engine.io-parser@5.2.3:
     resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
     engines: {node: '>=10.0.0'}
+    dev: false
+
+  /entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
     dev: false
 
   /error-stack-parser-es@1.0.5:
@@ -3424,6 +4308,10 @@ packages:
       - supports-color
     dev: true
 
+  /esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+    dev: false
+
   /espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3440,6 +4328,17 @@ packages:
       estraverse: 5.3.0
     dev: true
 
+  /esrap@2.2.5:
+    resolution: {integrity: sha512-/yLB1538mag+dn0wsePTe8C0rDIjUOaJpMs2McodSzmM2msWcZsBSdRtg6HOBt0A/r82BN+Md3pgwSc/uWt2Ig==}
+    peerDependencies:
+      '@typescript-eslint/types': ^8.2.0
+    peerDependenciesMeta:
+      '@typescript-eslint/types':
+        optional: true
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+    dev: false
+
   /esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
     engines: {node: '>=4.0'}
@@ -3454,6 +4353,10 @@ packages:
 
   /estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+    dev: false
+
+  /estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
     dev: false
 
   /esutils@2.0.3:
@@ -4024,6 +4927,12 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
+  /is-reference@3.0.3:
+    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+    dependencies:
+      '@types/estree': 1.0.8
+    dev: false
+
   /is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -4206,6 +5115,10 @@ packages:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
     dev: true
 
+  /locate-character@3.0.0:
+    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
+    dev: false
+
   /locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -4237,6 +5150,12 @@ packages:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0
     dependencies:
       react: 18.3.1
+    dev: false
+
+  /magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
     dev: false
 
   /markdown-table@3.0.4:
@@ -5160,6 +6079,15 @@ packages:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  /postcss@8.5.12:
+    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+    dev: false
+
   /postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -5168,6 +6096,10 @@ packages:
       picocolors: 1.1.1
       source-map-js: 1.2.1
     dev: true
+
+  /preact@10.29.1:
+    resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
+    dev: false
 
   /prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -5852,8 +6784,36 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
+  /svelte@5.55.5:
+    resolution: {integrity: sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.15.0)
+      '@types/estree': 1.0.8
+      '@types/trusted-types': 2.0.7
+      acorn: 8.15.0
+      aria-query: 5.3.1
+      axobject-query: 4.1.0
+      clsx: 2.1.1
+      devalue: 5.7.1
+      esm-env: 1.2.2
+      esrap: 2.2.5
+      is-reference: 3.0.3
+      locate-character: 3.0.0
+      magic-string: 0.30.21
+      zimmerframe: 1.1.4
+    transitivePeerDependencies:
+      - '@typescript-eslint/types'
+    dev: false
+
   /tailwind-merge@2.6.1:
     resolution: {integrity: sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==}
+    dev: false
+
+  /tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
     dev: false
 
   /tailwindcss@3.4.19:
@@ -6074,7 +7034,6 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
-    dev: true
 
   /unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -6298,6 +7257,22 @@ packages:
       component-emitter: 2.0.0
     dev: false
 
+  /vue@3.5.33(typescript@5.9.3):
+    resolution: {integrity: sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@vue/compiler-dom': 3.5.33
+      '@vue/compiler-sfc': 3.5.33
+      '@vue/runtime-dom': 3.5.33
+      '@vue/server-renderer': 3.5.33(vue@3.5.33)
+      '@vue/shared': 3.5.33
+      typescript: 5.9.3
+    dev: false
+
   /which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -6497,6 +7472,10 @@ packages:
       cookie: 1.1.1
       youch-core: 0.3.3
     dev: true
+
+  /zimmerframe@1.1.4:
+    resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
+    dev: false
 
   /zod@3.22.3:
     resolution: {integrity: sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==}

--- a/uv.lock
+++ b/uv.lock
@@ -3444,7 +3444,7 @@ wheels = [
 
 [[package]]
 name = "naas-abi"
-version = "1.22.5"
+version = "1.24.1"
 source = { editable = "libs/naas-abi" }
 dependencies = [
     { name = "alembic" },
@@ -3544,7 +3544,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-core"
-version = "1.28.2"
+version = "1.29.0"
 source = { editable = "libs/naas-abi-core" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Expands the Nexus file manager's preview system so users no longer fall through to "open in Lab" for common formats. Adds plain-text previews for ~80 extensions, office-document previews (docx / xlsx / pptx and ODF/RTF variants) via the existing LibreOffice → PDF pipeline, and replaces the iframe-based PDF viewer with a real PDFium-WASM viewer that ships toolbar / zoom / search / thumbnails out of the box.

## What changed

### Frontend (files/page.tsx)
- New `isTextFile()` covering ~80 source / config / markup extensions plus conventional filenames (`Dockerfile`, `Makefile`, `LICENSE`, `.gitignore`, `.env`, …) and broad MIME fallbacks (`text/*`, `application/json`, `+xml`, …).
- Markdown still rendered via ReactMarkdown; everything else as a monospace `<pre>` block. The previous `markdownViewer*` state collapses into one unified `textViewer*`.
- All five preview/raw fetches (PDF, image, text, office-preview, download) now pass `&scope=my_drive` when the active source is my-drive — fixes the **404 "File not found"** hit on my-drive files.

### New PDF viewer (components/files/pdf-viewer.tsx)
- Wraps [`@embedpdf/snippet`](https://www.embedpdf.com) (PDFium WASM) via a host div + dynamic import — multi-MB payload only fetched when a PDF is opened.
- Forces the mounted custom element to fill its parent with `position: absolute; inset: 0` so the viewer's own scroll viewport gets a bounded height (custom elements default to `display: inline`).
- Picks up dark/light from `next-themes`; cleans up the WASM document on unmount.
- Suppresses the harmless `ResizeObserver loop completed with undelivered notifications` toast that Next.js dev mode would otherwise show.

### API (service.py)
- `preview_file_as_pdf` allowlist expanded from `{ppt, pptx}` to the full office set: `doc/docx/odt/rtf`, `xls/xlsx/xlsm/xlsb/ods`, `ppt/pptx/odp`. Same LibreOffice subprocess path.

### Container (docker/images/Dockerfile)
- Adds `libreoffice-core / writer / calc / impress` + `fonts-dejavu / fonts-liberation` so the API can convert office docs to PDF. `--no-install-recommends` keeps the layer minimal (~400-500 MB).

### Makefile fixes
- `find src` silently tolerates the missing `src/` directory (it ran at parse time on every `make` invocation, polluting output).
- `check` no longer depends on a stale `.venv/.../site-packages/abi` symlink target that pointed at a now-defunct `lib/abi/` path. This was breaking `make check` and therefore the pre-commit hook in the current repo layout.

## How to test

1. `pnpm install` in `libs/naas-abi/naas_abi/apps/nexus/apps/web/` (lockfile updated).
2. Rebuild the API container: `docker compose build abi`.
3. In the nexus file manager:
   - Open a `.py`, `.json`, `.yaml`, etc. → text viewer with monospace rendering
   - Open a `.md` → markdown rendering preserved
   - Open a `.docx` / `.xlsx` / `.pptx` → LibreOffice → PDF → EmbedPDF viewer with toolbar, search, thumbnails
   - Open a native PDF → same viewer
   - Repeat all of the above from a my-drive folder (this previously 404'd)

## Notes for the reviewer

- Bundle impact: dynamic import keeps the EmbedPDF/PDFium payload off the initial route. It only loads once a user opens a PDF/office doc.
- API image size grows by ~400-500 MB with LibreOffice headless. Worth it for the corporate-formats preview UX. If image size becomes a concern, the cleanest follow-up is to split LibreOffice into a sidecar (`unoserver`-style) container.
- Possible follow-ups (not in this PR): caching of converted PDFs by `(path, mtime)`, `AbortController` on rapid file switching, notebook (`.ipynb`) preview, video/audio preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)