### PR TITLE
feat(nexus): remove Cloud and Sync Folder from files sidebar

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/files-section.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/files-section.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { ChevronRight, Folder, Plus, HardDrive, Upload, Cloud, Database } from 'lucide-react';
+import { ChevronRight, Folder, HardDrive } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { cn } from '@/lib/utils';
 import { useFilesStore } from '@/stores/files';
@@ -9,123 +9,17 @@ import { useWorkspaceStore } from '@/stores/workspace';
 import { CollapsibleSection } from './collapsible-section';
 import { getWorkspacePath } from './utils';
 
-const StorageSourceItem = React.memo(function StorageSourceItem({
-  source,
-  isActive,
-  onClick,
-}: {
-  source: { id: string; name: string; icon: string; connected: boolean; description?: string };
-  isActive: boolean;
-  onClick: () => void;
-}) {
-  const iconMap: Record<string, React.ReactNode> = {
-    'hard-drive': <HardDrive size={14} />,
-    'upload': <Upload size={14} />,
-    'cloud': <Cloud size={14} />,
-    'database': <Database size={14} />,
-  };
-
-  return (
-    <button
-      onClick={onClick}
-      className={cn(
-        'group flex w-full items-center gap-2 rounded-md px-2 py-1 text-sm transition-colors',
-        'hover:bg-workspace-accent-10',
-        isActive && 'bg-workspace-accent-15 text-workspace-accent',
-        !source.connected && 'opacity-50'
-      )}
-    >
-      <span className="text-muted-foreground">{iconMap[source.icon] || <Folder size={14} />}</span>
-      <span className="flex-1 truncate text-left">{source.name}</span>
-      {!source.connected && (
-        <span className="text-[10px] text-muted-foreground">Not connected</span>
-      )}
-    </button>
-  );
-});
-
-const StorageCategoryGroup = React.memo(function StorageCategoryGroup({
-  label,
-  sources,
-  isExpanded,
-  onToggle,
-  activeSource,
-  onSelectSource,
-  onAddSource,
-}: {
-  label: string;
-  sources: { id: string; name: string; icon: string; connected: boolean; description?: string }[];
-  isExpanded: boolean;
-  onToggle: () => void;
-  activeSource: string;
-  onSelectSource: (id: string) => void;
-  onAddSource?: () => void;
-}) {
-  const connectedSources = sources.filter((s) => s.connected);
-  const availableSources = sources.filter((s) => !s.connected);
-
-  return (
-    <div className="space-y-0.5">
-      <button
-        onClick={onToggle}
-        className="flex w-full items-center gap-1 rounded-md px-1 py-1 text-xs font-medium text-muted-foreground hover:text-foreground"
-      >
-        <ChevronRight
-          size={12}
-          className={cn('transition-transform', isExpanded && 'rotate-90')}
-        />
-        <span className="flex-1 truncate text-left">{label}</span>
-        <span className="text-[10px]">
-          {connectedSources.length}
-        </span>
-      </button>
-      {isExpanded && (
-        <div className="ml-3 space-y-0.5">
-          {connectedSources.map((source) => (
-            <StorageSourceItem
-              key={source.id}
-              source={source}
-              isActive={activeSource === source.id}
-              onClick={() => onSelectSource(source.id)}
-            />
-          ))}
-
-          {connectedSources.length === 0 && (
-            <div className="px-2 py-1 text-xs text-muted-foreground">
-              No sources connected
-            </div>
-          )}
-
-          {onAddSource && availableSources.length > 0 && (
-            <button
-              onClick={onAddSource}
-              className="flex w-full items-center gap-2 rounded-md px-2 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
-            >
-              <Plus size={12} />
-              <span>Connect {label}</span>
-            </button>
-          )}
-        </div>
-      )}
-    </div>
-  );
-});
-
 export function FilesSection({ collapsed }: { collapsed: boolean }) {
   const router = useRouter();
   const { currentWorkspaceId } = useWorkspaceStore();
   const {
-    storageSources,
     expandedCategories: fileExpandedCategories,
     toggleCategory: toggleFileCategory,
     activeSource,
     setActiveSource,
     syncedFolders,
-    syncLocalFolder,
     fetchLocalFiles,
   } = useFilesStore();
-
-  const cloudSources = storageSources.filter((s) => s.category === 'cloud');
 
   return (
     <CollapsibleSection
@@ -201,35 +95,9 @@ export function FilesSection({ collapsed }: { collapsed: boolean }) {
               </button>
             ))}
 
-            <button
-              onClick={async () => {
-                const folder = await syncLocalFolder();
-                if (folder) {
-                  router.push(getWorkspacePath(currentWorkspaceId, '/files'));
-                }
-              }}
-              className="flex w-full items-center gap-2 rounded-md px-2 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
-            >
-              <Plus size={12} />
-              <span>Sync Folder</span>
-            </button>
           </div>
         )}
       </div>
-
-      {/* Cloud Sources */}
-      <StorageCategoryGroup
-        label="Cloud"
-        sources={cloudSources}
-        isExpanded={fileExpandedCategories.includes('cloud')}
-        onToggle={() => toggleFileCategory('cloud')}
-        activeSource={activeSource}
-        onSelectSource={(id) => {
-          setActiveSource(id);
-          router.push(getWorkspacePath(currentWorkspaceId, '/files'));
-        }}
-        onAddSource={() => router.push(getWorkspacePath(currentWorkspaceId, '/settings/storage'))}
-      />
     </CollapsibleSection>
   );
 }


### PR DESCRIPTION
## Summary
- Remove the "Cloud" sources group and the "Sync Folder" action from the Files section in the Nexus sidebar.
- Drop the now-unused `StorageSourceItem` / `StorageCategoryGroup` helpers and trim related imports / store fields.

## Test plan
- [ ] Open the Nexus app and confirm the Files sidebar only shows the Local group (My Drive, Workspace Drive, and any synced folders) with no Cloud group or Sync Folder button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)