### PR TITLE
fix(naas-abi): include analytics app manifest.json in wheel

### DIFF
--- a/libs/naas-abi/pyproject.toml
+++ b/libs/naas-abi/pyproject.toml
@@ -64,6 +64,7 @@ naas_abi = [
     "apps/nexus/ontology/**/*",
     "ontologies/**/*",
     "apps/nexus/demo/**/*",
+    "apps/analytics/**/*",
 ]
 
 


### PR DESCRIPTION
## Summary

The `analytics` app under `libs/naas-abi/naas_abi/apps/analytics/` ships an `__init__.py` and a `manifest.json`, but only the `__init__.py` actually lands in the published wheel. After `pip install naas-abi==2.7.0`:

```
.venv/lib/python3.12/site-packages/naas_abi/apps/analytics/
└── __init__.py        # manifest.json is missing
```

## Why this happens

Setuptools' auto-discovery includes `.py` files inside recognized packages by default, but **non-Python files require explicit configuration**. The current `libs/naas-abi/pyproject.toml` has:

- `include-package-data = true` — but this only works in conjunction with a VCS plugin (`setuptools-scm` / `setuptools-git`) or a `MANIFEST.in`. Neither is configured in this repo (`[build-system]` is absent; `MANIFEST.in` does not exist).
- An explicit `[tool.setuptools.package-data]` glob list that does **not** include `apps/analytics/**`.

So setuptools has no signal to include `manifest.json` in the sdist/wheel.

## Fix

Add `"apps/analytics/**/*"` to the `[tool.setuptools.package-data]` list so every file in the analytics app is bundled.

## Test plan

- [ ] Build wheel locally: `cd libs/naas-abi && python -m build`
- [ ] Verify `manifest.json` is present: `unzip -l dist/naas_abi-*.whl | grep analytics`
- [ ] Confirm `naas_abi/apps/analytics/manifest.json` appears alongside `__init__.py`