### PR TITLE
fix-nexus: update naas-abi versions; fix db table_exists; improve VisNetwork node positions

### DIFF
--- a/libs/naas-abi-cli/uv.lock
+++ b/libs/naas-abi-cli/uv.lock
@@ -2295,7 +2295,7 @@ wheels = [
 
 [[package]]
 name = "naas-abi"
-version = "1.36.1"
+version = "1.37.1"
 source = { editable = "../naas-abi" }
 dependencies = [
     { name = "alembic" },
@@ -2406,7 +2406,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-core"
-version = "1.35.1"
+version = "1.36.0"
 source = { editable = "../naas-abi-core" }
 dependencies = [
     { name = "click" },

--- a/libs/naas-abi-marketplace/uv.lock
+++ b/libs/naas-abi-marketplace/uv.lock
@@ -2854,7 +2854,7 @@ wheels = [
 
 [[package]]
 name = "naas-abi-core"
-version = "1.35.1"
+version = "1.36.0"
 source = { editable = "../naas-abi-core" }
 dependencies = [
     { name = "click" },

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/database.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/database.py
@@ -195,7 +195,7 @@ async def table_exists(table_name: str) -> bool:
             """),
             {"name": table_name},
         )
-        return result.scalar()
+        return result.scalar() or False
 
 
 async def get_row_count(table_name: str) -> int:

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/graph/vis-network.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/graph/vis-network.tsx
@@ -94,6 +94,17 @@ function resolveBFOColor(node: GraphNode, nodesById?: Map<string, GraphNode>, vi
   return null;
 }
 
+function computeSpreadPositions(nodeIds: string[], spacing = 300): Map<string, { x: number; y: number }> {
+  const result = new Map<string, { x: number; y: number }>();
+  const goldenAngle = Math.PI * (3 - Math.sqrt(5));
+  nodeIds.forEach((id, i) => {
+    const r = spacing * Math.sqrt(i);
+    const theta = i * goldenAngle;
+    result.set(id, { x: r * Math.cos(theta), y: r * Math.sin(theta) });
+  });
+  return result;
+}
+
 const EDGE_COLORS: Record<string, string> = {
   // 'participates in': '#22c55e',
   // 'has participant': '#22c55e',
@@ -614,8 +625,7 @@ export function VisNetwork({
       dragView: true,
     },
     layout: {
-      improvedLayout: true,
-      randomSeed: 42,
+      improvedLayout: false,
     },
   };
 
@@ -771,10 +781,19 @@ export function VisNetwork({
     }
 
     // Initial load — full clear + add, then let physics stabilize.
+    // Pre-spread nodes without a saved position using a sunflower spiral so
+    // physics starts from a distributed layout rather than piling up at the origin.
+    const unsavedIds = uniqueNodes
+      .filter((n) => !nodePositionsRef.current.has(n.id))
+      .map((n) => n.id);
+    const spreadPositions = computeSpreadPositions(unsavedIds);
+
     const visNodes = uniqueNodes.map((node) => {
       const baseNode = toVisNode(node);
       const savedPos = nodePositionsRef.current.get(node.id);
       if (savedPos) return { ...baseNode, x: savedPos.x, y: savedPos.y };
+      const initPos = spreadPositions.get(node.id);
+      if (initPos) return { ...baseNode, x: initPos.x, y: initPos.y };
       return baseNode;
     });
 

--- a/uv.lock
+++ b/uv.lock
@@ -3444,7 +3444,7 @@ wheels = [
 
 [[package]]
 name = "naas-abi"
-version = "1.37.0"
+version = "1.37.1"
 source = { editable = "libs/naas-abi" }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
This pull request resolves issue **#fix-nexus**.

### Summary

This PR includes the following changes:

1. **`naas-abi` and `naas-abi-core` version updates**:  
   - `naas-abi` bumped from `1.36.1` to `1.37.1`.  
   - `naas-abi-core` updated from `1.35.1` to `1.36.0` in multiple lock files.

2. **Database utility fix**:  
   - The `table_exists` async function now explicitly returns `False` when a table does not exist (previously returned `None` when no row was found).

3. **Front-end graph component improvements**:  
   - Added `computeSpreadPositions`, a function using the sunflower spiral algorithm to pre-spread node positions before physics simulation in the graph network visualization.  
   - Modified initial node positioning in the `VisNetwork` component to use these pre-spread positions for nodes without saved positions, improving layout stability and distribution.  
   - Changed the `improvedLayout` option for the vis-network layout to `false` and removed the `randomSeed` setting.

### Impact

- Backend improvements ensure reliable boolean returns for table existence checks.  
- Frontend changes improve the initial visual layout of network graphs, reducing node overlap by distributing new nodes via a mathematical layout.  
- Version bumps keep dependencies current, potentially including bug fixes and enhancements.

Together, these fixes improve backend robustness and frontend user experience in the Nexus app.