### PR TITLE
ci: install Node.js and pnpm in PR check job

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,6 +24,16 @@ jobs:
         with:
           enable-cache: true
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8.15.0
+
       - name: Run checks
         run: make check
 


### PR DESCRIPTION
## Summary
- The `check-nexus` target added to `make check` invokes `pnpm build`, which currently fails in the `pull_request.yml` job with `pnpm: not found` because the CI runner only has Python/uv installed.
- Adds `actions/setup-node@v4` (Node 20) and `pnpm/action-setup@v4` (pnpm 8.15.0, matching the `packageManager` field in `libs/naas-abi/naas_abi/apps/nexus/package.json`) before `make check` runs.

## Why
PR CI has been failing on `make check` since `check-nexus` was wired into the top-level `check` target. The CI container needs the frontend toolchain to build the Nexus web app.

## Test plan
- [ ] CI `check` job passes on this PR (the previously failing `check-nexus` step now finds `pnpm`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)