### PR TITLE
feat(nexus): folder drag-and-drop upload with progress UI

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/files/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/files/page.tsx
@@ -36,6 +36,45 @@ import { authFetch, useAuthStore } from '@/stores/auth';
 import { usePrompt, useConfirm } from '@/components/ui/dialogs';
 import { PdfViewer } from '@/components/files/pdf-viewer';
 
+type FileWithRelativeDir = { file: File; relativeDir?: string };
+
+async function readDirectoryEntries(
+  reader: FileSystemDirectoryReader,
+): Promise<FileSystemEntry[]> {
+  const all: FileSystemEntry[] = [];
+  while (true) {
+    const batch: FileSystemEntry[] = await new Promise((resolve, reject) => {
+      reader.readEntries(resolve, reject);
+    });
+    if (batch.length === 0) break;
+    all.push(...batch);
+  }
+  return all;
+}
+
+async function collectEntries(
+  entries: FileSystemEntry[],
+  parentDir = '',
+): Promise<FileWithRelativeDir[]> {
+  const out: FileWithRelativeDir[] = [];
+  for (const entry of entries) {
+    if (entry.isFile) {
+      const fileEntry = entry as FileSystemFileEntry;
+      const file = await new Promise<File>((resolve, reject) => {
+        fileEntry.file(resolve, reject);
+      });
+      out.push({ file, relativeDir: parentDir || undefined });
+    } else if (entry.isDirectory) {
+      const dirEntry = entry as FileSystemDirectoryEntry;
+      const children = await readDirectoryEntries(dirEntry.createReader());
+      const childDir = parentDir ? `${parentDir}/${entry.name}` : entry.name;
+      const nested = await collectEntries(children, childDir);
+      out.push(...nested);
+    }
+  }
+  return out;
+}
+
 export default function FilesPage() {
   const router = useRouter();
   const params = useParams();
@@ -59,6 +98,7 @@ export default function FilesPage() {
     syncedFolders,
     fetchLocalFiles,
     setError,
+    uploadProgress,
   } = useFilesStore();
 
   const { prompt, dialog: promptDialog } = usePrompt();
@@ -196,6 +236,17 @@ export default function FilesPage() {
     }
   }, [fetchFiles, fetchLocalFiles, isLocalFolder, activeSyncedFolder, activeSource, setError]);
 
+  // Warn the user before leaving while an upload is in progress.
+  useEffect(() => {
+    if (!uploadProgress?.active) return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = '';
+    };
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [uploadProgress?.active]);
+
   const INTERNAL_DRAG_MIME = 'application/x-nexus-file';
 
   const isInternalDrag = (e: React.DragEvent) =>
