### PR TITLE
naas-abi-core: BranchContext + propagation primitives (#877)

### DIFF
--- a/libs/naas-abi-core/naas_abi_core/branching/__init__.py
+++ b/libs/naas-abi-core/naas_abi_core/branching/__init__.py
@@ -1,0 +1,46 @@
+"""Branching primitives: context propagation, executors, logging, tracing.
+
+The substrate every branch-aware service in ``naas_abi_core`` consumes.
+See spec issue #865 for the architectural motivation and acceptance
+issue #877 for this module's specific scope.
+
+Public API
+----------
+
+* :class:`BranchContext` — ``current()`` / ``use(name)`` ambient
+  branch propagation backed by a ``contextvars.ContextVar``.
+* :data:`DEFAULT_BRANCH` — the default branch name (``"main"``).
+* :class:`BranchAwareThreadPoolExecutor` — drop-in replacement for
+  ``concurrent.futures.ThreadPoolExecutor`` that propagates the
+  current context (and therefore the active branch) to worker threads.
+* :class:`BranchContextLogFilter` — ``logging.Filter`` that adds a
+  ``branch`` attribute to every record.
+* :func:`add_branch_to_span` — tag an OpenTelemetry span with the
+  active branch (no hard OTel dependency).
+* :class:`BranchValidationError` / :class:`BranchNotFoundError` —
+  syntactic vs. existential branch errors.
+* :data:`HTTP_BRANCH_HEADER` / :data:`BUS_BRANCH_FIELD` — boundary
+  propagation conventions.
+"""
+
+from __future__ import annotations
+
+from .context import BranchContext, DEFAULT_BRANCH
+from .conventions import BUS_BRANCH_FIELD, HTTP_BRANCH_HEADER
+from .exceptions import BranchNotFoundError, BranchValidationError
+from .executor import BranchAwareThreadPoolExecutor
+from .logging import BranchContextLogFilter
+from .tracing import DEFAULT_BRANCH_SPAN_ATTRIBUTE, add_branch_to_span
+
+__all__ = [
+    "BUS_BRANCH_FIELD",
+    "BranchAwareThreadPoolExecutor",
+    "BranchContext",
+    "BranchContextLogFilter",
+    "BranchNotFoundError",
+    "BranchValidationError",
+    "DEFAULT_BRANCH",
+    "DEFAULT_BRANCH_SPAN_ATTRIBUTE",
+    "HTTP_BRANCH_HEADER",
+    "add_branch_to_span",
+]

--- a/libs/naas-abi-core/naas_abi_core/branching/context.py
+++ b/libs/naas-abi-core/naas_abi_core/branching/context.py
@@ -1,0 +1,160 @@
+"""``BranchContext``: ambient "active branch" propagation primitive.
+
+The branching architecture from spec #865 has every Tier-1 service
+consult an *active branch* on every read and write. Threading that
+branch through every service method would be a signature explosion;
+instead we put it in a ``contextvars.ContextVar`` so any code under a
+``BranchContext.use(...)`` block sees the same value, including across
+``await``, ``asyncio.create_task``, and ``copy_context().run(...)``
+boundaries (this is the standard contextvars contract).
+
+The default is ``"main"``. Code that has not opted in sees no behavior
+change.
+
+Usage
+-----
+
+::
+
+    from naas_abi_core.branching import BranchContext
+
+    BranchContext.current()  # → "main"
+
+    with BranchContext.use("feature-x"):
+        BranchContext.current()  # → "feature-x"
+        # …every adapter underneath sees feature-x…
+
+    BranchContext.current()  # → "main" again
+
+Async
+-----
+
+``contextvars`` already propagates correctly through ``asyncio``: a
+``ContextVar`` set in a parent task is visible inside ``await``-ed
+coroutines and inside ``asyncio.create_task(...)`` (which copies the
+current context by default). No wrapper is needed for async.
+
+Threads
+-------
+
+Standard ``ThreadPoolExecutor`` does **not** propagate context to
+worker threads. Use ``BranchAwareThreadPoolExecutor`` from
+``naas_abi_core.branching.executor`` instead — it calls
+``copy_context().run(fn)`` on every submission so the worker sees the
+submitter's active branch. The repository test suite includes a guard
+that fails CI if a raw ``ThreadPoolExecutor`` is imported anywhere
+under ``naas_abi_core/`` (see ``no_raw_threadpool_test.py``).
+
+Loud-failure policy
+-------------------
+
+``BranchContext`` itself never validates that the branch exists in any
+store — it only validates the *name* (non-empty, no separators).
+Adapters that act on the context (e.g. the upcoming ``IVersionedStorePort``
+and the ``TripleStoreService`` versioned-store adapter) are responsible
+for raising ``BranchNotFoundError`` when an unknown branch reaches
+them. This keeps the substrate dependency-free while giving consumers
+a single import path for the loud-failure error.
+"""
+
+from __future__ import annotations
+
+import contextvars
+from contextlib import contextmanager
+from typing import Iterator
+
+from .exceptions import BranchValidationError
+
+
+DEFAULT_BRANCH = "main"
+"""Branch name returned by :func:`BranchContext.current` when no
+``use(...)`` block is active. Matches the versionstore default."""
+
+
+_INVALID_NAME_CHARS = ("/", "\\", "\0")
+"""Characters that would make a branch name unsafe to use in
+filesystem paths, URLs, or message metadata."""
+
+
+def _validate_branch_name(name: object) -> str:
+    """Return ``name`` if it is a syntactically valid branch identifier;
+    otherwise raise :class:`BranchValidationError`.
+
+    Validation is purely syntactic — it does not consult any store.
+    The rules are deliberately loose so consumers (versionstore,
+    HTTP middleware, bus adapters) can layer their own stricter rules
+    on top: this function only filters out names that would be
+    *universally* unsafe (empty, special-name, path-separator, NUL).
+    """
+    if not isinstance(name, str):
+        raise BranchValidationError(
+            f"branch name must be a string, got {type(name).__name__}"
+        )
+    if not name:
+        raise BranchValidationError("branch name must be non-empty")
+    if name in (".", ".."):
+        raise BranchValidationError(f"invalid branch name: {name!r}")
+    for ch in _INVALID_NAME_CHARS:
+        if ch in name:
+            raise BranchValidationError(
+                f"invalid character {ch!r} in branch name: {name!r}"
+            )
+    return name
+
+
+_active_branch: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "abi_active_branch", default=DEFAULT_BRANCH
+)
+"""Process-wide ContextVar carrying the active branch.
+
+Module-private; access it through :class:`BranchContext`. The name
+``abi_active_branch`` shows up in tracing tools that introspect
+``contextvars`` (e.g. when debugging propagation issues), so it is
+deliberately specific."""
+
+
+class BranchContext:
+    """Ambient branch propagation. All methods are static; do not
+    instantiate.
+
+    The class exists purely as a namespace — every operation reads or
+    writes the module-level :data:`_active_branch` ContextVar. There is
+    no instance state, so multiple imports of this module in the same
+    process see the same context.
+    """
+
+    __slots__ = ()
+
+    def __init__(self) -> None:  # pragma: no cover - never instantiated
+        raise TypeError(
+            "BranchContext is a namespace; use BranchContext.current() / "
+            "BranchContext.use(...) directly"
+        )
+
+    @staticmethod
+    def current() -> str:
+        """Return the active branch name, defaulting to ``"main"``."""
+        return _active_branch.get()
+
+    @staticmethod
+    @contextmanager
+    def use(branch: str) -> Iterator[str]:
+        """Set the active branch for the duration of the ``with`` block.
+
+        Yields the validated branch name (handy when the caller wants to
+        log or echo it). Restores the previous value on exit, including
+        on exception. Reentrant — nested ``use(...)`` blocks stack
+        correctly because ``ContextVar.reset`` uses the per-set token
+        rather than the previous value.
+        """
+        validated = _validate_branch_name(branch)
+        token = _active_branch.set(validated)
+        try:
+            yield validated
+        finally:
+            _active_branch.reset(token)
+
+    @staticmethod
+    def is_default() -> bool:
+        """True iff the active branch is the default (``"main"``)."""
+        return _active_branch.get() == DEFAULT_BRANCH

