### PR TITLE
feat(email): add filesystem adapter for local development

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -125,3 +125,8 @@ services:
         persistence_path: "storage/kv/python.sqlite3"
         journal_mode: "WAL"
         busy_timeout_ms: 5000
+  email:
+    email_adapter:
+      adapter: "filesystem"
+      config:
+        directory: "storage/email"

--- a/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_EmailService.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_EmailService.py
@@ -23,8 +23,14 @@ class EmailAdapterSMTPConfiguration(BaseModel):
     timeout: int = 10
 
 
+class EmailAdapterFilesystemConfiguration(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    directory: str = "storage/email"
+
+
 class EmailAdapterConfiguration(GenericLoader):
-    adapter: Literal["smtp", "custom"]
+    adapter: Literal["smtp", "filesystem", "custom"]
     config: dict | None = None
 
     @model_validator(mode="after")
@@ -40,6 +46,12 @@ class EmailAdapterConfiguration(GenericLoader):
                 self.config,
                 "Invalid configuration for services.email.email_adapter 'smtp' adapter",
             )
+        elif self.adapter == "filesystem":
+            pydantic_model_validator(
+                EmailAdapterFilesystemConfiguration,
+                self.config,
+                "Invalid configuration for services.email.email_adapter 'filesystem' adapter",
+            )
 
         return self
 
@@ -51,6 +63,15 @@ class EmailAdapterConfiguration(GenericLoader):
             )
 
             return SMTPAdapter(**self.config)
+        elif self.adapter == "filesystem":
+            assert self.config is not None, (
+                "config is required for filesystem adapter"
+            )
+            from naas_abi_core.services.email.adapters.secondary.FilesystemAdapter import (
+                FilesystemAdapter,
+            )
+
+            return FilesystemAdapter(**self.config)
         elif self.adapter == "custom":
             return super().load()
         else:

--- a/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_EmailService_test.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_EmailService_test.py
@@ -3,6 +3,9 @@ from naas_abi_core.engine.engine_configuration.EngineConfiguration_EmailService 
     EmailServiceConfiguration,
 )
 from naas_abi_core.services.email.EmailService import EmailService
+from naas_abi_core.services.email.adapters.secondary.FilesystemAdapter import (
+    FilesystemAdapter,
+)
 from naas_abi_core.services.email.adapters.secondary.SMTPAdapter import SMTPAdapter
 
 
@@ -22,4 +25,17 @@ def test_email_service_configuration_smtp_adapter():
 
     adapter = configuration.email_adapter.load()
     assert isinstance(adapter, SMTPAdapter)
+    assert isinstance(configuration.load(), EmailService)
+
+
+def test_email_service_configuration_filesystem_adapter(tmp_path):
+    configuration = EmailServiceConfiguration(
+        email_adapter=EmailAdapterConfiguration(
+            adapter="filesystem",
+            config={"directory": str(tmp_path)},
+        )
+    )
+
+    adapter = configuration.email_adapter.load()
+    assert isinstance(adapter, FilesystemAdapter)
     assert isinstance(configuration.load(), EmailService)

--- a/libs/naas-abi-core/naas_abi_core/services/email/EmailFactory.py
+++ b/libs/naas-abi-core/naas_abi_core/services/email/EmailFactory.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from naas_abi_core.services.email.EmailService import EmailService
+from naas_abi_core.services.email.adapters.secondary.FilesystemAdapter import (
+    FilesystemAdapter,
+)
 from naas_abi_core.services.email.adapters.secondary.SMTPAdapter import SMTPAdapter
 
 
@@ -27,3 +30,7 @@ class EmailFactory:
                 timeout=timeout,
             )
         )
+
+    @staticmethod
+    def EmailServiceFilesystem(*, directory: str) -> EmailService:
+        return EmailService(FilesystemAdapter(directory=directory))

