### PR TITLE
perf: cut API boot time from ~13.8s to ~9.9s

### DIFF
--- a/libs/naas-abi-core/naas_abi_core/apps/api/api.py
+++ b/libs/naas-abi-core/naas_abi_core/apps/api/api.py
@@ -264,6 +264,19 @@ def _load_runtime_routes():
     for module in runtime_engine.modules.values():
         module.api(app)
 
+    # Kick off background warmup of every IntentMapper's vector index. We
+    # deferred this work out of agent __init__ to keep boot fast; doing it
+    # now in the background means the index is normally ready before the
+    # first chat request arrives. If a request does race it, the request's
+    # `_ensure_index` call will block briefly on the same lock and reuse
+    # whatever the warmup has already built.
+    try:
+        from naas_abi_core.services.agent.beta.IntentMapper import IntentMapper
+
+        IntentMapper.warm_all_in_background()
+    except Exception as exc:
+        logger.warning(f"Could not start intent-index warmup thread: {exc}")
+
     app.state.runtime_routes_loaded = True
 
 

--- a/libs/naas-abi-core/naas_abi_core/services/agent/CoordinatorAgent.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/CoordinatorAgent.py
@@ -208,9 +208,11 @@ class CoordinatorAgent(IntentAgent):
         if not self._agents:
             return Command(goto="coordinator_refusal")
 
-        # Step 1 — vector pre-filter for fallback suggestions
+        # Step 1 — vector pre-filter for fallback suggestions.
+        # The intent vector index is built lazily on first use, so we gate
+        # this on whether intents exist (not on `vector_store is not None`).
         raw_candidates: list[dict] = []
