### PR TITLE
fix(cli): install libgl1 and libglib2.0-0 in deploy templates

### DIFF
--- a/libs/naas-abi-cli/naas_abi_cli/cli/deploy/templates/local/docker/images/Dockerfile
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/deploy/templates/local/docker/images/Dockerfile
@@ -1,8 +1,15 @@
 FROM python:3.11
 WORKDIR /app
 
-# Install CA certificates
-RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificates
+# Install CA certificates and runtime libs required by opencv (libGL, libglib),
+# which is pulled in transitively by docling for PDF conversion pipelines.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libgl1 \
+        libglib2.0-0 \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN pip install uv
 

--- a/libs/naas-abi-cli/naas_abi_cli/cli/deploy/templates/local/docker/images/Dockerfile.linux.x86_64
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/deploy/templates/local/docker/images/Dockerfile.linux.x86_64
@@ -42,7 +42,11 @@ RUN --mount=type=cache,target=/app/.cache/ chmod -R 777 /app/.cache/ && su abi /
 # Final stage
 FROM ubuntu:24.04
 
-RUN apt-get update && apt-get upgrade -y && rm -rf /var/cache/apt/*
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
+        libgl1 \
+        libglib2.0-0 \
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 # Create the same user in the final image
 RUN useradd -m -s /bin/bash -G sudo -u 1001 abi -d /app


### PR DESCRIPTION
The CLI's local deploy templates ship the same Dockerfiles to users' new projects. Apply the opencv runtime libs fix there too so freshly deployed projects don't hit the same ImportError on docling pipelines.