--- a/libs/naas-abi-core/naas_abi_core/branching/context_test.py
+++ b/libs/naas-abi-core/naas_abi_core/branching/context_test.py
@@ -1,0 +1,139 @@
+"""Tests for ``BranchContext`` — default value, ``use(...)`` block,
+nested contexts, exception unwinding, validation, async propagation."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from .context import BranchContext, DEFAULT_BRANCH
+from .exceptions import BranchValidationError
+
+
+def test_default_is_main():
+    assert BranchContext.current() == DEFAULT_BRANCH
+    assert DEFAULT_BRANCH == "main"
+    assert BranchContext.is_default() is True
+
+
+def test_use_sets_and_restores():
+    assert BranchContext.current() == "main"
+    with BranchContext.use("feature-x"):
+        assert BranchContext.current() == "feature-x"
+        assert BranchContext.is_default() is False
+    assert BranchContext.current() == "main"
+
+
+def test_use_yields_validated_name():
+    with BranchContext.use("feature-x") as name:
+        assert name == "feature-x"
+
+
+def test_nested_use_stacks_correctly():
+    with BranchContext.use("outer"):
+        assert BranchContext.current() == "outer"
+        with BranchContext.use("inner"):
+            assert BranchContext.current() == "inner"
+            with BranchContext.use("innermost"):
+                assert BranchContext.current() == "innermost"
+            assert BranchContext.current() == "inner"
+        assert BranchContext.current() == "outer"
+    assert BranchContext.current() == "main"
+
+
+def test_use_restores_on_exception():
+    class Boom(RuntimeError):
+        pass
+
+    with pytest.raises(Boom):
+        with BranchContext.use("feature-x"):
+            assert BranchContext.current() == "feature-x"
+            raise Boom("expected")
+    assert BranchContext.current() == "main"
+
+
+def test_validation_rejects_empty():
+    with pytest.raises(BranchValidationError, match="non-empty"):
+        with BranchContext.use(""):
+            pass
+
+
+def test_validation_rejects_non_string():
+    with pytest.raises(BranchValidationError, match="must be a string"):
+        with BranchContext.use(123):  # type: ignore[arg-type]
+            pass
+
+
+def test_validation_rejects_path_separators():
+    for bad in ("a/b", "a\\b", "a\0b", ".", ".."):
+        with pytest.raises(BranchValidationError):
+            with BranchContext.use(bad):
+                pass
+
+
+def test_cannot_instantiate():
+    with pytest.raises(TypeError):
+        BranchContext()
+
+
+# -------------------------------------------------------------------- async
+
+
+def test_use_propagates_through_await():
+    async def inner():
+        # The await crosses a coroutine boundary — contextvars should
+        # carry the active branch.
+        await asyncio.sleep(0)
+        return BranchContext.current()
+
+    async def outer():
+        with BranchContext.use("feature-x"):
+            return await inner()
+
+    assert asyncio.run(outer()) == "feature-x"
+
+
+def test_use_propagates_to_create_task():
+    """``asyncio.create_task`` copies the current context, so a task
+    created inside ``use(...)`` sees the branch even after the creating
+    coroutine yields."""
+
+    async def task_body():
+        await asyncio.sleep(0)
+        return BranchContext.current()
+
+    async def main():
+        with BranchContext.use("feature-x"):
+            t = asyncio.create_task(task_body())
+        # Branch context already exited; the task still sees feature-x
+        # because create_task captured the context at task creation.
+        return await t
+
+    assert asyncio.run(main()) == "feature-x"
+
+
+def test_concurrent_async_tasks_have_independent_contexts():
+    """Two coroutines running concurrently in the same event loop see
+    their own ``use(...)`` value, not each other's. This is the
+    contract that makes per-request branch isolation safe in async
+    web frameworks."""
+
+    seen: dict[str, str] = {}
+
+    async def task(name: str, branch: str, barrier: asyncio.Event):
+        with BranchContext.use(branch):
+            await barrier.wait()
+            seen[name] = BranchContext.current()
+
+    async def main():
+        barrier = asyncio.Event()
+        coros = [task("a", "feature-a", barrier), task("b", "feature-b", barrier)]
+        runners = [asyncio.create_task(c) for c in coros]
+        # Let both tasks reach the barrier.
+        await asyncio.sleep(0)
+        barrier.set()
+        await asyncio.gather(*runners)
+
+    asyncio.run(main())
+    assert seen == {"a": "feature-a", "b": "feature-b"}

--- a/libs/naas-abi-core/naas_abi_core/branching/conventions.py
+++ b/libs/naas-abi-core/naas_abi_core/branching/conventions.py
@@ -1,0 +1,64 @@
+"""Branch propagation conventions for the four boundary crossings.
+
+``BranchContext`` covers in-process propagation. When work crosses a
+process boundary — incoming HTTP, outgoing HTTP, incoming bus message,
+outgoing bus message — the active branch must travel along with it,
+or the loud-failure policy degrades into silent reads against ``main``
+on the receiving side.
+
+This module is **documentation by way of constants**: it defines the
+header / metadata-field names that consumers MUST use, and explains
+the four conventions in the module docstring. The middleware that
+actually plumbs these values lives in higher layers (the API package
+for HTTP, the bus adapter for messages); shipping that middleware
+from naas-abi-core would force a FastAPI / queue-vendor dependency on
+every consumer.
+
+The four boundaries
+-------------------
+
+1. **Incoming HTTP request.** Read ``X-Abi-Branch`` from the request.
+   Wrap the handler in ``BranchContext.use(branch)``. If the header
+   is absent, fall back to ``"main"`` — public endpoints stay
+   backwards-compatible with non-branch-aware clients.
+
+2. **Outgoing HTTP request.** Set ``X-Abi-Branch: <BranchContext.current()>``
+   on every request emitted by ``naas_abi_core`` so the receiver can
+   pick it up via convention 1. Skip the header when the branch is
+   ``"main"`` to keep traffic clean.
+
+3. **Outgoing bus message.** Stamp the active branch into the message
+   metadata under the field ``BUS_BRANCH_FIELD`` (``branch``). Whether
+   that is a Kafka header, a Pub/Sub attribute, or a JSON envelope key
+   is the bus adapter's call; the field name is shared.
+
+4. **Incoming bus message.** The consuming bus adapter reads the
+   metadata field and wraps message processing in
+   ``BranchContext.use(branch)``. Missing field → ``"main"``.
+
+Bus subscribers are inherently branch-scoped (per spec #865 §6): a
+subscriber on ``main`` does NOT see events emitted on ``feature-x``.
+This is by design — events on a feature branch are part of that
+feature's isolated experience and do not leak into production state.
+The bus per-branch isolation work lives in spec issue #885.
+"""
+
+from __future__ import annotations
+
+
+HTTP_BRANCH_HEADER = "X-Abi-Branch"
+"""HTTP header name used to carry the active branch across requests.
+
+The ``X-`` prefix marks it as application-defined (we are not
+registering an IANA header). Title-case is canonical; HTTP header
+names are case-insensitive on the wire so middleware should
+normalize before comparison."""
+
+
+BUS_BRANCH_FIELD = "branch"
+"""Bus message metadata field name used to carry the active branch.
+
+Whether this lands as a Kafka header, an SQS attribute, an AMQP
+property, or a JSON envelope key is a per-adapter detail. The
+*field name* is shared so cross-adapter routing and observability
+tooling can look it up consistently."""

--- a/libs/naas-abi-core/naas_abi_core/branching/exceptions.py
+++ b/libs/naas-abi-core/naas_abi_core/branching/exceptions.py
@@ -1,0 +1,32 @@
+"""Exceptions for the branching subsystem.
+
+These are the *consumer-facing* errors. ``BranchContext`` itself never
+raises them — it just hands a string back to the caller. The adapters
+that consume the context (versioned store, triple store, etc.) are the
+ones that turn a missing branch into a loud failure, per the design
+note in spec issue #865 / acceptance issue #877:
+
+> Loud-failure policy: reading from a non-existent branch raises
+> ``BranchNotFoundError`` instead of silently falling back to ``main``.
+"""
+
+from __future__ import annotations
+
+
+class BranchValidationError(ValueError):
+    """The branch *name* is structurally invalid.
+
+    Raised by ``BranchContext.use(name)`` for empty strings, names
+    containing path separators, etc. Validation here is purely
+    syntactic; it makes no claim that the branch exists in any store."""
+
+
+class BranchNotFoundError(LookupError):
+    """The branch is structurally valid but does not exist in the store.
+
+    Raised by adapters (not by ``BranchContext``) when the active branch
+    is propagated into a read or write that targets a non-existent
+    branch. Inheriting ``LookupError`` lets callers handle "missing
+    branch" alongside other "missing key" errors generically without
+    having to import the branching package.
+    """

--- a/libs/naas-abi-core/naas_abi_core/branching/executor.py
+++ b/libs/naas-abi-core/naas_abi_core/branching/executor.py
@@ -1,0 +1,73 @@
+"""``BranchAwareThreadPoolExecutor``: ``ThreadPoolExecutor`` that
+propagates ``contextvars`` (and therefore the active branch) to worker
+threads.
+
+Background
+----------
+
+``concurrent.futures.ThreadPoolExecutor`` does *not* propagate
+contextvars across ``submit``. A ``BranchContext.use(...)`` block in
+the caller has no effect on work running in a worker thread — the
+worker sees the default ``"main"`` instead. That silent fallback is
+exactly what the loud-failure policy is meant to prevent, so we ship
+this drop-in replacement and a repository guard test that fails CI if
+the raw class is imported anywhere under ``naas_abi_core/``.
+
+Behavior
+--------
+
+On every ``submit(fn, *args, **kwargs)``:
+
+1. ``copy_context()`` snapshots the *submitter's* full context
+   (active branch, log fields, OTel baggage, anything else stored in
+   ContextVars).
+2. The worker thread runs ``ctx.run(fn, *args, **kwargs)`` so the
+   submitted callable observes that snapshot.
+
+``map`` is implemented in the stdlib on top of ``submit``, so it
+inherits propagation for free. Same for ``concurrent.futures.wait``,
+``as_completed``, and the rest of the public surface.
+
+Cost
+----
+
+``copy_context()`` is roughly an O(n) shallow copy of the active
+ContextVars. In practice that's a handful of nanoseconds, dominated by
+the cost of crossing a thread boundary. There is no measurable
+overhead vs. raw ``ThreadPoolExecutor`` on real workloads.
+"""
+
+from __future__ import annotations
+
+import contextvars
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import Any, Callable, TypeVar
+
+
+_R = TypeVar("_R")
+
+
+class BranchAwareThreadPoolExecutor(ThreadPoolExecutor):
+    """Drop-in replacement for ``ThreadPoolExecutor`` that propagates
+    contextvars to worker threads.
+
+    Use it everywhere in ``naas_abi_core`` where you would have used
+    the stdlib executor. The constructor signature is unchanged; the
+    only behavioral difference is that submitted callables observe the
+    submitter's ``BranchContext`` (and any other ContextVar)."""
+
+    def submit(  # type: ignore[override]
+        self,
+        fn: Callable[..., _R],
+        /,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Future[_R]:
+        """Submit ``fn`` to a worker, capturing the current context.
+
+        The signature mirrors ``ThreadPoolExecutor.submit`` exactly so
+        the executor stays drop-in compatible. The override lives only
+        in the runtime path; type-checkers see the parent signature.
+        """
+        ctx = contextvars.copy_context()
+        return super().submit(ctx.run, fn, *args, **kwargs)

--- a/libs/naas-abi-core/naas_abi_core/branching/executor_test.py
+++ b/libs/naas-abi-core/naas_abi_core/branching/executor_test.py
@@ -1,0 +1,84 @@
+"""Tests for ``BranchAwareThreadPoolExecutor`` propagation."""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+from .context import BranchContext
+from .executor import BranchAwareThreadPoolExecutor
+
+
+def _capture_branch() -> str:
+    return BranchContext.current()
+
+
+def test_propagates_branch_to_worker():
+    """The submitted callable runs in a thread, and the thread sees the
+    submitter's active branch (not the default)."""
+    with BranchAwareThreadPoolExecutor(max_workers=2) as ex:
+        with BranchContext.use("feature-x"):
+            fut = ex.submit(_capture_branch)
+        assert fut.result(timeout=2) == "feature-x"
+
+
+def test_branch_does_not_leak_to_subsequent_submissions():
+    """A submission outside ``use(...)`` sees the default — the
+    executor doesn't keep state across submissions."""
+    with BranchAwareThreadPoolExecutor(max_workers=2) as ex:
+        with BranchContext.use("feature-x"):
+            inside = ex.submit(_capture_branch)
+        outside = ex.submit(_capture_branch)
+        assert inside.result(timeout=2) == "feature-x"
+        assert outside.result(timeout=2) == "main"
+
+
+def test_concurrent_submissions_have_independent_branches():
+    """Two threads holding different branches should each see their own
+    branch in the worker. This is the contract that makes per-request
+    branch isolation safe under threaded fan-out."""
+    seen: dict[str, str] = {}
+    barrier = threading.Barrier(2)
+
+    def submit_under(branch: str, key: str, ex: BranchAwareThreadPoolExecutor):
+        with BranchContext.use(branch):
+            fut = ex.submit(_capture_branch)
+        # Synchronize so both submissions are in flight before either
+        # result is read; rules out any "executor reused last context"
+        # style bug.
+        barrier.wait(timeout=2)
+        seen[key] = fut.result(timeout=2)
+
+    with BranchAwareThreadPoolExecutor(max_workers=4) as ex:
+        threads = [
+            threading.Thread(
+                target=submit_under, args=("feature-a", "a", ex)
+            ),
+            threading.Thread(
+                target=submit_under, args=("feature-b", "b", ex)
+            ),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+    assert seen == {"a": "feature-a", "b": "feature-b"}
+
+
+def test_map_propagates_branch():
+    """``map`` is built on ``submit`` in the stdlib, so propagation
+    inherits for free. Pin that behavior with a test."""
+    with BranchAwareThreadPoolExecutor(max_workers=2) as ex:
+        with BranchContext.use("feature-x"):
+            results = list(ex.map(lambda _: BranchContext.current(), range(3)))
+    assert results == ["feature-x"] * 3
+
+
+def test_raw_thread_pool_does_not_propagate():
+    """Sanity-check the documented motivation: a raw
+    ``ThreadPoolExecutor`` is the broken default and the reason this
+    wrapper exists."""
+    with ThreadPoolExecutor(max_workers=1) as ex:
+        with BranchContext.use("feature-x"):
+            fut = ex.submit(_capture_branch)
+        assert fut.result(timeout=2) == "main"  # NOT feature-x

--- a/libs/naas-abi-core/naas_abi_core/branching/logging.py
+++ b/libs/naas-abi-core/naas_abi_core/branching/logging.py
@@ -1,0 +1,55 @@
+"""Logging integration: tag every record with the active branch.
+
+Install :class:`BranchContextLogFilter` once on the root logger (or on
+specific loggers) and every emitted ``LogRecord`` gains a ``branch``
+attribute. Format strings can then reference ``%(branch)s``.
+
+Example
+-------
+
+::
+
+    import logging
+    from naas_abi_core.branching import BranchContextLogFilter
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(
+        logging.Formatter("[%(branch)s] %(levelname)s %(name)s: %(message)s")
+    )
+    handler.addFilter(BranchContextLogFilter())
+    logging.getLogger().addHandler(handler)
+
+The filter never rejects records — it only annotates them. ``filter``
+returns ``True`` unconditionally.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from .context import BranchContext
+
+
+class BranchContextLogFilter(logging.Filter):
+    """Annotate every ``LogRecord`` with ``record.branch``.
+
+    Read at filter time (not at emit time), so records logged inside a
+    ``BranchContext.use(...)`` block carry the correct branch even if
+    the formatter runs later in a different context. This matches how
+    ``LoggerAdapter.extra`` is conventionally captured.
+    """
+
+    def __init__(self, *, attribute: str = "branch") -> None:
+        """Customize the record attribute name if ``branch`` collides
+        with another extension. Defaults to ``branch`` everywhere
+        ``naas_abi_core`` ships."""
+        super().__init__()
+        self._attribute = attribute
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        # setattr (vs assignment) avoids overriding a value already set
+        # via LoggerAdapter.extra={"branch": ...} — explicit tagging
+        # wins over implicit ambient capture.
+        if not hasattr(record, self._attribute):
+            setattr(record, self._attribute, BranchContext.current())
+        return True

--- a/libs/naas-abi-core/naas_abi_core/branching/logging_test.py
+++ b/libs/naas-abi-core/naas_abi_core/branching/logging_test.py
@@ -1,0 +1,72 @@
+"""Tests for ``BranchContextLogFilter``."""
+
+from __future__ import annotations
+
+import logging
+from io import StringIO
+
+import pytest
+
+from .context import BranchContext
+from .logging import BranchContextLogFilter
+
+
+@pytest.fixture
+def captured() -> tuple[logging.Logger, StringIO]:
+    """A fresh logger + a string buffer capturing its output, scoped to
+    the test so test order can't pollute global handler state."""
+    logger = logging.getLogger(f"test.branching.{id(object())}")
+    logger.handlers.clear()
+    logger.setLevel(logging.DEBUG)
+    buf = StringIO()
+    handler = logging.StreamHandler(buf)
+    handler.setFormatter(logging.Formatter("%(branch)s | %(message)s"))
+    handler.addFilter(BranchContextLogFilter())
+    logger.addHandler(handler)
+    return logger, buf
+
+
+def test_default_branch_in_record(captured):
+    logger, buf = captured
+    logger.info("hello")
+    assert buf.getvalue().strip() == "main | hello"
+
+
+def test_active_branch_in_record(captured):
+    logger, buf = captured
+    with BranchContext.use("feature-x"):
+        logger.info("hi")
+    assert buf.getvalue().strip() == "feature-x | hi"
+
+
+def test_explicit_extra_wins(captured):
+    """``logger.log(..., extra={'branch': 'override'})`` wins over the
+    ambient capture — explicit always beats implicit."""
+    logger, buf = captured
+    with BranchContext.use("feature-x"):
+        logger.info("hi", extra={"branch": "override"})
+    assert buf.getvalue().strip() == "override | hi"
+
+
+def test_filter_never_drops_records(captured):
+    logger, buf = captured
+    f = BranchContextLogFilter()
+    record = logger.makeRecord(
+        logger.name, logging.INFO, __file__, 0, "msg", (), None
+    )
+    assert f.filter(record) is True
+    assert getattr(record, "branch") == BranchContext.current()
+
+
+def test_custom_attribute_name():
+    logger = logging.getLogger("test.branching.custom")
+    logger.handlers.clear()
+    logger.setLevel(logging.DEBUG)
+    buf = StringIO()
+    handler = logging.StreamHandler(buf)
+    handler.setFormatter(logging.Formatter("%(workspace)s | %(message)s"))
+    handler.addFilter(BranchContextLogFilter(attribute="workspace"))
+    logger.addHandler(handler)
+    with BranchContext.use("feature-x"):
+        logger.info("hi")
+    assert buf.getvalue().strip() == "feature-x | hi"

--- a/libs/naas-abi-core/naas_abi_core/branching/no_raw_threadpool_test.py
+++ b/libs/naas-abi-core/naas_abi_core/branching/no_raw_threadpool_test.py
@@ -1,0 +1,154 @@
+"""Repository guard: fail CI if anything under ``naas_abi_core/`` imports
+``concurrent.futures.ThreadPoolExecutor`` directly.
+
+Per spec issue #877, the loud-failure policy demands that branch context
+propagate to every worker thread. ``concurrent.futures.ThreadPoolExecutor``
+does not propagate ``contextvars`` automatically; using it silently drops
+the active branch and produces reads against ``main`` from inside what
+the caller thought was a ``BranchContext.use("feature-x")`` block.
+
+The fix is to use ``BranchAwareThreadPoolExecutor`` from this package.
+This test is the enforcement: it parses every Python file under
+``naas_abi_core/`` and fails if any non-allowlisted file imports the
+raw class.
+
+Why a pytest test rather than a ruff plugin? A custom ruff rule would
+require shipping a separate plugin package; a stdlib-only AST scan
+gives us the same coverage with zero added dependencies, runs as part
+of every test invocation, and surfaces the violation with a clear
+message at the file level. If/when the project adopts a custom ruff
+plugin, this test can become a thin wrapper around it (or be retired
+in favor of the rule)."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+# Files allowed to import the raw class. Keep this list minimal and
+# justified — every entry is documented.
+ALLOWLIST: frozenset[str] = frozenset(
+    {
+        # The wrapper itself: ``BranchAwareThreadPoolExecutor`` subclasses
+        # ``ThreadPoolExecutor``. This is the one place the raw class
+        # MUST be imported.
+        "branching/executor.py",
+        # The guard test: it imports the raw class to demonstrate the
+        # negative case (raw executor does NOT propagate). Allowlisting
+        # the test keeps the demo honest without a # noqa pragma.
+        "branching/executor_test.py",
+        # This file: the allowlist is data, the docstring above
+        # references the class by name.
+        "branching/no_raw_threadpool_test.py",
+        #
+        # ----------------------------------------------------------
+        # Migration debt — to be cleared across the per-service
+        # branching migration issues (#882–#888 and #883/#884/#887).
+        # Each entry below pre-dates BranchContext and uses a raw
+        # executor for fan-out that is not yet branch-aware. Once the
+        # corresponding service migrates onto IVersionedStorePort, its
+        # tests / production paths should switch to
+        # BranchAwareThreadPoolExecutor and the entry should be
+        # removed from this allowlist.
+        # ----------------------------------------------------------
+        #
+        # Production: agent IntentMapper fan-out, branch-unaware
+        # (cleanup with #883, agent memory migration).
+        "services/agent/beta/IntentMapper.py",
+        # Concurrency test suites for services that pre-date
+        # BranchContext. Tests use the executor as a generic fan-out
+        # tool, not to exercise branch propagation. Migrate alongside
+        # each service in its respective issue.
+        "services/bus/adapters/secondary/PythonQueueAdapter_test.py",
+        "services/cache/adapters/secondary/CacheFSAdapter_test.py",
+        "services/keyvalue/adapters/secondary/PythonAdapter_test.py",
+        "services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterFS_test.py",
+        "services/triple_store/adaptors/secondary/TripleStoreService__SecondaryAdaptor__Filesystem_concurrency_test.py",
+        "services/triple_store/adaptors/secondary/TripleStoreService__SecondaryAdaptor__OxigraphEmbedded_test.py",
+        "services/vector_store/adapters/QdrantInMemoryAdapter_test.py",
+        # Vendored versionstore: independent library that intentionally
+        # has no naas_abi_core.branching dependency. Its concurrency
+        # tests and benchmark belong in the upstream versionstore repo
+        # and stay raw on purpose.
+        "utils/versionstore/benchmark.py",
+        "utils/versionstore/store_concurrency_test.py",
+        "utils/versionstore/store_group_commit_test.py",
+    }
+)
+
+
+def _package_root() -> Path:
+    """Return the on-disk path to the ``naas_abi_core`` package, no
+    matter how the test is invoked. ``Path(__file__)`` resolves the
+    location of this test, which is two parents up from the package
+    root (``naas_abi_core/branching/no_raw_threadpool_test.py``)."""
+    return Path(__file__).resolve().parent.parent
+
+
+def _imports_raw_threadpool(source: str) -> bool:
+    """Return True if ``source`` imports
+    ``concurrent.futures.ThreadPoolExecutor`` in any common form."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        # Malformed Python isn't this test's job to flag; let the
+        # syntax-error elsewhere surface it.
+        return False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module == "concurrent.futures":
+                for alias in node.names:
+                    if alias.name == "ThreadPoolExecutor":
+                        return True
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                # ``import concurrent.futures`` followed by usage of
+                # ``concurrent.futures.ThreadPoolExecutor`` — heuristic
+                # check on the module-qualified name in subsequent
+                # ``ast.Attribute`` nodes.
+                if alias.name == "concurrent.futures":
+                    for sub in ast.walk(tree):
+                        if (
+                            isinstance(sub, ast.Attribute)
+                            and sub.attr == "ThreadPoolExecutor"
+                        ):
+                            return True
+    return False
+
+
+def test_no_raw_thread_pool_executor_in_naas_abi_core():
+    """Walk every .py file under ``naas_abi_core/`` and fail if any
+    non-allowlisted file imports the raw ``ThreadPoolExecutor``.
+
+    The error message lists every offender with its package-relative
+    path and an explanation of what to use instead, so a developer
+    seeing this fail in CI doesn't have to come read this test."""
+    root = _package_root()
+    offenders: list[str] = []
+    for py in root.rglob("*.py"):
+        rel = py.relative_to(root).as_posix()
+        if rel in ALLOWLIST:
+            continue
+        try:
+            source = py.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if _imports_raw_threadpool(source):
+            offenders.append(rel)
+    if offenders:
+        offenders_block = "\n  ".join(sorted(offenders))
+        pytest.fail(
+            "These files import concurrent.futures.ThreadPoolExecutor "
+            "directly, which silently drops the BranchContext when "
+            "submitting work to threads:\n  "
+            + offenders_block
+            + "\n\nUse BranchAwareThreadPoolExecutor from "
+            "naas_abi_core.branching instead. If a file genuinely needs "
+            "the raw class (very rare — the wrapper is a pure superset), "
+            "add it to the ALLOWLIST in this test with a one-line "
+            "justification.",
+            pytrace=False,
+        )

--- a/libs/naas-abi-core/naas_abi_core/branching/tracing.py
+++ b/libs/naas-abi-core/naas_abi_core/branching/tracing.py
@@ -1,0 +1,68 @@
+"""OpenTelemetry helper: tag spans with the active branch.
+
+The shape is a single function, ``add_branch_to_span(span, *, key="abi.branch")``,
+that calls ``span.set_attribute(key, BranchContext.current())`` if a span
+is provided. Anything duck-typed as "has ``set_attribute(name, value)``"
+works — the function does not import the OpenTelemetry SDK, so the
+branching package stays free of an OTel dependency.
+
+Convention
+----------
+
+The attribute key is ``abi.branch`` (Anthropic-style "abi" prefix to
+namespace it from generic OpenTelemetry semconv attributes). Spans
+emitted by ``naas_abi_core`` services should call this helper at span
+creation; consumers building their own spans are encouraged to do the
+same so traces from multiple branches stay distinguishable in any
+trace backend.
+
+Usage
+-----
+
+::
+
+    from opentelemetry import trace
+    from naas_abi_core.branching import add_branch_to_span
+
+    tracer = trace.get_tracer(__name__)
+    with tracer.start_as_current_span("triple_store.query") as span:
+        add_branch_to_span(span)
+        ...
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from .context import BranchContext
+
+
+DEFAULT_BRANCH_SPAN_ATTRIBUTE = "abi.branch"
+"""Span attribute key used by ``add_branch_to_span``. Documented as a
+constant so callers can reference it in dashboards and trace queries."""
+
+
+class _SetAttributeSpan(Protocol):
+    """Minimal structural type for any span object with
+    ``set_attribute``. Matches the OpenTelemetry SDK's ``Span`` and
+    ``trace.NonRecordingSpan`` without an import dependency."""
+
+    def set_attribute(self, key: str, value: Any) -> Any: ...
+
+
+def add_branch_to_span(
+    span: _SetAttributeSpan | None,
+    *,
+    key: str = DEFAULT_BRANCH_SPAN_ATTRIBUTE,
+) -> None:
+    """Tag ``span`` with the active branch under ``key``.
+
+    A ``None`` span is a no-op, so callers can safely pass
+    ``trace.get_current_span()`` without checking whether tracing is
+    actually active. If the span object lacks ``set_attribute`` the
+    ``AttributeError`` propagates — that is a programming error in the
+    caller, not something to silently swallow.
+    """
+    if span is None:
+        return
+    span.set_attribute(key, BranchContext.current())

--- a/libs/naas-abi-core/naas_abi_core/branching/tracing_test.py
+++ b/libs/naas-abi-core/naas_abi_core/branching/tracing_test.py
@@ -1,0 +1,45 @@
+"""Tests for ``add_branch_to_span`` (no real OTel dependency)."""
+
+from __future__ import annotations
+
+from .context import BranchContext
+from .tracing import DEFAULT_BRANCH_SPAN_ATTRIBUTE, add_branch_to_span
+
+
+class _FakeSpan:
+    """Stand-in for the OTel Span protocol — only ``set_attribute``
+    is exercised."""
+
+    def __init__(self) -> None:
+        self.attrs: dict[str, object] = {}
+
+    def set_attribute(self, key: str, value: object) -> None:
+        self.attrs[key] = value
+
+
+def test_tags_default_branch():
+    span = _FakeSpan()
+    add_branch_to_span(span)
+    assert span.attrs == {DEFAULT_BRANCH_SPAN_ATTRIBUTE: "main"}
+
+
+def test_tags_active_branch():
+    span = _FakeSpan()
+    with BranchContext.use("feature-x"):
+        add_branch_to_span(span)
+    assert span.attrs == {DEFAULT_BRANCH_SPAN_ATTRIBUTE: "feature-x"}
+
+
+def test_custom_key():
+    span = _FakeSpan()
+    add_branch_to_span(span, key="my.branch")
+    assert span.attrs == {"my.branch": "main"}
+
+
+def test_none_span_is_noop():
+    # No exception — spans default off cleanly when tracing is disabled.
+    add_branch_to_span(None)
+
+
+def test_default_attribute_constant():
+    assert DEFAULT_BRANCH_SPAN_ATTRIBUTE == "abi.branch"


### PR DESCRIPTION
Closes [#877](https://github.com/jupyter-naas/abi/issues/877). Adds the ambient branch propagation substrate every Tier-1 service in the upcoming branching architecture (#865) will consume — lets a caller declare *"this work is on feature-x"* once and have every adapter beneath see it without changing port signatures.

This is a pure-addition module (`naas_abi_core/branching/`); nothing existing changes behavior. Independent of #876 — does not depend on the versionstore branching work.

## What's in here

### `BranchContext`
- `BranchContext.current() -> str` (default `"main"`).
- `with BranchContext.use("feature-x"): ...` context manager.
- Backed by `contextvars.ContextVar`, so propagation through `await`, `asyncio.create_task`, and per-task isolation comes for free.
- Validation is purely syntactic (non-empty, no `/` `\` `\0` `.` `..`); existence checks are the adapters' job, per the loud-failure policy.

### `BranchAwareThreadPoolExecutor`
- Drop-in `concurrent.futures.ThreadPoolExecutor` replacement.
- Every `submit` wraps the callable in `copy_context().run(...)` so worker threads observe the submitter's ambient context. `map` inherits propagation.
- The wrapper is the *only* place under `naas_abi_core/` that should import the raw class.

### `BranchContextLogFilter`
- `logging.Filter` that adds a `branch` attribute to every record.
- Format strings can reference `%(branch)s`. Custom attribute name supported (e.g. `attribute="workspace"`).
- Explicit `logger.info("...", extra={"branch": "..."})` wins over ambient capture.

### `add_branch_to_span(span)` (OTel helper)
- Tags spans with `abi.branch = BranchContext.current()`.
- No hard OpenTelemetry dependency: spans are duck-typed via a `Protocol`. `None` is a no-op so callers can pass `trace.get_current_span()` unconditionally.

### Boundary conventions (`conventions.py`)
- `HTTP_BRANCH_HEADER = "X-Abi-Branch"`
- `BUS_BRANCH_FIELD = "branch"`
- The four crossings (HTTP in/out, bus in/out) documented in the module docstring. The middleware that actually plumbs them lives in higher layers (API package for HTTP, bus adapter for messages). This module ships only the shared names.

### Exceptions
- `BranchValidationError` — syntactic, raised by `BranchContext.use(...)`.
- `BranchNotFoundError(LookupError)` — existential, raised by adapters when an unknown branch reaches them. Inherits `LookupError` so callers can handle "missing branch" alongside other lookup failures generically.

### Repository guard
- [`no_raw_threadpool_test.py`](libs/naas-abi-core/naas_abi_core/branching/no_raw_threadpool_test.py) walks every `.py` under `naas_abi_core/` with stdlib `ast` and fails if any non-allowlisted file imports `concurrent.futures.ThreadPoolExecutor` directly.
- Equivalent to the lint rule the spec asks for, implemented as a stdlib-only AST scan so it adds no dependencies and runs as part of every test invocation.
- 11 pre-#877 offenders are explicitly allowlisted with one-line justifications and a pointer to the per-service migration issue (#882–#888 etc.) that should clear each one. Vendored versionstore is allowlisted permanently — it's an independent library with no `naas_abi_core.branching` dependency.

## Test plan

- [x] `uv run pytest naas_abi_core/branching/` — **28 passed, 0 failed**
- [x] Pre-commit ruff: passes
- [x] Pre-commit mypy on naas_abi_core / naas_abi_cli / naas_abi_marketplace: passes
- [x] Pre-commit bandit: passes (no new issues)

Coverage:
- `BranchContext` defaults, `use()` block, nested stacking, exception unwinding, validation cases (empty, non-string, path separators).
- Async propagation through `await` and `asyncio.create_task`.
- Concurrent async tasks have independent contexts (the contract that makes per-request isolation safe in async web frameworks).
- `BranchAwareThreadPoolExecutor`: propagation, no leak across submissions, concurrent submitters with different branches, `map` propagation.
- Sanity-check that raw `ThreadPoolExecutor` does **not** propagate (documents the motivation).
- Logging filter: default branch, active branch, explicit-extra-wins, custom attribute name, never drops records.
- OTel helper: default branch, active branch, custom key, `None`-span no-op.
- Repo guard passes with the documented allowlist.

## Notes for reviewers

1. **Why not a custom ruff rule for the guard?** A custom ruff plugin would require shipping a separate package and registering it in tooling. A stdlib-only AST scan as a pytest test gives the same coverage, runs everywhere pytest runs, and surfaces the violation with a clear file-level message. If/when the project adopts a ruff plugin we can swap.
2. **Why does `BranchContext.use` only do syntactic validation?** Loud-failure on a non-existent branch belongs at the adapter level, where the store is in scope. `BranchContext` itself has no notion of which stores exist or which branches they know about — coupling it to one would force every consumer to instantiate one.
3. **Why a `LookupError` subclass for `BranchNotFoundError`?** Callers handling generic "missing key" cases (e.g. an HTTP middleware turning lookup failures into 404s) can catch both `KeyError` and `BranchNotFoundError` via `LookupError`. The existing versionstore `BranchNotFoundError` is internal and subclasses `Exception` — that one stays where it is and the consumer-facing one lives in the branching package.
4. **The 11 allowlisted offenders are migration debt, not blockers.** Migrating them would balloon this PR's scope past "substrate" — each belongs in its own per-service issue. The allowlist is intentionally a TODO list for those follow-ups.

Refs: #877
Milestone: [Branching: versionstore-backed services](https://github.com/jupyter-naas/abi/milestone/1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)