### PR TITLE
fix(docker): install libgl1 for opencv runtime in deployed image

### DIFF
--- a/.deploy/docker/images/Dockerfile
+++ b/.deploy/docker/images/Dockerfile
@@ -1,8 +1,15 @@
 FROM python:3.11
 WORKDIR /app
 
-# Install CA certificates
-RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificates
+# Install CA certificates and runtime libs required by opencv (libGL, libglib),
+# which is pulled in transitively by docling for PDF conversion pipelines.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libgl1 \
+        libglib2.0-0 \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN pip install uv
 

--- a/.deploy/docker/images/Dockerfile.linux.x86_64
+++ b/.deploy/docker/images/Dockerfile.linux.x86_64
@@ -42,7 +42,11 @@ RUN --mount=type=cache,target=/app/.cache/ chmod -R 777 /app/.cache/ && su abi /
 # Final stage
 FROM ubuntu:24.04
 
-RUN apt-get update && apt-get upgrade -y && rm -rf /var/cache/apt/*
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
+        libgl1 \
+        libglib2.0-0 \
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 # Create the same user in the final image
 RUN useradd -m -s /bin/bash -G sudo -u 1001 abi -d /app

--- a/docker/images/Dockerfile
+++ b/docker/images/Dockerfile
@@ -12,6 +12,8 @@ RUN apt-get update \
         libreoffice-impress \
         fonts-dejavu \
         fonts-liberation \
+        libgl1 \
+        libglib2.0-0 \
     && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/images/Dockerfile.linux.x86_64
+++ b/docker/images/Dockerfile.linux.x86_64
@@ -42,7 +42,11 @@ RUN --mount=type=cache,target=/app/.cache/ chmod -R 777 /app/.cache/ && su abi /
 # Final stage
 FROM ubuntu:24.04
 
-RUN apt-get update && apt-get upgrade -y && rm -rf /var/cache/apt/*
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
+        libgl1 \
+        libglib2.0-0 \
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 # Create the same user in the final image
 RUN useradd -m -s /bin/bash -G sudo -u 1001 abi -d /app


### PR DESCRIPTION
## Summary
- Add `libgl1` and `libglib2.0-0` to the final stage of `Dockerfile.linux.x86_64` (both `.deploy/docker/images/` and `docker/images/`).
- Fixes `ImportError: libGL.so.1: cannot open shared object file` raised by `pdftohtml_pipeline` in Dagster when `docling` transitively imports `cv2` (opencv).

## Root cause
The Ubuntu 24.04 final image was missing the system libraries opencv needs at runtime. Build stage installs build tools only; the final image had no GL/glib. As soon as the docling table-structure model tries to load, `import cv2` fails.

## Test plan
- [ ] Rebuild the linux/x86_64 image and redeploy Dagster
- [ ] Trigger the `pdftohtml_pipeline` op; verify it no longer fails on `import cv2`
- [ ] Confirm image size delta is acceptable (libgl1 + libglib are small)

🤖 Generated with [Claude Code](https://claude.com/claude-code)