### PR TITLE
versionstore: complete branching DAG (merge, diff, fall-through, sidecars)

### DIFF
--- a/libs/naas-abi-core/naas_abi_core/utils/versionstore/WHITEPAPER.md
+++ b/libs/naas-abi-core/naas_abi_core/utils/versionstore/WHITEPAPER.md
@@ -210,16 +210,118 @@ projection layer. The store itself answers it.
 ```
 BEGIN IMMEDIATE
     DELETE FROM revisions
-    for each uid_dir in data/:
+    DELETE FROM merges
+    for each uid_dir in data/ (skipping data/__branches__/):
         for each file in uid_dir:
-            if file ends with .tmp: delete (orphan)
+            if file ends with .tmp:    delete (orphan)
+            elif file ends with .merge: stash as candidate sidecar
             else: parse filename → INSERT revision
+        for each accepted revision with a paired sidecar:
+            INSERT into merges(branch, uid, ts_ns, other_parent)
+        delete any unpaired sidecars (orphans)
+    DELETE FROM branches WHERE name != 'main'
+    for each branch sidecar in data/__branches__/:
+        INSERT OR REPLACE into branches (parent, fork_ts_ns, created_at)
+    for each branch discovered in filenames but not in sidecars:
+        INSERT with parent='main', fork_ts_ns=0   (legacy fallback)
 COMMIT
 ```
 
