### PR TITLE
feat(chat): add live processing time display during AI response generation

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
@@ -1953,7 +1953,9 @@ const MessageBubble = React.memo(function MessageBubble({
   const [showThinking, setShowThinking] = useState(false);
   const [autoCollapsed, setAutoCollapsed] = useState(false);
   const [copiedCodeKey, setCopiedCodeKey] = useState<string | null>(null);
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const wasProcessingRef = useRef(false);
+  const processingStartRef = useRef<number | null>(null);
   
   // Get user name and agent info for display
   const user = useAuthStore(state => state.user);
@@ -2013,6 +2015,22 @@ const MessageBubble = React.memo(function MessageBubble({
     (thinking !== null ? (!response || endsWithCaret) : (response === '▌'))
   );
   
+  // Live elapsed timer while processing
+  useEffect(() => {
+    if (isStillProcessing) {
+      if (processingStartRef.current === null) {
+        processingStartRef.current = Date.now();
+        setElapsedSeconds(0);
+      }
+      const interval = setInterval(() => {
+        setElapsedSeconds(Math.floor((Date.now() - (processingStartRef.current ?? Date.now())) / 1000));
+      }, 1000);
+      return () => clearInterval(interval);
+    } else {
+      processingStartRef.current = null;
+    }
+  }, [isStillProcessing]);
+
   // Auto-close thinking 3s after processing finishes
   useEffect(() => {
     if (isStillProcessing) {
@@ -2163,25 +2181,27 @@ const MessageBubble = React.memo(function MessageBubble({
         )}
         
         {/* Processing / Processed indicator */}
-        {hasThinkingSection && (!isStillProcessing || showThinking) && (
+        {hasThinkingSection && (
           <div className="w-full">
             <button
               onClick={() => thinking && setShowThinking(!showThinking)}
               className={cn(
                 'flex items-center gap-1.5 text-xs text-muted-foreground transition-colors',
-                thinking && 'hover:text-foreground cursor-pointer'
+                thinking && !isStillProcessing && 'hover:text-foreground cursor-pointer'
               )}
-              disabled={!thinking}
+              disabled={!thinking || isStillProcessing}
             >
-              {isStillProcessing ? null : (
+              {isStillProcessing ? (
+                <span className="font-medium tabular-nums">{formatDuration(elapsedSeconds)}</span>
+              ) : (
                 <span className="font-medium">
                   Processed in {formatDuration(message.thinkingDuration || 0)}
                 </span>
               )}
-              {thinking && (
-                <ChevronDown 
-                  size={12} 
-                  className={cn('transition-transform', showThinking && 'rotate-180')} 
+              {thinking && !isStillProcessing && (
+                <ChevronDown
+                  size={12}
+                  className={cn('transition-transform', showThinking && 'rotate-180')}
                 />
               )}
             </button>

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/ai-pane.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/ai-pane.tsx
@@ -614,7 +614,9 @@ function PaneMessage({ message }: { message: Message }) {
   const isUser = message.role === 'user';
   const [showThinking, setShowThinking] = useState(false);
   const [autoCollapsed, setAutoCollapsed] = useState(false);
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const wasProcessingRef = useRef(false);
+  const processingStartRef = useRef<number | null>(null);
 
   // Parse <think> tags
   const parseThinking = (content: string) => {
@@ -632,6 +634,22 @@ function PaneMessage({ message }: { message: Message }) {
     : parseThinking(message.content);
 
   const isStillProcessing = !isUser && thinking && (!response || response === '▌');
+
+  // Live elapsed timer while processing
+  useEffect(() => {
+    if (isStillProcessing) {
+      if (processingStartRef.current === null) {
+        processingStartRef.current = Date.now();
+        setElapsedSeconds(0);
+      }
+      const interval = setInterval(() => {
+        setElapsedSeconds(Math.floor((Date.now() - (processingStartRef.current ?? Date.now())) / 1000));
+      }, 1000);
+      return () => clearInterval(interval);
+    } else {
+      processingStartRef.current = null;
+    }
+  }, [isStillProcessing]);
 
   // Auto-close thinking 3s after processing finishes
   useEffect(() => {
@@ -673,21 +691,21 @@ function PaneMessage({ message }: { message: Message }) {
             onClick={() => thinking && setShowThinking(!showThinking)}
             className={cn(
               'flex items-center gap-1 text-[10px] text-muted-foreground transition-colors',
-              thinking && 'hover:text-foreground cursor-pointer'
+              thinking && !isStillProcessing && 'hover:text-foreground cursor-pointer'
             )}
-            disabled={!thinking}
+            disabled={!thinking || isStillProcessing}
           >
             {isStillProcessing ? (
-              <span className="font-medium animate-pulse">Processing...</span>
+              <span className="font-medium tabular-nums">{formatDuration(elapsedSeconds)}</span>
             ) : (
               <span className="font-medium">
                 Processed in {formatDuration(message.thinkingDuration || 0)}
               </span>
             )}
-            {thinking && (
+            {thinking && !isStillProcessing && (
               <ChevronDown
                 size={10}
-                className={cn('transition-transform', (showThinking || (isStillProcessing && !autoCollapsed)) && 'rotate-180')}
+                className={cn('transition-transform', showThinking && 'rotate-180')}
               />
             )}
           </button>


### PR DESCRIPTION
This pull request resolves #chat-time-processing

### Summary

This pull request introduces live processing time displays in the chat interface components for better user feedback during AI response generation.

### Details

- In `chat-interface.tsx`, a live elapsed timer has been added that updates every second while a response is still processing.
  - It shows the elapsed processing time instead of a static "Processing..." indicator.
  - Once processing completes, it reverts to showing the total processing duration as before.
- Similar enhancements are made in `ai-pane.tsx` to display ongoing process duration dynamically.
- The buttons controlling the thinking section now disable interaction during processing and conditionally render the timer or duration.

### Benefits

- Users get real-time feedback on how long an operation has been running, improving transparency.
- The UI now clearly distinguishes between ongoing processing and completed states.

### Files changed
- `libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx`
- `libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/ai-pane.tsx`