### PR TITLE
fix(nexus/web): workspace switch from chat page now redirects reliably

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -74,6 +74,24 @@ modules:
                 members:
                   - email: "admin@example.com"
                     role: "owner"
+              - name: "Alpha"
+                slug: "alpha"
+                owner_email: "admin@example.com"
+                members:
+                  - email: "admin@example.com"
+                    role: "owner"
+              - name: "Beta"
+                slug: "beta"
+                owner_email: "admin@example.com"
+                members:
+                  - email: "admin@example.com"
+                    role: "owner"
+              - name: "Gamma"
+                slug: "gamma"
+                owner_email: "admin@example.com"
+                members:
+                  - email: "admin@example.com"
+                    role: "owner"
   
   - module: naas_abi_marketplace.ai.chatgpt
     enabled: true

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
@@ -4,7 +4,7 @@ import React, { useState, useRef, useEffect, useMemo, useCallback, useLayoutEffe
 import { createPortal } from 'react-dom';
 import { Send, Plus, Bot, User, AlertCircle, Brain, ChevronDown, X, ArrowUp, Download, ExternalLink, HardDrive, RefreshCw, Mic, Check, Loader2, Wrench, Copy, FileText } from 'lucide-react';
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { cn } from '@/lib/utils';
@@ -594,14 +594,22 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialConversationId]);
 
+  const pathname = usePathname();
+
   // Keep the URL in sync with the active conversation so each conversation has a shareable link.
+  // Guarded against firing mid-workspace-switch: only rewrite the URL when the
+  // pathname already points at the current workspace's chat route. Otherwise a
+  // pending navigation to a different workspace (router.push from the sidebar)
+  // would race with this effect and get reverted.
   useEffect(() => {
     if (!mounted) return;
     if (!currentWorkspaceId) return;
     const base = `/workspace/${currentWorkspaceId}/chat`;
+    if (!pathname || !pathname.startsWith(`${base}`)) return;
     const target = activeConversationId ? `${base}/${activeConversationId}` : base;
+    if (pathname === target) return;
     router.replace(target, { scroll: false });
-  }, [activeConversationId, mounted, currentWorkspaceId, router]);
+  }, [activeConversationId, mounted, currentWorkspaceId, router, pathname]);
 
   // Narrow selector: only the active conversation's title — avoids re-renders on every streaming token.
   const activeConversationTitle = useWorkspaceStore((s) =>

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/index.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/index.tsx
@@ -52,7 +52,6 @@ export function Sidebar() {
   const {
     workspaces,
     currentWorkspaceId,
-    selectWorkspace,
     activePanelSection,
     setActivePanelSection,
   } = useWorkspaceStore();
@@ -305,7 +304,6 @@ export function Sidebar() {
               <button
                 key={workspace.id}
                 onClick={() => {
-                  selectWorkspace(workspace.id);
                   setWorkspaceMenuOpen(false);
                   router.push(`/workspace/${workspace.id}/chat`);
                 }}


### PR DESCRIPTION
## Summary

Switching workspace from the sidebar while on a chat page sometimes did not redirect to the newly selected workspace (or fell back to the previous one). On the file manager page the same switch worked fine. Two races were responsible.

## Root cause

1. **Sidebar mutated the store before navigating.** When the user clicked a workspace, the sidebar called `selectWorkspace`/`setCurrentWorkspace` *and* `router.push(...)`. Between the store update and the URL update, the `[workspaceId]/layout.tsx` URL→store sync effect briefly saw `workspaceId(old URL) !== currentWorkspaceId(new store)` and "fixed" it by calling `setCurrentWorkspace(old)` — reverting the store back to the old workspace.
2. **Chat interface fought the navigation.** The URL-sync effect in `chat-interface.tsx` (which keeps the URL aligned with `activeConversationId`) would `router.replace` to the current store's workspace path, racing the in-flight `router.push` from the sidebar to a different workspace.

The file manager page has no equivalent URL-sync effect tied to conversation state, which is why it was unaffected.

## Changes

- **`components/shell/sidebar/index.tsx`** — Stop mutating the workspace store from the workspace switcher. Just navigate. The layout's existing URL→store sync (`setCurrentWorkspace`, which also clears the active conversation) handles the rest after navigation commits.
- **`components/chat/chat-interface.tsx`** — Guard the URL-sync effect so it only rewrites the URL when the current pathname already points at the current workspace's chat route, and skip if the URL already matches the target. Prevents racing a pending `router.push` to a different workspace.
- **`config.yaml`** — Seed three additional workspaces (`Alpha`, `Beta`, `Gamma`) so the switcher can actually be exercised in dev.

## Test plan

- [ ] Start dev, sign in, confirm 4 workspaces (`Default`, `Alpha`, `Beta`, `Gamma`) are present in the sidebar switcher.
- [ ] From a chat page with an active conversation, switch workspaces — URL should update to `/workspace/<newId>/chat` and stay there.
- [ ] From `/workspace/<id>/chat` (no conversation), switch workspaces — should redirect on first click, repeatedly across all four.
- [ ] From the file manager page, switch workspaces — should still work (regression check).
- [ ] Open a conversation, refresh, confirm URL still includes the conversation id and the conversation loads.