-The index is defined entirely by what is on disk. If a file was deleted, its
-row disappears. If a row was orphaned (e.g. by external index corruption), it
-is recreated from the filename.
+The index is defined entirely by what is on disk. Three artifact classes
+participate:
+
+1. **Revision files** (`{ts}.{prev}.{content}[.{branch}]`) — primary state.
+2. **Merge sidecars** (`{revision_filename}.merge`, 64-char hex content) —
+   second-parent pointer for multi-parent revisions.
+3. **Branch sidecars** (`data/__branches__/{name}.json`) — branch DAG identity.
+
+If a file was deleted, its row disappears. If a row was orphaned (e.g. by
+external index corruption), it is recreated from the filename. If a branch
+sidecar is missing for a branch discovered in revision filenames, the
+branch is reseeded with `parent='main', fork_ts_ns=0` — preserving
+backward compatibility with stores written before the sidecar grammar
+shipped.
+
+### 3.5 The branching DAG
+
+A branch is a named, mutable pointer scoped to a `Store`. Branches form a
+DAG rooted at `main`: each non-root branch records its `parent`, the
+nanosecond timestamp at which it was forked (`fork_ts_ns`), and its
+creation time (`created_at`). The DAG is encoded twice — authoritatively
+on disk under `data/__branches__/{name}.json`, and as a cache in the
+`branches` SQLite table — so total index loss is recoverable.
+
+Three operations exercise the DAG:
+
+#### 3.5.1 Fall-through reads
+
+A read on branch `B` for uid `U`:
+
+```
+function resolve(uid, branch, ts_limit):
+    own = latest revision of (branch, uid) with ts_ns <= ts_limit
+    if own exists: return own
+    if branch has no parent: return None
+    return resolve(uid, parent(branch), min(ts_limit, fork_ts_ns(branch)))
+```
+
+The recursive cap on `ts_limit` is the key invariant: a child branch sees
+its parent's state *as of the fork moment*, never any later writes the
+parent made after the branch existed. This makes branches durable
+snapshots without copying any bytes.
+
+The write path stays per-branch: own chains start at `GENESIS` and never
+chain off an inherited tip. This keeps `verify` per-branch and lets
+branches be deleted without affecting any other branch's chain validity.
+
+#### 3.5.2 Merge — multi-parent revisions
+
+`Store.merge(source, target, *, resolver, strategy)` reconciles two
+branches per uid, using the target's view at `source.fork_ts_ns` as the
+base:
+
+| `source_tip` | `target_tip` | `base` | Outcome |
+|--------------|--------------|--------|---------|
+| `=` target   | `=` source   | any    | `no_op` |
+| changed      | unchanged    | base   | `fast_forwarded` (apply source bytes on target) |
+| unchanged    | changed      | base   | `no_op` (target's work wins) |
+| changed      | changed      | base   | `three_way_merged` (resolver) or `conflicts` |
+| present      | absent       | absent | `fast_forwarded` (uid added on source) |
+
+Each `fast_forwarded` / `three_way_merged` uid produces one new revision
+on `target` *plus* a `.merge` sidecar containing `source_tip.content_hash`
+(the second parent). The new revision's `prev_hash` is the prior
+own-target tip (its first parent), so the per-branch chain stays linear
+and `verify` requires no special case for merges.
+
+The `merges` SQLite table is a (branch, uid, ts_ns) → other_parent index,
+rebuildable from the on-disk sidecars.
+
+`MergeStrategy.FAST_FORWARD` raises `MergeConflict` on the first uid that
+needs three-way reconciliation (all-or-nothing semantics). `THREE_WAY`
+collects conflicts (resolver returned `None`) and raises `MergeConflict`
+at the end with the partial `MergeResult` attached, so callers can
+inspect what was applied before the conflict surfaced. Merges are
+non-atomic across uids by design — each uid's write is independently
+durable, and re-running `merge` after a partial run picks up where it
+left off (already-applied uids fall into `no_op`).
+
+V1 limitation: `merge` requires `source.parent == target`. Transitive
+merges (a grandchild back to a grandparent) need a real common-ancestor
+walk, deferred to a follow-up issue.
+
+#### 3.5.3 `delete_branch` and reachability
+
+`delete_branch(name)` removes the branch's own revision files, their
+`.merge` sidecars, the metadata sidecar, and the corresponding
+`revisions` / `merges` / `branches` rows. It refuses `main` and refuses
+when any branch's `parent` points at the target — the caller must
+delete or re-parent children first.
+
+This works because fall-through walks *up* the DAG (child → parent),
+never down, so removing a leaf branch can never invalidate an ancestor's
+reads. After `delete_branch` + `rebuild_index`, no orphaned references
+remain — that is the reachability-GC contract.
 
 ## 4. Integrity Model
 
@@ -236,6 +338,23 @@ The filesystem alone is sufficient to:
 
 `Store.verify(uid)` performs the full chain walk in one pass. It does not
 consult the SQLite index; it reads from disk only.
+
+### 4.1 Multi-parent revisions
+
+A merge revision is a normal revision file (its `content_hash` is the
+SHA-256 of its bytes; its `prev_hash` is the prior own-branch tip's
+`content_hash`) accompanied by a `.merge` sidecar containing the second
+parent's `content_hash`. The single-line per-branch chain is therefore
+unchanged — `verify(uid, branch=B)` walks `B`'s revisions chronologically
+and validates `prev_hash` equals the prior revision's `content_hash`,
+exactly as for non-merge revisions.
+
+The second parent is informational, not load-bearing for integrity: it
+records which cross-branch state was incorporated, useful for tooling
+(merge graphs, blame) and for reconstructing the DAG. A missing or
+malformed sidecar does not invalidate the revision; it only loses the
+cross-branch ancestry hint, which `rebuild_index` cleans up by deleting
+the sidecar.
 
 The threat model this covers is **local integrity**. It does not cover
 adversaries who can rewrite the entire `data/` directory, including the

--- a/libs/naas-abi-core/naas_abi_core/utils/versionstore/__init__.py
+++ b/libs/naas-abi-core/naas_abi_core/utils/versionstore/__init__.py
@@ -33,22 +33,32 @@ Public API:
 from .revision import DEFAULT_BRANCH, Revision
 from .registry import StoreRegistry
 from .store import (
+    BranchDiff,
     BranchNotFoundError,
     ConcurrencyConflict,
+    ConflictResolver,
     DURABILITY_FAST,
     DURABILITY_FULL,
     GENESIS,
+    MergeConflict,
+    MergeResult,
+    MergeStrategy,
     Store,
 )
 from .uuid7 import uuid7
 
 __all__ = [
+    "BranchDiff",
     "BranchNotFoundError",
     "ConcurrencyConflict",
+    "ConflictResolver",
     "DEFAULT_BRANCH",
     "DURABILITY_FAST",
     "DURABILITY_FULL",
     "GENESIS",
+    "MergeConflict",
+    "MergeResult",
+    "MergeStrategy",
     "Revision",
     "Store",
     "StoreRegistry",

--- a/libs/naas-abi-core/naas_abi_core/utils/versionstore/revision.py
+++ b/libs/naas-abi-core/naas_abi_core/utils/versionstore/revision.py
@@ -10,6 +10,20 @@ from pathlib import Path
 HASH_LEN = 64  # SHA-256 hex length
 TS_DIGITS = 20  # zero-padded nanosecond timestamp
 DEFAULT_BRANCH = "main"
+MERGE_SIDECAR_SUFFIX = ".merge"
+"""Suffix appended to a revision filename to form its merge sidecar.
+
+A merge revision is a normal revision file with prev_hash pointing at its
+first parent (the prior tip on the same branch). The sidecar — same path
+plus this suffix — contains the second parent's content_hash, identifying
+the cross-branch ancestor that was incorporated."""
+
+BRANCHES_DIRNAME = "__branches__"
+"""Subdirectory under ``data/`` holding per-branch metadata sidecars.
+
+Each branch X has a sidecar ``data/__branches__/X.json`` describing its
+parent, fork timestamp, and creation time. This lets ``rebuild_index``
+fully reconstruct the branch DAG from the filesystem alone."""
 
 
 @dataclass(frozen=True)
@@ -26,6 +40,9 @@ class Revision:
 
     ``prev_hash`` is the content_hash of the previous revision for this uid on
     this branch, or ``"0" * 64`` (GENESIS) for the first revision on the branch.
+    Multi-parent (merge) revisions carry their second parent in a sidecar
+    file named ``<filename>.merge``; the ``prev_hash`` of a merge revision
+    still points at the prior tip on the same branch (its first parent).
     """
 
     uid: str
@@ -51,13 +68,22 @@ class Revision:
         """Read the payload bytes from disk."""
         return self.path.read_bytes()
 
+    @property
+    def merge_sidecar_path(self) -> Path:
+        """Path to this revision's ``.merge`` sidecar (may not exist)."""
+        return self.path.parent / (self.path.name + MERGE_SIDECAR_SUFFIX)
+
     @classmethod
     def parse_filename(cls, uid: str, filename: str, dir_path: Path) -> "Revision":
-        """Parse a revision filename. Raises ValueError if malformed.
+        """Parse a revision filename. Raises ``ValueError`` if malformed.
 
-        Accepts both the legacy 3-part form (defaults to ``main``) and the
-        4-part form ``ts.prev.content.branch``.
+        Accepts the 3-part form ``ts.prev.content`` (defaults to ``main``)
+        and the 4-part form ``ts.prev.content.branch``. Merge sidecar
+        files (suffix ``.merge``) raise ``ValueError`` here; callers
+        detect them with ``is_merge_sidecar`` first.
         """
+        if is_merge_sidecar(filename):
+            raise ValueError(f"Not a revision (merge sidecar): {filename!r}")
         parts = filename.split(".")
         if len(parts) == 3:
             ts_str, prev_hash, content_hash = parts
@@ -80,3 +106,15 @@ class Revision:
             path=dir_path / filename,
             branch=branch,
         )
+
+
+def is_merge_sidecar(filename: str) -> bool:
+    """True if ``filename`` is a merge sidecar (``…<revision>.merge``)."""
+    return filename.endswith(MERGE_SIDECAR_SUFFIX)
+
+
+def revision_filename_for_sidecar(sidecar_filename: str) -> str:
+    """Strip the ``.merge`` suffix to recover the paired revision filename."""
+    if not is_merge_sidecar(sidecar_filename):
+        raise ValueError(f"Not a merge sidecar: {sidecar_filename!r}")
+    return sidecar_filename[: -len(MERGE_SIDECAR_SUFFIX)]

--- a/libs/naas-abi-core/naas_abi_core/utils/versionstore/store.py
+++ b/libs/naas-abi-core/naas_abi_core/utils/versionstore/store.py
@@ -18,10 +18,29 @@ This is the ABI-vendored copy of versionstore. It adds, on top of upstream:
   ``commit_window_ms > 0`` to the constructor; defaults to off. See
   ``WHITEPAPER.md §11`` for the durability model.
 
-* **Minimal branching scaffold.** A ``branches`` table tracks branch metadata;
-  every revision records its ``branch``; ``put / latest / history / get / verify``
-  accept an optional ``branch=`` argument (default ``"main"``). ``"main"`` is
-  seeded automatically and behaves byte-for-byte like the upstream store.
+* **Branching DAG.** A ``branches`` table tracks branch identities (parent,
+  fork timestamp), mirrored on disk as JSON sidecars under
+  ``data/__branches__/`` so ``rebuild_index`` reconstructs the full DAG
+  from the filesystem alone. Every revision records its ``branch``;
+  ``put / latest / history / get / verify`` accept an optional
+  ``branch=`` argument (default ``"main"``). ``"main"`` is seeded
+  automatically and behaves byte-for-byte like the upstream store.
+
+* **Fall-through reads.** ``latest`` / ``get`` / ``uids`` / ``uids_at`` on a
+  child branch transparently inherit revisions from the parent branch as
+  they existed at the fork timestamp, recursively up the DAG. The write
+  path stays per-branch (own chains start at ``GENESIS``).
+
+* **``merge`` and ``diff``.** ``Store.diff(a, b)`` returns a per-uid
+  snapshot diff that automatically cancels inherited state. ``Store.merge``
+  drives a per-uid three-way merge with a caller-supplied resolver and
+  produces multi-parent revisions: a normal revision file plus a
+  ``.merge`` sidecar holding the second parent's content_hash, indexed
+  in a ``merges`` table.
+
+* **``delete_branch``.** Removes the branch's own files, ``.merge``
+  sidecars, metadata sidecar, and table rows. Refuses ``main`` and
+  refuses if any branch points at the target as parent.
 
 * **Optimistic concurrency.** ``put`` accepts an optional
   ``expected_prev_hash``; if the actual tip has moved, ``ConcurrencyConflict``
@@ -29,15 +48,15 @@ This is the ABI-vendored copy of versionstore. It adds, on top of upstream:
 
 What is **not** here yet (deferred to follow-up):
 
-* ``delete_branch / merge / diff`` operations, branch metadata on the
-  filesystem (``data/__branches__/``), multi-parent merge revisions and their
-  sidecars, fall-through reads to a parent branch.
 * The ``IVersionedStorePort`` (lives in naas-abi-core, not in this library).
+* Transitive merges (a grandchild merging back into a grandparent in
+  one call). ``merge`` v1 requires ``source.parent == target``.
 """
 
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import sqlite3
 import sys
@@ -45,10 +64,19 @@ import threading
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
+from enum import Enum
 from pathlib import Path
-from typing import Iterator
+from typing import Callable, Iterator
 
-from .revision import DEFAULT_BRANCH, HASH_LEN, Revision
+from .revision import (
+    BRANCHES_DIRNAME,
+    DEFAULT_BRANCH,
+    HASH_LEN,
+    MERGE_SIDECAR_SUFFIX,
+    Revision,
+    is_merge_sidecar,
+    revision_filename_for_sidecar,
+)
 
 
 GENESIS = "0" * HASH_LEN
@@ -140,6 +168,99 @@ class BranchNotFoundError(Exception):
     """Raised when an operation targets a branch that does not exist."""
 
 
+class MergeConflict(Exception):
+    """Raised when ``merge`` cannot proceed: ``fast-forward`` strategy was
+    requested but a uid required three-way reconciliation, or the resolver
+    returned ``None`` for at least one uid under ``three-way``.
+
+    The ``conflicts`` mapping is uid → human-readable reason. ``result``
+    is the partial ``MergeResult`` describing what was applied before the
+    conflict surfaced (merge is non-atomic per uid by design — fall-through
+    reads on the target branch see partial progress, which is fine because
+    each uid's revision chain stays valid)."""
+
+    def __init__(self, conflicts: dict[str, str], result: "MergeResult"):
+        self.conflicts = conflicts
+        self.result = result
+        super().__init__(
+            f"Merge produced {len(conflicts)} conflict(s): "
+            + ", ".join(sorted(conflicts.keys())[:5])
+            + ("…" if len(conflicts) > 5 else "")
+        )
+
+
+class MergeStrategy(str, Enum):
+    """How ``Store.merge`` reconciles divergent uids.
+
+    * ``FAST_FORWARD`` — only succeeds when every diverging uid has not
+      changed on ``target`` since the fork point. Any uid that needs
+      three-way reconciliation raises ``MergeConflict`` and the merge
+      stops at that uid.
+    * ``THREE_WAY`` — calls the caller-provided resolver for every uid
+      that diverges on both sides. The resolver returns ``bytes`` to
+      apply or ``None`` to flag the uid as conflicted.
+    """
+
+    FAST_FORWARD = "fast-forward"
+    THREE_WAY = "three-way"
+
+
+@dataclass(frozen=True)
+class BranchDiff:
+    """Per-uid divergence between two branches' visible state.
+
+    All three sets are over uids:
+
+    * ``added`` — present on ``a`` (after fall-through), absent on ``b``.
+    * ``removed`` — present on ``b`` (after fall-through), absent on ``a``.
+    * ``changed`` — present on both with different visible content_hash.
+
+    Inherited state shared via fall-through automatically drops out (both
+    sides see the same hash). The result is a snapshot diff, not a
+    revision-by-revision diff.
+    """
+
+    added: frozenset[str]
+    removed: frozenset[str]
+    changed: frozenset[str]
+
+    def is_empty(self) -> bool:
+        return not (self.added or self.removed or self.changed)
+
+
+@dataclass
+class MergeResult:
+    """Outcome of a ``Store.merge`` call.
+
+    All four sets are over uids:
+
+    * ``no_op`` — source and target tips were already identical.
+    * ``fast_forwarded`` — target hadn't moved since fork; source's tip
+      was applied on target as a new revision (with a ``.merge`` sidecar
+      pointing at the source tip).
+    * ``three_way_merged`` — the resolver returned bytes that were
+      applied on target as a new revision (with a ``.merge`` sidecar).
+    * ``conflicts`` — uid → reason. Resolver returned ``None`` (under
+      ``three-way``) or a uid required three-way reconciliation under
+      ``fast-forward``. The corresponding uids were not modified on target.
+    """
+
+    no_op: set[str] = field(default_factory=set)
+    fast_forwarded: set[str] = field(default_factory=set)
+    three_way_merged: set[str] = field(default_factory=set)
+    conflicts: dict[str, str] = field(default_factory=dict)
+
+
+ConflictResolver = Callable[[str, bytes | None, bytes, bytes], "bytes | None"]
+"""Signature: ``resolver(uid, base, source, target) -> bytes | None``.
+
+* ``base`` may be ``None`` if the uid did not exist at the fork point
+  (i.e. it was added on both sides after fork).
+* Returning ``bytes`` produces a new revision on target.
+* Returning ``None`` flags the uid as conflicted; target is unchanged.
+"""
+
+
 class Store:
     """Append-only versioned blob store with branches.
 
@@ -152,15 +273,24 @@ class Store:
                     {ts_ns:020d}.{prev_hash}.{content_hash}            ← main
                     {ts_ns:020d}.{prev_hash}.{content_hash}.{branch}   ← other
 
-    The filesystem is the source of truth for revisions. The SQLite index can
-    be nuked and rebuilt from the filesystem at any time via ``rebuild_index``.
+    Merge revisions add a paired sidecar at ``{filename}.merge`` whose
+    content is the second parent's content_hash (64-char hex). The first
+    parent is encoded in ``prev_hash`` exactly like a non-merge revision,
+    so the per-branch chain stays linear and ``verify`` is unchanged.
 
-    Branch metadata (parent, fork timestamp) currently lives in SQLite only;
-    a follow-up will mirror it onto the filesystem under ``data/__branches__/``
-    so ``rebuild_index`` can fully reconstruct branch identities. Until then,
-    ``rebuild_index`` reconstructs the *set* of branches (from filenames) but
-    parent / fork-timestamp metadata is recreated as ``("main", 0)`` for
-    discovered branches that aren't already in the index.
+    Branch metadata lives in two places:
+
+    * Authoritative on disk under ``data/__branches__/{name}.json``
+      (parent, fork_ts_ns, created_at). Written tmp+rename + fsync on
+      every ``create_branch`` so a crash leaves either the previous or
+      the new content, never partial JSON.
+    * Cached in the ``branches`` SQLite table for query speed.
+
+    The filesystem is the source of truth: ``rebuild_index`` nukes the
+    SQLite index (revisions, merges, branches) and rebuilds the full
+    branch DAG from sidecars + revision filenames. Stores written before
+    sidecars existed still rebuild correctly — branches discovered only
+    from filenames default to ``parent='main', fork_ts_ns=0``.
     """
 
     def __init__(
@@ -361,16 +491,100 @@ class Store:
                 CREATE INDEX IF NOT EXISTS idx_revisions_ts ON revisions(ts_ns);
                 CREATE INDEX IF NOT EXISTS idx_revisions_branch_uid
                     ON revisions(branch, uid, ts_ns);
+
+                CREATE TABLE IF NOT EXISTS merges (
+                    branch        TEXT    NOT NULL,
+                    uid           TEXT    NOT NULL,
+                    ts_ns         INTEGER NOT NULL,
+                    other_parent  TEXT    NOT NULL,
+                    PRIMARY KEY (branch, uid, ts_ns)
+                );
                 """
             )
 
     def _seed_main_branch(self) -> None:
+        now_ns = time.time_ns()
         with self._db_lock:
             self._conn.execute(
                 "INSERT OR IGNORE INTO branches(name, parent, fork_ts_ns, created_at) "
                 "VALUES (?, NULL, 0, ?)",
-                (DEFAULT_BRANCH, time.time_ns()),
+                (DEFAULT_BRANCH, now_ns),
             )
+        # Pull the actual created_at back so the on-disk sidecar matches
+        # the row that won the INSERT OR IGNORE race.
+        with self._db_lock:
+            row = self._conn.execute(
+                "SELECT created_at FROM branches WHERE name = ?",
+                (DEFAULT_BRANCH,),
+            ).fetchone()
+        created_at = row[0] if row is not None else now_ns
+        self._write_branch_sidecar(
+            DEFAULT_BRANCH, parent=None, fork_ts_ns=0, created_at=created_at
+        )
+
+    # --------------------------------------------------------- branch sidecars
+
+    def _branches_dir(self) -> Path:
+        return self.data_dir / BRANCHES_DIRNAME
+
+    def _branch_sidecar_path(self, name: str) -> Path:
+        return self._branches_dir() / f"{name}.json"
+
+    def _write_branch_sidecar(
+        self,
+        name: str,
+        *,
+        parent: str | None,
+        fork_ts_ns: int,
+        created_at: int,
+    ) -> None:
+        """Atomically write the on-disk metadata sidecar for a branch.
+
+        ``rebuild_index`` reads these to reconstruct the branch DAG without
+        consulting SQLite. The write is tmp+rename so a crash mid-write
+        leaves either the previous content or nothing — never a partial
+        JSON document."""
+        branches_dir = self._branches_dir()
+        branches_dir.mkdir(exist_ok=True)
+        path = self._branch_sidecar_path(name)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        payload = {
+            "parent": parent,
+            "fork_ts_ns": fork_ts_ns,
+            "created_at": created_at,
+        }
+        try:
+            with open(tmp, "w") as f:
+                f.write(json.dumps(payload, sort_keys=True))
+                f.flush()
+                self._sync_fd(f.fileno())
+            os.rename(tmp, path)
+            self._sync_dir(branches_dir)
+        except Exception:
+            _best_effort_unlink(tmp)
+            raise
+
+    def _read_branch_sidecar(
+        self, name: str
+    ) -> tuple[str | None, int, int] | None:
+        """Read ``(parent, fork_ts_ns, created_at)`` for ``name``, or ``None``
+        if the sidecar is missing or unparseable."""
+        path = self._branch_sidecar_path(name)
+        if not path.is_file():
+            return None
+        try:
+            data = json.loads(path.read_text())
+            parent = data.get("parent")
+            fork_ts_ns = int(data["fork_ts_ns"])
+            created_at = int(data["created_at"])
+            if parent is not None and not isinstance(parent, str):
+                return None
+            return (parent, fork_ts_ns, created_at)
+        except (OSError, ValueError, KeyError, TypeError):
+            return None
+
+    def _delete_branch_sidecar(self, name: str) -> None:
+        _best_effort_unlink(self._branch_sidecar_path(name))
 
     def close(self) -> None:
         with self._db_lock:
@@ -387,12 +601,12 @@ class Store:
     def create_branch(
         self, name: str, *, parent: str = DEFAULT_BRANCH
     ) -> None:
-        """Register a branch. No data is copied; tips fall through at read time
-        (fall-through reads are deferred to the follow-up; for now reads only
-        return revisions explicitly written on the requested branch).
+        """Register a branch. No data is copied; reads on the new branch fall
+        through to ``parent`` at the fork timestamp (so every uid that
+        existed on ``parent`` at fork time is visible on the child).
 
-        Parent must exist. Branch name must be valid (alphanumeric + ``-``/``_``,
-        non-empty, no path separators, no ``.``).
+        Parent must exist. Branch name must be valid (no ``.``, no path
+        separators, not ``main``-reserved-words, etc — see ``_validate_branch``).
         """
         _validate_branch(name)
         if not self._branch_exists(parent):
@@ -403,6 +617,17 @@ class Store:
                 "INSERT OR IGNORE INTO branches(name, parent, fork_ts_ns, created_at) "
                 "VALUES (?, ?, ?, ?)",
                 (name, parent, now_ns, now_ns),
+            )
+        # If a row already existed (re-create is a no-op), keep its
+        # fork_ts_ns so the on-disk sidecar reflects the persisted truth.
+        meta = self._branch_meta(name)
+        if meta is not None:
+            actual_parent, fork_ts_ns, created_at = meta
+            self._write_branch_sidecar(
+                name,
+                parent=actual_parent,
+                fork_ts_ns=fork_ts_ns,
+                created_at=created_at,
             )
 
     def list_branches(self) -> list[str]:
@@ -418,6 +643,41 @@ class Store:
                 "SELECT 1 FROM branches WHERE name = ?", (name,)
             ).fetchone()
         return row is not None
+
+    def _branch_meta(self, name: str) -> tuple[str | None, int, int] | None:
+        """Return ``(parent, fork_ts_ns, created_at)`` for ``name``, or
+        ``None`` if unknown."""
+        with self._db_lock:
+            row = self._conn.execute(
+                "SELECT parent, fork_ts_ns, created_at FROM branches "
+                "WHERE name = ?",
+                (name,),
+            ).fetchone()
+        if row is None:
+            return None
+        return (row[0], int(row[1]), int(row[2]))
+
+    def _ancestor_chain(self, name: str) -> list[str]:
+        """Return ``[name, parent, grandparent, …]`` walking up the branch DAG.
+
+        Stops at the first branch with ``parent IS NULL`` (typically ``main``)
+        or at an unknown parent. Cycles are guarded by a seen-set.
+        """
+        chain: list[str] = []
+        seen: set[str] = set()
+        cursor: str | None = name
+        while cursor is not None and cursor not in seen:
+            chain.append(cursor)
+            seen.add(cursor)
+            meta = self._branch_meta(cursor)
+            if meta is None:
+                break
+            cursor = meta[0]
+        return chain
+
+    # The fall-through "now" cap. Sentinel "no upper bound" used internally
+    # so the recursive resolver can keep narrowing the timestamp ceiling.
+    _TS_FOREVER = (1 << 63) - 1
 
     # ------------------------------------------------------------------ write
 
@@ -771,32 +1031,67 @@ class Store:
         *,
         branch: str = DEFAULT_BRANCH,
     ) -> Revision | None:
