### PR TITLE
feat(nexus): split feature flags per sidebar section

### DIFF
--- a/config.local.yaml
+++ b/config.local.yaml
@@ -59,11 +59,15 @@ modules:
             - chat
             - files
             - agents
-            - knowledge
+            - apps
+            - marketplace
+            - search
+            - ontology
+            - graph
             - settings
           role_baseline:
-            owner:  [chat, files, agents, knowledge, settings]
-            admin:  [chat, files, agents, knowledge, settings]
+            owner:  [chat, files, agents, apps, marketplace, search, ontology, graph, settings]
+            admin:  [chat, files, agents, apps, marketplace, search, ontology, graph, settings]
             member: [chat, files]
             viewer: [chat, files]
           workspace_overrides: {}

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/project/config.local.yaml
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/project/config.local.yaml
@@ -36,11 +36,15 @@ modules:
             - chat
             - files
             - agents
-            - knowledge
+            - apps
+            - marketplace
+            - search
+            - ontology
+            - graph
             - settings
           role_baseline:
-            owner: [chat, files, agents, knowledge, settings]
-            admin: [chat, files, agents, knowledge, settings]
+            owner: [chat, files, agents, apps, marketplace, search, ontology, graph, settings]
+            admin: [chat, files, agents, apps, marketplace, search, ontology, graph, settings]
             member: [chat, files]
             viewer: [chat, files]
           workspace_overrides: {}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/config.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/config.py
@@ -153,7 +153,17 @@ class MarketplaceConfig(BaseModel):
     )
 
 
-FeatureKey = Literal["chat", "files", "agents", "knowledge", "settings"]
+FeatureKey = Literal[
+    "chat",
+    "files",
+    "agents",
+    "apps",
+    "marketplace",
+    "search",
+    "ontology",
+    "graph",
+    "settings",
+]
 
 
 class FeatureFlagsConfig(BaseModel):
@@ -162,12 +172,42 @@ class FeatureFlagsConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     enabled_features: list[FeatureKey] = Field(
-        default_factory=lambda: ["chat", "files", "agents", "knowledge", "settings"]
+        default_factory=lambda: [
+            "chat",
+            "files",
+            "agents",
+            "apps",
+            "marketplace",
+            "search",
+            "ontology",
+            "graph",
+            "settings",
+        ]
     )
     role_baseline: dict[str, list[FeatureKey]] = Field(
         default_factory=lambda: {
-            "owner": ["chat", "files", "agents", "knowledge", "settings"],
-            "admin": ["chat", "files", "agents", "knowledge", "settings"],
+            "owner": [
+                "chat",
+                "files",
+                "agents",
+                "apps",
+                "marketplace",
+                "search",
+                "ontology",
+                "graph",
+                "settings",
+            ],
+            "admin": [
+                "chat",
+                "files",
+                "agents",
+                "apps",
+                "marketplace",
+                "search",
+                "ontology",
+                "graph",
+                "settings",
+            ],
             "member": ["chat", "files"],
             "viewer": ["chat", "files"],
         }

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/feature_flags.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/feature_flags.py
@@ -8,7 +8,11 @@ KNOWN_FEATURE_KEYS: tuple[str, ...] = (
     "chat",
     "files",
     "agents",
-    "knowledge",
+    "apps",
+    "marketplace",
+    "search",
+    "ontology",
+    "graph",
     "settings",
 )
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/feature_flags_test.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/feature_flags_test.py
@@ -17,7 +17,11 @@ class TestBuildFeatureFlags:
             "chat": True,
             "files": True,
             "agents": False,
-            "knowledge": False,
+            "apps": False,
+            "marketplace": False,
+            "search": False,
+            "ontology": False,
+            "graph": False,
             "settings": False,
         }
 