@@ -221,6 +272,22 @@ export default function FilesPage() {
     e.preventDefault();
     e.stopPropagation();
     setIsDragging(false);
+
+    const items = e.dataTransfer.items;
+    if (items && items.length > 0 && typeof items[0].webkitGetAsEntry === 'function') {
+      const entries: FileSystemEntry[] = [];
+      for (let i = 0; i < items.length; i++) {
+        const entry = items[i].webkitGetAsEntry();
+        if (entry) entries.push(entry);
+      }
+      if (entries.length > 0) {
+        const collected = await collectEntries(entries);
+        if (collected.length > 0) {
+          await uploadFiles(collected);
+        }
+        return;
+      }
+    }
 
     const droppedFiles = e.dataTransfer.files;
     if (droppedFiles.length > 0) {
@@ -914,7 +981,44 @@ export default function FilesPage() {
               <div className="flex flex-col items-center gap-2 rounded-lg border-2 border-dashed border-primary p-8">
                 <Upload size={48} className="text-primary" />
                 <p className="text-lg font-medium">Drop files here to upload</p>
-                <p className="text-sm text-muted-foreground">Files will be uploaded to the current folder</p>
+                <p className="text-sm text-muted-foreground">Files and folders will be uploaded to the current folder</p>
+              </div>
+            </div>
+          )}
+
+          {uploadProgress && (
+            <div className="fixed bottom-4 right-4 z-50 w-80 rounded-lg border bg-background shadow-lg">
+              <div className="flex items-center justify-between border-b px-4 py-2">
+                <div className="flex items-center gap-2">
+                  <Upload size={16} className={uploadProgress.active ? 'animate-pulse text-primary' : 'text-muted-foreground'} />
+                  <p className="text-sm font-medium">
+                    {uploadProgress.active
+                      ? `Uploading ${uploadProgress.completed + 1} of ${uploadProgress.total}`
+                      : uploadProgress.failed > 0
+                        ? `Uploaded ${uploadProgress.completed} of ${uploadProgress.total} (${uploadProgress.failed} failed)`
+                        : `Uploaded ${uploadProgress.completed} file${uploadProgress.completed === 1 ? '' : 's'}`}
+                  </p>
+                </div>
+              </div>
+              <div className="px-4 py-3">
+                <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+                  <div
+                    className="h-full bg-primary transition-all"
+                    style={{
+                      width: `${uploadProgress.total === 0 ? 0 : ((uploadProgress.completed + uploadProgress.failed) / uploadProgress.total) * 100}%`,
+                    }}
+                  />
+                </div>
+                {uploadProgress.currentName && (
+                  <p className="mt-2 truncate text-xs text-muted-foreground" title={uploadProgress.currentName}>
+                    {uploadProgress.currentName}
+                  </p>
+                )}
+                {uploadProgress.active && (
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    Please keep this page open until the upload finishes.
+                  </p>
+                )}
               </div>
             </div>
           )}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/files.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/files.ts
@@ -104,6 +104,15 @@ interface FilesState {
   // Synced folders
   syncedFolders: SyncedFolder[];
 
+  // Upload progress (for folder / multi-file uploads)
+  uploadProgress: {
+    active: boolean;
+    total: number;
+    completed: number;
+    failed: number;
+    currentName: string | null;
+  } | null;
+
   // Actions
   setFiles: (files: FileInfo[]) => void;
   setCurrentPath: (path: string) => void;
@@ -136,8 +145,8 @@ interface FilesState {
   createFolder: (path: string) => Promise<FileInfo | null>;
   deleteFile: (path: string) => Promise<boolean>;
   renameFile: (oldPath: string, newPath: string) => Promise<boolean>;
-  uploadFile: (file: File) => Promise<FileInfo | null>;
-  uploadFiles: (files: FileList | File[]) => Promise<FileInfo[]>;
+  uploadFile: (file: File, relativeDir?: string) => Promise<FileInfo | null>;
+  uploadFiles: (files: FileList | File[] | { file: File; relativeDir?: string }[]) => Promise<FileInfo[]>;
   refreshFiles: () => Promise<void>;
   refreshLabFiles: () => Promise<void>;  // Refreshes Lab's file tree
   readFile: (path: string) => Promise<string | null>;
@@ -179,6 +188,8 @@ export const useFilesStore = create<FilesState>((set, get) => ({
   
   // Synced folders
   syncedFolders: [] as SyncedFolder[],
+
+  uploadProgress: null,
 
   setFiles: (files) => set({ files }),
   setCurrentPath: (currentPath) => set({ currentPath }),
@@ -676,9 +687,10 @@ export const useFilesStore = create<FilesState>((set, get) => ({
     }
   },
 
-  uploadFile: async (file) => {
+  uploadFile: async (file, relativeDir) => {
     const { currentPath } = get();
-    const uploadPath = currentPath ? currentPath : '';
+    const cleanRelative = (relativeDir || '').replace(/^\/+|\/+$/g, '');
+    const uploadPath = [currentPath, cleanRelative].filter(Boolean).join('/');
     const workspaceId = getCurrentWorkspaceId();
     const scope = getFilesScope(get().activeSource);
 
@@ -722,15 +734,63 @@ export const useFilesStore = create<FilesState>((set, get) => ({
 
   uploadFiles: async (files) => {
     const results: FileInfo[] = [];
-    const fileArray = Array.from(files);
-    
-    for (const file of fileArray) {
-      const result = await get().uploadFile(file);
-      if (result) {
-        results.push(result);
+    const fileArray = Array.from(files as ArrayLike<File | { file: File; relativeDir?: string }>);
+
+    set({
+      uploadProgress: {
+        active: true,
+        total: fileArray.length,
+        completed: 0,
+        failed: 0,
+        currentName: null,
+      },
+    });
+
+    try {
+      for (const item of fileArray) {
+        const file = item instanceof File ? item : item.file;
+        const relativeDir = item instanceof File ? undefined : item.relativeDir;
+        const displayName = relativeDir ? `${relativeDir}/${file.name}` : file.name;
+
+        set((state) => ({
+          uploadProgress: state.uploadProgress
+            ? { ...state.uploadProgress, currentName: displayName }
+            : state.uploadProgress,
+        }));
+
+        const result = await get().uploadFile(file, relativeDir);
+        if (result) {
+          results.push(result);
+          set((state) => ({
+            uploadProgress: state.uploadProgress
+              ? { ...state.uploadProgress, completed: state.uploadProgress.completed + 1 }
+              : state.uploadProgress,
+          }));
+        } else {
+          set((state) => ({
+            uploadProgress: state.uploadProgress
+              ? { ...state.uploadProgress, failed: state.uploadProgress.failed + 1 }
+              : state.uploadProgress,
+          }));
+        }
       }
+    } finally {
+      set((state) => ({
+        uploadProgress: state.uploadProgress
+          ? { ...state.uploadProgress, active: false, currentName: null }
+          : state.uploadProgress,
+      }));
+      // Auto-clear after a short delay so the user sees the final state
+      setTimeout(() => {
+        set((state) => {
+          if (state.uploadProgress && !state.uploadProgress.active) {
+            return { uploadProgress: null };
+          }
+          return state;
+        });
+      }, 4000);
     }
-    
+
     return results;
   },
 


### PR DESCRIPTION
## Summary

- Nexus file manager now supports dragging a **folder** from the OS to upload its entire tree (previously only individual files worked; folders were silently dropped).
- Adds an upload progress card (count, progress bar, current file) shown during multi-file/folder uploads.
- Adds a `beforeunload` guard so the user is warned not to close the tab mid-upload.

## What changed

**Frontend (`files/page.tsx`)**
- `handleDrop` now reads `dataTransfer.items` and recursively walks `webkitGetAsEntry()` so folder contents are preserved. Falls back to `dataTransfer.files` when entries aren't available.
- New `collectEntries` / `readDirectoryEntries` helpers traverse a directory tree into `{ file, relativeDir }` pairs.
- New progress card in the bottom-right that shows `Uploading N of M`, the current file path, and a "keep this page open" message while active.
- `useEffect` registers a `beforeunload` listener while `uploadProgress.active`.

**Store (`stores/files.ts`)**
- `uploadFile` now accepts an optional `relativeDir` that is joined onto `currentPath` so files land at the correct nested destination.
- `uploadFiles` accepts either `File`s or `{ file, relativeDir }` items and maintains an `uploadProgress` state (`total`, `completed`, `failed`, `currentName`, `active`). Card auto-clears 4s after completion.

## Why no backend change?

The existing `POST /api/files/upload` endpoint already takes a base `path` + `filename` and the storage layer uses object-storage semantics (`put_object(prefix, key, ...)`), so nested keys are created implicitly. No API change was required.

## Notes for the reviewer

- Empty subfolders are not uploaded (no file to anchor the key in object storage). Acceptable limitation for this storage model.
- Uploads are sequential — keeps progress accounting simple and avoids hammering the API for large folders.

## Test plan

- [ ] Drag a single file onto the files page — uploads to the current folder.
- [ ] Drag a folder containing nested subfolders — full tree appears under the current folder.
- [ ] Verify the progress card shows count + current file, then auto-dismisses.
- [ ] Try to close/reload the tab while uploading — browser shows the leave-page warning.
- [ ] Verify the existing internal drag-to-folder move still works (should be unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)