### PR TITLE
feat(document-agent): hybrid semantic + keyword search with accent folding

### DIFF
--- a/libs/naas-abi-marketplace/naas_abi_marketplace/domains/document/agents/DocumentAgent.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/domains/document/agents/DocumentAgent.py
@@ -1,11 +1,16 @@
 """DocumentAgent — an agent that can talk over all ingested and vectorized documents.
 
-It exposes a semantic search tool backed by the vector store collection(s)
-produced by the MarkdownToVector pipeline.
+It exposes a hybrid search tool that combines:
+- semantic search over the vector store collection
+- keyword (text) search over the chunk contents stored in the triple store
+
+Keyword matching is case-insensitive and accent-insensitive (NFKD normalization),
+so French queries like ``"épée"`` and ``"Epee"`` match the same chunks.
 """
 
 from __future__ import annotations
 
+import unicodedata
 from typing import Any, Dict, List, Optional
 
 import numpy as np
@@ -23,9 +28,11 @@ AVATAR_URL = (
     "https://naasai-public.s3.eu-west-3.amazonaws.com/abi/assets/document-agent.png"
 )
 DESCRIPTION = (
-    "Answers questions about ingested documents by performing semantic search over "
-    "vectorized Markdown chunks."
+    "Answers questions about ingested documents by performing semantic + keyword "
+    "search over vectorized Markdown chunks."
 )