@@ -25,7 +29,9 @@ class TestBuildFeatureFlags:
         config = FeatureFlagsConfig(
             workspace_overrides={
                 "demo": {
-                    "knowledge": True,
+                    "search": True,
+                    "apps": True,
+                    "marketplace": True,
                     "chat": False,
                 }
             }
@@ -38,7 +44,9 @@ class TestBuildFeatureFlags:
             workspace_id="ws-1",
         )
 
-        assert flags["knowledge"] is True
+        assert flags["search"] is True
+        assert flags["apps"] is True
+        assert flags["marketplace"] is True
         assert flags["chat"] is False
         assert flags["files"] is True
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/workspaces/adapters/primary/workspaces__primary_adapter__FastAPI_test.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/workspaces/adapters/primary/workspaces__primary_adapter__FastAPI_test.py
@@ -12,7 +12,9 @@ def test_to_schema_includes_role_and_feature_flags_for_member() -> None:
     settings.feature_flags = FeatureFlagsConfig(
         workspace_overrides={
             "demo": {
-                "knowledge": True,
+                "search": True,
+                "ontology": True,
+                "graph": True,
             }
         }
     )
@@ -33,7 +35,11 @@ def test_to_schema_includes_role_and_feature_flags_for_member() -> None:
             "chat": True,
             "files": True,
             "agents": False,
-            "knowledge": True,
+            "apps": False,
+            "marketplace": False,
+            "search": True,
+            "ontology": True,
+            "graph": True,
             "settings": False,
         }
     finally:

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/tests/test_workspaces.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/tests/test_workspaces.py
@@ -142,6 +142,10 @@ class TestWorkspaceFeatureFlags:
             "chat": True,
             "files": True,
             "agents": True,
