### PR TITLE
feat: seed ABI agents into Nexus DB for consistent agent metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ website/node_modules
 website/.docusaurus
 website/build
 .claude
+
+.pnpm-store/
+node_modules/

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/agent_seed.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/agent_seed.py
@@ -1,0 +1,284 @@
+"""
+Seed ABI agent classes into the database for every workspace.
+
+Called once during app startup (after workspace seeds). Builds the in-process
+agent class registry and upserts each agent record per workspace:
+  - creates a new row for newly discovered agent classes
+  - updates metadata (name, description, logo_url, module_path, suggestions,
+    intents) for existing rows whose class_name already has a DB entry
+
+Fields owned by users (enabled, system_prompt, model_id) are never overwritten
+by the seeding pass.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime
+from uuid import uuid4
+
+from naas_abi.apps.nexus.apps.api.app.core.database import async_engine
+from naas_abi.apps.nexus.apps.api.app.core.datetime_compat import UTC
+from naas_abi.apps.nexus.apps.api.app.models import AgentConfigModel, WorkspaceModel
+from naas_abi_core.services.agent.Agent import Agent
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import sessionmaker
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Process-level agent class registry cache (shared with the FastAPI adapter)
+# ---------------------------------------------------------------------------
+_agent_class_registry: dict[str, type[Agent]] | None = None
+_agent_class_registry_lock = threading.Lock()
+
+
+def get_agent_class_registry() -> dict[str, type[Agent]]:
+    """Return (and lazily build) the process-level agent class registry.
+
+    Thread-safe double-checked locking ensures the expensive discovery runs
+    at most once even under concurrent first requests.
+    """
+    global _agent_class_registry
+
+    if _agent_class_registry is not None:
+        return _agent_class_registry
+
+    with _agent_class_registry_lock:
+        if _agent_class_registry is not None:
+            return _agent_class_registry
+
+        from naas_abi import ABIModule
+
+        abi_module = ABIModule.get_instance()
+        candidate_classes: list[type[Agent]] = list(abi_module.agents)
+
+        for module in abi_module.engine.modules.values():
+            for agent_cls in module.agents:
+                if agent_cls is None:
+                    continue
+                candidate_classes.append(agent_cls)
+
+        def _resolve(agent_cls: type[Agent]) -> tuple[str, type[Agent]] | None:
+            name = _get_agent_class_name(agent_cls)
+            if not name:
+                logger.warning(
+                    "Skipping agent %s: no resolvable name (set class attribute 'name' or 'NAME')",
+                    agent_cls,
+                )
+                return None
+            class_name = f"{agent_cls.__module__}/{agent_cls.__name__}"
+            return class_name, agent_cls
+
+        registry: dict[str, type[Agent]] = {}
+        with ThreadPoolExecutor() as executor:
+            futures = {executor.submit(_resolve, c): c for c in candidate_classes}
+            for future in as_completed(futures):
+                result = future.result()
+                if result is not None:
+                    class_name, agent_cls = result
+                    registry[class_name] = agent_cls
+
+        logger.info("Agent class registry built: %d agents indexed", len(registry))
+        _agent_class_registry = registry
+        return _agent_class_registry
+
+
+# ---------------------------------------------------------------------------
+# Metadata extraction helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_agent_class_name(agent_cls: type) -> str | None:
+    name = getattr(agent_cls, "name", None)
+    if isinstance(name, str):
+        return name
+    if isinstance(name, property):
+        name = getattr(agent_cls, "NAME", None)
+    return name if isinstance(name, str) else None
+
+
+def _get_agent_class_description(agent_cls: type) -> str | None:
+    desc = getattr(agent_cls, "description", None)
+    if isinstance(desc, str):
+        return desc
+    if isinstance(desc, property):
+        desc = getattr(agent_cls, "DESCRIPTION", None)
+    return desc if isinstance(desc, str) else None
+
+
+def _get_agent_system_prompt(agent_cls: type) -> str | None:
+    system_prompt = getattr(agent_cls, "system_prompt", None)
+    if isinstance(system_prompt, str):
+        return system_prompt
+    from naas_abi_core.services.agent.Agent import AgentConfiguration
+
+    config = AgentConfiguration()
+    return config.get_system_prompt([])
+
+
+def _extract_agent_suggestions(agent_cls: type) -> list[dict[str, str]] | None:
+    suggestions = getattr(agent_cls, "suggestions", None)
+    if not isinstance(suggestions, list):
+        return None
+
+    normalized: list[dict[str, str]] = []
+    for item in suggestions:
+        if not isinstance(item, dict):
+            continue
+        label = item.get("label")
+        value = item.get("value")
+        if isinstance(label, str) and isinstance(value, str):
+            normalized.append({"label": label, "value": value})
+    return normalized or None
+
+
+def _extract_agent_intents(agent_cls: type) -> list[dict[str, str]] | None:
+    raw = getattr(agent_cls, "intents", None)
+    if not isinstance(raw, list) or not raw:
+        return None
+
+    output: list[dict[str, str]] = []
+    for item in raw:
+        if not hasattr(item, "intent_value") or not hasattr(item, "intent_type"):
+            continue
+        intent_payload: dict[str, str] = {
+            "intent_value": getattr(item, "intent_value", ""),
+            "intent_type": getattr(item.intent_type, "value", str(item.intent_type)),
+            "intent_target": str(getattr(item, "intent_target", "")),
+        }
+        scope = getattr(item, "intent_scope", None)
+        intent_payload["intent_scope"] = (
+            scope.value if scope is not None and hasattr(scope, "value") else str(scope or "")
+        )
+        output.append(intent_payload)
+
+    return output or None
+
+
+def _get_raw_logo_url(agent_cls: type) -> str | None:
+    """Return the raw logo_url from the agent class (file path, not a public URL)."""
+    return getattr(agent_cls, "logo_url", None) or None
+
+
+# ---------------------------------------------------------------------------
+# Per-workspace upsert
+# ---------------------------------------------------------------------------
+
+
+async def _upsert_agents_for_workspace(
+    session: AsyncSession,
+    workspace_id: str,
+    registry: dict[str, type[Agent]],
+) -> tuple[int, int]:
+    """Create or update agent records for one workspace. Returns (created, updated)."""
+    result = await session.execute(
+        select(AgentConfigModel).where(AgentConfigModel.workspace_id == workspace_id)
+    )
+    existing: dict[str, AgentConfigModel] = {
+        str(row.class_name): row
+        for row in result.scalars().all()
+        if row.class_name
+    }
+
+    now = datetime.now(UTC).replace(tzinfo=None)
+    created = 0
+    updated = 0
+
+    for class_name, agent_cls in registry.items():
+        name = _get_agent_class_name(agent_cls)
+        if not name:
+            continue
+
+        description = _get_agent_class_description(agent_cls) or ""
+        module_path = getattr(agent_cls, "__module__", None)
+        logo_url = _get_raw_logo_url(agent_cls)
+        suggestions = _extract_agent_suggestions(agent_cls)
+        intents = _extract_agent_intents(agent_cls)
+
+        if class_name in existing:
+            row = existing[class_name]
+            row.name = name
+            row.description = description
+            row.module_path = module_path
+            row.logo_url = logo_url
+            row.suggestions = suggestions
+            row.intents = intents
+            row.updated_at = now
+            updated += 1
+        else:
+            system_prompt = _get_agent_system_prompt(agent_cls)
+            enabled = name == "Abi"
+            session.add(
+                AgentConfigModel(
+                    id=f"agent-{uuid4()}",
+                    workspace_id=workspace_id,
+                    name=name,
+                    description=description,
+                    class_name=class_name,
+                    module_path=module_path,
+                    provider="abi",
+                    logo_url=logo_url,
+                    suggestions=suggestions,
+                    intents=intents,
+                    system_prompt=system_prompt,
+                    enabled=enabled,
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
+            created += 1
+
+    return created, updated
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+async def seed_abi_agents() -> None:
+    """Upsert ABI agent metadata for every workspace in the database.
+
+    Runs at app startup after workspace seeds so new agent classes are visible
+    immediately and changed metadata (logo, suggestions, intents, …) is
+    propagated without any request-time DB writes.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+        registry = await loop.run_in_executor(None, get_agent_class_registry)
+    except Exception:
+        logger.exception("Failed to build agent class registry — skipping agent seed")
+        return
+
+    async_session = sessionmaker(async_engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_session() as session:
+        ws_result = await session.execute(select(WorkspaceModel.id))
+        workspace_ids: list[str] = [str(row[0]) for row in ws_result.fetchall()]
+
+    if not workspace_ids:
+        logger.info("No workspaces found; skipping agent seed")
+        return
+
+    total_created = 0
+    total_updated = 0
+
+    async with async_session() as session:
+        async with session.begin():
+            for workspace_id in workspace_ids:
+                created, updated = await _upsert_agents_for_workspace(
+                    session, workspace_id, registry
+                )
+                total_created += created
+                total_updated += updated
+
+    logger.info(
+        "Agent seed complete: %d workspaces, %d created, %d updated",
+        len(workspace_ids),
+        total_created,
+        total_updated,
+    )

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/main.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/main.py
@@ -28,25 +28,21 @@ from naas_abi.apps.nexus.apps.api.app.services.websocket import init_websocket
 from starlette.middleware.base import BaseHTTPMiddleware
 
 
-async def _prefetch_agent_class_registry() -> None:
-    """Warm up the agent class registry in a thread-pool worker.
+async def _seed_abi_agents() -> None:
+    """Build the agent class registry and upsert agents for all workspaces.
 
-    The registry build triggers dynamic imports of all ~160 agent modules, which
-    is synchronous and CPU/IO-bound.  Running it via run_in_executor keeps the
-    event loop free during startup while ensuring the cache is hot before the
-    first GET /agents/ request arrives.
+    Runs in a background task so it does not block the event loop during
+    startup.  Any failure is logged but non-fatal — agents already in the DB
+    remain available.
     """
     _log = logging.getLogger(__name__)
     try:
-        from naas_abi.apps.nexus.apps.api.app.services.agents.adapters.primary.agents__primary_adapter__FastAPI import (
-            _get_agent_class_registry,
-        )
+        from naas_abi.apps.nexus.apps.api.app.core.agent_seed import seed_abi_agents
 
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(None, _get_agent_class_registry)
-        _log.info("✓ Agent class registry pre-populated at startup")
+        await seed_abi_agents()
+        _log.info("✓ ABI agent seed complete")
     except Exception:
-        _log.exception("Background agent registry pre-fetch failed (non-fatal)")
+        _log.exception("ABI agent seed failed (non-fatal)")
 
 
 async def _startup(app: FastAPI) -> None:
@@ -88,10 +84,10 @@ async def _startup(app: FastAPI) -> None:
     except Exception:
         logging.getLogger(__name__).exception("Unable to start chat ingestion consumer")
 
-    # Pre-populate the agent class registry in the background so the first
-    # GET /agents/ request returns instantly from cache instead of waiting
-    # for all agent modules to be imported.  create_task returns immediately.
-    asyncio.create_task(_prefetch_agent_class_registry())
+    # Seed ABI agents into the database in the background.  The task builds the
+    # class registry (once) and upserts all agent metadata per workspace so
+    # GET /agents/ only needs to query the DB.
+    asyncio.create_task(_seed_abi_agents())
 
     # # Auto-start Ollama and pull default model (Qwen3-VL:2b for vision demos)
     # print("Checking Ollama status...")

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/models.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/models.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from naas_abi.apps.nexus.apps.api.app.core.database import Base
 from naas_abi.apps.nexus.apps.api.app.core.datetime_compat import UTC
 from sqlalchemy import (
+    JSON,
     Boolean,
     Column,
     DateTime,
@@ -585,6 +586,8 @@ class AgentConfigModel(Base):
     )  # Provider name (xai, openai, anthropic, etc.)
     is_default = Column(Integer, nullable=False, default=0)
     enabled = Column(Boolean, nullable=False, default=False)  # Whether agent is available for chat
+    suggestions = Column(JSON, nullable=True)  # [{label, value}, ...]
+    intents = Column(JSON, nullable=True)  # [{intent_value, intent_type, ...}, ...]
     created_at = Column(DateTime(timezone=False), nullable=False, default=_utcnow)
     updated_at = Column(DateTime(timezone=False), nullable=False, default=_utcnow, onupdate=_utcnow)
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/agents/adapters/primary/agents__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/agents/adapters/primary/agents__primary_adapter__FastAPI.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import threading
 from dataclasses import replace
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -23,75 +22,8 @@ from naas_abi.apps.nexus.apps.api.app.services.registry import (
     get_service_registry,
 )
 from naas_abi_core import logger
-from naas_abi_core.services.agent.Agent import Agent
 
 router = APIRouter(dependencies=[Depends(get_current_user_required)])
-
-# ---------------------------------------------------------------------------
-# Process-level agent class registry cache
-#
-# Building this registry is expensive: it iterates every engine module and
-# triggers dynamic Python imports for all ~160 agent classes.  The classes
-# themselves never change at runtime, so we compute the mapping once and
-# reuse it for every subsequent request.
-# ---------------------------------------------------------------------------
-_agent_class_registry: dict[str, type[Agent]] | None = None
-_agent_class_registry_lock = threading.Lock()
-
-
-def _get_agent_class_registry() -> dict[str, type[Agent]]:
-    """Return (and lazily build) the process-level agent class registry.
-
-    Thread-safe double-checked locking ensures the expensive discovery runs
-    at most once even under concurrent first requests.  Agent classes are
-    resolved in parallel via a thread pool to minimise startup latency.
-    """
-    global _agent_class_registry
-
-    if _agent_class_registry is not None:
-        return _agent_class_registry
-
-    with _agent_class_registry_lock:
-        if _agent_class_registry is not None:
-            return _agent_class_registry
-
-        from concurrent.futures import ThreadPoolExecutor, as_completed
-
-        from naas_abi import ABIModule
-
-        abi_module = ABIModule.get_instance()
-        candidate_classes: list[type[Agent]] = list(abi_module.agents)
-
-        for module in abi_module.engine.modules.values():
-            for agent_cls in module.agents:
-                if agent_cls is None:
-                    continue
-                candidate_classes.append(agent_cls)
-
-        def _resolve(agent_cls: type[Agent]) -> tuple[str, type[Agent]] | None:
-            name = _get_agent_class_name(agent_cls)
-            if not name:
-                logger.warning(
-                    "Skipping agent %s because it has no resolvable name"
-                    " (use class attribute 'name' or 'NAME')",
-                    agent_cls,
-                )
-                return None
-            class_name = f"{agent_cls.__module__}/{agent_cls.__name__}"
-            return class_name, agent_cls
-
-        registry: dict[str, type[Agent]] = {}
-        with ThreadPoolExecutor() as executor:
-            futures = {executor.submit(_resolve, c): c for c in candidate_classes}
-            for future in as_completed(futures):
-                result = future.result()
-                if result is not None:
-                    class_name, agent_cls = result
-                    registry[class_name] = agent_cls
-
-        logger.info("Agent class registry built: %d agents indexed", len(registry))
-        _agent_class_registry = registry
-        return _agent_class_registry
 
 
 class AgentsFastAPIPrimaryAdapter:
@@ -111,91 +43,13 @@ def request_context(current_user: User) -> RequestContext:
     )
 
 
-def _extract_agent_suggestions(agent_cls: type) -> list[dict[str, str]] | None:
-    suggestions = getattr(agent_cls, "suggestions", None)
-    if not isinstance(suggestions, list):
-        return None
-
-    normalized: list[dict[str, str]] = []
-    for item in suggestions:
-        if not isinstance(item, dict):
-            continue
-        label = item.get("label")
-        value = item.get("value")
-        if isinstance(label, str) and isinstance(value, str):
-            normalized.append({"label": label, "value": value})
-    return normalized
-
-
-def _get_agent_class_name(agent_cls: type) -> str | None:
-    name = getattr(agent_cls, "name", None)
-    if isinstance(name, str):
-        return name
-    if isinstance(name, property):
-        name = getattr(agent_cls, "NAME", None)
-    return name if isinstance(name, str) else None
-
-
-def _get_agent_class_description(agent_cls: type) -> str | None:
-    desc = getattr(agent_cls, "description", None)
-    if isinstance(desc, str):
-        return desc
-    if isinstance(desc, property):
-        desc = getattr(agent_cls, "DESCRIPTION", None)
-    return desc if isinstance(desc, str) else None
-
-
-def _get_agent_system_prompt(agent_cls: type) -> str | None:
-    system_prompt = getattr(agent_cls, "system_prompt", None)
-    if isinstance(system_prompt, str):
-        return system_prompt
-    from naas_abi_core.services.agent.Agent import AgentConfiguration
-
-    config = AgentConfiguration()
-    return config.get_system_prompt([])
-
-
-def _extract_agent_intents(agent_cls: type) -> list[dict[str, str]] | None:
-    raw = getattr(agent_cls, "intents", None)
-    if not isinstance(raw, list) or not raw:
-        return None
-
-    output: list[dict[str, str]] = []
-    for item in raw:
-        if not hasattr(item, "intent_value") or not hasattr(item, "intent_type"):
-            continue
-
-        intent_payload: dict[str, str] = {
-            "intent_value": getattr(item, "intent_value", ""),
-            "intent_type": getattr(item.intent_type, "value", str(item.intent_type)),
-            "intent_target": str(getattr(item, "intent_target", "")),
-        }
-        scope = getattr(item, "intent_scope", None)
-        if scope is not None and hasattr(scope, "value"):
-            intent_payload["intent_scope"] = scope.value
-        else:
-            intent_payload["intent_scope"] = str(scope) if scope is not None else ""
-
-        output.append(intent_payload)
-
-    return output if output else None
-
-
 def _module_name_from_module_path(module_path: str | None) -> str | None:
     if not module_path:
         return None
-    # module_path is a Python module path, module "name" is the top-level package
-    # (e.g. naas_abi_marketplace from naas_abi_marketplace.applications.openrouter)
     return module_path.split(".", 1)[0] or None
 
 
 def _normalize_logo_path_for_module(logo_url: str, module_name: str) -> str:
-    """
-    Convert absolute/container paths like:
-      /app/libs/.../naas_abi_marketplace/.../logo.png
-    into module-relative paths like:
-      naas_abi_marketplace/.../logo.png
-    """
     if logo_url.startswith(f"{module_name}/"):
         return logo_url
     if logo_url.startswith(f"/{module_name}/"):
@@ -213,6 +67,28 @@ def _public_modules_url(path: str) -> str:
     return f"{public_api_host}/modules/{path.lstrip('/')}"
 
 
+def _resolve_logo_url(agent: AgentRecord) -> str | None:
+    """Convert a raw file-path logo_url stored in the DB to a public /modules URL."""
+    logo_url = agent.logo_url
+    if not isinstance(logo_url, str) or not logo_url:
+        return logo_url
+
+    module_path = agent.module_path
+    if not module_path and agent.class_name and "/" in agent.class_name:
+        module_path = agent.class_name.split("/", 1)[0] or None
+
+    module_name = _module_name_from_module_path(module_path)
+    if (
+        module_name
+        and module_name in logo_url
+        and not (logo_url.startswith("http://") or logo_url.startswith("https://"))
+    ):
+        normalized_path = _normalize_logo_path_for_module(logo_url, module_name)
+        return _public_modules_url(normalized_path)
+
+    return logo_url
+
+
 @router.get("/")
 async def list_agents(
     workspace_id: str | None = None,
@@ -224,98 +100,13 @@ async def list_agents(
 
     await require_workspace_access(current_user.id, workspace_id)
 
-    # Retrieve agent records from the database (fast)
     agent_list = await agent_service.list_workspace_agents(
         context=request_context(current_user),
         workspace_id=workspace_id,
     )
-    existing_agents_by_class_name = {
-        agent.class_name: agent for agent in agent_list if agent.class_name
-    }
 
-    # Retrieve the cached class registry — expensive only on the very first call
-    # (triggers dynamic Python imports for all agent modules).  Subsequent calls
-    # return instantly from the process-level cache.
-    class_name_to_agent_class = _get_agent_class_registry()
-
-    # Persist any newly discovered agent classes to the database
-    for class_name, agent_cls in class_name_to_agent_class.items():
-        if class_name in existing_agents_by_class_name:
-            continue
-
-        name = _get_agent_class_name(agent_cls)
-        description = _get_agent_class_description(agent_cls)
-        enabled = name == "Abi"
-
-        logger.debug("Creating agent in nexus backend: %s", name)
-        system_prompt = _get_agent_system_prompt(agent_cls)
-        created_agent = await agent_service.create_agent(
-            context=request_context(current_user),
-            data=AgentCreateInput(
-                name=name,
-                description=description or "",
-                workspace_id=workspace_id,
-                class_name=class_name,
-                module_path=getattr(agent_cls, "__module__", None),
-                provider="abi",
-                enabled=enabled,
-                system_prompt=system_prompt,
-            ),
-        )
-        agent_list.append(created_agent)
-        existing_agents_by_class_name[class_name] = created_agent
-
-    enriched_agent_list: list[AgentRecord] = []
-    for agent in agent_list:
-        suggestions = None
-        logo_url = None
-        intents = None
-        module_path = agent.module_path
-        if agent.class_name:
-            resolved_cls = class_name_to_agent_class.get(agent.class_name)
-            if resolved_cls is not None and isinstance(resolved_cls, type):
-                suggestions = _extract_agent_suggestions(resolved_cls)
-                logo_url = getattr(resolved_cls, "logo_url", None)
-                intents = _extract_agent_intents(resolved_cls)
-
-                # Backfill module_path (persist) when missing on existing DB records.
-                if not module_path:
-                    module_path = getattr(resolved_cls, "__module__", None)
-                    if module_path:
-                        updated = await agent_service.update_agent(
-                            context=request_context(current_user),
-                            agent_id=agent.id,
-                            updates=AgentUpdateInput(module_path=module_path),
-                        )
-                        if updated is not None:
-                            agent = updated
-
-        # If module_path is still missing but class_name is available, derive it from class_name.
-        if not module_path and agent.class_name and "/" in agent.class_name:
-            module_path = agent.class_name.split("/", 1)[0] or None
-
-        # Normalize logo_url to be module-relative, then convert to public /modules URL.
-        if isinstance(logo_url, str) and logo_url:
-            module_name = _module_name_from_module_path(module_path)
-            if (
-                module_name
-                and module_name in logo_url
-                and not (logo_url.startswith("http://") or logo_url.startswith("https://"))
-            ):
-                normalized_path = _normalize_logo_path_for_module(logo_url, module_name)
-                logo_url = _public_modules_url(normalized_path)
-
-        enriched_agent_list.append(
-            replace(
-                agent,
-                module_path=module_path,
-                suggestions=suggestions,
-                logo_url=logo_url,
-                intents=intents,
-            )
-        )
-
-    return enriched_agent_list
+    # Resolve logo_url from stored raw path to public /modules URL.
+    return [replace(agent, logo_url=_resolve_logo_url(agent)) for agent in agent_list]
 
 
 @router.post("/")

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/agents/adapters/secondary/postgres.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/agents/adapters/secondary/postgres.py
@@ -46,10 +46,12 @@ class AgentSecondaryAdapterPostgres(AgentPersistencePort):
             system_prompt=str(model.system_prompt),
             model_id=str(model.model_id),
             provider=str(model.provider),
-            logo_url=str(model.logo_url),
+            logo_url=str(model.logo_url) if model.logo_url is not None else None,
             enabled=bool(model.enabled),
             created_at=datetime.fromisoformat(str(model.created_at)),
             updated_at=datetime.fromisoformat(str(model.updated_at)),
+            suggestions=model.suggestions if isinstance(model.suggestions, list) else None,
+            intents=model.intents if isinstance(model.intents, list) else None,
         )
 
     async def list_by_workspace(self, workspace_id: str) -> list[AgentRecord]:
@@ -99,6 +101,8 @@ class AgentSecondaryAdapterPostgres(AgentPersistencePort):
             provider=data.provider,
             logo_url=data.logo_url,
             enabled=data.enabled,
+            suggestions=data.suggestions,
+            intents=data.intents,
         )
         self.db.add(agent_model)
         await self.db.commit()
@@ -123,6 +127,8 @@ class AgentSecondaryAdapterPostgres(AgentPersistencePort):
                 provider=data.provider,
                 logo_url=data.logo_url,
                 enabled=data.enabled,
+                suggestions=data.suggestions,
+                intents=data.intents,
             )
             self.db.add(model)
             models.append(model)
@@ -157,6 +163,10 @@ class AgentSecondaryAdapterPostgres(AgentPersistencePort):
             agent_model.logo_url = str(updates.logo_url)
         if updates.enabled is not None:
             agent_model.enabled = bool(updates.enabled)
+        if updates.suggestions is not None:
+            agent_model.suggestions = updates.suggestions
+        if updates.intents is not None:
+            agent_model.intents = updates.intents
 
         await self.db.commit()
         await self.db.refresh(agent_model)

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/agents/port.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/agents/port.py
@@ -46,6 +46,8 @@ class AgentCreateInput:
     provider: str | None = None
     logo_url: str | None = None
     enabled: bool = False
+    suggestions: list[dict[str, str]] | None = None
+    intents: list[dict[str, str]] | None = None
 
 
 @dataclass
@@ -59,6 +61,8 @@ class AgentUpdateInput:
     logo_url: str | None = None
     enabled: bool | None = None
     model: str | None = None
+    suggestions: list[dict[str, str]] | None = None
+    intents: list[dict[str, str]] | None = None
 
 
 class AgentPersistencePort(ABC):

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/migrations/0026_add_agent_suggestions_intents.sql
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/migrations/0026_add_agent_suggestions_intents.sql
@@ -1,0 +1,7 @@
+-- Migration: Add suggestions and intents columns to agent_configs table
+
+ALTER TABLE agent_configs ADD COLUMN IF NOT EXISTS suggestions JSONB;
+ALTER TABLE agent_configs ADD COLUMN IF NOT EXISTS intents JSONB;
+
+COMMENT ON COLUMN agent_configs.suggestions IS 'Suggested prompts for the agent (list of {label, value} objects)';
+COMMENT ON COLUMN agent_configs.intents IS 'Agent intents (list of intent descriptor objects)';


### PR DESCRIPTION
This pull request resolves **#nexus-list-agents**.

### Summary

This PR introduces a comprehensive seeding mechanism for ABI agents into the Nexus system database, ensuring agent metadata is systematically created or updated for each workspace upon application startup.

### Key Changes

- Added a new module `agent_seed.py` that builds a thread-safe, process-level registry of all ABI agent classes discovered dynamically.
- Implements logic to upsert agent metadata (name, description, logo URL, module path, suggestions, intents) in the database.
- Protects user-modifiable fields (enabled, system_prompt, model_id) from being overwritten during seeding.
- Supports parallel resolution of agent classes for efficient registry building.
- Added new JSON columns `suggestions` and `intents` to the `agent_configs` table for storing detailed agent metadata.
- Extended `AgentConfigModel` and related data transfer classes to include new `suggestions` and `intents` fields.
- Modified the Postgres agent secondary adapter to read and write these new fields.
- Refactored agent listing endpoint to remove runtime dynamic discovery logic; it now relies on seeded data ensuring faster response and less runtime overhead.
- Introduced proper logo URL normalization that converts raw file paths (stored in the DB) into public module URLs.
- Agent registry prefetch replaced with background task to perform full ABI agent seeding (`seed_abi_agents`) during app startup.
- The ABI agent seeding runs asynchronously on startup, maintaining non-blocking event loop behavior and ensuring agents are ready in the DB without impacting response times.

### Benefits

Improved startup efficiency and runtime performance due to pre-seeded agent data; persistent storage and querying of agent suggestions and intents for richer client experiences; safer handling of user-controlled fields by separating seeding updates from user edits; and a cleaner, more maintainable codebase by consolidating agent discovery and seeding logic.

### Miscellaneous

Added `.pnpm-store/` and `node_modules/` to `.gitignore` for cleanup. Includes SQL migration for the new agent config columns.

This change sets the foundation for consistent and scalable ABI agent management in Nexus.