### PR TITLE
chore(api): add early boot timestamps to diagnose slow startup

### DIFF
--- a/libs/naas-abi-core/naas_abi_core/apps/api/api.py
+++ b/libs/naas-abi-core/naas_abi_core/apps/api/api.py
@@ -1,3 +1,10 @@
+# ruff: noqa: E402
+import sys
+import time
+
+_BOOT_T0 = time.monotonic()
+print(f"[abi-boot] api module import started (pid={__import__('os').getpid()})", file=sys.stderr, flush=True)
+
 import os
 import subprocess
 from importlib.resources import files
@@ -16,7 +23,9 @@ from fastapi.security import OAuth2PasswordRequestForm
 from fastapi.security.oauth2 import OAuth2
 from fastapi.security.utils import get_authorization_scheme_param
 from fastapi.staticfiles import StaticFiles
+print(f"[abi-boot] heavy imports starting (+{time.monotonic() - _BOOT_T0:.2f}s)", file=sys.stderr, flush=True)
 from naas_abi_core import logger
+print(f"[abi-boot] naas_abi_core imported (+{time.monotonic() - _BOOT_T0:.2f}s)", file=sys.stderr, flush=True)
 
 # Docs
 from naas_abi_core.apps.api.openapi_doc import API_LANDING_HTML
@@ -296,6 +305,7 @@ def get_app() -> FastAPI:
 
 
 def api():
+    print(f"[abi-boot] api() entered, starting uvicorn (+{time.monotonic() - _BOOT_T0:.2f}s)", file=sys.stderr, flush=True)
     import uvicorn
 
     reload_enabled = api_runtime_configuration.reload


### PR DESCRIPTION
## Summary

Adds three stderr-flushed `print` markers in `naas_abi_core/apps/api/api.py` so we can tell from container logs exactly where time is spent during ABI boot:

- `[abi-boot] api module import started` — fires the instant Python begins importing the module.
- `[abi-boot] heavy imports starting … naas_abi_core imported (+Xs)` — brackets the `naas_abi_core` package import.
- `[abi-boot] api() entered, starting uvicorn (+Xs)` — printed just before `uvicorn.run`.

Each message includes seconds elapsed since module-load start.

## Why

Today `abi` can sit silent for a long time after `docker compose up` and there's no way to tell whether the delay is:

1. waiting on the 6 `depends_on: service_healthy` services,
2. `uv run --no-dev` syncing the venv into the `venv_cache` volume,
3. heavy Python imports (LangGraph / transformers / docling / etc.) before the logger fires,
4. uvicorn itself.

These markers split that black box into measurable chunks.

## Notes

- Uses `print(..., file=sys.stderr, flush=True)` rather than the project logger on purpose — the logger import is itself part of what we're trying to time.
- Adds a module-level `# ruff: noqa: E402` so ruff is happy with the print statements interleaved between imports.
- No behavior change beyond the extra stderr output.

## Test plan

- [ ] `docker compose up abi` and confirm the three `[abi-boot]` lines appear in order with sensible offsets.
- [ ] Confirm `uv run --no-dev python -m naas_abi_core.apps.api.api` still starts the API as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)