### PR TITLE
feat(nexus): admin live event stream + superadmin user flag

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -59,6 +59,7 @@ modules:
         users:
           - email: "admin@example.com"
             name: "Dev Admin"
+            is_superadmin: true
         organizations:
           - name: "Dev"
             slug: "dev"

--- a/libs/naas-abi/naas_abi/__init__.py
+++ b/libs/naas-abi/naas_abi/__init__.py
@@ -237,6 +237,7 @@ class UserSeedConfig(BaseModel):
     company: str | None = None
     role: str | None = None
     bio: str | None = None
+    is_superadmin: bool = False
     store_credentials_in_secrets: bool = True
 
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/api/endpoints/admin.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/api/endpoints/admin.py
@@ -1,0 +1,100 @@
+"""Platform admin endpoints.
+
+Surfaces capabilities scoped to platform superadmins (users with the
+``is_superadmin`` flag set in ``config.yaml``), independent of workspace
+membership.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, Query
+from naas_abi.apps.nexus.apps.api.app.services.auth.adapters.primary.auth__primary_adapter__dependencies import (
+    get_current_user_required,
+    require_superadmin,
+)
+from naas_abi.apps.nexus.apps.api.app.services.auth.adapters.primary.auth__primary_adapter__schemas import (
+    User,
+)
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class AdminMeResponse(BaseModel):
+    is_superadmin: bool
+
+
+@router.get("/me", response_model=AdminMeResponse)
+async def admin_me(
+    current_user: User = Depends(get_current_user_required),
+) -> AdminMeResponse:
+    """Lightweight check the frontend can call to decide whether to show
+    platform-admin surfaces (event stream, etc.). Does not 403 — returns
+    a boolean so non-admin clients can simply hide the UI."""
+    return AdminMeResponse(is_superadmin=bool(current_user.is_superadmin))
+
+
+@router.get("/ping")
+async def admin_ping(_: User = Depends(require_superadmin)) -> dict[str, bool]:
+    """403s for non-superadmins. Used by the admin page to gate access."""
+    return {"ok": True}
+
+
+@router.get("/events/recent")
+async def admin_events_recent(
+    limit: int = Query(100, ge=1, le=1000),
+    _: User = Depends(require_superadmin),
+) -> list[dict[str, Any]]:
+    """Return the most recent ``limit`` LogProcess events from the durable log.
+
+    Used by the admin events page to hydrate its live stream on first mount
+    so the user immediately sees recent activity instead of an empty list.
+    Events come back oldest-first; the frontend reverses them for display.
+    """
+    try:
+        from naas_abi import ABIModule
+        from naas_abi_core.services.event import EventCodec
+
+        engine = ABIModule.get_instance().engine
+    except Exception:
+        logger.exception("admin events recent: engine unavailable")
+        return []
+
+    if not engine.services.events_available():
+        return []
+
+    event_service = engine.services.events
+
+    try:
+        adapter = event_service._adapter  # type: ignore[attr-defined]
+        max_seq = adapter.max_seq()
+        since_seq = max(0, max_seq - limit)
+        # event_class=None → query across every event type; rows are
+        # reconstructed via the stored ``_class_uri`` so subclass-specific
+        # fields survive.
+        events = event_service.query(
+            event_class=None,
+            since_seq=since_seq,
+            limit=limit,
+        )
+    except Exception:
+        logger.exception("admin events recent: query failed")
+        return []
+
+    out: list[dict[str, Any]] = []
+    for ev in events:
+        try:
+            payload = EventCodec.to_event_dict(ev)
+            payload["_seq"] = getattr(ev, "_seq", None)
+            payload["_stored_at"] = getattr(ev, "_stored_at", None) or None
+            # JSON round-trip drops anything non-JSON-safe.
+            out.append(json.loads(json.dumps(payload, default=str)))
+        except Exception:
+            logger.exception("admin events recent: serialize failed")
+    return out

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/api/router.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/api/router.py
@@ -5,6 +5,7 @@ Main API router that aggregates all endpoint routers.
 from fastapi import APIRouter
 from naas_abi.apps.nexus.apps.api.app.api.endpoints import (
     abi,
+    admin,
     analytics,
     graph,
     ontology,
@@ -52,3 +53,4 @@ api_router.include_router(abi.router, prefix="/abi", tags=["abi"])
 api_router.include_router(tenant.router, prefix="/tenant", tags=["tenant"])
 api_router.include_router(transcribe.router, prefix="/transcribe", tags=["transcribe"])
 api_router.include_router(analytics.router, prefix="/analytics", tags=["analytics"])
+api_router.include_router(admin.router, prefix="/admin", tags=["admin"])

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/config.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/config.py
@@ -232,6 +232,7 @@ class UserSeedConfig(BaseModel):
     company: str | None = None
     role: str | None = None
     bio: str | None = None
+    is_superadmin: bool = False
     store_credentials_in_secrets: bool = True
 
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/org_seed.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/org_seed.py
@@ -222,6 +222,7 @@ async def _upsert_users(
                 company=user_cfg.company,
                 role=user_cfg.role,
                 bio=user_cfg.bio,
+                is_superadmin=user_cfg.is_superadmin,
                 created_at=now,
                 updated_at=now,
             )
@@ -249,6 +250,17 @@ async def _upsert_users(
                 "User email=%s already exists; skipping config-driven updates",
                 normalized_email,
             )
+            # is_superadmin is the one config-driven field we always
+            # reconcile, so an admin can promote/demote users via config.yaml
+            # without recreating the account.
+            if bool(user.is_superadmin) != bool(user_cfg.is_superadmin):
+                user.is_superadmin = user_cfg.is_superadmin
+                user.updated_at = now
+                logger.info(
+                    "Reconciled is_superadmin=%s for email=%s from config",
+                    user_cfg.is_superadmin,
+                    normalized_email,
+                )
 
         users_by_email[normalized_email] = user
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/main.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/main.py
@@ -99,6 +99,17 @@ async def _startup(app: FastAPI) -> None:
     except Exception:
         logging.getLogger(__name__).exception("Unable to start chat ingestion consumer")
 
+    # Relay platform LogProcess events to the Socket.IO admin_events room
+    # for the superadmin live event stream UI.
+    try:
+        from naas_abi.apps.nexus.apps.api.app.services.websocket.admin_events import (
+            start_admin_event_relay,
+        )
+
+        start_admin_event_relay()
+    except Exception:
+        logging.getLogger(__name__).exception("Unable to start admin event relay")
+
     # Pre-populate the agent class registry in the background so the first
     # GET /agents/ request returns instantly from cache instead of waiting
     # for all agent modules to be imported.  create_task returns immediately.

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/models.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/models.py
@@ -153,6 +153,7 @@ class UserModel(Base):
     company = Column(String, nullable=True)
     role = Column(String, nullable=True)
     bio = Column(String, nullable=True)
+    is_superadmin = Column(Boolean, nullable=False, default=False, server_default="false")
     created_at = Column(DateTime(timezone=False), nullable=False, default=_utcnow)
     updated_at = Column(DateTime(timezone=False), nullable=False, default=_utcnow, onupdate=_utcnow)
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/auth/adapters/primary/auth__primary_adapter__dependencies.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/auth/adapters/primary/auth__primary_adapter__dependencies.py
@@ -32,6 +32,7 @@ def to_user_schema(user: AuthUserRecord) -> User:
         company=user.company,
         role=user.role,
         bio=user.bio,
+        is_superadmin=user.is_superadmin,
         created_at=user.created_at,
     )
 
@@ -124,6 +125,24 @@ async def require_workspace_platform_drive(user_id: str, workspace_id: str) -> N
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Platform drive is not enabled for this workspace",
         )
+
+
+async def require_superadmin(
+    current_user: User = Depends(get_current_user_required),
+) -> User:
+    """Authorize platform-level admin access.
+
+    The ``is_superadmin`` flag is set on the user record (from
+    ``settings.users[].is_superadmin`` in ``config.yaml``, applied by the
+    startup seeder). Used for cross-workspace diagnostic surfaces like the
+    live platform event stream.
+    """
+    if not current_user.is_superadmin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Platform superadmin role required",
+        )
+    return current_user
 
 
 async def require_workspace_admin(user_id: str, workspace_id: str) -> None:

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/auth/adapters/primary/auth__primary_adapter__schemas.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/auth/adapters/primary/auth__primary_adapter__schemas.py
@@ -36,6 +36,7 @@ class User(UserBase):
     company: str | None = None
     role: str | None = None
     bio: str | None = None
+    is_superadmin: bool = False
 
 
 class UserInDB(User):

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/auth/adapters/secondary/postgres.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/auth/adapters/secondary/postgres.py
@@ -51,6 +51,7 @@ class AuthSecondaryAdapterPostgres(AuthPersistencePort):
             company=model.company,
             role=model.role,
             bio=model.bio,
+            is_superadmin=bool(model.is_superadmin),
             created_at=model.created_at,
         )
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/auth/port.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/auth/port.py
@@ -16,6 +16,7 @@ class AuthUserRecord:
     company: str | None = None
     role: str | None = None
     bio: str | None = None
+    is_superadmin: bool = False
 
 
 @dataclass

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/websocket/admin_events.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/websocket/admin_events.py
@@ -1,0 +1,103 @@
+"""Relay platform LogProcess events to the Socket.IO ``admin_events`` room.
+
+We install a tap on ``EventService.publish`` so every event the engine
+publishes — regardless of whether its subclass had been imported at
+startup time — is serialized through ``EventCodec`` and broadcast as a
+``platform_event`` Socket.IO message.
+
+We tap ``publish`` rather than calling ``subscribe`` per subclass because
+``BusService.subscribe`` requires the subclass to exist at registration
+time, which silently drops event types loaded later in the process.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+ADMIN_EVENTS_ROOM = "admin_events"
+PLATFORM_EVENT = "platform_event"
+
+_relay_installed: bool = False
+
+
+def _emit_event_threadsafe(loop: asyncio.AbstractEventLoop, payload: dict[str, Any]) -> None:
+    """Schedule a Socket.IO emit from a non-async bus subscriber thread."""
+    from naas_abi.apps.nexus.apps.api.app.services.websocket.runtime import sio
+
+    async def _emit() -> None:
+        try:
+            await sio.emit(PLATFORM_EVENT, payload, room=ADMIN_EVENTS_ROOM)
+        except Exception:
+            logger.exception("[admin-events] sio.emit failed")
+
+    try:
+        asyncio.run_coroutine_threadsafe(_emit(), loop)
+    except RuntimeError:
+        logger.debug("[admin-events] event loop closed; dropping event")
+
+
+def _relay(loop: asyncio.AbstractEventLoop, event: Any) -> None:
+    from naas_abi_core.services.event import EventCodec
+
+    try:
+        payload = EventCodec.to_event_dict(event)
+        payload["_seq"] = getattr(event, "_seq", None)
+        payload["_stored_at"] = getattr(event, "_stored_at", None) or None
+        payload = json.loads(json.dumps(payload, default=str))
+    except Exception:
+        logger.exception("[admin-events] failed to serialize event")
+        return
+    logger.debug("[admin-events] emit %s", payload.get("_class_uri"))
+    _emit_event_threadsafe(loop, payload)
+
+
+def start_admin_event_relay() -> None:
+    """Install a tap on ``EventService.publish`` and relay events to SIO.
+
+    Idempotent: a second call is a no-op once the tap is installed. Safe
+    to call when no engine/event service is available — it logs and
+    returns instead of raising.
+    """
+    global _relay_installed
+    if _relay_installed:
+        logger.info("[admin-events] relay already installed; skipping")
+        return
+
+    try:
+        from naas_abi import ABIModule
+
+        engine = ABIModule.get_instance().engine
+    except Exception:
+        logger.warning("[admin-events] ABIModule engine not available; relay disabled")
+        return
+
+    if not engine.services.events_available():
+        logger.warning("[admin-events] EventService not configured; relay disabled")
+        return
+
+    event_service = engine.services.events
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        logger.warning("[admin-events] no running event loop; relay disabled")
+        return
+
+    original_publish = event_service.publish
+
+    def _wrapped_publish(event: Any):  # type: ignore[no-redef]
+        stored = original_publish(event)
+        try:
+            _relay(loop, event)
+        except Exception:
+            logger.exception("[admin-events] relay tap failed")
+        return stored
+
+    event_service.publish = _wrapped_publish  # type: ignore[assignment]
+    _relay_installed = True
+    logger.info("[admin-events] relay installed via EventService.publish tap")

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/websocket/runtime.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/websocket/runtime.py
@@ -83,11 +83,29 @@ async def connect(sid, environ, auth):
         logger.warning("[WS] Token revoked; rejecting connection")
         return False
 
