### PR TITLE
fix(engine): declare EmailService dependency in ABIModule

### DIFF
--- a/libs/naas-abi/naas_abi/__init__.py
+++ b/libs/naas-abi/naas_abi/__init__.py
@@ -8,6 +8,7 @@ from naas_abi_core.module.Module import (
 )
 from naas_abi_core.services.bus.BusService import BusService
 from naas_abi_core.services.cache.CacheService import CacheService
+from naas_abi_core.services.email.EmailService import EmailService
 from naas_abi_core.services.object_storage.ObjectStorageService import (
     ObjectStorageService,
 )
@@ -305,7 +306,7 @@ class ABIModule(BaseModule):
             "naas_abi_marketplace.applications.zoho#soft",
             "naas_abi_marketplace.domains.support#soft",
         ],
-        services=[Secret, TripleStoreService, ObjectStorageService, VectorStoreService, BusService, CacheService],
+        services=[Secret, TripleStoreService, ObjectStorageService, VectorStoreService, BusService, CacheService, EmailService],
     )
 
     class Configuration(ModuleConfiguration):

--- a/uv.lock
+++ b/uv.lock
@@ -3444,7 +3444,7 @@ wheels = [
 
 [[package]]
 name = "naas-abi"
-version = "1.41.0"
+version = "1.43.0"
 source = { editable = "libs/naas-abi" }
 dependencies = [
     { name = "alembic" },
@@ -3522,7 +3522,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-cli"
-version = "1.33.0"
+version = "1.34.0"
 source = { editable = "libs/naas-abi-cli" }
 dependencies = [
     { name = "naas-abi" },


### PR DESCRIPTION
## Summary

- The previous auth fix (124f23d) wired `app.state.email_service = self.engine.services.email` into Nexus API startup, but `ABIModule.dependencies.services` never declared `EmailService`.
- `EngineServiceLoader` only instantiates services requested by a module, so `services.email` stayed `None` and the property assertion in `IEngine.py` blew up at startup with `AssertionError: Email service is not initialized`.
- Add `EmailService` to the `services=[...]` list (and its import) in `libs/naas-abi/naas_abi/__init__.py` so the engine instantiates the configured email adapter (filesystem in dev, SMTP in prod).

## Repro (before this fix)

```
abi-1  | File ".../naas_abi/__init__.py", line 441, in api
abi-1  |   app.state.email_service = self.engine.services.email
abi-1  | File ".../engine/IEngine.py", line 97, in email
abi-1  |   assert self.__email is not None, "Email service is not initialized"
abi-1  | AssertionError: Email service is not initialized
```

## Test plan

- [ ] `docker compose up` brings the `abi` container to a healthy state
- [ ] Magic-link request hits the configured email adapter (filesystem in dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)