### PR TITLE
fix(nexus): align outer FeatureKey literal with new flag set

### DIFF
--- a/libs/naas-abi/naas_abi/__init__.py
+++ b/libs/naas-abi/naas_abi/__init__.py
@@ -169,13 +169,27 @@ class ExternalAppConfig(BaseModel):
     icon_emoji: str | None = None
 
 
-FeatureKey = Literal["chat", "files", "agents", "knowledge", "settings"]
+FeatureKey = Literal[
+    "chat",
+    "files",
+    "agents",
+    "apps",
+    "marketplace",
+    "search",
+    "ontology",
+    "graph",
+    "settings",
+]
 
 _ALL_FEATURES: list[FeatureKey] = [
     "chat",
     "files",
     "agents",
-    "knowledge",
+    "apps",
+    "marketplace",
+    "search",
+    "ontology",
+    "graph",
     "settings",
 ]
 


### PR DESCRIPTION
## Summary

Follow-up to #974. The previous PR updated the inner `FeatureKey` literal in `apps/nexus/apps/api/app/core/config.py` but missed a **second, parallel** `FeatureKey` literal in `libs/naas-abi/naas_abi/__init__.py:172` — the outer module schema that pydantic-settings validates the YAML against *before* the inner Settings is constructed.

As a result, after #974 landed, any deployment whose YAML had already been migrated to the new keys (`apps`, `marketplace`, `search`, `ontology`, `graph`) — or any deployment whose YAML still had `knowledge` — failed to boot with a Pydantic `literal_error` during \`on_initialized\`:

\`\`\`
pydantic_core._pydantic_core.ValidationError: 3 validation errors for Settings
feature_flags.enabled_features.3
  Input should be 'chat', 'files', 'agents', 'apps', 'marketplace', 'search', 'ontology', 'graph' or 'settings'
  [type=literal_error, input_value='knowledge', ...]
\`\`\`

## Fix

Update the outer `FeatureKey` literal and `_ALL_FEATURES` list to match the inner one. Both now expose the same 9-flag set: `chat`, `files`, `agents`, `apps`, `marketplace`, `search`, `ontology`, `graph`, `settings`.

## Test plan

- [x] API boots locally with the migrated `config.local.yaml`
- [ ] Re-run \`make check\`