### PR TITLE
fix(nexus): system drive shows full object storage root

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/files/adapters/primary/files__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/files/adapters/primary/files__primary_adapter__FastAPI.py
@@ -100,8 +100,12 @@ def _normalize_user_id(user_id: str) -> str:
 
 def _scope_to_path(root: str, path: str) -> str:
     """Anchor ``path`` under ``root`` regardless of whether the caller already
-    prefixed it. Accepts an empty path (returns the root itself)."""
+    prefixed it. Accepts an empty path (returns the root itself). An empty
+    ``root`` means "no prefix" — paths are returned as-is, resolving against
+    the underlying object-storage root."""
     normalized_path = FilesService.normalize_relative_path(path, allow_empty=True)
+    if not root:
+        return normalized_path
     if not normalized_path:
         return root
     if normalized_path == root or normalized_path.startswith(f"{root}/"):

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/files/drive_roots.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/files/drive_roots.py
@@ -22,10 +22,12 @@ MODULE_ROOT = "naas_abi"
 MY_DRIVE_ROOT = f"{MODULE_ROOT}/my-drive"
 WORKSPACE_DRIVE_ROOT = f"{MODULE_ROOT}/workspace-drive"
 PLATFORM_DRIVE_ROOT = f"{MODULE_ROOT}/platform-drive"
-# The system drive exposes the full module storage tree — every drive sits
-# below this root. Reserved for workspace admins/owners to inspect and
-# manage object storage across all users and workspaces.
-SYSTEM_DRIVE_ROOT = MODULE_ROOT
+# The system drive exposes the full object-storage tree — not just the
+# ``naas_abi`` module root, but everything stored alongside it. Reserved for
+# workspace admins/owners to inspect and manage object storage across all
+# users and workspaces. An empty root means "no prefix": paths are resolved
+# directly against the underlying object storage.
+SYSTEM_DRIVE_ROOT = ""
 
 SCOPE_WORKSPACE = "workspace"
 SCOPE_MY_DRIVE = "my_drive"

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/files/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/files/page.tsx
@@ -196,7 +196,7 @@ export default function FilesPage() {
       : activeSource === 'platform-drive'
         ? 'naas_abi/platform-drive'
         : activeSource === 'system-drive'
-          ? 'naas_abi'
+          ? ''
           : workspaceId
             ? `naas_abi/workspace-drive/${workspaceId}`
             : '';


### PR DESCRIPTION
## Summary
- System Drive in the Nexus file manager was anchored under the `naas_abi/` module prefix, so it only ever showed the module subtree
- `SYSTEM_DRIVE_ROOT` is now empty (no prefix), and `_scope_to_path` short-circuits when the root is empty so paths resolve against the real object-storage root
- Frontend `driveRoot` for `system-drive` is now `''`, so the breadcrumb shows the full storage tree instead of stripping a `naas_abi/` prefix
- Workspace-admin authorization is unchanged

## Test plan
- [ ] As a workspace admin, open the Nexus file manager and select System Drive — verify the listing shows the object-storage root (including `naas_abi/` and any siblings) rather than the contents of `naas_abi/`
- [ ] Navigate into subfolders from the system drive root and confirm breadcrumb + listing behave correctly
- [ ] Confirm non-admins still get a 403 on `scope=system_drive`
- [ ] Confirm `my_drive`, `platform_drive`, and `workspace` scopes are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)