### PR TITLE
feat(cli): add --modules flag to `abi config validate`

### DIFF
--- a/libs/naas-abi-cli/naas_abi_cli/cli/config.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/config.py
@@ -1,6 +1,8 @@
+import importlib
 import os
 
 import click
+import pydantic_core
 import yaml
 
 from naas_abi_core.engine.engine_configuration.EngineConfiguration import (
@@ -13,9 +15,70 @@ def config():
     pass
 
 
+def _validate_modules(configuration: EngineConfiguration) -> None:
+    errors: list[str] = []
+
+    for module_config in configuration.modules:
+        if not module_config.enabled:
+            continue
+
+        if module_config.module is None:
+            # path-based modules are not importable via importlib here; skip.
+            continue
+
+        module_name = module_config.module
+
+        try:
+            module = importlib.import_module(module_name)
+        except Exception as e:
+            errors.append(f"{module_name}: failed to import ({e})")
+            continue
+
+        if not hasattr(module, "ABIModule"):
+            errors.append(f"{module_name}: missing ABIModule class")
+            continue
+
+        if not hasattr(module.ABIModule, "Configuration"):
+            errors.append(f"{module_name}: ABIModule missing Configuration class")
+            continue
+
+        if not hasattr(module.ABIModule, "get_dependencies"):
+            errors.append(f"{module_name}: ABIModule missing get_dependencies method")
+            continue
+
+        try:
+            module.ABIModule.Configuration(
+                global_config=configuration.global_config,
+                **module_config.config,
+            )
+        except pydantic_core._pydantic_core.ValidationError as e:
+            errors.append(f"{module_name}: invalid configuration ({e})")
+            continue
+        except Exception as e:
+            errors.append(
+                f"{module_name}: failed to instantiate Configuration ({e})"
+            )
+            continue
+
+        print(f"  ✓ {module_name}")
+
+    if errors:
+        for err in errors:
+            print(f"  ✗ {err}")
+        raise click.ClickException(
+            f"{len(errors)} module(s) failed validation"
+        )
+
+
 @config.command("validate")
 @click.option("--configuration-file", type=str, required=False, default=None)
-def validate(configuration_file: str | None):
+@click.option(
+    "--modules",
+    is_flag=True,
+    default=False,
+    help="Also validate that each enabled module is importable and its config is valid.",
+)
+def validate(configuration_file: str | None, modules: bool):
     configuration_content: str | None = None
 
     if configuration_file is not None:
@@ -26,8 +89,13 @@ def validate(configuration_file: str | None):
         with open(configuration_file, "r") as file:
             configuration_content = file.read()
 
-    EngineConfiguration.load_configuration(configuration_content)
+    configuration = EngineConfiguration.load_configuration(configuration_content)
     print("Configuration is valid")
+
+    if modules:
+        print("Validating modules...")
+        _validate_modules(configuration)
+        print("All enabled modules are valid")
 
 
 @config.command("render")


### PR DESCRIPTION
## Summary
- `abi config validate` previously only ran the Pydantic schema check on the configuration file, so a malformed/missing/misconfigured module would only surface at engine startup.
- Adds an opt-in `--modules` flag that, after schema validation, walks every enabled module and verifies it can actually be loaded:
  - importable via `importlib.import_module`
  - exposes an `ABIModule` class with both `Configuration` and `get_dependencies`
  - the module's `Configuration` can be instantiated with the supplied `global_config` + `config` dict (catches pydantic validation errors per-module)
- Errors are collected and printed together, then the command exits non-zero. Without the flag, behavior is unchanged.

## Test plan
- [ ] `abi config validate` — still passes schema-only validation
- [ ] `abi config validate --modules` against a valid config — prints a check per module and `All enabled modules are valid`
- [ ] `abi config validate --modules` against a config with a non-existent module name — fails with a clear import error
- [ ] `abi config validate --modules` against a module with an invalid `config:` block — fails with the pydantic validation error attributed to that module

🤖 Generated with [Claude Code](https://claude.com/claude-code)