-            "knowledge": True,
+            "apps": True,
+            "marketplace": True,
+            "search": True,
+            "ontology": True,
+            "graph": True,
             "settings": True,
         }

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/index.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/index.tsx
@@ -18,19 +18,19 @@ type SectionDef = {
   icon: React.ReactNode;
   label: string;
   href: string;
-  feature?: 'chat' | 'files' | 'agents' | 'knowledge';
+  feature?: 'chat' | 'files' | 'agents' | 'apps' | 'marketplace' | 'search' | 'ontology' | 'graph';
   extraHref?: string;
 };
 
 const SECTIONS: SectionDef[] = [
-  { id: 'search',   icon: <Search size={18} />,      label: 'Search',          href: '/search',   feature: 'knowledge' },
+  { id: 'search',   icon: <Search size={18} />,      label: 'Search',          href: '/search',   feature: 'search' },
   { id: 'chat',     icon: <MessageSquare size={18} />, label: 'Chat',           href: '/chat',     feature: 'chat' },
-  { id: 'ontology', icon: <BrainCircuit size={18} />,  label: 'Ontology',       href: '/ontology', feature: 'knowledge' },
-  { id: 'graph',    icon: <Waypoints size={18} />,     label: 'Knowledge Graph', href: '/graph',    feature: 'knowledge' },
+  { id: 'ontology', icon: <BrainCircuit size={18} />,  label: 'Ontology',       href: '/ontology', feature: 'ontology' },
+  { id: 'graph',    icon: <Waypoints size={18} />,     label: 'Knowledge Graph', href: '/graph',    feature: 'graph' },
   { id: 'files',    icon: <Folder size={18} />,        label: 'Files',          href: '/files',    feature: 'files' },
   { id: 'lab',      icon: <FlaskConical size={18} />,  label: 'Lab',            href: '/lab',         feature: 'agents' },
-  { id: 'apps',        icon: <LayoutGrid size={18} />,    label: 'Apps',        href: '/apps',        feature: 'agents' },
-  { id: 'marketplace', icon: <Store size={18} />,        label: 'Marketplace', href: '/marketplace', feature: 'agents' },
+  { id: 'apps',        icon: <LayoutGrid size={18} />,    label: 'Apps',        href: '/apps',        feature: 'apps' },
+  { id: 'marketplace', icon: <Store size={18} />,        label: 'Marketplace', href: '/marketplace', feature: 'marketplace' },
 ];
 
 export function Sidebar() {
@@ -56,13 +56,17 @@ export function Sidebar() {
   const canChat = useFeature('chat');
   const canFiles = useFeature('files');
   const canAgents = useFeature('agents');
-  const canKnowledge = useFeature('knowledge');
+  const canApps = useFeature('apps');
+  const canMarketplace = useFeature('marketplace');
+  const canSearch = useFeature('search');
+  const canOntology = useFeature('ontology');
+  const canGraph = useFeature('graph');
 
   useEffect(() => {
     setMounted(true);
     if (canFiles) { fetchFiles(); fetchLabFiles(); }
-    if (canKnowledge) { fetchOntology(); }
-  }, [canFiles, canKnowledge, fetchFiles, fetchLabFiles, fetchOntology]);
+    if (canOntology) { fetchOntology(); }
+  }, [canFiles, canOntology, fetchFiles, fetchLabFiles, fetchOntology]);
 
   // Derive active panel section from the current URL if none is persisted
   useEffect(() => {
@@ -83,7 +87,11 @@ export function Sidebar() {
     if (feature === 'chat') return !!canChat;
     if (feature === 'files') return !!canFiles;
     if (feature === 'agents') return !!canAgents;
-    if (feature === 'knowledge') return !!canKnowledge;
+    if (feature === 'apps') return !!canApps;
+    if (feature === 'marketplace') return !!canMarketplace;
+    if (feature === 'search') return !!canSearch;
+    if (feature === 'ontology') return !!canOntology;
+    if (feature === 'graph') return !!canGraph;
     return true;
   };
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/section-panel.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/section-panel.tsx
@@ -28,16 +28,20 @@ function SectionContent({ section }: { section: SidebarSection }) {
   const canChat = useFeature('chat');
   const canFiles = useFeature('files');
   const canAgents = useFeature('agents');
-  const canKnowledge = useFeature('knowledge');
+  const canApps = useFeature('apps');
+  const canMarketplace = useFeature('marketplace');
+  const canSearch = useFeature('search');
+  const canOntology = useFeature('ontology');
+  const canGraph = useFeature('graph');
 
-  if (section === 'search' && canKnowledge) return <SearchSection collapsed={false} detailOnly />;
+  if (section === 'search' && canSearch) return <SearchSection collapsed={false} detailOnly />;
   if (section === 'chat' && canChat) return <ChatSection collapsed={false} detailOnly />;
-  if (section === 'ontology' && canKnowledge) return <OntologySection collapsed={false} detailOnly />;
-  if (section === 'graph' && canKnowledge) return <KnowledgeGraphSection collapsed={false} detailOnly />;
+  if (section === 'ontology' && canOntology) return <OntologySection collapsed={false} detailOnly />;
+  if (section === 'graph' && canGraph) return <KnowledgeGraphSection collapsed={false} detailOnly />;
   if (section === 'files' && canFiles) return <FilesSection collapsed={false} detailOnly />;
   if (section === 'lab' && canAgents) return <LabSection collapsed={false} detailOnly />;
-  if (section === 'apps' && canAgents) return <AppsSection collapsed={false} detailOnly />;
-  if (section === 'marketplace' && canAgents) return <MarketplaceSection collapsed={false} detailOnly />;
+  if (section === 'apps' && canApps) return <AppsSection collapsed={false} detailOnly />;
+  if (section === 'marketplace' && canMarketplace) return <MarketplaceSection collapsed={false} detailOnly />;
   return null;
 }
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/feature-access.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/feature-access.test.ts
@@ -14,22 +14,38 @@ test('mergeFeatureFlags keeps member defaults', () => {
   assert.equal(flags.chat, true);
   assert.equal(flags.files, true);
   assert.equal(flags.agents, false);
-  assert.equal(flags.knowledge, false);
+  assert.equal(flags.apps, false);
+  assert.equal(flags.marketplace, false);
+  assert.equal(flags.search, false);
+  assert.equal(flags.ontology, false);
+  assert.equal(flags.graph, false);
   assert.equal(flags.settings, false);
 });
 
+test('mergeFeatureFlags can enable apps and marketplace independently', () => {
+  const flags = mergeFeatureFlags('member', { apps: true, marketplace: true });
+
+  assert.equal(flags.apps, true);
+  assert.equal(flags.marketplace, true);
+  assert.equal(flags.agents, false);
+});
+
 test('mergeFeatureFlags applies workspace overrides', () => {
-  const flags = mergeFeatureFlags('member', { knowledge: true, chat: false });
+  const flags = mergeFeatureFlags('member', { search: true, chat: false });
 
   assert.equal(flags.chat, false);
   assert.equal(flags.files, true);
-  assert.equal(flags.knowledge, true);
+  assert.equal(flags.search, true);
 });
 
 test('guard maps workspace paths to features', () => {
   assert.equal(getFeatureForWorkspacePath('/workspace/ws1/chat'), 'chat');
-  assert.equal(getFeatureForWorkspacePath('/workspace/ws1/graph'), 'knowledge');
+  assert.equal(getFeatureForWorkspacePath('/workspace/ws1/search'), 'search');
+  assert.equal(getFeatureForWorkspacePath('/workspace/ws1/ontology'), 'ontology');
+  assert.equal(getFeatureForWorkspacePath('/workspace/ws1/graph'), 'graph');
   assert.equal(getFeatureForWorkspacePath('/workspace/ws1/settings/agents'), 'agents');
+  assert.equal(getFeatureForWorkspacePath('/workspace/ws1/apps'), 'apps');
+  assert.equal(getFeatureForWorkspacePath('/workspace/ws1/marketplace'), 'marketplace');
   assert.equal(getFeatureForWorkspacePath('/workspace/ws1/help'), 'settings');
 });
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/feature-access.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/feature-access.ts
@@ -1,8 +1,27 @@
-export type FeatureKey = 'chat' | 'files' | 'agents' | 'knowledge' | 'settings';
+export type FeatureKey =
+  | 'chat'
+  | 'files'
+  | 'agents'
+  | 'apps'
+  | 'marketplace'
+  | 'search'
+  | 'ontology'
+  | 'graph'
+  | 'settings';
 
 export type WorkspaceFeatureFlags = Partial<Record<FeatureKey, boolean>>;
 
-export const FEATURE_KEYS: FeatureKey[] = ['chat', 'files', 'agents', 'knowledge', 'settings'];
+export const FEATURE_KEYS: FeatureKey[] = [
+  'chat',
+  'files',
+  'agents',
+  'apps',
+  'marketplace',
+  'search',
+  'ontology',
+  'graph',
+  'settings',
+];
 
 const DEFAULT_ROLE_BASELINE: Record<string, FeatureKey[]> = {
   owner: [...FEATURE_KEYS],
@@ -15,7 +34,11 @@ const FEATURE_FALLBACK_ROUTE: Record<FeatureKey, string> = {
   chat: '/chat',
   files: '/files',
   agents: '/lab',
-  knowledge: '/search',
+  apps: '/apps',
+  marketplace: '/marketplace',
+  search: '/search',
+  ontology: '/ontology',
+  graph: '/graph',
   settings: '/settings',
 };
 
@@ -63,13 +86,23 @@ export function getFeatureForWorkspacePath(pathname: string): FeatureKey | null 
   if (firstSegment === 'files') {
     return 'files';
   }
-  if (firstSegment === 'search' || firstSegment === 'ontology' || firstSegment === 'graph') {
-    return 'knowledge';
+  if (firstSegment === 'search') {
+    return 'search';
+  }
+  if (firstSegment === 'ontology') {
+    return 'ontology';
+  }
+  if (firstSegment === 'graph') {
+    return 'graph';
+  }
+  if (firstSegment === 'apps') {
+    return 'apps';
+  }
+  if (firstSegment === 'marketplace') {
+    return 'marketplace';
   }
   if (
     firstSegment === 'lab' ||
-    firstSegment === 'apps' ||
-    firstSegment === 'marketplace' ||
     (firstSegment === 'settings' && parts[workspaceIndex + 3] === 'agents')
   ) {
     return 'agents';
@@ -103,7 +136,7 @@ export function getFirstAllowedWorkspacePath(params: {
   workspaceFlags?: WorkspaceFeatureFlags;
 }): string {
   const resolved = mergeFeatureFlags(params.role, params.workspaceFlags);
-  const priority: FeatureKey[] = ['chat', 'files', 'knowledge', 'agents', 'settings'];
+  const priority: FeatureKey[] = ['chat', 'files', 'search', 'ontology', 'graph', 'agents', 'apps', 'marketplace', 'settings'];
 
   for (const feature of priority) {
     if (resolved[feature]) {


### PR DESCRIPTION
## Summary

Splits the Nexus workspace feature-flag system so each left-sidebar section is independently toggleable, instead of three sections sharing a single flag.

- `agents` previously gated **Lab**, **Apps**, and **Marketplace** together → now `agents` (Lab only), `apps`, and `marketplace` are separate flags.
- `knowledge` previously gated **Search**, **Ontology**, and **Knowledge Graph** together → now `search`, `ontology`, and `graph` are separate flags.
- Net result: each of the 8 sidebar sections maps to its own flag, so workspaces can enable/disable them independently via `workspace_overrides`.

## What changed

**Frontend (`apps/web`)**
- `lib/feature-access.ts` — `FeatureKey` union, `FEATURE_KEYS`, role baseline, fallback routes, and `getFeatureForWorkspacePath` updated.
- `lib/feature-access.test.ts` — new assertions for `search`/`ontology`/`graph`/`apps`/`marketplace` route mapping and overrides.
- `components/shell/sidebar/index.tsx` — per-section flag wiring; `ontology` data fetch now gated on `canOntology` instead of `canKnowledge`.
- `components/shell/sidebar/section-panel.tsx` — per-section gating for `AppsSection`, `MarketplaceSection`, `SearchSection`, `OntologySection`, `KnowledgeGraphSection`.

**Backend (`apps/api`)**
- `core/config.py` — `FeatureKey` literal + default `enabled_features` and `role_baseline` updated.
- `core/feature_flags.py` — `KNOWN_FEATURE_KEYS` updated.
- `core/feature_flags_test.py`, `services/workspaces/.../FastAPI_test.py`, `tests/test_workspaces.py` — expected payloads updated.

**Config**
- `config.local.yaml` and `libs/naas-abi-cli/.../templates/project/config.local.yaml` — new flags listed in `enabled_features` and owner/admin baselines.

## Reviewer notes

- `FeatureFlagsConfig` uses `extra=\"forbid\"`. **Any existing deployment with `knowledge:` under `feature_flags.enabled_features`, `role_baseline`, or `workspace_overrides` will fail to boot until the YAML is migrated** to the new `search/ontology/graph` keys. No backward-compat shim is included — happy to add one if you'd prefer a deprecation path.
- Defaults unchanged for member/viewer roles (still chat + files only); owner/admin get all flags.
- The `settings` flag and chrome around it (header gear, \"Workspace Settings\", \"Organization Settings\", \"Help\" links, AI pane toggle) are unchanged in this PR. They're worth a follow-up — flagged in review discussion but out of scope here.

## Test plan

- [x] \`make check\` passed locally
- [ ] Boot Nexus with default config and confirm sidebar renders all 8 sections for owner
- [ ] Boot Nexus as \`member\` and confirm only Chat + Files render
- [ ] Apply a \`workspace_overrides\` entry (e.g. \`{ apps: true, marketplace: false }\`) and confirm only Apps appears in addition to defaults
- [ ] Visit \`/workspace/<id>/apps\`, \`/marketplace\`, \`/search\`, \`/ontology\`, \`/graph\` and confirm the route-level guard allows/denies correctly