+    # Resolve the user's superadmin flag once at connect time so the
+    # admin-events room gate doesn't have to re-query on every event.
+    is_superadmin = False
+    try:
+        from naas_abi.apps.nexus.apps.api.app.core.database import AsyncSessionLocal
+        from naas_abi.apps.nexus.apps.api.app.services.auth.adapters.secondary.postgres import (
+            AuthSecondaryAdapterPostgres,
+        )
+
+        async with AsyncSessionLocal() as db:
+            adapter = AuthSecondaryAdapterPostgres(db=db)
+            record = await adapter.get_user_by_id(user_id)
+            if record is not None:
+                is_superadmin = bool(record.is_superadmin)
+    except Exception:
+        logger.exception("[WS] failed to resolve user record for sid=%s", sid)
+
     logger.info(f"[WS] Client connected sid={sid} user={user_id}")
 
     # Store user_id with session
     async with sio.session(sid) as session:
         session["user_id"] = user_id
+        session["is_superadmin"] = is_superadmin
         session["workspaces"] = set()
 
     return True
@@ -296,6 +314,57 @@ async def cursor_position(sid, data):
         room=f"workspace:{workspace_id}",
         skip_sid=sid,
     )
+
+
+@sio.event
+async def join_admin_events(sid, data=None):
+    """Subscribe a connected client to the platform admin event stream.
+
+    Membership is gated by ``user.is_superadmin`` (set via the ``users``
+    section of ``config.yaml``); non-superadmins receive an error and are
+    not added to the room. Once joined, the client receives every
+    ``platform_event`` emitted by the EventService relay.
+    """
+    from naas_abi.apps.nexus.apps.api.app.core.database import AsyncSessionLocal
+    from naas_abi.apps.nexus.apps.api.app.services.auth.adapters.secondary.postgres import (
+        AuthSecondaryAdapterPostgres,
+    )
+    from naas_abi.apps.nexus.apps.api.app.services.websocket.admin_events import (
+        ADMIN_EVENTS_ROOM,
+    )
+
+    async with sio.session(sid) as session:
+        user_id = session.get("user_id")
+
+    # Re-check is_superadmin against the DB on every join (don't trust the
+    # cached connect-time flag — the user may have been promoted after their
+    # socket connected).
+    is_superadmin = False
+    try:
+        async with AsyncSessionLocal() as db:
+            adapter = AuthSecondaryAdapterPostgres(db=db)
+            record = await adapter.get_user_by_id(user_id) if user_id else None
+            is_superadmin = bool(record.is_superadmin) if record else False
+    except Exception:
+        logger.exception("[WS] admin events: failed to refresh superadmin flag sid=%s", sid)
+
+    if not is_superadmin:
+        logger.warning("[WS] admin events join denied sid=%s user=%s", sid, user_id)
+        return {"error": "superadmin required"}
+
+    sio.enter_room(sid, ADMIN_EVENTS_ROOM)
+    logger.info("[WS] admin events join sid=%s user=%s room=%s", sid, user_id, ADMIN_EVENTS_ROOM)
+    return {"status": "joined", "room": ADMIN_EVENTS_ROOM}
+
+
+@sio.event
+async def leave_admin_events(sid, data=None):
+    from naas_abi.apps.nexus.apps.api.app.services.websocket.admin_events import (
+        ADMIN_EVENTS_ROOM,
+    )
+
+    sio.leave_room(sid, ADMIN_EVENTS_ROOM)
+    return {"status": "left", "room": ADMIN_EVENTS_ROOM}
 
 
 def get_workspace_presence(workspace_id: str) -> list[str]:

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/migrations/0029_add_user_is_superadmin.sql
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/migrations/0029_add_user_is_superadmin.sql
@@ -1,0 +1,7 @@
+-- Migration: Add is_superadmin flag on users
+
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS is_superadmin BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMENT ON COLUMN users.is_superadmin IS
+    'When TRUE, the user has platform-wide admin access (e.g. live event stream). Toggled via the users section of config.yaml.';

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/admin/events/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/admin/events/page.tsx
@@ -1,0 +1,261 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuthStore, authFetch } from '@/stores/auth';
+
+interface PlatformEvent {
+  _uri: string;
+  _class_uri: string;
+  _seq: number | null;
+  _stored_at: string | null;
+  created_at?: string | null;
+  [key: string]: unknown;
+}
+
+interface EventRow {
+  receivedAt: string;
+  event: PlatformEvent;
+}
+
+const MAX_EVENTS = 500;
+const POLL_INTERVAL_MS = 5000;
+
+function shortClassUri(uri: string): string {
+  const slashed = uri.split('/').filter(Boolean).pop() ?? uri;
+  const hashed = slashed.split('#').pop() ?? slashed;
+  return hashed;
+}
+
+export default function AdminEventsPage() {
+  const router = useRouter();
+  const user = useAuthStore((s) => s.user);
+
+  const [authState, setAuthState] = useState<'checking' | 'authorized' | 'denied'>('checking');
+  const [lastPollAt, setLastPollAt] = useState<Date | null>(null);
+  const [secondsToNextPoll, setSecondsToNextPoll] = useState<number>(POLL_INTERVAL_MS / 1000);
+  const [events, setEvents] = useState<EventRow[]>([]);
+  const [paused, setPaused] = useState(false);
+  const [classFilter, setClassFilter] = useState<string>('');
+  const [textFilter, setTextFilter] = useState<string>('');
+  const pausedRef = useRef(paused);
+  pausedRef.current = paused;
+
+  useEffect(() => {
+    if (!user) {
+      router.replace('/auth/login');
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await authFetch('/api/admin/me');
+        if (!res.ok) {
+          if (!cancelled) setAuthState('denied');
+          return;
+        }
+        const data = await res.json();
+        if (cancelled) return;
+        setAuthState(data.is_superadmin ? 'authorized' : 'denied');
+      } catch {
+        if (!cancelled) setAuthState('denied');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [user, router]);
+
+  // Track event URIs we've already shown so polling doesn't duplicate them.
+  const seenUrisRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (authState !== 'authorized') return;
+    let cancelled = false;
+
+    const poll = async () => {
+      try {
+        const res = await authFetch('/api/admin/events/recent?limit=100');
+        if (!res.ok || cancelled) return;
+        const recent: PlatformEvent[] = await res.json();
+        if (cancelled) return;
+        setLastPollAt(new Date());
+        setSecondsToNextPoll(POLL_INTERVAL_MS / 1000);
+        if (pausedRef.current) return;
+        // Server returns oldest-first; we show newest-first.
+        const ordered = [...recent].reverse();
+        const newRows: EventRow[] = [];
+        for (const event of ordered) {
+          if (seenUrisRef.current.has(event._uri)) continue;
+          seenUrisRef.current.add(event._uri);
+          newRows.push({
+            receivedAt: event._stored_at || event.created_at || new Date().toISOString(),
+            event,
+          });
+        }
+        if (newRows.length === 0) return;
+        setEvents((prev) => {
+          const next = [...newRows, ...prev];
+          return next.length > MAX_EVENTS ? next.slice(0, MAX_EVENTS) : next;
+        });
+      } catch {
+        /* non-fatal: next tick will try again */
+      }
+    };
+
+    poll();
+    const pollId = setInterval(poll, POLL_INTERVAL_MS);
+    const tickId = setInterval(() => {
+      setSecondsToNextPoll((s) => (s > 0 ? s - 1 : 0));
+    }, 1000);
+    return () => {
+      cancelled = true;
+      clearInterval(pollId);
+      clearInterval(tickId);
+    };
+  }, [authState]);
+
+  const knownClasses = useMemo(() => {
+    const set = new Set<string>();
+    for (const row of events) set.add(row.event._class_uri);
+    return Array.from(set).sort();
+  }, [events]);
+
+  const filtered = useMemo(() => {
+    return events.filter((row) => {
+      if (classFilter && row.event._class_uri !== classFilter) return false;
+      if (textFilter) {
+        const needle = textFilter.toLowerCase();
+        if (!JSON.stringify(row.event).toLowerCase().includes(needle)) return false;
+      }
+      return true;
+    });
+  }, [events, classFilter, textFilter]);
+
+  const clear = useCallback(() => setEvents([]), []);
+
+  if (authState === 'checking') {
+    return (
+      <div className="flex h-screen items-center justify-center text-sm text-muted-foreground">
+        Checking access…
+      </div>
+    );
+  }
+
+  if (authState === 'denied') {
+    return (
+      <div className="flex h-screen flex-col items-center justify-center gap-2 p-8 text-center">
+        <h1 className="text-xl font-semibold">Forbidden</h1>
+        <p className="text-sm text-muted-foreground">
+          Platform superadmin role required. Set
+          <code className="mx-1 rounded bg-muted px-1 py-0.5">is_superadmin: true</code>
+          on the matching user in <code className="mx-1 rounded bg-muted px-1 py-0.5">config.yaml</code>
+          and restart the API to grant access.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-screen flex-col bg-background text-foreground">
+      <header className="border-b px-6 py-4">
+        <div className="flex items-baseline justify-between">
+          <div>
+            <h1 className="text-lg font-semibold">Platform events</h1>
+            <p className="text-xs text-muted-foreground">
+              Live LogProcess stream from the EventService. Showing {filtered.length} of{' '}
+              {events.length} (max {MAX_EVENTS}).
+            </p>
+          </div>
+          <div className="flex items-center gap-2 text-xs">
+            <span
+              className={`inline-block h-2 w-2 rounded-full ${
+                lastPollAt ? 'bg-green-500' : 'bg-zinc-400'
+              }`}
+            />
+            <span className="text-muted-foreground">
+              {lastPollAt
+                ? `last ${lastPollAt.toLocaleTimeString()} · next in ${secondsToNextPoll}s`
+                : 'polling…'}
+            </span>
+          </div>
+        </div>
+
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          <button
+            onClick={() => setPaused((p) => !p)}
+            className="rounded border px-3 py-1 text-xs hover:bg-accent"
+          >
+            {paused ? 'Resume' : 'Pause'}
+          </button>
+          <button
+            onClick={clear}
+            className="rounded border px-3 py-1 text-xs hover:bg-accent"
+          >
+            Clear
+          </button>
+          <select
+            value={classFilter}
+            onChange={(e) => setClassFilter(e.target.value)}
+            className="rounded border px-2 py-1 text-xs"
+          >
+            <option value="">All event classes</option>
+            {knownClasses.map((c) => (
+              <option key={c} value={c}>
+                {shortClassUri(c)}
+              </option>
+            ))}
+          </select>
+          <input
+            type="text"
+            value={textFilter}
+            onChange={(e) => setTextFilter(e.target.value)}
+            placeholder="Search payload…"
+            className="flex-1 min-w-[200px] rounded border px-2 py-1 text-xs"
+          />
+        </div>
+      </header>
+
+      <div className="flex-1 overflow-y-auto px-6 py-3">
+        {filtered.length === 0 ? (
+          <div className="py-12 text-center text-sm text-muted-foreground">
+            {paused
+              ? 'Paused — no new events captured.'
+              : events.length === 0
+                ? 'No events recorded yet. Waiting for live events…'
+                : 'No events match the current filters.'}
+          </div>
+        ) : (
+          <ul className="space-y-1 font-mono text-xs">
+            {filtered.map((row) => (
+              <EventLine key={`${row.receivedAt}-${row.event._uri}`} row={row} />
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function EventLine({ row }: { row: EventRow }) {
+  const [expanded, setExpanded] = useState(false);
+  const ts = row.event.created_at || row.event._stored_at || row.receivedAt;
+  const cls = shortClassUri(row.event._class_uri);
+  return (
+    <li className="rounded border border-transparent hover:border-border">
+      <button
+        onClick={() => setExpanded((e) => !e)}
+        className="flex w-full items-center gap-3 px-2 py-1 text-left"
+      >
+        <span className="text-muted-foreground">{ts}</span>
+        <span className="rounded bg-muted px-1.5 py-0.5">{cls}</span>
+        <span className="truncate text-muted-foreground">{row.event._uri}</span>
+      </button>
+      {expanded && (
+        <pre className="max-h-96 overflow-auto whitespace-pre-wrap bg-muted/40 px-3 py-2 text-[11px]">
+          {JSON.stringify(row.event, null, 2)}
+        </pre>
+      )}
+    </li>
+  );
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/index.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/index.tsx
@@ -3,10 +3,11 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import {
-  Check, Search, MessageSquare, BrainCircuit, Waypoints, Folder, FlaskConical, LayoutGrid, Store, Settings,
+  Check, Search, MessageSquare, BrainCircuit, Waypoints, Folder, FlaskConical, LayoutGrid, Store, Settings, Activity,
 } from 'lucide-react';
 import { useRouter, usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
+import { useAuthStore } from '@/stores/auth';
 import { useFeature } from '@/hooks/use-feature';
 import { useWorkspaceStore, type SidebarSection } from '@/stores/workspace';
 import { useFilesStore } from '@/stores/files';
@@ -68,6 +69,7 @@ export function Sidebar() {
   const canOntology = useFeature('ontology');
   const canGraph = useFeature('graph');
   const canSettingsWorkspace = useFeature('settings.workspace');
+  const isSuperadmin = useAuthStore((s) => !!s.user?.is_superadmin);
 
   useEffect(() => {
     setMounted(true);
@@ -248,6 +250,25 @@ export function Sidebar() {
           expanded ? 'px-2' : 'items-center px-2'
         )}
       >
+        {isSuperadmin && (() => {
+          const active = pathname.startsWith('/admin');
+          return (
+            <button
+              key="admin-events"
+              onClick={() => router.push('/admin/events')}
+              title={!expanded ? 'Platform events' : undefined}
+              className={cn(
+                'flex items-center rounded-lg transition-all',
+                'hover:bg-workspace-accent-10 hover:text-workspace-accent',
+                active ? 'bg-workspace-accent-15 text-workspace-accent' : 'text-muted-foreground',
+                expanded ? 'w-full gap-3 px-3 py-2' : 'h-10 w-10 justify-center'
+              )}
+            >
+              <span className="flex-shrink-0"><Activity size={18} /></span>
+              {expanded && <span className="truncate text-sm font-medium">Platform events</span>}
+            </button>
+          );
+        })()}
         {BOTTOM_SECTIONS.filter((s) => isFeatureEnabled(s.feature)).map((section) => {
           const active = isSectionActive(section);
           return (

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/auth.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/auth.ts
@@ -14,6 +14,7 @@ export interface User {
   company?: string;
   role?: string;
   bio?: string;
+  is_superadmin?: boolean;
   createdAt: Date;
 }
 


### PR DESCRIPTION
## Summary

Adds an `/admin/events` page in the Nexus web app that polls every 5 seconds and shows a live, filterable feed of `LogProcess` events from the core `EventService` (the typed events emitted from `cache`, `bus`, `email`, `keyvalue`, `secret`, `triple_store`, `vector_store`, and the `agent` chat events added in #986).

Visibility is gated by a new platform-level **`is_superadmin`** flag on users — toggled from `config.yaml`, not via env vars — so promotion/demotion is part of the config and survives restarts.

## What changed

**Auth model**
- New `users.is_superadmin BOOLEAN NOT NULL DEFAULT FALSE` column (migration `0029_add_user_is_superadmin.sql`).
- `UserSeedConfig.is_superadmin` (both in the Nexus settings and the `naas_abi` module config) — seeder sets it on user creation **and** reconciles it on existing users so flipping the YAML flag takes effect on the next API restart.
- `is_superadmin` carried through `AuthUserRecord` → `User` schema, so `/api/auth/me` exposes it to the frontend.
- `require_superadmin` FastAPI dependency.

**Backend endpoints**
- `GET /api/admin/me` → `{ is_superadmin }` (no 403, used for nav gating).
- `GET /api/admin/events/recent?limit=N` (superadmin-only) — reads the last N events from the durable SQLite event log via `EventService.query(event_class=None, since_seq=max_seq-N)` so subclass-specific fields round-trip through `_class_uri`.
- Socket.IO `join_admin_events` / `leave_admin_events` handlers + a `start_admin_event_relay()` that taps `EventService.publish` to broadcast to an `admin_events` room. **Currently unused** — kept for an eventual switch from polling to push.

**Frontend**
- `/admin/events` page: hydrates with the recent-events endpoint, then polls every 5s. Dedup by event `_uri` (Set ref). Class + free-text filter, pause/resume, clear, countdown to next poll, 500-event in-memory buffer.
- Sidebar gets an `Activity` icon linking to the page, only rendered when `user.is_superadmin` is true.

**Config**
- `config.yaml`: `admin@example.com` is now `is_superadmin: true` for local dev.

## Reviewer notes

- The Socket.IO relay/handlers are dead code on the current main flow (page uses polling). Keeping them around so we can swap to push without restructuring auth/room wiring. Happy to rip out if you'd rather not carry the deadweight.
- The `event_class=None` path on `/admin/events/recent` reaches into `event_service._adapter.max_seq()` because `EventService` doesn't expose a "tail N across all classes" helper. Could add a public method to `IEventService` later.
- Filters are purely client-side over the in-memory buffer (500 events). Server doesn't know about them.
- Polling currently re-fetches the last 100 every tick — wasteful when traffic is low. Easy follow-up: thread a `since_seq` cursor through.

## Test plan

- [ ] Migration `0029` applies on a fresh DB and on an existing one.
- [ ] Setting `is_superadmin: true` on a YAML-seeded user grants access to `/admin/events`; setting it to `false` and restarting revokes access (verifies the reconcile path on existing users).
- [ ] A non-superadmin sees Forbidden on the page and **no** sidebar entry.
- [ ] Recent endpoint returns up to 100 latest events across subclasses with correct `_class_uri` and payload fields.
- [ ] Polling page shows hydrated events on first load, then new events appear within ~5s of being emitted.
- [ ] Pause stops appending; Resume continues; Clear empties the visible list.

## CI

Local pre-commit hook (`make check-nexus`) couldn't run the Nexus production build from my environment (Google Fonts unreachable). CI will run it on the PR.