-        """Return the latest ``Revision`` for ``uid`` on ``branch`` at time
-        ``at``, or ``None``."""
+        """Return the latest visible ``Revision`` for ``uid`` on ``branch`` at
+        ``at``, or ``None``.
+
+        "Visible" means: own-branch revisions are checked first; if none
+        match, fall through to the parent branch capped at the fork
+        timestamp, recursively up the branch DAG. This mirrors how reads
+        on a fresh feature branch see whatever existed on its parent at
+        the moment the branch was created."""
         _validate_uid(uid)
         _validate_branch(branch)
-        if at is None:
-            with self._db_lock:
-                row = self._conn.execute(
-                    "SELECT ts_ns, prev_hash, content_hash FROM revisions "
-                    "WHERE branch = ? AND uid = ? ORDER BY ts_ns DESC LIMIT 1",
-                    (branch, uid),
-                ).fetchone()
-        else:
-            ts_limit = _dt_to_ns(at)
-            with self._db_lock:
-                row = self._conn.execute(
-                    "SELECT ts_ns, prev_hash, content_hash FROM revisions "
-                    "WHERE branch = ? AND uid = ? AND ts_ns <= ? "
-                    "ORDER BY ts_ns DESC LIMIT 1",
-                    (branch, uid, ts_limit),
-                ).fetchone()
+        ts_limit = self._TS_FOREVER if at is None else _dt_to_ns(at)
+        return self._resolve_latest_walking(uid, branch, ts_limit)
+
+    def _resolve_latest_walking(
+        self, uid: str, branch: str, ts_limit: int
+    ) -> Revision | None:
+        """Walk ``branch`` and its ancestors looking for the most recent
+        revision of ``uid`` at or before ``ts_limit``."""
+        seen: set[str] = set()
+        cursor: str | None = branch
+        cap = ts_limit
+        while cursor is not None and cursor not in seen:
+            seen.add(cursor)
+            rev = self._latest_own(uid, cursor, cap)
+            if rev is not None:
+                return rev
+            meta = self._branch_meta(cursor)
+            if meta is None:
+                return None
+            parent, fork_ts_ns, _ = meta
+            if parent is None:
+                return None
+            # Looking up the parent: only revisions that existed at
+            # fork-time are inherited.
+            cap = min(cap, fork_ts_ns)
+            cursor = parent
+        return None
+
+    def _latest_own(
+        self, uid: str, branch: str, ts_limit: int
+    ) -> Revision | None:
+        """Latest revision of ``uid`` written *on* ``branch`` (no fall-through),
+        capped at ``ts_limit`` (inclusive)."""
+        with self._db_lock:
+            row = self._conn.execute(
+                "SELECT ts_ns, prev_hash, content_hash FROM revisions "
+                "WHERE branch = ? AND uid = ? AND ts_ns <= ? "
+                "ORDER BY ts_ns DESC LIMIT 1",
+                (branch, uid, ts_limit),
+            ).fetchone()
         if row is None:
             return None
         return self._build_revision(uid, *row, branch=branch)
 
     def _latest_on_branch(self, uid: str, branch: str) -> Revision | None:
