### PR TITLE
build: add nexus web build to make check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,7 @@ help:
 	@echo "  check                    Run all code quality checks (core, custom, marketplace)"
 	@echo "  check-core               Run code quality checks for core modules"
 	@echo "  check-marketplace        Run code quality checks for marketplace modules"
+	@echo "  check-nexus              Build the Nexus web app to catch frontend errors"
 	@echo "  fmt                      Format code using ruff"
 	@echo "  bandit                   Run security scanning with bandit"
 	@echo "  trivy-container-scan     Run container security scanning with trivy"
@@ -605,7 +606,19 @@ hello:
 # =============================================================================
 
 # Master check target - runs all code quality checks
-check: deps check-core check-marketplace
+check: deps check-core check-marketplace check-nexus
+
+# Build Nexus web app to catch frontend build errors before commit
+check-nexus: deps
+	@echo ""
+	@echo "  _____ _____ _____ _____ _____ "
+	@echo " |     |     |     |     |     |"
+	@echo " |  N  |  E  |  X  |  U  |  S  |"
+	@echo " |_____|_____|_____|_____|_____|"
+	@echo ""
+	@echo "\033[1;4m🔨 Building Nexus web app...\033[0m\n"
+	@cd libs/naas-abi/naas_abi/apps/nexus/apps/web && pnpm build
+	@echo "\n✅ NEXUS build passed!"
 
 # Code quality checks for core modules
 check-core: deps


### PR DESCRIPTION
## Summary
- Adds a `check-nexus` Makefile target that runs `pnpm build` in `libs/naas-abi/naas_abi/apps/nexus/apps/web`
- Wires `check-nexus` into the master `check` target so the pre-commit hook catches Nexus build failures before they land
- Updates the help text to list the new target

## Why
Frontend build errors in the Nexus app were not caught by `make check` and could slip into commits. Building the Next.js app locally as part of the pre-commit check surfaces these regressions early.

## Test plan
- [ ] `make check-nexus` builds successfully
- [ ] `make check` runs core, marketplace, and nexus checks end-to-end
- [ ] Pre-commit hook fails when the Nexus build is broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)