### PR TITLE
feat(api): auto-serve module assets/public directories

### DIFF
--- a/libs/naas-abi-core/naas_abi_core/apps/api/api.py
+++ b/libs/naas-abi-core/naas_abi_core/apps/api/api.py
@@ -250,6 +250,17 @@ def _load_runtime_routes():
     app.include_router(workflows_router)
 
     for module in runtime_engine.modules.values():
+        public_dir = os.path.join(module.module_root_path, "assets", "public")
+        if os.path.isdir(public_dir):
+            mount_path = f"/modules/{module.module_path}/public"
+            logger.debug(f"Mounting module public assets: {mount_path} -> {public_dir}")
+            app.mount(
+                mount_path,
+                StaticFiles(directory=public_dir),
+                name=f"module-{module.module_path}-public",
+            )
+
+    for module in runtime_engine.modules.values():
         module.api(app)
 
     app.state.runtime_routes_loaded = True


### PR DESCRIPTION
## Summary

- Modules can now ship a `assets/public/` directory that's auto-discovered and mounted at `/modules/<module_path>/public/...`
- No auth required (matches the "public" naming) — separate from the existing core `/static` mount to avoid collisions
- Wired into `_load_runtime_routes()` so it benefits from the existing `runtime_routes_loaded` guard (no double-mount on reload)

## Why

Modules previously had to wire their own `StaticFiles` mount via `module.api(app)` to expose static assets. This adds a convention so dropping files into `assets/public/` is enough.

## Test plan

- [x] Add a file at `<some_module>/assets/public/test.txt`, start the API, confirm `GET /modules/<module_path>/public/test.txt` returns it
- [ ] Confirm modules without `assets/public/` are unaffected (no mount, no error)
- [ ] Confirm reload mode doesn't double-mount

🤖 Generated with [Claude Code](https://claude.com/claude-code)