+
+DEFAULT_GRAPH_NAME = "http://ontology.naas.ai/graph/document"
 
 SYSTEM_PROMPT = """<role>
 You are a Document Expert Agent with access to a knowledge base of ingested documents.
@@ -33,12 +40,19 @@ You are a Document Expert Agent with access to a knowledge base of ingested docu
 
 <objective>
 Your primary mission is to answer user questions by retrieving the most relevant document
-chunks using semantic search and synthesizing a coherent, accurate response.
+chunks using a combination of semantic search and keyword (text) search, then synthesizing
+a coherent, accurate response.
 </objective>
 
 <context>
-All documents have been pre-processed into Markdown and chunked into vector embeddings.
-You can search across all documents or within a specific collection.
+All documents have been pre-processed into Markdown and chunked. Each chunk is:
+- embedded into a vector store for semantic search, and
+- stored as text in the triple store for keyword search.
+
+You can search across all documents or within a specific collection. The search tool accepts
+both a natural language ``query`` (for semantic search) and an optional list of ``keywords``
+that must ALL appear in the chunk content (case-insensitive, accent-insensitive — so
+``"epee"`` matches ``"épée"``).
 </context>
 
 <tools>
@@ -47,7 +61,8 @@ You can search across all documents or within a specific collection.
 
 <tasks>
 1. Understand the user's question.
-2. Use the search tool to retrieve the most relevant document chunks.
+2. Use the search tool to retrieve the most relevant document chunks. Provide ``keywords``
+   when the user mentions specific terms, names, or identifiers that must appear verbatim.
 3. Synthesize a clear, accurate answer based on the retrieved chunks.
 4. Cite the source file path for each piece of information you use.
 </tasks>
@@ -67,62 +82,224 @@ You can search across all documents or within a specific collection.
 
 
 class DocumentSearchInput(BaseModel):
-    query: str = Field(description="The natural language question or search query.")
+    query: str = Field(
+        default="",
+        description="The natural language question for semantic similarity search.",
+    )
+    keywords: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Optional list of text terms that must ALL appear in a chunk's content. "
+            "Matching is case-insensitive and accent-insensitive."
+        ),
+    )
     collection_name: str = Field(
         default="documents",
         description="The vector collection to search (default: 'documents').",
     )
     k: int = Field(
-        default=5, ge=1, le=20, description="Number of top results to return."
+        default=5, ge=1, le=20, description="Number of top results to return per search mode."
     )
+
+
+def _normalize_text(text: str) -> str:
+    """Lowercase ``text`` and strip combining marks (accents).
+
+    Uses NFKD normalization so ``"Épée"`` → ``"epee"``. Works for the
+    Latin-script accents typically found in French, Spanish, etc.
+    """
+    if not text:
+        return ""
+    decomposed = unicodedata.normalize("NFKD", text)
+    stripped = "".join(ch for ch in decomposed if not unicodedata.combining(ch))
+    return stripped.lower()
+
+
+def _result_key(file_path: str, chunk_index: Any) -> tuple:
+    return (file_path, chunk_index)
+
+
+def _vector_search(
+    *,
+    query: str,
+    collection_name: str,
+    k: int,
+    embeddings_model: OpenAIEmbeddings,
+    vector_store_service: Any,
+    keywords_normalized: List[str],
+) -> List[Dict[str, Any]]:
+    query_vector = np.array(embeddings_model.embed_query(query), dtype=np.float32)
+    # When keywords are also provided, fetch a wider net so we can intersect
+    # them with the keyword constraint without starving the result set.
+    fetch_k = k * 4 if keywords_normalized else k
+    results = vector_store_service.search_similar(
+        collection_name=collection_name,
+        query_vector=query_vector,
+        k=fetch_k,
+        include_metadata=True,
+    )
+
+    formatted: List[Dict[str, Any]] = []
+    for result in results:
+        meta = result.metadata or {}
+        payload = result.payload or {}
+        content = payload.get("content", "")
+
+        if keywords_normalized:
+            normalized = _normalize_text(content)
+            if not all(kw in normalized for kw in keywords_normalized):
+                continue
+
+        formatted.append(
+            {
+                "score": float(result.score),
+                "file_path": meta.get("file_path", "unknown"),
+                "chunk_index": meta.get("chunk_index", -1),
+                "content": content,
+                "match_type": "vector",
+            }
+        )
+        if len(formatted) >= k:
+            break
+    return formatted
+
+
+def _keyword_search(
+    *,
+    keywords_normalized: List[str],
+    collection_name: str,
+    k: int,
+    triple_store_service: Any,
+    graph_name: str,
+) -> List[Dict[str, Any]]:
+    """Pull chunk contents from the triple store and return those that match
+    *all* normalized keywords.
+    """
+    # Pull every chunk's (file_path, index, content) for this collection.
+    # Filtering happens in Python so we get proper Unicode case + accent folding.
+    safe_collection = collection_name.replace('"', '\\"')
+    query = f"""
+    PREFIX doc: <http://ontology.naas.ai/abi/document/>
+    SELECT ?file_path ?chunk_index ?content WHERE {{
+        GRAPH <{graph_name}> {{
+            ?chunk a doc:Chunk ;
+                   doc:file_path ?file_path ;
+                   doc:chunk_index ?chunk_index ;
+                   doc:content ?content ;
+                   doc:collection_name "{safe_collection}" .
+        }}
+    }}
+    """
+    rows = triple_store_service.query(query)
+
+    matches: List[Dict[str, Any]] = []
+    for row in rows:
+        try:
+            if hasattr(row, "file_path"):
+                file_path = str(getattr(row, "file_path"))
+                chunk_index_raw = getattr(row, "chunk_index")
+                content = str(getattr(row, "content"))
+            else:
+                file_path = str(row["file_path"])  # type: ignore[index]
+                chunk_index_raw = row["chunk_index"]  # type: ignore[index]
+                content = str(row["content"])  # type: ignore[index]
+        except Exception:
+            continue
+
+        try:
+            chunk_index: Any = int(str(chunk_index_raw))
+        except (TypeError, ValueError):
+            chunk_index = str(chunk_index_raw)
+
+        normalized = _normalize_text(content)
+        if not all(kw in normalized for kw in keywords_normalized):
+            continue
+
+        matches.append(
+            {
+                "score": 1.0,
+                "file_path": file_path,
+                "chunk_index": chunk_index,
+                "content": content,
+                "match_type": "keyword",
+            }
+        )
+        if len(matches) >= k:
+            break
+    return matches
 
 
 def _build_search_tool(
     embeddings_model: OpenAIEmbeddings,
     vector_store_service: Any,
+    triple_store_service: Optional[Any] = None,
+    graph_name: str = DEFAULT_GRAPH_NAME,
 ) -> StructuredTool:
-    """Create a LangChain StructuredTool that performs vector similarity search."""
+    """Create a LangChain StructuredTool that performs hybrid search.
+
+    The tool returns the union of:
+    - vector similarity results for ``query`` (filtered by ``keywords`` when both
+      are provided), and
+    - chunks whose content contains every entry in ``keywords`` (normalized).
+    """
 
     def search_documents(**kwargs: Any) -> List[Dict[str, Any]]:
-        query: str = kwargs.get("query", "")
+        query: str = (kwargs.get("query") or "").strip()
+        raw_keywords = kwargs.get("keywords") or []
         collection_name: str = kwargs.get("collection_name", "documents")
         k: int = kwargs.get("k", 5)
 
-        if not query:
-            return [{"error": "query is required"}]
+        keywords_normalized = [
+            _normalize_text(str(kw)) for kw in raw_keywords if str(kw).strip()
+        ]
+
+        if not query and not keywords_normalized:
+            return [{"error": "query or keywords is required"}]
+
+        combined: List[Dict[str, Any]] = []
+        seen: set = set()
 
         try:
-            query_vector = np.array(
-                embeddings_model.embed_query(query), dtype=np.float32
-            )
-            results = vector_store_service.search_similar(
-                collection_name=collection_name,
-                query_vector=query_vector,
-                k=k,
-                include_metadata=True,
-            )
+            if query:
+                for hit in _vector_search(
+                    query=query,
+                    collection_name=collection_name,
+                    k=k,
+                    embeddings_model=embeddings_model,
+                    vector_store_service=vector_store_service,
+                    keywords_normalized=keywords_normalized,
+                ):
+                    key = _result_key(hit["file_path"], hit["chunk_index"])
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    combined.append(hit)
 
-            formatted: List[Dict[str, Any]] = []
-            for result in results:
-                meta = result.metadata or {}
-                payload = result.payload or {}
-                formatted.append(
-                    {
-                        "score": float(result.score),
-                        "file_path": meta.get("file_path", "unknown"),
-                        "chunk_index": meta.get("chunk_index", -1),
-                        "content": payload.get("content", ""),
-                    }
-                )
-            return formatted
+            if keywords_normalized and triple_store_service is not None:
+                for hit in _keyword_search(
+                    keywords_normalized=keywords_normalized,
+                    collection_name=collection_name,
+                    k=k,
+                    triple_store_service=triple_store_service,
+                    graph_name=graph_name,
+                ):
+                    key = _result_key(hit["file_path"], hit["chunk_index"])
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    combined.append(hit)
+
+            return combined
         except Exception as exc:
             return [{"error": str(exc)}]
 
     return StructuredTool(
         name="search_documents",
         description=(
-            "Search the document knowledge base using semantic similarity. "
-            "Returns the most relevant text chunks with their source file paths and similarity scores."
+            "Search the document knowledge base. Supply a natural-language ``query`` "
+            "for semantic similarity and/or a list of ``keywords`` (case-insensitive, "
+            "accent-insensitive) that must ALL appear in the chunk content. Returns "
+            "the relevant text chunks with their source file paths and scores."
         ),
         func=search_documents,
         args_schema=DocumentSearchInput,
@@ -146,8 +323,13 @@ def create_agent(
         api_key=agent_config.api_key,
     )
     vector_store_service = module.engine.services.vector_store
+    triple_store_service = module.engine.services.triple_store
 
-    search_tool = _build_search_tool(embeddings_model, vector_store_service)
+    search_tool = _build_search_tool(
+        embeddings_model,
+        vector_store_service,
+        triple_store_service=triple_store_service,
+    )
     tools: list[BaseTool] = [search_tool]
 
     system_prompt = SYSTEM_PROMPT.replace(

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/domains/document/agents/DocumentAgent_test.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/domains/document/agents/DocumentAgent_test.py
@@ -1,16 +1,16 @@
-"""Basic smoke tests for the DocumentAgent search tool builder."""
+"""Tests for the DocumentAgent hybrid search tool."""
 
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any, List
 from unittest.mock import MagicMock
 
-import numpy as np
 import pytest
 
 from naas_abi_marketplace.domains.document.agents.DocumentAgent import (
     DocumentSearchInput,
     _build_search_tool,
+    _normalize_text,
 )
 
 
@@ -24,8 +24,10 @@ class FakeSearchResult:
 class FakeVectorStore:
     def __init__(self, results: List[FakeSearchResult]):
         self._results = results
+        self.last_k: int | None = None
 
     def search_similar(self, collection_name, query_vector, k, include_metadata=True):
+        self.last_k = k
         return self._results[:k]
 
 
@@ -34,8 +36,43 @@ class FakeEmbeddingsModel:
         return [0.1, 0.2, 0.3, 0.4]
 
 
+class FakeTripleStore:
+    """Returns object-attr rows (mimics rdflib's bindings access)."""
+
+    def __init__(self, rows: list[dict]):
+        self._rows = rows
+        self.last_query: str | None = None
+
+    def query(self, query: str):
+        self.last_query = query
+        out = []
+        for row in self._rows:
+            obj = MagicMock()
+            obj.file_path = row["file_path"]
+            obj.chunk_index = row["chunk_index"]
+            obj.content = row["content"]
+            out.append(obj)
+        return out
+
+
+class TestNormalizeText:
+    def test_lowercases(self):
+        assert _normalize_text("Hello") == "hello"
+
+    def test_strips_french_accents(self):
+        assert _normalize_text("Épée") == "epee"
+        assert _normalize_text("château") == "chateau"
+        assert _normalize_text("Noël") == "noel"
+
+    def test_strips_mixed_accents(self):
+        assert _normalize_text("Crème Brûlée") == "creme brulee"
+
+    def test_empty(self):
+        assert _normalize_text("") == ""
+
+
 class TestBuildSearchTool:
-    def test_search_returns_formatted_results(self):
+    def test_vector_search_returns_formatted_results(self):
         fake_results = [
             FakeSearchResult(
                 score=0.95,
@@ -54,16 +91,15 @@ class TestBuildSearchTool:
         assert len(result) == 2
         assert result[0]["score"] == pytest.approx(0.95)
         assert result[0]["file_path"] == "docs/guide.md"
-        assert result[0]["content"] == "This is the installation guide."
-        assert result[1]["file_path"] == "docs/faq.md"
+        assert result[0]["match_type"] == "vector"
 
-    def test_search_empty_query_returns_error(self):
+    def test_empty_query_and_keywords_returns_error(self):
         tool = _build_search_tool(FakeEmbeddingsModel(), FakeVectorStore([]))
-        result = tool.func(query="", collection_name="documents", k=5)
+        result = tool.func(query="", keywords=[], collection_name="documents", k=5)
         assert len(result) == 1
         assert "error" in result[0]
 
-    def test_k_limits_results(self):
+    def test_k_limits_vector_results(self):
         fake_results = [
             FakeSearchResult(
                 score=0.9 - i * 0.1,
@@ -87,17 +123,140 @@ class TestBuildSearchTool:
         assert "error" in result[0]
         assert "connection failed" in result[0]["error"]
 
+    def test_keyword_search_matches_all_terms_accent_insensitive(self):
+        triple = FakeTripleStore(
+            [
+                {
+                    "file_path": "docs/a.md",
+                    "chunk_index": 0,
+                    "content": "Le château de l'épée brille.",
+                },
+                {
+                    "file_path": "docs/b.md",
+                    "chunk_index": 1,
+                    "content": "Just a guide with no special terms.",
+                },
+                {
+                    "file_path": "docs/c.md",
+                    "chunk_index": 2,
+                    "content": "Une épée sans forteresse.",
+                },
+            ]
+        )
+        tool = _build_search_tool(
+            FakeEmbeddingsModel(),
+            FakeVectorStore([]),
+            triple_store_service=triple,
+        )
+        # No vector query — keyword-only search must match all terms.
+        result = tool.func(
+            query="",
+            keywords=["EPEE", "Chateau"],
+            collection_name="documents",
+            k=10,
+        )
+
+        paths = [r["file_path"] for r in result]
+        assert "docs/a.md" in paths
+        assert "docs/c.md" not in paths  # missing one of the keywords
+        assert "docs/b.md" not in paths
+        for r in result:
+            assert r["match_type"] == "keyword"
+
+    def test_hybrid_search_dedupes_results(self):
+        fake_results = [
+            FakeSearchResult(
+                score=0.95,
+                metadata={"file_path": "docs/a.md", "chunk_index": 0},
+                payload={"content": "Le château de l'épée brille."},
+            ),
+        ]
+        triple = FakeTripleStore(
+            [
+                {
+                    "file_path": "docs/a.md",
+                    "chunk_index": 0,
+                    "content": "Le château de l'épée brille.",
+                },
+            ]
+        )
+        tool = _build_search_tool(
+            FakeEmbeddingsModel(),
+            FakeVectorStore(fake_results),
+            triple_store_service=triple,
+        )
+        result = tool.func(
+            query="forteresse médiévale",
+            keywords=["chateau", "epee"],
+            collection_name="documents",
+            k=5,
+        )
+        assert len(result) == 1
+        assert result[0]["match_type"] == "vector"
+
+    def test_vector_results_filtered_by_keywords(self):
+        fake_results = [
+            FakeSearchResult(
+                score=0.95,
+                metadata={"file_path": "docs/match.md", "chunk_index": 0},
+                payload={"content": "Le château et l'épée."},
+            ),
+            FakeSearchResult(
+                score=0.90,
+                metadata={"file_path": "docs/skip.md", "chunk_index": 1},
+                payload={"content": "Unrelated content."},
+            ),
+        ]
+        tool = _build_search_tool(
+            FakeEmbeddingsModel(),
+            FakeVectorStore(fake_results),
+            triple_store_service=FakeTripleStore([]),
+        )
+        result = tool.func(
+            query="anything",
+            keywords=["chateau", "epee"],
+            collection_name="documents",
+            k=5,
+        )
+        paths = [r["file_path"] for r in result]
+        assert "docs/match.md" in paths
+        assert "docs/skip.md" not in paths
+
+    def test_vector_search_fetches_wider_net_when_keywords_present(self):
+        store = FakeVectorStore([])
+        tool = _build_search_tool(
+            FakeEmbeddingsModel(),
+            store,
+            triple_store_service=FakeTripleStore([]),
+        )
+        tool.func(query="hi", keywords=["foo"], collection_name="documents", k=3)
+        # widened to k*4 so keyword filtering doesn't starve the result set.
+        assert store.last_k == 12
+
+    def test_keyword_search_without_triple_store_is_skipped(self):
+        tool = _build_search_tool(FakeEmbeddingsModel(), FakeVectorStore([]))
+        result = tool.func(query="", keywords=["foo"], collection_name="documents", k=5)
+        # No vector results, no triple store → empty (not error).
+        assert result == []
+
 
 class TestDocumentSearchInput:
     def test_defaults(self):
         inp = DocumentSearchInput(query="hello")
         assert inp.collection_name == "documents"
         assert inp.k == 5
+        assert inp.keywords == []
 
     def test_custom_values(self):
-        inp = DocumentSearchInput(query="test", collection_name="my_collection", k=10)
+        inp = DocumentSearchInput(
+            query="test",
+            keywords=["a", "b"],
+            collection_name="my_collection",
+            k=10,
+        )
         assert inp.collection_name == "my_collection"
         assert inp.k == 10
+        assert inp.keywords == ["a", "b"]
 
     def test_k_bounds(self):
         with pytest.raises(Exception):


### PR DESCRIPTION
## Summary

- The DocumentAgent's `search_documents` tool now combines vector similarity search with a keyword text search over chunk contents pulled from the triple store.
- Keyword matching is case-insensitive and accent-insensitive (NFKD normalization), so `"epee"` matches `"épée"` — important for French content.
- When both `query` and `keywords` are supplied, vector hits are filtered to those whose content contains every keyword, and results from both modes are merged and deduped by `(file_path, chunk_index)`.

## What changed

**`DocumentAgent.py`**
- New `keywords: List[str]` field on `DocumentSearchInput`. All terms must appear in a chunk's content for it to match.
- `_normalize_text()` lowercases and strips combining marks via `unicodedata.normalize("NFKD")`.
- `_vector_search()` widens the fetched set (`k*4`) when keywords are present, then filters with the normalized keyword constraint.
- `_keyword_search()` issues a SPARQL query against the document graph to retrieve every `doc:Chunk` in the collection, then applies the accent/case-folded keyword filter in Python (so Unicode folding stays reliable across triple-store backends).
- `create_agent()` now wires `module.engine.services.triple_store` into the tool.
- System prompt updated so the agent knows when to pass `keywords` vs. relying on semantic similarity.

## Why

The previous implementation could only retrieve chunks via embedding similarity. For exact-term lookups (names, identifiers, French keywords with accents) semantic search alone misses obvious matches. Hybrid search closes that gap while keeping the architectural boundary clean — the vector store port is unchanged, and text matching reuses the existing triple-store chunks.

## Test plan

- [x] `pytest naas_abi_marketplace/domains/document/agents/DocumentAgent_test.py` — 16/16 pass
- [x] French accent normalization (`Épée` → `epee`, `château` → `chateau`, `Crème Brûlée` → `creme brulee`)
- [x] Keyword-only search returns chunks containing all terms, skips chunks missing any
- [x] Hybrid search dedupes overlapping vector + keyword hits
- [x] Vector results filtered by keywords when both provided
- [x] Wider fetch-k (`k*4`) when keywords accompany a vector query
- [x] Graceful fallback when no triple store is wired in

🤖 Generated with [Claude Code](https://claude.com/claude-code)