### PR TITLE
fix(nexus): expose email_from_address/email_from_name in NexusConfig

### DIFF
--- a/libs/naas-abi/naas_abi/__init__.py
+++ b/libs/naas-abi/naas_abi/__init__.py
@@ -340,6 +340,8 @@ class NexusConfig(BaseModel):
         '<p><a href="{magic_link_url}">Sign in to {app_name}</a></p>'
         "<p>This link expires in {expire_minutes} minutes.</p>"
     )
+    email_from_address: EmailStr = "no-reply@nexus.example.com"
+    email_from_name: str = "NEXUS"
 
     rate_limit_enabled: bool = True
     rate_limit_login_attempts: int = 5


### PR DESCRIPTION
## Summary

- The outer `NexusConfig` Pydantic model in `libs/naas-abi/naas_abi/__init__.py` is declared with `extra="forbid"`, but it was missing `email_from_address` and `email_from_name` — even though the inner `Settings` (`apps/nexus/.../app/core/config.py`) already defines them.
- Result: setting either field in a project's YAML (`nexus_config:`) blows up at startup with `Extra inputs are not permitted`, so consumers have no way to configure the magic-link From identity from config and have to fall back to env vars.
- This change mirrors the inner defaults on `NexusConfig` so YAML can pass these values through.

## Why

Hit while debugging a customer where magic-link emails stopped sending after the SMTP→engine `EmailService` refactor: the engine adapter was wired correctly, but `email_from_address` defaulted to `no-reply@nexus.example.com` and the SMTP relay silently dropped messages. Trying to set the field via YAML triggered the validation error above.

## Test plan

- [ ] Set `email_from_address` and `email_from_name` under `nexus_config:` in a project's `config.local.yaml` and confirm the engine boots without `extra_forbidden` errors.
- [ ] Confirm magic-link emails go out with the configured From address/name.
- [ ] Existing projects that don't set these fields fall back to the same defaults as before (no behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)