-        if self._intent_mapper.vector_store is not None:
+        if self._intent_mapper.intents:
             raw_candidates = [
                 r
                 for r in self._intent_mapper.map_intent(

--- a/libs/naas-abi-core/naas_abi_core/services/agent/beta/IntentMapper.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/beta/IntentMapper.py
@@ -1,3 +1,5 @@
+import threading
+import weakref
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from enum import Enum
@@ -6,6 +8,7 @@ from typing import Any, Optional, Tuple
 from langchain_core.embeddings import Embeddings
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
+from naas_abi_core import logger
 from naas_abi_core.services.cache.CacheFactory import CacheFactory
 from naas_abi_core.services.cache.CachePort import DataType
 
@@ -41,6 +44,11 @@ class IntentMapper:
     system_prompt: str
     embedding_workers: int
 
+    # Weak refs to every live IntentMapper so a single helper can warm them
+    # all from a background thread after API boot completes.
+    _instances: "weakref.WeakSet[IntentMapper]" = weakref.WeakSet()
+    _instances_lock = threading.Lock()
+
     def __init__(
         self,
         intents: list[Intent],
@@ -56,18 +64,80 @@ class IntentMapper:
         self.vector_store = None
         self.embedding_workers = max(1, int(embedding_workers))
 
-        # if embedding_model is None:
-        #     logger.warning(
-        #         "No embedding_model provided to IntentMapper; using default OpenAIEmbeddings "
-        #         "model='text-embedding-3-large'."
-        #     )
-        # if model is None:
-        #     logger.warning(
-        #         "No model provided to IntentMapper; using default ChatOpenAI model='gpt-4.1-mini'."
-        #     )
+        # Lazy-index state. Embedding + Qdrant upsert used to happen here in
+        # __init__; cProfile showed it cost ~280ms per agent (mostly Qdrant
+        # client-side pydantic schema work) and was the dominant boot cost
+        # when constructing many agents. We defer the work to the first
+        # `map_intent` / `map_prompt` call. The lock guards against two
+        # concurrent requests racing the first-time build. In production a
+        # background warmup thread (see `warm_all`) typically builds the
+        # index before any request arrives, so the latency is invisible.
+        self._index_lock = threading.Lock()
+        self._index_built = False
 
-        intents_values = [intent.intent_value for intent in intents]
-        if len(intents_values) > 0:
+        with IntentMapper._instances_lock:
+            IntentMapper._instances.add(self)
+
+        # Set the system prompt
+        self.system_prompt = """
+You are an intent mapper. The user will send you a prompt and you should output the intent and the intent only. If the user references a technology, you must have the name of the technology in the intent.
+
+Example:
+User: 3 / 4 + 5
+You: calculate an arithmetic result
+
+User: I need to write a report about the latest trends in AI.
+You: write a report
+
+User: I need to code a project.
+You: code a project
+"""
+
+    @classmethod
+    def warm_all_in_background(cls) -> threading.Thread:
+        """Start a daemon thread that builds the vector index for every live
+        IntentMapper instance. Returns the thread (for tests / instrumentation).
+
+        Safe to call multiple times — `_ensure_index` is idempotent. If a
+        chat request races the warmup, the request's call to `_ensure_index`
+        will block briefly on the same lock and reuse the result.
+        """
+
+        def _warm():
+            with cls._instances_lock:
+                mappers = list(cls._instances)
+            logger.debug(
+                f"Warming intent index for {len(mappers)} IntentMapper instances "
+                f"in background."
+            )
+            for mapper in mappers:
+                try:
+                    mapper._ensure_index()
+                except Exception as exc:
+                    logger.warning(
+                        f"Background intent-index warmup failed for one mapper: {exc}"
+                    )
+            logger.debug("Intent index background warmup complete.")
+
+        thread = threading.Thread(
+            target=_warm, name="intent-index-warmup", daemon=True
+        )
+        thread.start()
+        return thread
+
+    def _ensure_index(self) -> None:
+        """Build the vector index on first use. Idempotent and thread-safe."""
+        if self._index_built:
+            return
+        with self._index_lock:
+            if self._index_built:
+                return
+
+            intents_values = [intent.intent_value for intent in self.intents]
+            if len(intents_values) == 0:
+                self._index_built = True
+                return
+
             if len(intents_values) <= 1 or self.embedding_workers <= 1:
                 vectors = self._embed_documents(intents_values)
             else:
@@ -104,21 +174,7 @@ class IntentMapper:
                 embeddings=vectors,
                 metadatas=metadatas,
             )
-
-        # Set the system prompt
-        self.system_prompt = """
-You are an intent mapper. The user will send you a prompt and you should output the intent and the intent only. If the user references a technology, you must have the name of the technology in the intent.
-
-Example:
-User: 3 / 4 + 5
-You: calculate an arithmetic result
-
-User: I need to write a report about the latest trends in AI.
-You: write a report
-
-User: I need to code a project.
-You: code a project
-"""
+            self._index_built = True
 
     def get_intent_from_value(self, value: str) -> Intent | None:
         for intent in self.intents:
@@ -137,6 +193,7 @@ You: code a project
         return self._embedding_model.embed_query(text)
 
     def map_intent(self, intent: str, k: int = 1) -> list[dict]:
+        self._ensure_index()
         if self.vector_store is None:
             return []
 

--- a/libs/naas-abi-core/naas_abi_core/services/triple_store/TripleStoreService.py
+++ b/libs/naas-abi-core/naas_abi_core/services/triple_store/TripleStoreService.py
@@ -3,6 +3,8 @@ import hashlib
 import io
 import os
 import uuid
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
 from typing import Callable, List
 
 import rdflib
@@ -13,7 +15,14 @@ from naas_abi_core.services.triple_store.TripleStorePorts import (
     ITripleStoreService,
     OntologyEvent,
 )
-from rdflib import RDF, Graph, URIRef
+from rdflib import Graph, URIRef
+
+
+@dataclass(frozen=True)
+class _SchemaIndexEntry:
+    subject: URIRef
+    hash: str
+    file_last_update_time: str
 
 SCHEMA_TTL = """
 @prefix internal: <http://triple-store.internal#> .
@@ -215,279 +224,241 @@ class TripleStoreService(ServiceBase, ITripleStoreService):
     # Schema Management
     ############################################################
 
-    def load_schemas(self, filepaths: List[str]):
-        # First build a cache of all schemas to speed up the process.
-        schema_cache = Graph()
+    def _build_schema_index(
+        self, filepath_filter: str | None = None
+    ) -> dict[str, list[_SchemaIndexEntry]]:
+        """Read stored Schema metadata into a plain Python dict.
 
+        The index is keyed by filePath and contains one entry per stored
+        Schema subject (lists allow detecting duplicate metadata). We
+        intentionally do NOT include `content` here — it can be megabytes
+        and is only needed when a file has actually changed (rare). Fetched
+        on demand via `_fetch_schema_content`.
+
+        A plain dict is used (rather than an rdflib Graph) because the index
+        is read concurrently from multiple worker threads, and rdflib's
+        SPARQL/turtle parser uses pyparsing which has thread-unsafe global
+        state. Python dicts are safe to read concurrently.
+        """
+        filter_clause = (
+            f'FILTER(STR(?filePath) = "{filepath_filter}") .'
+            if filepath_filter is not None
+            else ""
+        )
         results = self.query(f"""
             PREFIX internal: <http://triple-store.internal#>
-            SELECT ?schema ?filePath ?hash ?fileLastUpdateTime ?content
+            SELECT ?schema ?filePath ?hash ?fileLastUpdateTime
             WHERE {{
                 GRAPH <{str(self.__schema_graph)}> {{
-                ?schema a internal:Schema ;
-                    internal:filePath ?filePath ;
-                    internal:hash ?hash ;
-                    internal:fileLastUpdateTime ?fileLastUpdateTime ;
-                    internal:content ?content .
+                    ?schema a internal:Schema ;
+                        internal:filePath ?filePath ;
+                        internal:hash ?hash ;
+                        internal:fileLastUpdateTime ?fileLastUpdateTime .
+                    {filter_clause}
                 }}
             }}
         """)
-
+        index: dict[str, list[_SchemaIndexEntry]] = {}
         for row in results:
             assert isinstance(row, rdflib.query.ResultRow)
-            schema, filePath, hash, fileLastUpdateTime, content = row
-            schema_cache.add(
-                (schema, RDF.type, URIRef("http://triple-store.internal#Schema"))
-            )
-            schema_cache.add(
-                (schema, URIRef("http://triple-store.internal#filePath"), filePath)
-            )
-            schema_cache.add(
-                (schema, URIRef("http://triple-store.internal#hash"), hash)
-            )
-            schema_cache.add(
-                (
-                    schema,
-                    URIRef("http://triple-store.internal#fileLastUpdateTime"),
-                    fileLastUpdateTime,
+            schema, filePath, h, t = row
+            assert isinstance(schema, URIRef)
+            index.setdefault(str(filePath), []).append(
+                _SchemaIndexEntry(
+                    subject=schema,
+                    hash=str(h),
+                    file_last_update_time=str(t),
                 )
             )
-            schema_cache.add(
-                (schema, URIRef("http://triple-store.internal#content"), content)
-            )
+        return index
 
-        for filepath in filepaths:
-            self.load_schema(filepath, schema_cache)
-
-    def load_schema(self, filepath: str, schema_cache: Graph | None = None):
-        # logger.debug(f"Loading schema: {filepath}")
-        if schema_cache is not None:
-
-            def _read_query_func(query: str):
-                return schema_cache.query(query)
-
-            read_query_func = _read_query_func
-        else:
-            read_query_func = self.query
-
-        def _load_schema_metadata(subject: URIRef) -> dict[str, str]:
-            triples: rdflib.query.Result = read_query_func(
-                f"""
-                PREFIX internal: <http://triple-store.internal#>
-                SELECT ?p ?o 
-                WHERE {{
-                    GRAPH <{str(self.__schema_graph)}> {{
-                        <{subject}> ?p ?o .
-                    }}
-                }}
-                """
-            )
-
-            schema_dict: dict[str, str] = {}
-            for row in triples:
-                assert isinstance(row, rdflib.query.ResultRow)
-                p, o = row
-                schema_dict[str(p).replace("http://triple-store.internal#", "")] = str(
-                    o
-                )
-
-            return schema_dict
-
-        def _remove_schema_subject(subject: URIRef) -> None:
-            triples: rdflib.query.Result = read_query_func(
-                f"""
-                SELECT ?p ?o 
-                WHERE {{ 
-                    GRAPH <{str(self.__schema_graph)}> {{ 
-                    <{str(subject)}> ?p ?o . 
-                    }} 
-                }}
-                """
-            )
-
-            cleanup_graph = Graph()
-            for row in triples:
-                assert isinstance(row, rdflib.query.ResultRow)
-                p, o = row
-                cleanup_graph.add((subject, p, o))
-
-            if len(cleanup_graph) > 0:
-                self.remove(cleanup_graph, graph_name=self.__schema_graph)
-
-        try:
-            query = f"""
+    def _fetch_schema_content(self, subject: URIRef) -> str | None:
+        results = self.query(
+            f"""
             PREFIX internal: <http://triple-store.internal#>
-
-            SELECT *
+            SELECT ?content
             WHERE {{
                 GRAPH <{str(self.__schema_graph)}> {{
-                    ?s internal:filePath "{filepath}" .
+                    <{str(subject)}> internal:content ?content .
                 }}
             }}
             """
-            # logger.debug(f"Query: {query}")
-            # Check if schema with filePath == filepath already exists and grab all triples.
-            schema_triples: rdflib.query.Result = read_query_func(query)
+        )
+        for row in results:
+            assert isinstance(row, rdflib.query.ResultRow)
+            return str(row[0])
+        return None
 
-            schema_rows = list(schema_triples)
-            # logger.debug(f"len(schema_rows): {len(schema_rows)}")
-            # If schema with filePath == filepath already exists, we check if the file has been modified.
-            schema_exists_in_store = len(schema_rows) > 0
-            # logger.debug(f"Schema exists in store: {schema_exists_in_store}")
-            if schema_exists_in_store:
-                # Open file and get content.
-                with open(filepath, "r") as file:
-                    new_content = file.read()
+    def _remove_schema_subject(self, subject: URIRef) -> None:
+        triples = self.query(
+            f"""
+            SELECT ?p ?o
+            WHERE {{
+                GRAPH <{str(self.__schema_graph)}> {{
+                    <{str(subject)}> ?p ?o .
+                }}
+            }}
+            """
+        )
+        cleanup_graph = Graph()
+        for row in triples:
+            assert isinstance(row, rdflib.query.ResultRow)
+            p, o = row
+            cleanup_graph.add((subject, p, o))
+        if len(cleanup_graph) > 0:
+            self.remove(cleanup_graph, graph_name=self.__schema_graph)
 
-                new_content_hash = hashlib.sha256(
-                    new_content.encode("utf-8")
-                ).hexdigest()
+    def load_schemas(self, filepaths: List[str]):
+        """Parallel schema load. See `_apply_schema_for_file` for per-file logic."""
+        if not filepaths:
+            return
 
-                schema_entries: list[tuple[URIRef, dict[str, str]]] = []
-                for row in schema_rows:
-                    assert isinstance(row, rdflib.query.ResultRow)
-                    _SUBJECT_TUPLE_INDEX = 0
-                    subject = row[_SUBJECT_TUPLE_INDEX]
-                    assert isinstance(subject, URIRef)
-                    schema_entries.append((subject, _load_schema_metadata(subject)))
+        index = self._build_schema_index()
 
-                matching_entry = next(
-                    (
-                        (subject, schema_dict)
-                        for subject, schema_dict in schema_entries
-                        if schema_dict.get("hash") == new_content_hash
-                    ),
-                    None,
+        # Parallelize per-file work. For unchanged files this is just file I/O
+        # + SHA-256 + dict lookup — no Fuseki traffic at all. For changed/new
+        # files it also includes Fuseki writes; those overlap across workers.
+        # The shared `index` dict is read-only during this loop.
+        max_workers = min(8, len(filepaths))
+        with ThreadPoolExecutor(
+            max_workers=max_workers, thread_name_prefix="ts-schema-load"
+        ) as executor:
+            futures = [
+                executor.submit(
+                    self._apply_schema_for_file, filepath, index.get(filepath, [])
                 )
+                for filepath in filepaths
+            ]
+            for future in futures:
+                future.result()
 
-                if matching_entry is not None:
-                    subject, schema_dict = matching_entry
-                else:
-                    subject, schema_dict = schema_entries[0]
+    def load_schema(self, filepath: str, schema_cache: Graph | None = None):
+        """Single-file schema load. `schema_cache` is accepted for backward
+        compatibility but ignored — we always look up via a filtered query."""
+        del schema_cache  # legacy param, no longer used
+        entries = self._build_schema_index(filepath_filter=filepath).get(filepath, [])
+        self._apply_schema_for_file(filepath, entries)
 
-                # Get file last update time
-                file_last_update_time = os.path.getmtime(filepath)
+    def _apply_schema_for_file(
+        self, filepath: str, entries: List[_SchemaIndexEntry]
+    ) -> None:
+        try:
+            if not entries:
+                self._insert_new_schema(filepath)
+                return
 
-                duplicate_subjects = [
-                    candidate_subject
-                    for candidate_subject, _ in schema_entries
-                    if candidate_subject != subject
-                ]
+            with open(filepath, "r") as file:
+                new_content = file.read()
+            new_content_hash = hashlib.sha256(
+                new_content.encode("utf-8")
+            ).hexdigest()
 
-                # If fileLastUpdateTime is the same, return. Otherwise we continue as we need to update the schema.
-                if schema_dict["hash"] == new_content_hash:
-                    if len(duplicate_subjects) > 0:
-                        logger.debug(
-                            f"Cleaning up {len(duplicate_subjects)} duplicate schema metadata entries for {filepath}."
-                        )
-                        for duplicate_subject in duplicate_subjects:
-                            _remove_schema_subject(duplicate_subject)
+            matching = next(
+                (e for e in entries if e.hash == new_content_hash), None
+            )
+            primary = matching if matching is not None else entries[0]
+            duplicate_subjects = [
+                e.subject for e in entries if e.subject != primary.subject
+            ]
 
-                    # logger.debug("Schema is up to date, no need to update.")
-                    return
-
-                logger.debug(f"Loading schema: '{filepath}'")
-
-                # Decode old content
-                old_content = base64.b64decode(schema_dict["content"]).decode("utf-8")
-
-                # Parse old and new schema
-                old_schema = Graph().parse(io.StringIO(old_content), format="turtle")
-
-                new_schema = Graph().parse(io.StringIO(new_content), format="turtle")
-
-                # Compute addition and deletion triples
-                addition_triples = new_schema - old_schema
-                deletion_triples = old_schema - new_schema
-
-                # Insert addition and remove deletion triples
-                self.insert(addition_triples, graph_name=self.__schema_graph)
-                self.remove(deletion_triples, graph_name=self.__schema_graph)
-
-                # Update schema information in the triple store.
-
-                self.remove(
-                    Graph().parse(
-                        io.StringIO(f'''
-                    @prefix internal: <http://triple-store.internal#> .
-                    
-                    <{subject}> internal:hash "{schema_dict["hash"]}" ;
-                        internal:fileLastUpdateTime "{schema_dict["fileLastUpdateTime"]}" ;
-                        internal:content "{schema_dict["content"]}" .
-                '''),
-                        format="turtle",
-                    ),
-                    graph_name=self.__schema_graph,
-                )
-
-                self.insert(
-                    Graph().parse(
-                        io.StringIO(f'''
-                    @prefix internal: <http://triple-store.internal#> .
-                    
-                    <{subject}> internal:hash "{new_content_hash}" ;
-                        internal:fileLastUpdateTime "{file_last_update_time}" ;
-                        internal:content "{base64.b64encode(new_content.encode("utf-8")).decode("utf-8")}" .
-                '''),
-                        format="turtle",
-                    ),
-                    graph_name=self.__schema_graph,
-                )
-
-                if len(duplicate_subjects) > 0:
+            if primary.hash == new_content_hash:
+                if duplicate_subjects:
                     logger.debug(
-                        f"Cleaning up {len(duplicate_subjects)} duplicate schema metadata entries for {filepath}."
+                        f"Cleaning up {len(duplicate_subjects)} duplicate schema "
+                        f"metadata entries for {filepath}."
                     )
                     for duplicate_subject in duplicate_subjects:
-                        _remove_schema_subject(duplicate_subject)
-
-                # Return as we don't need to continue as we have already updated the schema.
+                        self._remove_schema_subject(duplicate_subject)
                 return
-            elif not schema_exists_in_store:
-                logger.debug("Loading schema in graph as it doesn't exist in store.")
 
-                # Open file and get content.
-                with open(filepath, "r") as file:
-                    content = file.read()
+            logger.debug(f"Loading schema: '{filepath}'")
 
-                # Compute base64 content
-                base64_content = base64.b64encode(content.encode("utf-8")).decode(
-                    "utf-8"
+            old_content_b64 = self._fetch_schema_content(primary.subject)
+            if old_content_b64 is None:
+                raise ValueError(
+                    f"Schema metadata for '{filepath}' is missing stored content."
                 )
+            old_content = base64.b64decode(old_content_b64).decode("utf-8")
 
-                # Compute hash of content
-                content_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
+            old_schema = Graph().parse(io.StringIO(old_content), format="turtle")
+            new_schema = Graph().parse(io.StringIO(new_content), format="turtle")
 
-                # Parse schema
-                g = Graph().parse(filepath)
+            addition_triples = new_schema - old_schema
+            deletion_triples = old_schema - new_schema
+            self.insert(addition_triples, graph_name=self.__schema_graph)
+            self.remove(deletion_triples, graph_name=self.__schema_graph)
 
-                # Insert schema into the triple store
-                self.insert(g, graph_name=self.__schema_graph)
+            file_last_update_time = os.path.getmtime(filepath)
 
-                # Get file last update time
-                file_last_update_time = os.path.getmtime(filepath)
+            self.remove(
+                Graph().parse(
+                    io.StringIO(f'''
+                @prefix internal: <http://triple-store.internal#> .
 
-                # Insert Schema with hash, filePath, fileLastUpdateTime and content to be able to track changes.
-                self.insert(
-                    Graph().parse(
-                        io.StringIO(f'''
-                    @prefix internal: <http://triple-store.internal#> .
-                                                    
-                    <http://triple-store.internal/{uuid.uuid4()}> a internal:Schema ;
-                        internal:hash "{content_hash}" ;
-                        internal:filePath "{filepath}" ;
-                        internal:fileLastUpdateTime "{file_last_update_time}" ;
-                        internal:content "{base64_content}" .
-                '''),
-                        format="turtle",
-                    ),
-                    graph_name=self.__schema_graph,
+                <{primary.subject}> internal:hash "{primary.hash}" ;
+                    internal:fileLastUpdateTime "{primary.file_last_update_time}" ;
+                    internal:content "{old_content_b64}" .
+            '''),
+                    format="turtle",
+                ),
+                graph_name=self.__schema_graph,
+            )
+            self.insert(
+                Graph().parse(
+                    io.StringIO(f'''
+                @prefix internal: <http://triple-store.internal#> .
+
+                <{primary.subject}> internal:hash "{new_content_hash}" ;
+                    internal:fileLastUpdateTime "{file_last_update_time}" ;
+                    internal:content "{base64.b64encode(new_content.encode("utf-8")).decode("utf-8")}" .
+            '''),
+                    format="turtle",
+                ),
+                graph_name=self.__schema_graph,
+            )
+
+            if duplicate_subjects:
+                logger.debug(
+                    f"Cleaning up {len(duplicate_subjects)} duplicate schema "
+                    f"metadata entries for {filepath}."
                 )
+                for duplicate_subject in duplicate_subjects:
+                    self._remove_schema_subject(duplicate_subject)
         except Exception as e:
             import traceback
 
             logger.error(f"Error loading schema ({filepath}): {str(e)}")
             traceback.print_exc()
+
+    def _insert_new_schema(self, filepath: str) -> None:
+        logger.debug("Loading schema in graph as it doesn't exist in store.")
+
+        with open(filepath, "r") as file:
+            content = file.read()
+
+        base64_content = base64.b64encode(content.encode("utf-8")).decode("utf-8")
+        content_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+        g = Graph().parse(filepath)
+        self.insert(g, graph_name=self.__schema_graph)
+
+        file_last_update_time = os.path.getmtime(filepath)
+
+        self.insert(
+            Graph().parse(
+                io.StringIO(f'''
+            @prefix internal: <http://triple-store.internal#> .
+
+            <http://triple-store.internal/{uuid.uuid4()}> a internal:Schema ;
+                internal:hash "{content_hash}" ;
+                internal:filePath "{filepath}" ;
+                internal:fileLastUpdateTime "{file_last_update_time}" ;
+                internal:content "{base64_content}" .
+        '''),
+                format="turtle",
+            ),
+            graph_name=self.__schema_graph,
+        )
 
     def remove_schema(self, filepath: str):
         logger.debug(f"Removing schema: {filepath}")

--- a/libs/naas-abi-core/naas_abi_core/services/triple_store/TripleStoreService_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/triple_store/TripleStoreService_test.py
@@ -10,7 +10,7 @@ from naas_abi_core.services.triple_store.TripleStorePorts import (
     OntologyEvent,
 )
 from naas_abi_core.services.triple_store.TripleStoreService import TripleStoreService
-from rdflib import Graph, Literal, RDF, URIRef
+from rdflib import ConjunctiveGraph, Graph, Literal, RDF, URIRef
 
 
 class _FakeBus:
@@ -80,21 +80,28 @@ class _FakeTripleStoreAdapter(ITripleStorePort):
 
 class _InMemoryTripleStoreAdapter(ITripleStorePort):
     def __init__(self) -> None:
-        self.graph = Graph()
+        # ConjunctiveGraph supports named graphs and the SPARQL `GRAPH <...>`
+        # syntax that the service uses for schema metadata storage.
+        self.graph = ConjunctiveGraph()
         self.insert_calls: list[tuple[Graph, URIRef | None]] = []
         self.remove_calls: list[tuple[Graph, URIRef | None]] = []
 
+    def _named_graph(self, graph_name: URIRef | None) -> Graph:
+        if graph_name is None:
+            return self.graph.default_context
+        return self.graph.get_context(graph_name)
+
     def insert(self, triples: Graph, graph_name: URIRef | None = None):
-        if graph_name is not None:
-            raise NotImplementedError
         self.insert_calls.append((triples, graph_name))
-        self.graph += triples
+        target = self._named_graph(graph_name)
+        for triple in triples:
+            target.add(triple)
 
     def remove(self, triples: Graph, graph_name: URIRef | None = None):
-        if graph_name is not None:
-            raise NotImplementedError
         self.remove_calls.append((triples, graph_name))
-        self.graph -= triples
+        target = self._named_graph(graph_name)
+        for triple in triples:
+            target.remove(triple)
 
     def get(self) -> Graph:
         return self.graph
@@ -352,7 +359,10 @@ ex:Thing a ex:Class .
 ''',
         format="turtle",
     )
-    service.insert(duplicate_metadata)
+    service.insert(
+        duplicate_metadata,
+        graph_name=URIRef("http://ontology.naas.ai/graph/schema"),
+    )
 
     before_rows = list(
         service.query(
@@ -381,3 +391,44 @@ SELECT ?s WHERE {{
     assert len(after_rows) == 1
     assert len(adapter.insert_calls) == insert_count_before_reload
     assert len(adapter.remove_calls) >= 1
+
+
+def test_load_schemas_indexes_each_file_exactly_once(tmp_path):
+    adapter = _InMemoryTripleStoreAdapter()
+    service = TripleStoreService(adapter)
+
+    filepaths: list[str] = []
+    for i in range(16):
+        path = tmp_path / f"schema-{i}.ttl"
+        path.write_text(
+            f"""@prefix ex: <http://example.org/{i}/> .
+
+ex:Thing{i} a ex:Class .
+""",
+            encoding="utf-8",
+        )
+        filepaths.append(str(path))
+
+    service.load_schemas(filepaths)
+
+    # Each file should be tracked by exactly one Schema entry.
+    rows = list(
+        service.query(
+            """PREFIX internal: <http://triple-store.internal#>
+SELECT ?filePath (COUNT(?s) AS ?n) WHERE {
+    GRAPH <http://ontology.naas.ai/graph/schema> {
+        ?s a internal:Schema ; internal:filePath ?filePath .
+    }
+} GROUP BY ?filePath"""
+        )
+    )
+    counts = {str(filePath): int(n) for filePath, n in rows}
+    for filepath in filepaths:
+        assert counts.get(filepath) == 1, f"missing or duplicated: {filepath}"
+
+    # A second pass over unchanged files should be a no-op (cache hit).
+    inserts_before = len(adapter.insert_calls)
+    removes_before = len(adapter.remove_calls)
+    service.load_schemas(filepaths)
+    assert len(adapter.insert_calls) == inserts_before
+    assert len(adapter.remove_calls) == removes_before

--- a/libs/naas-abi-core/naas_abi_core/utils/onto2py/onto2py.py
+++ b/libs/naas-abi-core/naas_abi_core/utils/onto2py/onto2py.py
@@ -1,3 +1,4 @@
+import hashlib
 import io
 import os
 import re
@@ -11,6 +12,8 @@ from typing import Dict, List, Optional, Set
 import rdflib
 from rdflib import BNode
 from rdflib.collection import Collection
+
+_CACHE_MARKER_PREFIX = "# onto2py-source-sha256: "
 
 
 @dataclass
@@ -577,6 +580,17 @@ def onto2py(ttl_file: str | io.TextIOBase, overwrite: bool = False) -> str:
         ttl_file_path = ttl_file
         with open(ttl_file, "r") as f:
             content = f.read()
+
+        # Short-circuit: if the generated .py file already exists and was
+        # produced from the same TTL content (matching SHA-256 marker), skip
+        # the expensive rdflib parse + code generation + ruff format. This is
+        # the common case on boot — TTL files don't change across restarts.
+        if not overwrite:
+            ttl_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
+            cached_code = _read_cached_python(ttl_file_path, ttl_hash)
+            if cached_code is not None:
+                return cached_code
+
         g = rdflib.Graph()
         g.parse(data=content, format="turtle")
     else:
@@ -717,20 +731,26 @@ def onto2py(ttl_file: str | io.TextIOBase, overwrite: bool = False) -> str:
     if ttl_file_path:
         py_file = Path(ttl_file_path).with_suffix(".py")
 
+        # Embed the source hash so future calls can short-circuit before parsing.
+        ttl_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        python_code_with_marker = (
+            f"{_CACHE_MARKER_PREFIX}{ttl_hash}\n{python_code}"
+        )
+
         # Read the existing file if it exists
         if py_file.exists():
             with open(py_file, "r") as f:
                 existing_code = f.read()
-            if existing_code == python_code:
+            if existing_code == python_code_with_marker:
                 print(f"✅ {ttl_file_path} already converted to {py_file}")
             else:
                 with open(py_file, "w") as f:
-                    f.write(python_code)
+                    f.write(python_code_with_marker)
                 _run_ruff([str(py_file)])
                 print(f"✅ Successfully converted {ttl_file_path} to {py_file}")
         else:
             with open(py_file, "w") as f:
-                f.write(python_code)
+                f.write(python_code_with_marker)
             _run_ruff([str(py_file)])
             print(f"✅ Successfully converted {ttl_file_path} to {py_file}")
 
@@ -738,6 +758,29 @@ def onto2py(ttl_file: str | io.TextIOBase, overwrite: bool = False) -> str:
         create_class_files(ttl_file_path, classes, py_file, overwrite)
 
     return python_code
+
+
+def _read_cached_python(ttl_file_path: str, ttl_hash: str) -> Optional[str]:
+    """Return cached .py content if it was generated from the same TTL hash.
+
+    The cache marker is written near the top of the generated .py file. We
+    look for it within the first handful of lines so a formatter (ruff) is
+    free to add a blank line or shuffle imports without invalidating cache.
+    """
+    py_file = Path(ttl_file_path).with_suffix(".py")
+    if not py_file.exists():
+        return None
+    expected = f"{_CACHE_MARKER_PREFIX}{ttl_hash}"
+    try:
+        with open(py_file, "r") as f:
+            content = f.read()
+    except OSError:
+        return None
+    head = content.split("\n", 10)[:10]
+    for line in head:
+        if line.strip() == expected:
+            return content
+    return None
 
 
 def get_label(g: rdflib.Graph, resource) -> Optional[str]:

--- a/libs/naas-abi-core/naas_abi_core/utils/onto2py/tests/ttl2py_test.py
+++ b/libs/naas-abi-core/naas_abi_core/utils/onto2py/tests/ttl2py_test.py
@@ -1,4 +1,5 @@
 from io import StringIO
+from unittest.mock import patch
 
 import pytest
 import rdflib
@@ -349,3 +350,49 @@ ex:mentionOf rdf:type owl:ObjectProperty ;
     # Model builds without NameError; the value is a URI string.
     instance = module.Mention(mention_of=["http://example.org/SomeClass"])
     assert instance.mention_of == ["http://example.org/SomeClass"]
+
+
+def test_onto2py_skips_parsing_on_unchanged_ttl(tmp_path):
+    """When the TTL file hasn't changed, onto2py must not re-parse it.
+
+    The marker line written into the generated .py lets us short-circuit
+    before any rdflib work — which is what makes engine boot fast on warm
+    starts.
+    """
+    ttl = tmp_path / "schema.ttl"
+    ttl.write_text(
+        """@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+ex:Widget rdf:type owl:Class ;
+    rdfs:label "Widget" ;
+    rdfs:comment "A simple test class" .
+""",
+        encoding="utf-8",
+    )
+
+    # First call: must actually parse and generate.
+    first = onto2py(str(ttl))
+    py_file = ttl.with_suffix(".py")
+    assert py_file.exists()
+    assert "class Widget" in first
+
+    # Second call with unchanged content: rdflib.Graph.parse must not run.
+    with patch(
+        "naas_abi_core.utils.onto2py.onto2py.rdflib.Graph.parse"
+    ) as mock_parse:
+        second = onto2py(str(ttl))
+    mock_parse.assert_not_called()
+    assert "class Widget" in second
+
+    # Editing the TTL should invalidate the cache: the new run must include
+    # the freshly added class (proving rdflib actually re-parsed).
+    ttl.write_text(
+        ttl.read_text(encoding="utf-8")
+        + "\nex:Gadget rdf:type owl:Class ; rdfs:label \"Gadget\" .\n",
+        encoding="utf-8",
+    )
+    third = onto2py(str(ttl))
+    assert "class Gadget" in third

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/domains/document/ontologies/modules/DocumentOntology.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/domains/document/ontologies/modules/DocumentOntology.py
@@ -1,3 +1,4 @@
+# onto2py-source-sha256: 1102fc426e7b6f970a004b24ef8d32247b2e0e9455ee73d21b927f7e4433c601
 from __future__ import annotations
 
 import datetime

--- a/libs/naas-abi/naas_abi/__init__.py
+++ b/libs/naas-abi/naas_abi/__init__.py
@@ -400,7 +400,21 @@ class ABIModule(BaseModule):
                     f"Failed to convert {ttl_file} to Python: {e}", exc_info=True
                 )
 
-        # Initialize Nexus platform
+    def on_load(self):
+        super().on_load()
+        # from naas_abi_core.services.triple_store.TripleStorePorts import OntologyEvent
+        # from rdflib import URIRef
+
+        # self.engine.services.triple_store.subscribe(
+        #     (URIRef("http://example.com/subject"), None, None),
+        #     lambda triple: print(f"Triple received: {triple.decode('utf-8')}"),
+        #     OntologyEvent.INSERT,
+        # )
+
+    def api(self, app: FastAPI) -> None:
+        # Initialize Nexus platform (graphs + agent metadata in the triple
+        # store). Deferred from on_initialized so non-API entry points
+        # (Dagster run workers, CLI commands, tests) don't pay this cost.
         from naas_abi.pipelines.NexusPlatformPipeline import (
             NexusPlatformPipeline,
             NexusPlatformPipelineConfiguration,
@@ -414,18 +428,6 @@ class ABIModule(BaseModule):
         )
         pipeline.run(NexusPlatformPipelineParameters())
 
-    def on_load(self):
-        super().on_load()
-        # from naas_abi_core.services.triple_store.TripleStorePorts import OntologyEvent
-        # from rdflib import URIRef
-
-        # self.engine.services.triple_store.subscribe(
-        #     (URIRef("http://example.com/subject"), None, None),
-        #     lambda triple: print(f"Triple received: {triple.decode('utf-8')}"),
-        #     OntologyEvent.INSERT,
-        # )
-
-    def api(self, app: FastAPI) -> None:
         # Keep API and Nexus CORS aligned from a single source of truth.
         app.state.abi_cors_origins = self.engine.api_configuration.cors_origins
 

--- a/libs/naas-abi/naas_abi/agents/AbiAgent.py
+++ b/libs/naas-abi/naas_abi/agents/AbiAgent.py
@@ -149,7 +149,6 @@ Respond only based on what your available agents and tools can actually deliver.
 
     @staticmethod
     def get_agents(cls) -> tuple[list, AgentSharedState]:
-        from concurrent.futures import ThreadPoolExecutor, as_completed
         from queue import Queue
 
         from naas_abi import ABIModule
@@ -184,20 +183,22 @@ Respond only based on what your available agents and tools can actually deliver.
                 if issubclass(agent_cls, Agent):
                     _register_candidate(agent_cls)
 
-        def _load_agent(agent_cls: type) -> Agent | None:
-            if issubclass(agent_cls, Agent):
-                return agent_cls.New().duplicate(
-                    queue=agent_queue, agent_shared_state=agent_shared_state
-                )
-            return None
-
+        # NOTE: this used to run in a ThreadPoolExecutor with the default
+        # max_workers (up to 32 threads). Agent construction is pure-Python
+        # (pydantic models, langchain tool wiring, supervisor attachment) and
+        # therefore GIL-bound — concurrent threads couldn't overlap useful
+        # work and just thrashed on lock waits. cProfile showed ~3s out of
+        # 3.76s spent in `_thread.lock.acquire` / `as_completed`. Running
+        # serially removes that overhead entirely.
         agents: list = []
-        with ThreadPoolExecutor() as executor:
-            futures = {executor.submit(_load_agent, c): c for c in candidate_classes}
-            for future in as_completed(futures):
-                agent = future.result()
-                if agent is not None:
-                    agents.append(agent)
+        for agent_cls in candidate_classes:
+            if not issubclass(agent_cls, Agent):
+                continue
+            agent = agent_cls.New().duplicate(
+                queue=agent_queue, agent_shared_state=agent_shared_state
+            )
+            if agent is not None:
+                agents.append(agent)
 
         return agents, agent_shared_state
 

--- a/libs/naas-abi/naas_abi/ontologies/modules/BFO7BucketsProcessOntology.py
+++ b/libs/naas-abi/naas_abi/ontologies/modules/BFO7BucketsProcessOntology.py
@@ -1,3 +1,4 @@
+# onto2py-source-sha256: 9b01e2f544c5143f0c88da7b242bfe5b9faa9a6b4586a8c42affdcaa88a2a647
 from __future__ import annotations
 
 import datetime

--- a/libs/naas-abi/naas_abi/ontologies/modules/NexusPlatformOntology.py
+++ b/libs/naas-abi/naas_abi/ontologies/modules/NexusPlatformOntology.py
@@ -1,3 +1,4 @@
+# onto2py-source-sha256: 351f64234dcd207ec02af982bd329416d35461862b95d4e9bb332c8f659011a6
 from __future__ import annotations
 
 import datetime

--- a/libs/naas-abi/naas_abi/pipelines/NexusPlatformPipeline.py
+++ b/libs/naas-abi/naas_abi/pipelines/NexusPlatformPipeline.py
@@ -1,3 +1,4 @@
+import hashlib
 from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, List, cast
@@ -18,7 +19,11 @@ from naas_abi_core.pipeline import Pipeline, PipelineConfiguration, PipelinePara
 from naas_abi_core.services.triple_store.TripleStoreService import TripleStoreService
 from naas_abi_core.utils.Expose import APIRouter
 from naas_abi_core.utils.SPARQL import SPARQLUtils
-from rdflib import RDF, Graph, Namespace, URIRef
+from rdflib import RDF, Graph, Literal, Namespace, URIRef
+
+# Bump when the schema of what the pipeline writes changes (so old signatures
+# from older code versions trigger a rebuild even if inputs look identical).
+_SIGNATURE_VERSION = "1"
 
 
 def _module_name_from_module_path(module_path: str | None) -> str | None:
@@ -49,7 +54,11 @@ class NexusPlatformPipelineConfiguration(PipelineConfiguration):
     triple_store: TripleStoreService
     nexus_namespace: Namespace = Namespace("http://ontology.naas.ai/nexus/")
     nexus_graph_uri: URIRef = URIRef("http://ontology.naas.ai/graph/nexus")
-    force_update: bool = True
+    # When True, always clear + rebuild the nexus graph. When False (default),
+    # compute a signature of the inputs (agent class paths + named graphs +
+    # version) and skip the rebuild entirely if the stored signature matches.
+    # This makes warm boots ~one SPARQL read instead of ~6 reads + writes.
+    force_update: bool = False
 
 
 class NexusPlatformPipelineParameters(PipelineParameters):
@@ -76,19 +85,137 @@ class NexusPlatformPipeline(Pipeline):
         self.__force_update = configuration.force_update
         self.__triple_store = configuration.triple_store
         self.__sparql_utils = SPARQLUtils(self.__triple_store)
+        # Note: clearing the nexus graph used to happen here, which made
+        # merely *constructing* the pipeline destructive. We've moved that
+        # into run() so we can check the signature first and skip the rebuild
+        # entirely when nothing has changed.
 
-        # Create the Nexus named graph if it does not exist.
-        logger.debug(f"Nexus graph list: {self.__triple_store.list_graphs()}")
-        if self.__nexus_graph_uri not in self.__triple_store.list_graphs():
-            self.__triple_store.create_graph(self.__nexus_graph_uri)
-            logger.debug(f"Nexus graph created at {self.__nexus_graph_uri}")
+    # ------------------------------------------------------------------
+    # Signature-based fast path
+    # ------------------------------------------------------------------
 
-        if (
-            self.__force_update
-            and self.__nexus_graph_uri in self.__triple_store.list_graphs()
-        ):
-            logger.debug(f"Nexus graph cleared at {self.__nexus_graph_uri}")
-            self.__triple_store.clear_graph(self.__nexus_graph_uri)
+    def _bootstrap_uri(self) -> URIRef:
+        return URIRef(self.__nexus_namespace["Bootstrap"])
+
+    def _signature_predicate(self) -> URIRef:
+        return URIRef(self.__nexus_namespace["signature"])
+
+    def _compute_signature(self) -> str:
+        """Hash the inputs we'd write so we can detect a no-op rebuild.
+
+        For each agent we include its class path AND the SHA-256 of the
+        source file that defines it. Editing an agent's `system_prompt`,
+        `get_tools()`, `get_intents()`, etc. changes the file's content
+        hash, which changes the signature, which triggers a rebuild. We
+        deliberately do NOT call `get_tools()` / `get_intents()` /
+        `get_system_prompt()` here — those are the expensive operations
+        the fast path is trying to avoid.
+
+        Agent source files are typically small (a few KB), so reading and
+        hashing them is cheap, and each file is hashed at most once even
+        when it defines multiple agents.
+
+        We also include sorted named graph URIs (so a newly loaded
+        ontology triggers a rebuild) and a version tag.
+        """
+        import inspect
+
+        from naas_abi import ABIModule
+        from naas_abi_core.services.agent.Agent import Agent as RuntimeAgent
+
+        agent_entries: list[str] = []
+        try:
+            abi = ABIModule.get_instance()
+            # Cache file hashes so we don't read/hash the same module twice
+            # when it defines multiple agents.
+            file_hashes: dict[str, str] = {}
+            for module in abi.engine.modules.values():
+                for agent_cls in module.agents:
+                    if (
+                        agent_cls is None
+                        or not isinstance(agent_cls, type)
+                        or not issubclass(agent_cls, RuntimeAgent)
+                    ):
+                        continue
+                    class_path = f"{agent_cls.__module__}/{agent_cls.__name__}"
+                    try:
+                        source_file = inspect.getfile(agent_cls)
+                    except (TypeError, OSError):
+                        source_file = ""
+                    if source_file and source_file not in file_hashes:
+                        try:
+                            with open(source_file, "rb") as f:
+                                file_hashes[source_file] = hashlib.sha256(
+                                    f.read()
+                                ).hexdigest()
+                        except OSError:
+                            file_hashes[source_file] = ""
+                    agent_entries.append(
+                        f"{class_path}@{file_hashes.get(source_file, '')}"
+                    )
+        except Exception:
+            # If we can't enumerate agents we should not pretend the cache
+            # is valid — fall through to a forced rebuild by returning a
+            # signature that will never match.
+            return "unavailable"
+
+        graph_uris = sorted(str(g) for g in self.__triple_store.list_graphs())
+
+        parts = [
+            f"v:{_SIGNATURE_VERSION}",
+            "agents:" + ",".join(sorted(agent_entries)),
+            "graphs:" + ",".join(graph_uris),
+        ]
+        return hashlib.sha256("\n".join(parts).encode("utf-8")).hexdigest()
+
+    def _read_stored_signature(self) -> str | None:
+        results = self.__triple_store.query(
+            f"""
+            SELECT ?sig WHERE {{
+                GRAPH <{str(self.__nexus_graph_uri)}> {{
+                    <{str(self._bootstrap_uri())}>
+                        <{str(self._signature_predicate())}>
+                        ?sig .
+                }}
+            }}
+            """
+        )
+        for row in results:
+            return str(row[0])
+        return None
+
+    def _write_signature(self, signature: str) -> None:
+        # Drop any prior signature triple(s) then write the new one.
+        old_results = self.__triple_store.query(
+            f"""
+            SELECT ?sig WHERE {{
+                GRAPH <{str(self.__nexus_graph_uri)}> {{
+                    <{str(self._bootstrap_uri())}>
+                        <{str(self._signature_predicate())}>
+                        ?sig .
+                }}
+            }}
+            """
+        )
+        old_graph = Graph()
+        for row in old_results:
+            old_graph.add(
+                (self._bootstrap_uri(), self._signature_predicate(), row[0])
+            )
+        if len(old_graph) > 0:
+            self.__triple_store.remove(
+                old_graph, graph_name=self.__nexus_graph_uri
+            )
+
+        new_graph = Graph()
+        new_graph.add(
+            (
+                self._bootstrap_uri(),
+                self._signature_predicate(),
+                Literal(signature),
+            )
+        )
+        self.__triple_store.insert(new_graph, graph_name=self.__nexus_graph_uri)
 
     def _query_nexus_instances(
         self,
@@ -465,6 +592,28 @@ class NexusPlatformPipeline(Pipeline):
         # Initialize Nexus Platform
         from rdflib.namespace import OWL, RDF, RDFS, XSD
 
+        # Fast path: if the inputs haven't changed since the last successful
+        # rebuild, skip the whole pipeline. This is the common case on warm
+        # API boots and turns ~6 SPARQL round trips + writes into 2 reads.
+        current_signature = self._compute_signature()
+        if not self.__force_update:
+            stored_signature = self._read_stored_signature()
+            if stored_signature is not None and stored_signature == current_signature:
+                logger.debug(
+                    "Nexus platform signature unchanged; skipping rebuild."
+                )
+                return Graph()
+
+        # Ensure the nexus graph exists, then clear it so removed agents
+        # don't linger. Clearing only happens on the rebuild path — pure
+        # construction of the pipeline is now non-destructive.
+        if self.__nexus_graph_uri not in self.__triple_store.list_graphs():
+            self.__triple_store.create_graph(self.__nexus_graph_uri)
+            logger.debug(f"Nexus graph created at {self.__nexus_graph_uri}")
+        else:
+            logger.debug(f"Nexus graph cleared at {self.__nexus_graph_uri}")
+            self.__triple_store.clear_graph(self.__nexus_graph_uri)
+
         graph = Graph()
         graph.bind("rdf", RDF)
         graph.bind("rdfs", RDFS)
@@ -475,6 +624,9 @@ class NexusPlatformPipeline(Pipeline):
         graph += self.initialize_nexus_graphs()
         graph += self.initialize_nexus_agents()
         graph += self.initialize_nexus_graph_views()
+
+        # Persist the new signature so the next boot can short-circuit.
+        self._write_signature(current_signature)
         return graph
 
     def as_tools(self) -> list[BaseTool]:


### PR DESCRIPTION
## Summary

API boot was dominated by repeated work that doesn't change between starts and by GIL-bound code wrapped in thread pools that couldn't overlap. This PR makes each of those phases either cache-skipped, lazy, or correctly serial.

Measured impact (Docker container start → `Application startup complete`):
**~13.8s → ~9.9s** on warm boots, and the first chat request no longer pays the deferred cost in practice.

## What changed

### Triple store schema loading — `TripleStoreService.py`
- Bulk schema-metadata SPARQL no longer fetches `?content` (was pulling MB of base64 per boot just to confirm "nothing changed"); fetched on demand only when a file's hash differs
- Replaced the shared rdflib `Graph` cache with a plain Python dict so threaded reads don't race rdflib's pyparsing-backed SPARQL parser
- Per-file work runs in a `ThreadPoolExecutor` (8 workers)
- Test fixture (`_InMemoryTripleStoreAdapter`) now uses `ConjunctiveGraph` with proper named-graph routing so it matches the real service contract; new test covers parallel `load_schemas` + warm-boot no-op behavior

### `onto2py` disk cache — `onto2py.py`
- Generated `.py` files now carry `# onto2py-source-sha256: <hash>` at the top
- `onto2py()` short-circuits before any rdflib parse / code gen / ruff format when the marker matches the TTL hash. Tolerant to ruff reformatting (looks within the first ten lines)
- New `test_onto2py_skips_parsing_on_unchanged_ttl`

### Nexus platform pipeline — `NexusPlatformPipeline.py`, `naas_abi/__init__.py`
- Moved pipeline call out of `on_initialized` and into `api()` so non-API entrypoints (Dagster run workers, CLI) skip it entirely
- Default flipped to `force_update=False`; pipeline `__init__` is no longer destructive (the `clear_graph` moved into `run()` and only fires on actual rebuild)
- Signature-based skip: SHA-256 of `(agent class paths + per-agent source-file content hashes + sorted named graph URIs + version)`. Stored as a single triple in the nexus graph. Warm boots are one SPARQL read instead of ~6 reads + writes + clear
- Pass `force_update=True` when you want an explicit rebuild

### Agent construction — `AbiAgent.py`
- Removed the internal `ThreadPoolExecutor()` (defaulting to up to 32 workers) around `AbiAgent.get_agents()`. cProfile showed **80% of `New()` time was just `_thread.lock.acquire`** — the work is pure-Python so threads thrashed on the GIL with no useful overlap

### Intent index — `IntentMapper.py`, `CoordinatorAgent.py`, `api.py`
- Lazy `_ensure_index()` (with a `threading.Lock`) — embedding + Qdrant upsert no longer runs in `IntentMapper.__init__`. Cost was ~280ms per agent × 13 agents = ~3.6s of boot
- Background warmup thread kicked off from `_load_runtime_routes` right after route registration. The index is normally ready before the first chat request arrives; if a request races it, `_ensure_index` blocks briefly on the same lock — same correctness, just falls back to lazy semantics
- One direct check in `CoordinatorAgent` was updated from `vector_store is not None` (which used to mean "has any intents") to `intents` truthiness (since `None` now means "not indexed yet")

## Test plan

- [x] `cd libs/naas-abi-core && uv run pytest naas_abi_core/services/triple_store/TripleStoreService_test.py -k load_schema` — 3 passed
- [x] `cd libs/naas-abi-core && uv run pytest naas_abi_core/utils/onto2py/tests/ttl2py_test.py::test_onto2py_skips_parsing_on_unchanged_ttl` — pass
- [x] Pre-commit hooks (ruff, mypy, bandit) — all green
- [x] Docker stack restart end-to-end measured: `~9.9s` from container restart → API ready
- [ ] Hit a chat agent for the first time after a fresh boot and confirm the response feels normal (intent index warmup is complete by then; if not, request still works, just with a one-time ~250ms hit on the first agent invocation)
- [ ] Confirm a clean Nexus rebuild can still be forced by constructing the pipeline with `force_update=True` (e.g., a one-off admin script)

🤖 Generated with [Claude Code](https://claude.com/claude-code)