-        """Internal hot-path: latest tip on a branch, validation skipped."""
+        """Internal hot-path: latest *own-branch* tip, validation skipped.
+
+        Used by the write path: ``put`` chains a new revision off the
+        previous own write on the same branch, never off an inherited tip.
+        Inheritance is a read-time concern (see ``_resolve_latest_walking``).
+        """
         with self._db_lock:
             row = self._conn.execute(
                 "SELECT ts_ns, prev_hash, content_hash FROM revisions "
@@ -806,6 +1101,309 @@ class Store:
         if row is None:
             return None
         return self._build_revision(uid, *row, branch=branch)
+
+    # ----------------------------------------------------------- diff / merge
+
+    def diff(self, a: str, b: str) -> BranchDiff:
+        """Snapshot diff between two branches' visible state.
+
+        Compares ``_resolve_latest_walking`` for every uid visible on
+        either branch. Inherited state shared via fall-through automatically
+        cancels out (both sides resolve to the same content_hash). See
+        ``BranchDiff``."""
+        _validate_branch(a)
+        _validate_branch(b)
+        if not self._branch_exists(a):
+            raise BranchNotFoundError(f"Branch does not exist: {a!r}")
+        if not self._branch_exists(b):
+            raise BranchNotFoundError(f"Branch does not exist: {b!r}")
+        a_uids = self._visible_uids(a, self._TS_FOREVER)
+        b_uids = self._visible_uids(b, self._TS_FOREVER)
+        added: set[str] = set()
+        removed: set[str] = set()
+        changed: set[str] = set()
+        for uid in a_uids | b_uids:
+            ra = self._resolve_latest_walking(uid, a, self._TS_FOREVER)
+            rb = self._resolve_latest_walking(uid, b, self._TS_FOREVER)
+            if ra is None and rb is not None:
+                removed.add(uid)
+            elif rb is None and ra is not None:
+                added.add(uid)
+            elif (
+                ra is not None
+                and rb is not None
+                and ra.content_hash != rb.content_hash
+            ):
+                changed.add(uid)
+        return BranchDiff(
+            added=frozenset(added),
+            removed=frozenset(removed),
+            changed=frozenset(changed),
+        )
+
+    def merge(
+        self,
+        source: str,
+        target: str,
+        *,
+        resolver: ConflictResolver | None = None,
+        strategy: MergeStrategy = MergeStrategy.THREE_WAY,
+    ) -> MergeResult:
+        """Merge ``source`` into ``target``, writing multi-parent revisions.
+
+        Preconditions:
+
+        * Both branches exist.
+        * ``source != target``.
+        * ``source.parent == target``. (V1 limitation: only single-hop
+          merges. Transitive merges — merging a grandchild into a
+          grandparent — are a follow-up that requires a real common-ancestor
+          walk. Raises ``ValueError`` otherwise.)
+
+        Per-uid algorithm with ``base = target's view of uid at source.fork_ts_ns``:
+
+        * ``source_tip == target_tip`` → ``no_op``.
+        * Source added a uid that target lacks → ``fast_forwarded``.
+        * ``source_tip == base`` → target changed alone, ``no_op``.
+        * ``target_tip == base`` → source changed alone, ``fast_forwarded``.
+        * Both diverged from base → ``three_way_merged`` (resolver) or
+          ``conflicts`` (resolver returned ``None``, or ``FAST_FORWARD``
+          strategy).
+
+        Each ``fast_forwarded`` / ``three_way_merged`` uid produces one new
+        revision on ``target`` (chained off the last own-target tip via the
+        regular write path) plus a ``.merge`` sidecar pointing at
+        ``source_tip.content_hash``. The sidecar is also recorded in the
+        ``merges`` index table.
+
+        Merge is non-atomic across uids by design: each uid's write is
+        independently durable. A crash mid-merge leaves a valid prefix on
+        target (every applied uid is fully written before the next is
+        attempted). Resume by re-running ``merge`` — already-applied uids
+        will fall into the ``no_op`` bucket.
+        """
+        _validate_branch(source)
+        _validate_branch(target)
+        if source == target:
+            raise ValueError("source and target must differ")
+        for b in (source, target):
+            if not self._branch_exists(b):
+                raise BranchNotFoundError(f"Branch does not exist: {b!r}")
+        source_meta = self._branch_meta(source)
+        if source_meta is None or source_meta[0] != target:
+            raise ValueError(
+                f"merge v1 requires source.parent == target; "
+                f"{source!r}.parent = {source_meta[0] if source_meta else None!r}"
+            )
+        fork_ts_ns = source_meta[1]
+
+        # Union of uids visible on either side. Order is sorted so merge
+        # progress is deterministic across runs (helps reasoning about
+        # crash recovery).
+        all_uids = sorted(
+            self._visible_uids(source, self._TS_FOREVER)
+            | self._visible_uids(target, self._TS_FOREVER)
+        )
+        result = MergeResult()
+        for uid in all_uids:
+            source_tip = self._resolve_latest_walking(
+                uid, source, self._TS_FOREVER
+            )
+            target_tip = self._resolve_latest_walking(
+                uid, target, self._TS_FOREVER
+            )
+            base_tip = self._resolve_latest_walking(uid, target, fork_ts_ns)
+
+            if source_tip is None:
+                # Nothing to merge from source for this uid (it only
+                # exists on target post-fork, or doesn't exist at all).
+                continue
+
+            if (
+                target_tip is not None
+                and source_tip.content_hash == target_tip.content_hash
+            ):
+                result.no_op.add(uid)
+                continue
+
+            base_hash = base_tip.content_hash if base_tip is not None else None
+            target_hash = target_tip.content_hash if target_tip is not None else None
+
+            if target_hash == base_hash:
+                # Target hasn't moved since fork — fast-forward apply
+                # source's bytes on target.
+                source_payload = source_tip.read()
+                self._apply_merge(
+                    uid, target, source_payload, source_tip.content_hash
+                )
+                result.fast_forwarded.add(uid)
+                continue
+
+            if source_tip.content_hash == base_hash:
+                # Source hasn't moved since fork — target's own work wins.
+                result.no_op.add(uid)
+                continue
+
+            # Both sides moved. Three-way territory.
+            if strategy is MergeStrategy.FAST_FORWARD:
+                reason = (
+                    f"uid {uid!r} requires three-way merge but strategy "
+                    f"is fast-forward (base={base_hash!r}, "
+                    f"source={source_tip.content_hash!r}, "
+                    f"target={target_hash!r})"
+                )
+                result.conflicts[uid] = reason
+                # Stop on first ff failure — semantics of fast-forward are
+                # all-or-nothing per the strategy contract.
+                raise MergeConflict({uid: reason}, result)
+
+            if resolver is None:
+                reason = "three-way merge needed but no resolver provided"
+                result.conflicts[uid] = reason
+                continue
+
+            base_payload = base_tip.read() if base_tip is not None else None
+            assert target_tip is not None  # target_hash != base_hash → tip exists
+            target_payload = target_tip.read()
+            source_payload = source_tip.read()
+
+            resolved = resolver(uid, base_payload, source_payload, target_payload)
+            if resolved is None:
+                result.conflicts[uid] = "resolver returned None"
+                continue
+            if resolved == target_payload:
+                # Resolver said "keep target as-is" — no new revision.
+                result.no_op.add(uid)
+                continue
+
+            self._apply_merge(uid, target, resolved, source_tip.content_hash)
+            result.three_way_merged.add(uid)
+
+        if result.conflicts:
+            raise MergeConflict(dict(result.conflicts), result)
+        return result
+
+    def _apply_merge(
+        self,
+        uid: str,
+        target: str,
+        payload: bytes,
+        other_parent: str,
+    ) -> None:
+        """Write a new revision on ``target`` plus its ``.merge`` sidecar.
+
+        The revision is written through the regular ``put`` path so it
+        participates in the same concurrency, durability, and idempotency
+        rules. The sidecar is then written and the ``merges`` index row
+        inserted; both are durable before this returns.
+
+        If ``put`` returns ``None`` (the resolved payload exactly matches
+        target's own latest tip), no sidecar is written — there is no
+        new revision to attach it to."""
+        rev = self.put(uid, payload, branch=target)
+        if rev is None:
+            return
+        self._write_merge_sidecar(rev, other_parent)
+
+    def _write_merge_sidecar(self, rev: Revision, other_parent: str) -> None:
+        if len(other_parent) != HASH_LEN:
+            raise ValueError(
+                f"other_parent must be a {HASH_LEN}-char hex hash, got "
+                f"{len(other_parent)} chars"
+            )
+        sidecar = rev.merge_sidecar_path
+        tmp = sidecar.parent / (sidecar.name + ".tmp")
+        try:
+            with open(tmp, "w") as f:
+                f.write(other_parent)
+                f.flush()
+                self._sync_fd(f.fileno())
+            os.rename(tmp, sidecar)
+            self._sync_dir(rev.path.parent)
+        except Exception:
+            _best_effort_unlink(tmp)
+            raise
+        with self._db_lock:
+            self._conn.execute(
+                "INSERT OR REPLACE INTO merges"
+                "(branch, uid, ts_ns, other_parent) VALUES (?, ?, ?, ?)",
+                (rev.branch, rev.uid, rev.ts_ns, other_parent),
+            )
+
+    # --------------------------------------------------------- delete branch
+
+    def delete_branch(self, name: str) -> None:
+        """Remove ``name`` and every artifact it owns.
+
+        Refuses to delete ``main``. Refuses if any branch's ``parent``
+        points at ``name`` — delete the children first, or rebase them.
+
+        Removes:
+
+        * Every revision file written on this branch (``data/{uid}/…{branch}``).
+        * Every ``.merge`` sidecar on those revisions.
+        * The branch's metadata sidecar (``data/__branches__/{name}.json``).
+        * The corresponding rows in ``revisions``, ``merges``, ``branches``.
+
+        Other branches' inherited views are unaffected: fall-through walks
+        from child to parent, never the other way, so deleting a leaf
+        branch can never strand an ancestor's reads. After ``delete_branch``,
+        ``rebuild_index`` produces no orphaned references — that is the
+        reachability-GC contract (issue #876)."""
+        _validate_branch(name)
+        if name == DEFAULT_BRANCH:
+            raise ValueError("Cannot delete the main branch")
+        if not self._branch_exists(name):
+            raise BranchNotFoundError(f"Branch does not exist: {name!r}")
+        with self._db_lock:
+            children = self._conn.execute(
+                "SELECT name FROM branches WHERE parent = ?", (name,)
+            ).fetchall()
+        if children:
+            child_names = ", ".join(repr(c[0]) for c in children)
+            raise ValueError(
+                f"Branch {name!r} has child branches: {child_names}. "
+                "Delete or re-parent them first."
+            )
+
+        # Collect every (uid, ts_ns, prev_hash, content_hash) on the branch
+        # so we can remove the underlying files. Done before the SQL
+        # delete so the rows are still available.
+        with self._db_lock:
+            rows = self._conn.execute(
+                "SELECT uid, ts_ns, prev_hash, content_hash FROM revisions "
+                "WHERE branch = ?",
+                (name,),
+            ).fetchall()
+        for uid, ts_ns, prev_hash, content_hash in rows:
+            rev = self._build_revision(
+                uid, ts_ns, prev_hash, content_hash, branch=name
+            )
+            _best_effort_unlink(rev.merge_sidecar_path)
+            _best_effort_unlink(rev.path)
+
+        with self._db_lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                self._conn.execute(
+                    "DELETE FROM merges WHERE branch = ?", (name,)
+                )
+                self._conn.execute(
+                    "DELETE FROM revisions WHERE branch = ?", (name,)
+                )
+                self._conn.execute(
+                    "DELETE FROM branches WHERE name = ?", (name,)
+                )
+                self._conn.execute("COMMIT")
+            except Exception:
+                self._conn.execute("ROLLBACK")
+                raise
+        self._delete_branch_sidecar(name)
+        # Drop the per-(branch, uid) locks for the dead branch so they
+        # don't accumulate forever on long-lived stores.
+        with self._uid_locks_guard:
+            for key in [k for k in self._uid_locks if k[0] == name]:
+                self._uid_locks.pop(key, None)
 
     def history(
         self, uid: str, *, branch: str = DEFAULT_BRANCH
@@ -824,13 +1422,10 @@ class Store:
             yield self._build_revision(uid, *row, branch=branch)
 
     def uids(self, *, branch: str = DEFAULT_BRANCH) -> Iterator[str]:
-        """Yield every uid that has at least one revision on ``branch``."""
+        """Yield every uid visible on ``branch`` (own writes plus inherited
+        uids from ancestors at their respective fork timestamps)."""
         _validate_branch(branch)
-        with self._db_lock:
-            rows = self._conn.execute(
-                "SELECT DISTINCT uid FROM revisions WHERE branch = ?", (branch,)
-            ).fetchall()
-        for (uid,) in rows:
+        for uid in sorted(self._visible_uids(branch, self._TS_FOREVER)):
             yield uid
 
     def uids_at(
@@ -839,42 +1434,41 @@ class Store:
         *,
         branch: str = DEFAULT_BRANCH,
     ) -> Iterator[tuple[str, Revision]]:
-        """Yield ``(uid, latest_revision)`` for every uid on ``branch`` that
-        has a revision at or before ``at``."""
+        """Yield ``(uid, latest_revision)`` for every uid visible on
+        ``branch`` at or before ``at`` (own writes plus inherited)."""
         _validate_branch(branch)
-        if at is None:
+        ts_limit = self._TS_FOREVER if at is None else _dt_to_ns(at)
+        for uid in sorted(self._visible_uids(branch, ts_limit)):
+            rev = self._resolve_latest_walking(uid, branch, ts_limit)
+            if rev is not None:
+                yield uid, rev
+
+    def _visible_uids(self, branch: str, ts_limit: int) -> set[str]:
+        """Set of uids reachable on ``branch`` at or before ``ts_limit``,
+        walking the parent chain at each fork timestamp."""
+        visible: set[str] = set()
+        seen: set[str] = set()
+        cursor: str | None = branch
+        cap = ts_limit
+        while cursor is not None and cursor not in seen:
+            seen.add(cursor)
             with self._db_lock:
                 rows = self._conn.execute(
-                    """
-                    SELECT uid, ts_ns, prev_hash, content_hash
-                    FROM revisions
-                    WHERE branch = ?
-                      AND (uid, ts_ns) IN (
-                        SELECT uid, MAX(ts_ns) FROM revisions
-                        WHERE branch = ? GROUP BY uid
-                      )
-                    """,
-                    (branch, branch),
+                    "SELECT DISTINCT uid FROM revisions "
+                    "WHERE branch = ? AND ts_ns <= ?",
+                    (cursor, cap),
                 ).fetchall()
-        else:
-            ts_limit = _dt_to_ns(at)
-            with self._db_lock:
-                rows = self._conn.execute(
-                    """
-                    SELECT uid, ts_ns, prev_hash, content_hash
-                    FROM revisions
-                    WHERE branch = ?
-                      AND (uid, ts_ns) IN (
-                        SELECT uid, MAX(ts_ns) FROM revisions
-                        WHERE branch = ? AND ts_ns <= ? GROUP BY uid
-                      )
-                    """,
-                    (branch, branch, ts_limit),
-                ).fetchall()
-        for uid, ts_ns, prev_hash, content_hash in rows:
-            yield uid, self._build_revision(
-                uid, ts_ns, prev_hash, content_hash, branch=branch
-            )
+            for (uid,) in rows:
+                visible.add(uid)
+            meta = self._branch_meta(cursor)
+            if meta is None:
+                break
+            parent, fork_ts_ns, _ = meta
+            if parent is None:
+                break
+            cap = min(cap, fork_ts_ns)
+            cursor = parent
+        return visible
 
     # ---------------------------------------------------------- integrity ops
 
@@ -907,6 +1501,8 @@ class Store:
         for f in uid_dir.iterdir():
             if not f.is_file() or f.name.endswith(".tmp"):
                 continue
+            if is_merge_sidecar(f.name):
+                continue
             try:
                 rev = Revision.parse_filename(uid, f.name, uid_dir)
             except ValueError:
@@ -919,15 +1515,25 @@ class Store:
         """Drop and repopulate the SQLite index from the filesystem.
 
         Orphan ``.tmp`` files are deleted. Unparseable filenames are skipped
-        silently. Branch metadata not already in ``branches`` is recreated as
-        ``parent='main', fork_ts_ns=0`` for any branch discovered in
-        filenames (the spec follow-up will store branch metadata on disk so
-        parent / fork timestamps are also rebuildable).
+        silently. Branch metadata is reconstructed in two stages:
+
+        1. ``data/__branches__/{name}.json`` sidecars are read first — they
+           carry the authoritative ``(parent, fork_ts_ns, created_at)`` so
+           the branch DAG fully rebuilds without SQLite.
+        2. Any branch present in revision filenames but missing a sidecar
+           falls back to ``parent='main', fork_ts_ns=0`` (legacy behavior,
+           preserved for stores written before the sidecar grammar shipped).
+
+        Merge revisions: a revision file accompanied by a ``.merge`` sidecar
+        gets a row in the ``merges`` table whose ``other_parent`` is the
+        sidecar's content. Sidecar files without a paired revision are
+        deleted as orphans.
         """
         with self._db_lock:
             self._conn.execute("BEGIN IMMEDIATE")
             try:
                 self._conn.execute("DELETE FROM revisions")
+                self._conn.execute("DELETE FROM merges")
                 discovered_branches: set[str] = {DEFAULT_BRANCH}
                 # (branch, uid, prev_hash)
                 seen_keys: set[tuple[str, str, str]] = set()
@@ -936,13 +1542,20 @@ class Store:
                     for uid_dir in self.data_dir.iterdir():
                         if not uid_dir.is_dir():
                             continue
+                        if uid_dir.name == BRANCHES_DIRNAME:
+                            continue
                         uid = uid_dir.name
                         revs: list[Revision] = []
+                        sidecars: dict[str, Path] = {}
                         for f in uid_dir.iterdir():
                             if not f.is_file():
                                 continue
                             if f.name.endswith(".tmp"):
                                 _best_effort_unlink(f)
+                                continue
+                            if is_merge_sidecar(f.name):
+                                rev_filename = revision_filename_for_sidecar(f.name)
+                                sidecars[rev_filename] = f
                                 continue
                             try:
                                 revs.append(
@@ -951,16 +1564,22 @@ class Store:
                             except ValueError:
                                 continue
                         revs.sort(key=lambda r: r.ts_ns)
+                        rev_filenames: set[str] = set()
                         for rev in revs:
                             discovered_branches.add(rev.branch)
                             key = (rev.branch, rev.uid, rev.prev_hash)
                             if key in seen_keys:
                                 # Two files share (branch, uid, prev_hash).
                                 # Keep the earliest (already inserted), drop
-                                # the rest.
+                                # the rest along with any sidecar.
+                                _best_effort_unlink(
+                                    rev.path.parent
+                                    / (rev.path.name + MERGE_SIDECAR_SUFFIX)
+                                )
                                 _best_effort_unlink(rev.path)
                                 continue
                             seen_keys.add(key)
+                            rev_filenames.add(rev.path.name)
                             self._conn.execute(
                                 "INSERT INTO revisions"
                                 "(branch, uid, ts_ns, prev_hash, content_hash) "
@@ -973,21 +1592,88 @@ class Store:
                                     rev.content_hash,
                                 ),
                             )
+                            sidecar_path = sidecars.pop(rev.path.name, None)
+                            if sidecar_path is not None:
+                                other_parent = _read_sidecar_hash(sidecar_path)
+                                if other_parent is not None:
+                                    self._conn.execute(
+                                        "INSERT INTO merges"
+                                        "(branch, uid, ts_ns, other_parent) "
+                                        "VALUES (?, ?, ?, ?)",
+                                        (
+                                            rev.branch,
+                                            rev.uid,
+                                            rev.ts_ns,
+                                            other_parent,
+                                        ),
+                                    )
+                                else:
+                                    # Unreadable / malformed sidecar — drop it.
+                                    _best_effort_unlink(sidecar_path)
+                        # Any sidecar whose paired revision was dropped
+                        # (or never existed) is an orphan — clean it up.
+                        for orphan in sidecars.values():
+                            _best_effort_unlink(orphan)
 
-                # Re-seed any branch we saw on disk that isn't in `branches`.
-                now_ns = time.time_ns()
-                for b in discovered_branches:
+                # Stage 1: read on-disk branch sidecars (authoritative).
+                branches_dir = self._branches_dir()
+                sidecar_branches: dict[str, tuple[str | None, int, int]] = {}
+                if branches_dir.is_dir():
+                    for f in branches_dir.iterdir():
+                        if not f.is_file() or not f.name.endswith(".json"):
+                            continue
+                        if f.name.endswith(".json.tmp"):
+                            _best_effort_unlink(f)
+                            continue
+                        name = f.name[: -len(".json")]
+                        try:
+                            _validate_branch(name)
+                        except ValueError:
+                            continue
+                        meta = self._read_branch_sidecar(name)
+                        if meta is not None:
+                            sidecar_branches[name] = meta
+                            discovered_branches.add(name)
+
+                # Wipe and re-seed branches table from sidecars + filenames.
+                self._conn.execute(
+                    "DELETE FROM branches WHERE name != ?", (DEFAULT_BRANCH,)
+                )
+                # Ensure main exists (sidecar-or-default).
+                if DEFAULT_BRANCH in sidecar_branches:
+                    parent, fork_ts_ns, created_at = sidecar_branches[DEFAULT_BRANCH]
+                    self._conn.execute(
+                        "INSERT OR REPLACE INTO branches"
+                        "(name, parent, fork_ts_ns, created_at) "
+                        "VALUES (?, ?, ?, ?)",
+                        (DEFAULT_BRANCH, parent, fork_ts_ns, created_at),
+                    )
+                else:
                     self._conn.execute(
                         "INSERT OR IGNORE INTO branches"
                         "(name, parent, fork_ts_ns, created_at) "
-                        "VALUES (?, ?, ?, ?)",
-                        (
-                            b,
-                            None if b == DEFAULT_BRANCH else DEFAULT_BRANCH,
-                            0,
-                            now_ns,
-                        ),
+                        "VALUES (?, NULL, 0, ?)",
+                        (DEFAULT_BRANCH, time.time_ns()),
                     )
+                now_ns = time.time_ns()
+                for b in discovered_branches:
+                    if b == DEFAULT_BRANCH:
+                        continue
+                    if b in sidecar_branches:
+                        parent, fork_ts_ns, created_at = sidecar_branches[b]
+                        self._conn.execute(
+                            "INSERT OR REPLACE INTO branches"
+                            "(name, parent, fork_ts_ns, created_at) "
+                            "VALUES (?, ?, ?, ?)",
+                            (b, parent, fork_ts_ns, created_at),
+                        )
+                    else:
+                        self._conn.execute(
+                            "INSERT OR IGNORE INTO branches"
+                            "(name, parent, fork_ts_ns, created_at) "
+                            "VALUES (?, ?, 0, ?)",
+                            (b, DEFAULT_BRANCH, now_ns),
+                        )
                 self._conn.execute("COMMIT")
             except Exception:
                 self._conn.execute("ROLLBACK")
@@ -1026,11 +1712,25 @@ class Store:
 # ------------------------------------------------------------------ utilities
 
 
+_RESERVED_BRANCH_NAMES = frozenset({"merge"})
+"""Branch names that would collide with the merge-sidecar grammar.
+
+A merge sidecar on the main branch is named ``{ts}.{prev}.{content}.merge``
+— four dot-separated parts, indistinguishable from a non-main revision on
+a branch named ``merge``. Reserving the literal ``"merge"`` keeps the
+filename grammar a function of the file alone."""
+
+_RESERVED_UID_NAMES = frozenset({BRANCHES_DIRNAME})
+"""UIDs that would collide with reserved subdirectories under ``data/``."""
+
+
 def _validate_uid(uid: str) -> None:
     if not isinstance(uid, str) or not uid:
         raise ValueError("uid must be a non-empty string")
     if "/" in uid or "\\" in uid or "\0" in uid or uid in (".", ".."):
         raise ValueError(f"Invalid uid: {uid!r}")
+    if uid in _RESERVED_UID_NAMES:
+        raise ValueError(f"Reserved uid: {uid!r}")
 
 
 def _validate_branch(name: str) -> None:
@@ -1043,6 +1743,10 @@ def _validate_branch(name: str) -> None:
     for ch in (".", "/", "\\", "\0"):
         if ch in name:
             raise ValueError(f"Invalid character {ch!r} in branch name: {name!r}")
+    if name in _RESERVED_BRANCH_NAMES:
+        raise ValueError(
+            f"Reserved branch name: {name!r} (collides with merge-sidecar grammar)"
+        )
 
 
 def _dt_to_ns(dt: datetime) -> int:
@@ -1056,3 +1760,21 @@ def _best_effort_unlink(path: Path) -> None:
             path.unlink()
     except OSError:
         pass
+
+
+def _read_sidecar_hash(path: Path) -> str | None:
+    """Read a ``.merge`` sidecar's content_hash, validating shape.
+
+    Returns the 64-char hex string, or ``None`` if the file is missing,
+    malformed, or has the wrong length."""
+    try:
+        text = path.read_text().strip()
+    except OSError:
+        return None
+    if len(text) != HASH_LEN:
+        return None
+    try:
+        int(text, 16)
+    except ValueError:
+        return None
+    return text

--- a/libs/naas-abi-core/naas_abi_core/utils/versionstore/store_dag_test.py
+++ b/libs/naas-abi-core/naas_abi_core/utils/versionstore/store_dag_test.py
@@ -1,0 +1,410 @@
+"""Tests for the issue #876 branching surface: branch metadata sidecars,
+fall-through reads, diff, delete_branch, merge (fast-forward and three-way)
+with multi-parent ``.merge`` sidecars and the ``merges`` index table."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from .revision import BRANCHES_DIRNAME, MERGE_SIDECAR_SUFFIX
+from .store import (
+    BranchDiff,
+    BranchNotFoundError,
+    MergeConflict,
+    MergeStrategy,
+    Store,
+)
+
+
+# ----------------------------------------------------------- branch sidecars
+
+
+def test_main_branch_has_metadata_sidecar(tmp_path: Path):
+    Store(tmp_path).close()
+    sidecar = tmp_path / "data" / BRANCHES_DIRNAME / "main.json"
+    assert sidecar.is_file()
+    meta = json.loads(sidecar.read_text())
+    assert meta["parent"] is None
+    assert meta["fork_ts_ns"] == 0
+    assert isinstance(meta["created_at"], int)
+
+
+def test_create_branch_writes_sidecar(tmp_path: Path):
+    with Store(tmp_path) as store:
+        store.create_branch("feature-x")
+    sidecar = tmp_path / "data" / BRANCHES_DIRNAME / "feature-x.json"
+    assert sidecar.is_file()
+    meta = json.loads(sidecar.read_text())
+    assert meta["parent"] == "main"
+    assert meta["fork_ts_ns"] > 0
+    assert isinstance(meta["created_at"], int)
+
+
+def test_branch_name_merge_is_reserved(tmp_path: Path):
+    with Store(tmp_path) as store:
+        with pytest.raises(ValueError, match="Reserved branch name"):
+            store.create_branch("merge")
+
+
+def test_uid_branches_dir_name_is_reserved(tmp_path: Path):
+    with Store(tmp_path) as store:
+        with pytest.raises(ValueError, match="Reserved uid"):
+            store.put(BRANCHES_DIRNAME, b"hi")
+
+
+# -------------------------------------------------------- fall-through reads
+
+
+def test_child_inherits_parent_state_at_fork(tmp_path: Path):
+    """A fresh child branch sees its parent's tips at the moment of fork."""
+    with Store(tmp_path) as store:
+        store.put("alice", b"main-v1")
+        store.put("bob", b"main-bob")
+        store.create_branch("feature-x")
+        # Without writes on feature-x, both uids resolve via fall-through.
+        assert store.get("alice", branch="feature-x") == b"main-v1"
+        assert store.get("bob", branch="feature-x") == b"main-bob"
+
+
+def test_child_does_not_see_parent_writes_after_fork(tmp_path: Path):
+    """Parent writes that happen after the fork are NOT visible on child."""
+    with Store(tmp_path) as store:
+        store.put("alice", b"v1")
+        store.create_branch("feature-x")
+        store.put("alice", b"v2-on-main")  # post-fork on parent
+        # feature-x still inherits v1; v2 is invisible.
+        assert store.get("alice", branch="feature-x") == b"v1"
+        assert store.get("alice", branch="main") == b"v2-on-main"
+
+
+def test_child_overrides_inherited_uid(tmp_path: Path):
+    """Own writes on child shadow the inherited tip."""
+    with Store(tmp_path) as store:
+        store.put("alice", b"main-v1")
+        store.create_branch("feature-x")
+        store.put("alice", b"feat-v1", branch="feature-x")
+        assert store.get("alice", branch="feature-x") == b"feat-v1"
+        assert store.get("alice", branch="main") == b"main-v1"
+
+
+def test_uids_at_includes_inherited(tmp_path: Path):
+    with Store(tmp_path) as store:
+        store.put("alice", b"a")
+        store.put("bob", b"b")
+        store.create_branch("feature-x")
+        store.put("carol", b"c", branch="feature-x")
+        visible = {u for u, _ in store.uids_at(branch="feature-x")}
+        assert visible == {"alice", "bob", "carol"}
+
+
+def test_fall_through_walks_grandparent(tmp_path: Path):
+    """A branch of a branch falls all the way through to the root."""
+    with Store(tmp_path) as store:
+        store.put("alice", b"v1")
+        store.create_branch("feature-x")
+        store.create_branch("feature-y", parent="feature-x")
+        assert store.get("alice", branch="feature-y") == b"v1"
+
+
+# ---------------------------------------------------------------- diff
+
+
+def test_diff_empty_for_fresh_child(tmp_path: Path):
+    with Store(tmp_path) as store:
+        store.put("alice", b"v1")
+        store.create_branch("feature-x")
+        diff = store.diff("feature-x", "main")
+        assert isinstance(diff, BranchDiff)
+        assert diff.is_empty()
+
+
+def test_diff_detects_added_on_a(tmp_path: Path):
+    with Store(tmp_path) as store:
+        store.create_branch("feature-x")
+        store.put("alice", b"new", branch="feature-x")
+        diff = store.diff("feature-x", "main")
+        assert "alice" in diff.added
+        assert not diff.removed
+        assert not diff.changed
+
+
+def test_diff_detects_changed(tmp_path: Path):
+    with Store(tmp_path) as store:
+        store.put("alice", b"v1")
+        store.create_branch("feature-x")
+        store.put("alice", b"feat", branch="feature-x")
+        store.put("alice", b"main-v2")
+        diff = store.diff("feature-x", "main")
+        assert diff.changed == frozenset({"alice"})
+        assert not diff.added
+        assert not diff.removed
+
+
+def test_diff_detects_removed(tmp_path: Path):
+    """Symmetry: present on b, absent on a → 'removed' (with respect to a)."""
+    with Store(tmp_path) as store:
+        store.create_branch("feature-x")
+        store.put("alice", b"main-only")
+        # main has alice; feature-x has no own writes and forked before
+        # alice was written, so feature-x's view doesn't include alice.
+        diff = store.diff("feature-x", "main")
+        assert diff.removed == frozenset({"alice"})
+
+
+def test_diff_unknown_branch_raises(tmp_path: Path):
+    with Store(tmp_path) as store:
+        with pytest.raises(BranchNotFoundError):
+            store.diff("ghost", "main")
+
+
+# ----------------------------------------------------------- delete_branch
+
+
+def test_delete_branch_removes_files_and_sidecars(tmp_path: Path):
+    with Store(tmp_path) as store:
+        store.create_branch("feature-x")
+        store.put("alice", b"feat-v1", branch="feature-x")
+        store.put("alice", b"feat-v2", branch="feature-x")
+        # Sanity: files exist before delete.
+        uid_dir = tmp_path / "data" / "alice"
+        feat_files = [
+            f for f in uid_dir.iterdir() if f.name.endswith(".feature-x")
+        ]
+        assert len(feat_files) == 2
+
+        store.delete_branch("feature-x")
+        # No more feature-x files anywhere.
+        for f in uid_dir.iterdir():
+            assert not f.name.endswith(".feature-x")
+        # Branch sidecar gone.
+        assert not (tmp_path / "data" / BRANCHES_DIRNAME / "feature-x.json").is_file()
+        # Branch row gone.
+        assert "feature-x" not in store.list_branches()
+
+
+def test_delete_branch_refuses_main(tmp_path: Path):
+    with Store(tmp_path) as store:
+        with pytest.raises(ValueError, match="main"):
+            store.delete_branch("main")
+
+
+def test_delete_branch_refuses_with_children(tmp_path: Path):
+    with Store(tmp_path) as store:
+        store.create_branch("feature-x")
+        store.create_branch("feature-y", parent="feature-x")
+        with pytest.raises(ValueError, match="child"):
+            store.delete_branch("feature-x")
+
+
+def test_delete_branch_then_rebuild_index_no_orphans(tmp_path: Path):
+    with Store(tmp_path) as store:
+        store.create_branch("feature-x")
+        store.put("alice", b"v1", branch="feature-x")
+        store.delete_branch("feature-x")
+        store.rebuild_index()
+        assert "feature-x" not in store.list_branches()
+        # Walking data dir, no feature-x revision files remain.
+        for uid_dir in (tmp_path / "data").iterdir():
+            if uid_dir.name == BRANCHES_DIRNAME:
+                continue
+            for f in uid_dir.iterdir():
+                assert not f.name.endswith(".feature-x")
+
+
+# ----------------------------------------------------- merge fast-forward
+
+
+def test_merge_fast_forward_applies_source_tip(tmp_path: Path):
+    with Store(tmp_path) as store:
+        store.put("alice", b"base")
+        store.create_branch("feature-x")
+        store.put("alice", b"feat", branch="feature-x")
+        # Target hasn't moved → fast-forward.
+        result = store.merge(
+            "feature-x", "main", strategy=MergeStrategy.FAST_FORWARD
+        )
+        assert "alice" in result.fast_forwarded
+        assert not result.conflicts
+        assert store.get("alice", branch="main") == b"feat"
+
+
+def test_merge_writes_merge_sidecar(tmp_path: Path):
+    with Store(tmp_path) as store:
+        store.put("alice", b"base")
+        store.create_branch("feature-x")
+        store.put("alice", b"feat", branch="feature-x")
+        store.merge("feature-x", "main")
+        # The new revision on main is the merge revision; its sidecar
+        # records the second parent (source tip's content_hash).
+        uid_dir = tmp_path / "data" / "alice"
+        sidecars = [
+            f for f in uid_dir.iterdir() if f.name.endswith(MERGE_SIDECAR_SUFFIX)
+        ]
+        assert len(sidecars) == 1
+        # The sidecar's payload should be a 64-char hex hash.
+        content = sidecars[0].read_text().strip()
+        assert len(content) == 64
+        int(content, 16)  # parses as hex
+
+
+def test_merge_no_op_when_target_already_has_source_content(tmp_path: Path):
+    with Store(tmp_path) as store:
+        store.put("alice", b"v1")
+        store.create_branch("feature-x")
+        # Source unchanged from base.
+        result = store.merge("feature-x", "main")
+        assert result.no_op == {"alice"}
+        assert not result.fast_forwarded
+        assert not result.three_way_merged
+
+
+def test_merge_idempotent_replay(tmp_path: Path):
+    """Running the same merge twice is harmless: the second run finds the
+    target already up to date and reports no_op."""
+    with Store(tmp_path) as store:
+        store.put("alice", b"base")
+        store.create_branch("feature-x")
+        store.put("alice", b"feat", branch="feature-x")
+        store.merge("feature-x", "main")
+        result = store.merge("feature-x", "main")
+        assert result.no_op == {"alice"}
+        assert not result.fast_forwarded
+
+
+def test_merge_requires_direct_parent(tmp_path: Path):
+    with Store(tmp_path) as store:
+        store.create_branch("feature-x")
+        store.create_branch("feature-y")  # sibling, not child of feature-x
+        with pytest.raises(ValueError, match="source.parent == target"):
+            store.merge("feature-y", "feature-x")
+
+
+# ----------------------------------------------------- merge three-way
+
+
+def test_merge_three_way_calls_resolver(tmp_path: Path):
+    """Both sides moved from base → resolver runs and its bytes land on target."""
+    with Store(tmp_path) as store:
+        store.put("alice", b"base")
+        store.create_branch("feature-x")
+        store.put("alice", b"feat", branch="feature-x")
+        store.put("alice", b"main-v2")  # target moves after fork
+
+        calls: list[tuple[str, bytes | None, bytes, bytes]] = []
+
+        def resolver(uid, base, src, tgt):
+            calls.append((uid, base, src, tgt))
+            return b"merged"
+
+        result = store.merge("feature-x", "main", resolver=resolver)
+        assert calls == [("alice", b"base", b"feat", b"main-v2")]
+        assert result.three_way_merged == {"alice"}
+        assert store.get("alice", branch="main") == b"merged"
+
+
+def test_merge_three_way_resolver_none_is_conflict(tmp_path: Path):
+    with Store(tmp_path) as store:
+        store.put("alice", b"base")
+        store.create_branch("feature-x")
+        store.put("alice", b"feat", branch="feature-x")
+        store.put("alice", b"main-v2")
+
+        with pytest.raises(MergeConflict) as exc_info:
+            store.merge("feature-x", "main", resolver=lambda *a: None)
+        assert "alice" in exc_info.value.conflicts
+        # Target unchanged.
+        assert store.get("alice", branch="main") == b"main-v2"
+
+
+def test_merge_fast_forward_strategy_refuses_three_way(tmp_path: Path):
+    with Store(tmp_path) as store:
+        store.put("alice", b"base")
+        store.create_branch("feature-x")
+        store.put("alice", b"feat", branch="feature-x")
+        store.put("alice", b"main-v2")
+        with pytest.raises(MergeConflict):
+            store.merge(
+                "feature-x", "main", strategy=MergeStrategy.FAST_FORWARD
+            )
+
+
+def test_merge_revision_passes_verify(tmp_path: Path):
+    """Multi-parent revisions still satisfy the per-branch chain check."""
+    with Store(tmp_path) as store:
+        store.put("alice", b"base")
+        store.create_branch("feature-x")
+        store.put("alice", b"feat", branch="feature-x")
+        store.merge("feature-x", "main")
+        assert store.verify("alice", branch="main") is True
+        assert store.verify("alice", branch="feature-x") is True
+
+
+# ------------------------------------------------------- rebuild_index DAG
+
+
+def test_rebuild_index_reconstructs_branch_dag_from_sidecars(tmp_path: Path):
+    """Filesystem-only rebuild: nuke SQLite entirely, recover full DAG
+    (parent + fork_ts_ns) from the on-disk sidecars."""
+    with Store(tmp_path) as store:
+        store.put("alice", b"v1")  # on main, before any branch exists
+        store.create_branch("feature-x")
+        store.create_branch("feature-y", parent="feature-x")
+        store.put("alice", b"feat", branch="feature-x")
+        original_meta_x = store._branch_meta("feature-x")
+        original_meta_y = store._branch_meta("feature-y")
+        assert original_meta_x is not None and original_meta_y is not None
+
+        # Nuke the entire index (mimicking total SQLite loss).
+        store._conn.execute("DELETE FROM revisions")
+        store._conn.execute("DELETE FROM merges")
+        store._conn.execute("DELETE FROM branches")
+        store.rebuild_index()
+
+        # DAG fully reconstructed.
+        assert set(store.list_branches()) >= {"main", "feature-x", "feature-y"}
+        rebuilt_x = store._branch_meta("feature-x")
+        rebuilt_y = store._branch_meta("feature-y")
+        assert rebuilt_x == original_meta_x
+        assert rebuilt_y == original_meta_y
+        # Reads still work, fall-through and all.
+        assert store.get("alice", branch="feature-y") == b"v1"
+
+
+def test_rebuild_index_reconstructs_merges_table(tmp_path: Path):
+    with Store(tmp_path) as store:
+        store.put("alice", b"base")
+        store.create_branch("feature-x")
+        store.put("alice", b"feat", branch="feature-x")
+        store.merge("feature-x", "main")
+
+        with store._db_lock:
+            before = store._conn.execute(
+                "SELECT branch, uid, ts_ns, other_parent FROM merges"
+            ).fetchall()
+        assert len(before) == 1
+
+        store._conn.execute("DELETE FROM merges")
+        store.rebuild_index()
+
+        with store._db_lock:
+            after = store._conn.execute(
+                "SELECT branch, uid, ts_ns, other_parent FROM merges"
+            ).fetchall()
+        assert before == after
+
+
+def test_rebuild_index_drops_orphan_merge_sidecars(tmp_path: Path):
+    with Store(tmp_path) as store:
+        store.put("alice", b"v1")
+        # Create a stray .merge sidecar that doesn't pair with anything real.
+        uid_dir = tmp_path / "data" / "alice"
+        orphan = uid_dir / ("00000000000000000000."
+                            + "0" * 64 + "."
+                            + "1" * 64
+                            + MERGE_SIDECAR_SUFFIX)
+        orphan.write_text("a" * 64)
+        store.rebuild_index()
+        assert not orphan.exists()


### PR DESCRIPTION
Closes [#876](https://github.com/jupyter-naas/abi/issues/876) — the substrate the upcoming `IVersionedStorePort` (#878) and TripleStore versioned-store adapter (#879) will sit on. Adds, on top of the minimum-viable scaffold from PR #870, the full branching surface that PR deliberately deferred.

## What's in here

### Branch DAG with on-disk metadata sidecars
- `data/__branches__/{name}.json` (atomic tmp+rename + fsync) carries `parent`, `fork_ts_ns`, `created_at`. `rebuild_index` reads these as the authoritative branch DAG, so total SQLite loss is recoverable.
- Stores written before sidecars existed still rebuild correctly — branches discovered only from filenames default to `parent='main', fork_ts_ns=0`.

### Fall-through reads
- `latest` / `get` / `uids` / `uids_at` on a child branch transparently inherit revisions from the parent at `fork_ts_ns`, recursively up the DAG. Branches become durable snapshots without copying any bytes.
- The write path stays per-branch (own chains start at GENESIS), so `verify` remains per-branch and `delete_branch` can never strand another branch's chain.

### `Store.diff(a, b) -> BranchDiff`
- Snapshot diff over visible content_hash: `added` / `removed` / `changed`. Inherited state shared via fall-through cancels out automatically.

### `Store.delete_branch(name)`
- Refuses `main`, refuses if any branch's `parent` points at the target, removes own files + `.merge` sidecars + branch metadata sidecar + table rows.
- Reachability-GC contract: `rebuild_index` after `delete_branch` leaves no orphaned references.

### `Store.merge` with multi-parent revisions
- `Store.merge(source, target, *, resolver, strategy)` returns `MergeResult` (no_op / fast_forwarded / three_way_merged / conflicts) or raises `MergeConflict` (with the partial result attached).
- Multi-parent revision = a normal revision file on `target` (its `prev_hash` is the prior own-target tip — first parent) plus a `{filename}.merge` sidecar containing the second parent's `content_hash`, indexed in a new `merges` SQLite table.
- Per-uid: `source_tip == target_tip` → no_op; only one side moved → fast-forward; both sides moved → resolver. `MergeStrategy.FAST_FORWARD` raises on the first uid that needs three-way (all-or-nothing); `THREE_WAY` collects all conflicts then raises.
- Non-atomic across uids by design — partial run is recoverable by re-running merge (already-applied uids fall into `no_op`).

### `rebuild_index` updated
- Skips `data/__branches__/`, separates revision files from `.merge` sidecars, repopulates `merges` from sidecar pairs, deletes orphan sidecars, reconstructs branch DAG from sidecars first.

### Reservations (filename-grammar disambiguation)
- `merge` is now a reserved branch name (would collide with main-branch merge sidecars).
- `__branches__` is now a reserved uid.

### Whitepaper
- §3.4 (rebuild protocol) rewritten to cover the three artifact classes.
- New §3.5 covers the DAG model (fall-through, merge, delete_branch).
- New §4.1 on multi-parent revision integrity.

## V1 limitation

`merge` requires `source.parent == target` (single-hop). Transitive merges (grandchild back to grandparent in one call) need a real common-ancestor walk and are deferred to a follow-up. Documented in the docstring and whitepaper.

## Test plan

- [x] `uv run pytest naas_abi_core/utils/versionstore/` — **96 passed, 1 platform-skipped** (was 66/1; added 30 tests in `store_dag_test.py`)
- [x] Pre-commit ruff: passes
- [x] Pre-commit mypy on naas_abi_core / naas_abi_cli / naas_abi_marketplace: passes
- [x] Pre-commit bandit: passes (no new issues)

## Notes for reviewers

1. **Per-branch chains stay independent.** Merge revisions chain off the prior own-target tip (or GENESIS if target had no own writes for that uid), not the inherited tip. This keeps `verify` per-branch and removes any need for special handling of merge revisions in the chain-walk integrity check.
2. **Merge atomicity is per-uid, not per-call.** This is intentional — it means a partial merge leaves the store in a consistent state (every applied uid is fully durable) and is trivially resumable. The alternative (transactional merge across many uids) would require either holding a long write lock or building a two-phase protocol, neither of which fits the "filesystem is truth" principle.
3. **Branch sidecars are written tmp+rename + fsync.** A crash mid-write leaves either the previous content or nothing — never partial JSON. Same durability mode (full/fast) as revision files.
4. **`BranchDiff` is a snapshot diff**, not a revision-by-revision diff. The "since fork" framing in the issue is implicit: shared inherited state cancels out because both sides resolve to identical `content_hash`. No explicit ancestor walk needed.

Refs: #876
Milestone: [Branching: versionstore-backed services](https://github.com/jupyter-naas/abi/milestone/1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)