### PR TITLE
feat(nexus): download folders as ZIP archives

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/exceptions.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/exceptions.py
@@ -21,6 +21,7 @@ from naas_abi.apps.nexus.apps.api.app.services.chat.chat__schema import (
 )
 from naas_abi.apps.nexus.apps.api.app.services.files.files__schema import (
     AlreadyExistsError,
+    ArchiveTooLargeError,
     InvalidPathError,
     IsDirectoryError,
     NotFoundError,
@@ -74,6 +75,7 @@ EXCEPTION_TO_HTTP: dict[type[Exception], tuple[int, DetailResolver]] = {
     IsDirectoryError: (400, _default_detail),
     NotTextError: (400, _default_detail),
     UploadTooLargeError: (413, _default_detail),
+    ArchiveTooLargeError: (413, _default_detail),
     UnsupportedPreviewError: (400, _default_detail),
     PreviewUnavailableError: (501, _default_detail),
     PreviewConversionError: (500, _default_detail),

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/files/adapters/primary/files__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/files/adapters/primary/files__primary_adapter__FastAPI.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, Response, status
 from fastapi import File as FastAPIFile
 from fastapi import UploadFile as FastAPIUploadFile
+from fastapi.responses import StreamingResponse
 from naas_abi.apps.nexus.apps.api.app.api.endpoints.auth import (
     User,
     get_current_user_required,
@@ -256,6 +257,23 @@ async def preview_file_as_pdf(
         content=preview.content,
         media_type="application/pdf",
         headers={"Content-Disposition": f'inline; filename="{preview.filename}"'},
+    )
+
+
+@router.get("/archive/{path:path}")
+async def download_folder_archive(
+    path: str,
+    workspace_id: str | None = Query(default=None, max_length=100),
+    scope: str = Query(default="workspace", pattern="^(workspace|my_drive)$"),
+    current_user: User = Depends(get_current_user_required),
+    files_service: FilesService = Depends(get_files_service),
+):
+    scoped_path = await _authorize_path(current_user, path, workspace_id, scope)
+    filename, archive_iterator = files_service.stream_folder_archive(path=scoped_path)
+    return StreamingResponse(
+        archive_iterator,
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )
 
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/files/files__schema.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/files/files__schema.py
@@ -46,6 +46,15 @@ class UploadTooLargeError(FilesDomainError):
         super().__init__(f"File too large. Max size is {max_size_bytes // (1024 * 1024)}MB")
 
 
+class ArchiveTooLargeError(FilesDomainError):
+    def __init__(self, file_count: int, max_files: int):
+        self.file_count = file_count
+        self.max_files = max_files
+        super().__init__(
+            f"Folder is too large to archive: {file_count} files (limit {max_files})"
+        )
+
+
 @dataclass(frozen=True)
 class FileInfoData:
     name: str

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/files/service.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/files/service.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 import shutil
 import subprocess
 import tempfile
+import zipfile
+from collections.abc import Iterator
 from datetime import datetime
 from pathlib import Path, PurePosixPath
 
 from naas_abi.apps.nexus.apps.api.app.services.files.files__schema import (
     AlreadyExistsError,
+    ArchiveTooLargeError,
     FileContentData,
     FileInfoData,
     FileListResponseData,
@@ -30,6 +33,8 @@ class FilesService:
     object_storage_prefix = ""
     folder_marker = ".nexus_folder"
     max_upload_size = 50 * 1024 * 1024
+    max_archive_files = 10_000
+    archive_chunk_size = 64 * 1024
 
     _content_types = {
         ".py": "text/x-python",
@@ -288,6 +293,48 @@ class FilesService:
                 raise PreviewConversionError("Failed to convert presentation to PDF preview.")
 
             return PdfPreviewData(content=output_path.read_bytes(), filename=output_name)
+
+    def stream_folder_archive(self, path: str) -> tuple[str, Iterator[bytes]]:
+        normalized_path = self.normalize_relative_path(path, allow_empty=True)
+        if not self._is_directory(normalized_path):
+            raise NotFoundError("Folder not found")
+
+        files, _dirs = self._collect_directory_tree(normalized_path)
+        if len(files) > self.max_archive_files:
+            raise ArchiveTooLargeError(
+                file_count=len(files), max_files=self.max_archive_files
+            )
+
+        folder_name = normalized_path.rsplit("/", 1)[-1] if normalized_path else "files"
+        archive_filename = f"{folder_name}.zip"
+        root_prefix = f"{normalized_path}/" if normalized_path else ""
+
+        def _iter_archive() -> Iterator[bytes]:
+            tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".zip")
+            tmp.close()
+            tmp_path = Path(tmp.name)
+            try:
+                with zipfile.ZipFile(
+                    tmp_path, mode="w", compression=zipfile.ZIP_DEFLATED
+                ) as zip_file:
+                    for file_path in files:
+                        if root_prefix and file_path.startswith(root_prefix):
+                            arcname = file_path[len(root_prefix) :]
+                        else:
+                            arcname = file_path
+                        if not arcname:
+                            continue
+                        zip_file.writestr(arcname, self._read_bytes(file_path))
+                with tmp_path.open("rb") as handle:
+                    while chunk := handle.read(self.archive_chunk_size):
+                        yield chunk
+            finally:
+                try:
+                    tmp_path.unlink(missing_ok=True)
+                except OSError:
+                    pass
+
+        return archive_filename, _iter_archive()
 
     def read_file_raw(self, path: str) -> RawFileData:
         normalized_path = self.normalize_relative_path(path)

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/files/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/files/page.tsx
@@ -596,6 +596,37 @@ export default function FilesPage() {
     }
   };
 
+  const downloadFolderToDesktop = async (folder: FileInfo) => {
+    if (folder.type !== 'folder') return;
+    try {
+      const encodedPath = folder.path.split('/').map(encodeURIComponent).join('/');
+      const response = await authFetch(
+        `/api/files/archive/${encodedPath}?${fileQueryParams}`
+      );
+      if (!response.ok) {
+        let detail = 'Failed to download folder';
+        try {
+          const data = await response.json();
+          if (data?.detail) detail = data.detail;
+        } catch {
+          /* ignore */
+        }
+        throw new Error(detail);
+      }
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${folder.name}.zip`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      setError(error instanceof Error ? error.message : 'Failed to download folder');
+    }
+  };
+
   const handleRefresh = () => {
     if (isLocalFolder && activeSyncedFolder) {
       fetchLocalFiles(activeSyncedFolder.id, currentPath);
@@ -876,18 +907,20 @@ export default function FilesPage() {
                     </td>
                     <td className="py-2">
                       <div className="relative flex items-center justify-end gap-0.5">
-                        {file.type === 'file' && (
-                          <button
-                            title="Download"
-                            onClick={(e) => {
-                              e.stopPropagation();
+                        <button
+                          title={file.type === 'folder' ? 'Download as ZIP' : 'Download'}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            if (file.type === 'folder') {
+                              downloadFolderToDesktop(file);
+                            } else {
                               downloadFileToDesktop(file);
-                            }}
-                            className="hidden h-6 w-6 items-center justify-center rounded text-muted-foreground/50 hover:bg-muted hover:text-foreground group-hover:flex"
-                          >
-                            <Download size={14} />
-                          </button>
-                        )}
+                            }
+                          }}
+                          className="hidden h-6 w-6 items-center justify-center rounded text-muted-foreground/50 hover:bg-muted hover:text-foreground group-hover:flex"
+                        >
+                          <Download size={14} />
+                        </button>
                         <button
                           onClick={(e) => {
                             e.stopPropagation();
@@ -977,6 +1010,19 @@ export default function FilesPage() {
                                 Download
                               </button>
                             )}
+                            {file.type === 'folder' && (
+                              <button
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  setActiveContextMenu(null);
+                                  downloadFolderToDesktop(file);
+                                }}
+                                className="flex w-full items-center gap-2 px-3 py-1.5 text-xs hover:bg-muted"
+                              >
+                                <Download size={12} />
+                                Download as ZIP
+                              </button>
+                            )}
                             <button
                               onClick={(e) => {
                                 e.stopPropagation();
@@ -1035,18 +1081,20 @@ export default function FilesPage() {
                     {getFileIcon(file, 40)}
                     <span className="w-full truncate text-center text-sm">{file.name}</span>
                   </button>
-                  {file.type === 'file' && (
-                    <button
-                      title="Download"
-                      onClick={(e) => {
-                        e.stopPropagation();
+                  <button
+                    title={file.type === 'folder' ? 'Download as ZIP' : 'Download'}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      if (file.type === 'folder') {
+                        downloadFolderToDesktop(file);
+                      } else {
                         downloadFileToDesktop(file);
-                      }}
-                      className="absolute right-1.5 top-1.5 hidden h-6 w-6 items-center justify-center rounded bg-background/80 text-muted-foreground shadow-sm hover:bg-muted hover:text-foreground group-hover:flex"
-                    >
-                      <Download size={13} />
-                    </button>
-                  )}
+                      }
+                    }}
+                    className="absolute right-1.5 top-1.5 hidden h-6 w-6 items-center justify-center rounded bg-background/80 text-muted-foreground shadow-sm hover:bg-muted hover:text-foreground group-hover:flex"
+                  >
+                    <Download size={13} />
+                  </button>
                 </div>
               ))}
             </div>


### PR DESCRIPTION
## Summary
- New `GET /files/archive/{path:path}` endpoint streams a zip of the requested folder via the existing `ObjectStorageService` (works uniformly across local FS, S3, Naas backends). The zip is built into a tempfile then streamed in 64 KB chunks; the tempfile is unlinked in `finally`.
- 10,000-file guard returns HTTP 413 (`ArchiveTooLargeError`) to prevent runaway archives.
- File manager UI: folders now expose download via the hover icon (list + grid views) and a "Download as ZIP" entry in the row context menu.

## Why
The Nexus file manager previously only supported single-file downloads — users had to download files one at a time to grab the contents of a folder. Server-side streaming keeps the browser flow identical to the existing per-file download (blob → object URL → `<a download>` click) without introducing a job/queue dependency for what is fundamentally pure I/O passthrough.

## Notes for reviewers
- Route ordering: `/archive/{path:path}` is registered before the catch-all `/{path:path}` so it isn't shadowed.
- The tempfile-then-stream approach is deliberate: `zipfile.ZipFile` needs to seek back to update the central directory at end-of-stream, which doesn't compose with a non-seekable streaming buffer.
- Size guard is file-count only for now. A total-byte guard would require a `head_object`-style call on `ObjectStoragePort`, which doesn't exist today.
- Not jobified. Since there is no artifact worth persisting and the browser already shows native download progress, a background job wasn't justified for v1. We can revisit if folder sizes outgrow what an HTTP connection can sanely deliver.

## Test plan
- [ ] Download a small folder from list view via the hover icon — verify zip contents and arcnames have no leading folder prefix.
- [ ] Download via the ⋮ → "Download as ZIP" context menu entry.
- [ ] Download from grid view via hover icon.
- [ ] Download a nested folder — verify the directory structure inside the zip.
- [ ] Download an empty folder — should yield an empty zip without error.
- [ ] Trigger the size guard (manual test or temporarily lower max_archive_files) — verify the UI surfaces the API 413 detail message.
- [ ] Verify single-file download still works unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)