### PR TITLE
fix(compose): build nexus-web locally for dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,13 +86,16 @@ x-abi-template: &abi_template
 
 services:
   nexus-web:
-    image: ${NEXUS_WEB_IMAGE}:${NEXUS_WEB_TAG}
-    pull_policy: always
+    build:
+      context: libs/naas-abi/naas_abi/apps/nexus/
+      dockerfile: Dockerfile
     restart: unless-stopped
     ports:
       - ${NEXUS_WEB_PORT}:3000
+    volumes:
+      - ./libs/naas-abi/naas_abi/apps/nexus/apps/web:/app/apps/web
     environment:
-      - NODE_ENV=production
+      - NODE_ENV=development
       - PORT=3000
       - NEXT_PUBLIC_NEXUS_ENV=local
       - NEXUS_API_URL=${NEXUS_API_URL}


### PR DESCRIPTION
## Summary
- Switch `nexus-web` in `docker-compose.yml` from the published image (`${NEXUS_WEB_IMAGE}:${NEXUS_WEB_TAG}`) back to a local `build:` against `libs/naas-abi/naas_abi/apps/nexus/Dockerfile`, so the frontend can be iterated on in dev.
- Bind-mount `libs/naas-abi/naas_abi/apps/nexus/apps/web` into the container for hot reload, and flip `NODE_ENV` to `development`. `NEXUS_API_URL` wiring is preserved.

## Test plan
- [ ] `docker compose build nexus-web` succeeds
- [ ] `docker compose up nexus-web` serves the local frontend with hot reload working

🤖 Generated with [Claude Code](https://claude.com/claude-code)