--- a/libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/FilesystemAdapter.py
+++ b/libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/FilesystemAdapter.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import time
+import uuid
+from email.message import EmailMessage
+from email.utils import formataddr
+from pathlib import Path
+
+from naas_abi_core.services.email.EmailPorts import IEmailAdapter
+
+
+class FilesystemAdapter(IEmailAdapter):
+    def __init__(self, *, directory: str) -> None:
+        self._directory = Path(directory).expanduser()
+
+    def send(
+        self,
+        *,
+        to_email: str,
+        subject: str,
+        text_body: str,
+        html_body: str | None = None,
+        from_email: str,
+        from_name: str | None = None,
+        reply_to: str | None = None,
+    ) -> None:
+        msg = EmailMessage()
+        msg["To"] = to_email
+        msg["Subject"] = subject
+        msg["From"] = (
+            formataddr((from_name or "", from_email)) if from_name else from_email
+        )
+        if reply_to:
+            msg["Reply-To"] = reply_to
+
+        msg.set_content(text_body)
+        if html_body:
+            msg.add_alternative(html_body, subtype="html")
+
+        self._directory.mkdir(parents=True, exist_ok=True)
+        filename = f"{int(time.time() * 1000)}-{uuid.uuid4().hex}.eml"
+        (self._directory / filename).write_bytes(bytes(msg))

--- a/libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/FilesystemAdapter_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/FilesystemAdapter_test.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from email import message_from_bytes
+from pathlib import Path
+
+import pytest
+from naas_abi_core.services.email.adapters.secondary.FilesystemAdapter import (
+    FilesystemAdapter,
+)
+from naas_abi_core.services.email.tests.email__secondary_adapter__generic_test import (
+    GenericEmailSecondaryAdapterTest,
+)
+
+
+class TestFilesystemAdapter(GenericEmailSecondaryAdapterTest):
+    @pytest.fixture
+    def adapter_class(self):
+        return FilesystemAdapter
+
+    def test_send_writes_eml_file(self, tmp_path: Path) -> None:
+        adapter = FilesystemAdapter(directory=str(tmp_path))
+
+        adapter.send(
+            to_email="alice@example.com",
+            subject="Hello",
+            text_body="Hello world",
+            from_email="noreply@example.com",
+            from_name="NEXUS",
+            reply_to="support@example.com",
+        )
+
+        files = list(tmp_path.glob("*.eml"))
+        assert len(files) == 1
+        msg = message_from_bytes(files[0].read_bytes())
+        assert msg["To"] == "alice@example.com"
+        assert msg["Subject"] == "Hello"
+        assert msg["From"] == "NEXUS <noreply@example.com>"
+        assert msg["Reply-To"] == "support@example.com"
+
+    def test_send_creates_directory_if_missing(self, tmp_path: Path) -> None:
+        target = tmp_path / "does" / "not" / "exist"
+        adapter = FilesystemAdapter(directory=str(target))
+
+        adapter.send(
+            to_email="bob@example.com",
+            subject="Hi",
+            text_body="Body",
+            from_email="noreply@example.com",
+        )
+
+        assert target.is_dir()
+        assert len(list(target.glob("*.eml"))) == 1
+
+    def test_send_includes_html_alternative(self, tmp_path: Path) -> None:
+        adapter = FilesystemAdapter(directory=str(tmp_path))
+
+        adapter.send(
+            to_email="alice@example.com",
+            subject="Hello",
+            text_body="plain",
+            html_body="<p>html</p>",
+            from_email="noreply@example.com",
+        )
+
+        msg = message_from_bytes(next(tmp_path.glob("*.eml")).read_bytes())
+        assert msg.is_multipart()
+        subtypes = {part.get_content_subtype() for part in msg.walk() if not part.is_multipart()}
+        assert "plain" in subtypes
+        assert "html" in subtypes


### PR DESCRIPTION
## Summary

Adds a `FilesystemAdapter` to `EmailService` that writes outgoing emails as `.eml` files in a configured directory, so development environments don't have to rely on a real SMTP server.

## What changed

- **New secondary adapter** `FilesystemAdapter` ([libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/FilesystemAdapter.py](libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/FilesystemAdapter.py)) — serializes the message via `email.message.EmailMessage` (same shape as `SMTPAdapter`) and writes a unique `<timestamp>-<uuid>.eml` per send. Creates the target directory if missing.
- **Tests** in [FilesystemAdapter_test.py](libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/FilesystemAdapter_test.py) covering basic send, directory auto-creation, and HTML alternative — plus the shared `GenericEmailSecondaryAdapterTest`.
- **Factory** gains `EmailFactory.EmailServiceFilesystem(directory=...)`.
- **EngineConfiguration** loader supports `adapter: "filesystem"` with a typed `EmailAdapterFilesystemConfiguration` (validated, `extra="forbid"`).
- **config.yaml** now wires `services.email` to the filesystem adapter writing to `storage/email`.

## Test plan

- [x] `uv run pytest` for the email service and email engine-configuration tests (10 passed)
- [ ] Smoke: trigger a local send and confirm a `.eml` file appears under `storage/email/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)