### PR TITLE
feat(nexus/files): Escape closes preview, drive switch refreshes, drag-and-drop move

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/files/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/files/page.tsx
@@ -68,6 +68,7 @@ export default function FilesPage() {
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedFiles, setSelectedFiles] = useState<string[]>([]);
   const [isDragging, setIsDragging] = useState(false);
+  const [dropTargetPath, setDropTargetPath] = useState<string | null>(null);
   const [activeContextMenu, setActiveContextMenu] = useState<string | null>(null);
   const [pdfViewerFileName, setPdfViewerFileName] = useState<string | null>(null);
   const [pdfViewerUrl, setPdfViewerUrl] = useState<string | null>(null);
@@ -108,6 +109,19 @@ export default function FilesPage() {
     };
   }, [pdfViewerUrl]);
 
+  // Close any open preview viewer when the user presses Escape.
+  useEffect(() => {
+    if (!pdfViewerFileName && !imageViewerFileName && !textViewerFileName) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      if (pdfViewerFileName) closePdfViewer();
+      else if (imageViewerFileName) closeImageViewer();
+      else if (textViewerFileName) closeTextViewer();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [pdfViewerFileName, imageViewerFileName, textViewerFileName]);
+
   useEffect(() => {
     return () => {
       if (imageViewerUrl) {
@@ -127,29 +141,37 @@ export default function FilesPage() {
   useEffect(() => {
     // Clear any previous errors
     setError(null);
-    
+
     // Fetch files based on active source
     if (isLocalFolder && activeSyncedFolder) {
       fetchLocalFiles(activeSyncedFolder.id);
     } else {
       fetchFiles();
     }
-  }, [fetchFiles, fetchLocalFiles, isLocalFolder, activeSyncedFolder, setError]);
+  }, [fetchFiles, fetchLocalFiles, isLocalFolder, activeSyncedFolder, activeSource, setError]);
 
-  // Drag and drop handlers
+  const INTERNAL_DRAG_MIME = 'application/x-nexus-file';
+
+  const isInternalDrag = (e: React.DragEvent) =>
+    e.dataTransfer.types.includes(INTERNAL_DRAG_MIME);
+
+  // Drag and drop handlers (external upload only — internal moves bubble up but are ignored here)
   const handleDragOver = useCallback((e: React.DragEvent) => {
+    if (isInternalDrag(e)) return;
     e.preventDefault();
     e.stopPropagation();
     setIsDragging(true);
   }, []);
 
   const handleDragLeave = useCallback((e: React.DragEvent) => {
+    if (isInternalDrag(e)) return;
     e.preventDefault();
     e.stopPropagation();
     setIsDragging(false);
   }, []);
 
   const handleDrop = useCallback(async (e: React.DragEvent) => {
+    if (isInternalDrag(e)) return;
     e.preventDefault();
     e.stopPropagation();
     setIsDragging(false);
@@ -159,6 +181,49 @@ export default function FilesPage() {
       await uploadFiles(droppedFiles);
     }
   }, [uploadFiles]);
+
+  // Internal move via drag onto a folder row.
+  const handleRowDragStart = (e: React.DragEvent, file: FileInfo) => {
+    e.dataTransfer.setData(INTERNAL_DRAG_MIME, file.path);
+    e.dataTransfer.effectAllowed = 'move';
+  };
+
+  const handleFolderDragOver = (e: React.DragEvent, folder: FileInfo) => {
+    if (!isInternalDrag(e)) return;
+    e.preventDefault();
+    e.stopPropagation();
+    e.dataTransfer.dropEffect = 'move';
+    setDropTargetPath(folder.path);
+  };
+
+  const handleFolderDragLeave = (e: React.DragEvent, folder: FileInfo) => {
+    if (!isInternalDrag(e)) return;
+    e.stopPropagation();
+    setDropTargetPath((current) => (current === folder.path ? null : current));
+  };
+
+  const handleFolderDrop = async (e: React.DragEvent, folder: FileInfo) => {
+    if (!isInternalDrag(e)) return;
+    e.preventDefault();
+    e.stopPropagation();
+    setDropTargetPath(null);
+
+    const sourcePath = e.dataTransfer.getData(INTERNAL_DRAG_MIME);
+    if (!sourcePath) return;
+    // dataTransfer.getData isn't always available during dragover, so re-validate here
+    const sourceParent = sourcePath.includes('/') ? sourcePath.slice(0, sourcePath.lastIndexOf('/')) : '';
+    if (
+      sourcePath === folder.path ||
+      sourceParent === folder.path ||
+      folder.path === sourcePath ||
+      folder.path.startsWith(`${sourcePath}/`)
+    ) {
+      return;
+    }
+    const name = sourcePath.includes('/') ? sourcePath.slice(sourcePath.lastIndexOf('/') + 1) : sourcePath;
+    const newPath = `${folder.path}/${name}`;
+    await renameFile(sourcePath, newPath);
+  };
 
   const handleFileInputChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const selectedFiles = e.target.files;
@@ -870,7 +935,15 @@ export default function FilesPage() {
                 {filteredFiles.map((file) => (
                   <tr
                     key={file.path}
-                    className="group border-b border-border/50 hover:bg-muted/50"
+                    draggable={!isLocalFolder}
+                    onDragStart={(e) => handleRowDragStart(e, file)}
+                    onDragOver={file.type === 'folder' && !isLocalFolder ? (e) => handleFolderDragOver(e, file) : undefined}
+                    onDragLeave={file.type === 'folder' && !isLocalFolder ? (e) => handleFolderDragLeave(e, file) : undefined}
+                    onDrop={file.type === 'folder' && !isLocalFolder ? (e) => handleFolderDrop(e, file) : undefined}
+                    className={cn(
+                      "group border-b border-border/50 hover:bg-muted/50",
+                      dropTargetPath === file.path && "bg-primary/10 ring-1 ring-primary"
+                    )}
                   >
                     <td className="py-2">
                       <button
@@ -1055,7 +1128,18 @@ export default function FilesPage() {
             /* Grid view */
             <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
               {filteredFiles.map((file) => (
-                <div key={file.path} className="group relative">
+                <div
+                  key={file.path}
+                  draggable={!isLocalFolder}
+                  onDragStart={(e) => handleRowDragStart(e, file)}
+                  onDragOver={file.type === 'folder' && !isLocalFolder ? (e) => handleFolderDragOver(e, file) : undefined}
+                  onDragLeave={file.type === 'folder' && !isLocalFolder ? (e) => handleFolderDragLeave(e, file) : undefined}
+                  onDrop={file.type === 'folder' && !isLocalFolder ? (e) => handleFolderDrop(e, file) : undefined}
+                  className={cn(
+                    "group relative rounded-lg",
+                    dropTargetPath === file.path && "ring-2 ring-primary"
+                  )}
+                >
                   <button
                     onClick={() => {
                       if (file.type === 'folder') {


### PR DESCRIPTION
## Summary

Three small UX fixes/additions to the Nexus file manager page:

- **Escape closes the preview viewer.** A `keydown` listener is attached while a PDF, image, or text viewer is open and routes Escape to the matching close handler (which also revokes the blob URL).
- **Switching between My Drive and Workspace Drive now refetches.** The fetch effect was missing `activeSource` in its dependency array. Both scopes resolve to `isLocalFolder=false`/`activeSyncedFolder=undefined`, so toggling between them never re-ran the effect and the previous source's listing stayed on screen.
- **Drag-and-drop move.** File rows in both list and grid views are now `draggable`. Dropping onto a folder row moves the item via the existing `renameFile(oldPath, newPath)` store action (rename already supports re-parenting). Internal drags use a custom `application/x-nexus-file` MIME so the page-level external-upload drop handler ignores them; the drop target gets a primary-color ring. Disabled on read-only synced local folders.

All changes are in a single file: `libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/files/page.tsx`.

## Test plan

- [ ] Open a PDF/image/markdown/text file and press Escape → preview closes.
- [ ] Click "My Drive" then "Workspace Drive" (and vice versa) → listing refreshes for each scope.
- [ ] List view: drag a file onto a folder row → file moves; drop target shows a ring while hovering.
- [ ] Grid view: drag a file onto a folder tile → file moves; drop target shows a ring.
- [ ] Drag a folder onto one of its descendants → no-op.
- [ ] Drag a file onto its current parent or itself → no-op.
- [ ] Drag an external file from the OS into the page → upload still works (no move flow triggered).
- [ ] On a synced local folder view → rows are not draggable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)