### PR TITLE
feat(chat): add user profile context injection on first message turn

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__streaming.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__streaming.py
@@ -20,7 +20,6 @@ from naas_abi.apps.nexus.apps.api.app.services.chat.adapters.primary.chat__prima
 from naas_abi.apps.nexus.apps.api.app.services.chat.adapters.primary.chat__primary_adapter__schemas import (
     ChatRequest,
 )
-from naas_abi.apps.nexus.apps.api.app.services.chat.service import AGENT_SYSTEM_PROMPTS
 from naas_abi.apps.nexus.apps.api.app.services.provider_runtime import (
     ProviderConfig,
     stream_with_abi_inprocess,
@@ -40,15 +39,6 @@ OPENAI_COMPATIBLE = [
     "perplexity",
 ]
 SUPPORTED_STREAMING = ["ollama", "cloudflare", "abi", *OPENAI_COMPATIBLE]
-
-MULTI_AGENT_NOTICE = (
-    "\n\n🔄 CRITICAL MULTI-AGENT NOTICE: You are in a conversation where MULTIPLE different AI models "
-    "have responded. You are currently responding as the SELECTED agent. Previous assistant responses "
-    "may be from DIFFERENT AI agents (Grok, Claude, Qwen, etc.). DO NOT claim authorship of other "
-    "agents' responses. DO NOT apologize for what other AIs said. DO NOT correct other AIs' identities. "
-    "When asked 'who are you?', ONLY identify yourself based on YOUR model, not what previous agents "
-    "said. Each assistant message may be from a different AI - treat them as separate participants."
-)
 
 
 async def stream_chat_response(
@@ -115,16 +105,21 @@ async def stream_chat_response(
                     conversation_id=conversation_id,
                     user_id=current_user.id,
                 )
+                prior_messages = list(request.messages or [])
+                system_prompt = await registry.chat.build_system_prompt(
+                    agent=request.agent,
+                    explicit_system_prompt=request.system_prompt,
+                    prior_messages=prior_messages,
+                    user_id=current_user.id,
+                )
+                user_context_preamble = await registry.chat.build_user_context_addendum(
+                    prior_messages=prior_messages,
+                    user_id=current_user.id,
+                )
             await db.commit()
         except Exception:
             await db.rollback()
             raise
-
-    system_prompt = request.system_prompt or AGENT_SYSTEM_PROMPTS.get(
-        request.agent, AGENT_SYSTEM_PROMPTS["aia"]
-    )
-    if request.messages and any(m.role == "assistant" for m in request.messages):
-        system_prompt += MULTI_AGENT_NOTICE
 
     # search_context = await run_search_if_needed(request)
     # if search_context:
@@ -235,6 +230,7 @@ async def stream_chat_response(
                         provider_messages,
                         provider_config,
                         thread_id=conversation_id,
+                        user_context_preamble=user_context_preamble,
                     )
                 ):
                     inprocess_emitted = True

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/service.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/service.py
@@ -8,6 +8,10 @@ from typing import Any
 from uuid import uuid4
 
 import numpy as np
+from naas_abi.apps.nexus.apps.api.app.services.auth.port import (
+    AuthPersistencePort,
+    AuthUserRecord,
+)
 from naas_abi.apps.nexus.apps.api.app.services.chat.chat__schema import (
     CompleteChatInput,
     CompleteChatResult,
@@ -106,10 +110,82 @@ _MULTI_AGENT_NOTICE = (
 )
 
 
+def _render_user_context_block(user: AuthUserRecord) -> str:
+    fields: list[tuple[str, str | None]] = [
+        ("Name", user.name),
+        ("Email", user.email),
+        ("Company", user.company),
+        ("Role", user.role),
+        ("Bio", user.bio),
+    ]
+    lines = [f"- {label}: {value}" for label, value in fields if value]
+    if not lines:
+        return ""
+    return (
+        "\n\nYou are speaking with the following user. Use this profile to "
+        "personalize your responses naturally; do not repeat it back verbatim "
+        "unless asked.\n" + "\n".join(lines)
+    )
+
+
 class ChatService:
-    def __init__(self, adapter: ChatPersistencePort, iam_service: IAMService | None = None):
+    def __init__(
+        self,
+        adapter: ChatPersistencePort,
+        iam_service: IAMService | None = None,
+        auth_adapter: AuthPersistencePort | None = None,
+    ):
         self.adapter = adapter
         self.iam_service = iam_service
+        self.auth_adapter = auth_adapter
+
+    async def build_system_prompt(
+        self,
+        agent: str,
+        explicit_system_prompt: str | None,
+        prior_messages: list,
+        user_id: str | None,
+    ) -> str:
+        system_prompt = explicit_system_prompt or AGENT_SYSTEM_PROMPTS.get(
+            agent, AGENT_SYSTEM_PROMPTS["aia"]
+        )
+        has_prior_assistant = any(
+            getattr(m, "role", None) == "assistant" for m in prior_messages
+        )
+        if has_prior_assistant:
+            system_prompt += _MULTI_AGENT_NOTICE
+            return system_prompt
+
+        addendum = await self.build_user_context_addendum(prior_messages, user_id)
+        return system_prompt + addendum
+
+    async def build_user_context_addendum(
+        self,
+        prior_messages: list,
+        user_id: str | None,
+    ) -> str:
+        """Return the user-profile addendum to inject on the first conversation turn.
+
+        Returns empty string when:
+        - a prior assistant message exists (not the first turn),
+        - no auth adapter is wired,
+        - no user_id is provided,
+        - the lookup fails or returns no user.
+        """
+        has_prior_assistant = any(
+            getattr(m, "role", None) == "assistant" for m in prior_messages
+        )
+        if has_prior_assistant:
+            return ""
+        if self.auth_adapter is None or not user_id:
+            return ""
+        try:
+            user = await self.auth_adapter.get_user_by_id(user_id)
+        except Exception:
+            return ""
+        if user is None:
+            return ""
+        return _render_user_context_block(user)
 
     def _inject_chat_vector_context(
         self,
@@ -583,12 +659,12 @@ class ChatService:
                     conversation_id=conversation_id,
                     user_id=context.actor_user_id,
                 )
-                system_prompt = request.system_prompt or AGENT_SYSTEM_PROMPTS.get(
-                    request.agent,
-                    AGENT_SYSTEM_PROMPTS["aia"],
+                system_prompt = await self.build_system_prompt(
+                    agent=request.agent,
+                    explicit_system_prompt=request.system_prompt,
+                    prior_messages=list(request.messages or []),
+                    user_id=context.actor_user_id,
                 )
-                if request.messages and any(m.role == "assistant" for m in request.messages):
-                    system_prompt += _MULTI_AGENT_NOTICE
 
                 response_content = await complete_with_provider(
                     messages=provider_messages,

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/service_test.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/service_test.py
@@ -6,12 +6,17 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+from naas_abi.apps.nexus.apps.api.app.services.auth.port import AuthUserRecord
 from naas_abi.apps.nexus.apps.api.app.services.chat.chat__schema import (
     ChatInputMessage,
     CompleteChatInput,
 )
 from naas_abi.apps.nexus.apps.api.app.services.chat.port import ChatConversationRecord
-from naas_abi.apps.nexus.apps.api.app.services.chat.service import ChatService, ResolvedProvider
+from naas_abi.apps.nexus.apps.api.app.services.chat.service import (
+    AGENT_SYSTEM_PROMPTS,
+    ChatService,
+    ResolvedProvider,
+)
 from naas_abi.apps.nexus.apps.api.app.services.iam.port import (
     RequestContext,
     TokenData,
@@ -590,3 +595,207 @@ def test_inject_skips_chunks_from_other_users(monkeypatch) -> None:
     # No chunks from other-user → message must be unaugmented
     assert result == msgs
     assert sources == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: build_system_prompt (user profile injection on first turn)
+# ---------------------------------------------------------------------------
+
+def _user_record(
+    name: str = "Alice Smith",
+    email: str = "alice@example.com",
+    company: str | None = None,
+    role: str | None = None,
+    bio: str | None = None,
+) -> AuthUserRecord:
+    return AuthUserRecord(
+        id="user-1",
+        email=email,
+        name=name,
+        hashed_password="x",
+        created_at=datetime.now(),
+        company=company,
+        role=role,
+        bio=bio,
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_system_prompt_injects_user_on_first_turn() -> None:
+    auth_adapter = SimpleNamespace(
+        get_user_by_id=AsyncMock(
+            return_value=_user_record(
+                company="Acme Corp",
+                role="CTO",
+                bio="Loves bicycles.",
+            )
+        )
+    )
+    service = ChatService(adapter=SimpleNamespace(), auth_adapter=auth_adapter)
+
+    prompt = await service.build_system_prompt(
+        agent="aia",
+        explicit_system_prompt=None,
+        prior_messages=[ChatInputMessage(role="user", content="hi")],
+        user_id="user-1",
+    )
+
+    assert AGENT_SYSTEM_PROMPTS["aia"] in prompt
+    assert "Name: Alice Smith" in prompt
+    assert "Email: alice@example.com" in prompt
+    assert "Company: Acme Corp" in prompt
+    assert "Role: CTO" in prompt
+    assert "Bio: Loves bicycles." in prompt
+    auth_adapter.get_user_by_id.assert_awaited_once_with("user-1")
+
+
+@pytest.mark.asyncio
+async def test_build_system_prompt_omits_empty_user_fields() -> None:
+    auth_adapter = SimpleNamespace(
+        get_user_by_id=AsyncMock(return_value=_user_record())
+    )
+    service = ChatService(adapter=SimpleNamespace(), auth_adapter=auth_adapter)
+
+    prompt = await service.build_system_prompt(
+        agent="aia",
+        explicit_system_prompt=None,
+        prior_messages=[],
+        user_id="user-1",
+    )
+
+    assert "Name: Alice Smith" in prompt
+    assert "Email: alice@example.com" in prompt
+    assert "Company:" not in prompt
+    assert "Role:" not in prompt
+    assert "Bio:" not in prompt
+
+
+@pytest.mark.asyncio
+async def test_build_system_prompt_skips_user_when_prior_assistant_message() -> None:
+    auth_adapter = SimpleNamespace(get_user_by_id=AsyncMock())
+    service = ChatService(adapter=SimpleNamespace(), auth_adapter=auth_adapter)
+
+    prompt = await service.build_system_prompt(
+        agent="aia",
+        explicit_system_prompt=None,
+        prior_messages=[
+            ChatInputMessage(role="user", content="hi"),
+            ChatInputMessage(role="assistant", content="hello"),
+        ],
+        user_id="user-1",
+    )
+
+    assert "Name:" not in prompt
+    assert "MULTI-AGENT NOTICE" in prompt
+    auth_adapter.get_user_by_id.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_build_system_prompt_without_auth_adapter_returns_base() -> None:
+    service = ChatService(adapter=SimpleNamespace())
+
+    prompt = await service.build_system_prompt(
+        agent="aia",
+        explicit_system_prompt=None,
+        prior_messages=[],
+        user_id="user-1",
+    )
+
+    assert prompt == AGENT_SYSTEM_PROMPTS["aia"]
+
+
+@pytest.mark.asyncio
+async def test_build_system_prompt_swallows_auth_errors() -> None:
+    auth_adapter = SimpleNamespace(
+        get_user_by_id=AsyncMock(side_effect=RuntimeError("db down"))
+    )
+    service = ChatService(adapter=SimpleNamespace(), auth_adapter=auth_adapter)
+
+    prompt = await service.build_system_prompt(
+        agent="aia",
+        explicit_system_prompt=None,
+        prior_messages=[],
+        user_id="user-1",
+    )
+
+    assert prompt == AGENT_SYSTEM_PROMPTS["aia"]
+
+
+@pytest.mark.asyncio
+async def test_build_system_prompt_respects_explicit_override() -> None:
+    auth_adapter = SimpleNamespace(
+        get_user_by_id=AsyncMock(return_value=_user_record())
+    )
+    service = ChatService(adapter=SimpleNamespace(), auth_adapter=auth_adapter)
+
+    prompt = await service.build_system_prompt(
+        agent="aia",
+        explicit_system_prompt="CUSTOM PROMPT",
+        prior_messages=[],
+        user_id="user-1",
+    )
+
+    assert prompt.startswith("CUSTOM PROMPT")
+    assert "Name: Alice Smith" in prompt
+
+
+@pytest.mark.asyncio
+async def test_build_user_context_addendum_returns_block_on_first_turn() -> None:
+    auth_adapter = SimpleNamespace(
+        get_user_by_id=AsyncMock(
+            return_value=_user_record(name="Bob", email="bob@example.com", role="PM")
+        )
+    )
+    service = ChatService(adapter=SimpleNamespace(), auth_adapter=auth_adapter)
+
+    addendum = await service.build_user_context_addendum(
+        prior_messages=[],
+        user_id="user-1",
+    )
+
+    assert "Name: Bob" in addendum
+    assert "Email: bob@example.com" in addendum
+    assert "Role: PM" in addendum
+
+
+@pytest.mark.asyncio
+async def test_build_user_context_addendum_empty_when_prior_assistant() -> None:
+    auth_adapter = SimpleNamespace(
+        get_user_by_id=AsyncMock(return_value=_user_record())
+    )
+    service = ChatService(adapter=SimpleNamespace(), auth_adapter=auth_adapter)
+
+    addendum = await service.build_user_context_addendum(
+        prior_messages=[SimpleNamespace(role="assistant", content="hi")],
+        user_id="user-1",
+    )
+
+    assert addendum == ""
+    auth_adapter.get_user_by_id.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_build_user_context_addendum_empty_without_auth_adapter() -> None:
+    service = ChatService(adapter=SimpleNamespace(), auth_adapter=None)
+
+    addendum = await service.build_user_context_addendum(
+        prior_messages=[],
+        user_id="user-1",
+    )
+
+    assert addendum == ""
+
+
+@pytest.mark.asyncio
+async def test_build_user_context_addendum_empty_when_lookup_fails() -> None:
+    auth_adapter = SimpleNamespace(
+        get_user_by_id=AsyncMock(side_effect=RuntimeError("db down"))
+    )
+    service = ChatService(adapter=SimpleNamespace(), auth_adapter=auth_adapter)
+
+    addendum = await service.build_user_context_addendum(
+        prior_messages=[],
+        user_id="user-1",
+    )
+
+    assert addendum == ""

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/provider_runtime.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/provider_runtime.py
@@ -1303,8 +1303,14 @@ async def stream_with_abi_inprocess(
     messages: list[Message],
     config: ProviderConfig,
     thread_id: str,
+    user_context_preamble: str | None = None,
 ) -> AsyncGenerator[str | dict[str, Any], None]:
-    """Stream chat by invoking ABI agent directly in-process."""
+    """Stream chat by invoking ABI agent directly in-process.
+
+    ``user_context_preamble`` is prepended to the latest user message (separated
+    by a blank line) so first-turn profile context reaches agents that ignore
+    custom system prompts.
+    """
     import asyncio
     import json
 
@@ -1322,6 +1328,9 @@ async def stream_with_abi_inprocess(
         logger.warning("No user message found in conversation")
         yield "Error: No user message to send"
         return
+
+    if user_context_preamble:
+        latest_user_message = f"{user_context_preamble.strip()}\n\n{latest_user_message}"
 
     agent_name = config.model
     agent = _resolve_inprocess_abi_agent(agent_name)

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/registry_bootstrap.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/registry_bootstrap.py
@@ -11,6 +11,9 @@ from naas_abi.apps.nexus.apps.api.app.services.apps.adapters.secondary.postgres 
     AppSecondaryAdapterPostgres,
 )
 from naas_abi.apps.nexus.apps.api.app.services.apps.service import AppsService
+from naas_abi.apps.nexus.apps.api.app.services.auth.adapters.secondary.postgres import (
+    AuthSecondaryAdapterPostgres,
+)
 from naas_abi.apps.nexus.apps.api.app.services.chat.adapters.secondary.postgres import (
     ChatSecondaryAdapterPostgres,
 )
@@ -53,6 +56,7 @@ def initialize_nexus_service_registry() -> ServiceRegistry:
     chat_service = ChatService(
         adapter=ChatSecondaryAdapterPostgres(db_getter=db_getter),
         iam_service=iam_service,
+        auth_adapter=AuthSecondaryAdapterPostgres(db_getter=db_getter),
     )
     search_service = SearchService()
     agents_service = AgentService(


### PR DESCRIPTION
This pull request resolves #acess-profile-info-chat

### Summary

This PR enhances the chat service to improve personalization of chat responses by injecting user profile information on the first turn of a conversation. It integrates user profile details such as name, email, company, role, and bio into the system prompt, providing the AI assistant with context about the user to generate more tailored and natural replies.

### Key Changes

- Removed the static multi-agent notice string and replaced it with dynamic system prompt building logic.
- Added new methods `build_system_prompt` and `build_user_context_addendum` in the `ChatService` class to inject user profile information into the system prompt on the first assistant message turn.
- Integrated an `auth_adapter` into the `ChatService` to fetch user profile data from the authentication system.
- Adapted streaming chat response function to use the new system prompt construction logic.
- Updated in-process ABI streaming function to prepend user profile context directly to the user's latest message for agents that ignore custom system prompts.
- Modified service registry initialization to include the `AuthSecondaryAdapterPostgres` for user profile data access.
- Comprehensive tests added for the new user context injection features, including scenarios for:
  - Injecting user profiles on first turn
  - Omitting injection if prior assistant messages exist
  - Handling missing or failing auth adapter gracefully
  - Respecting explicit system prompt overrides

### Impact

This update aims to make chat interactions more personalized by allowing the assistant to naturally incorporate known user profile data, enhancing user experience without exposing or repeating private information explicitly unless asked.

### Testing

Extensive unit tests verify the new prompt-building logic and correct behavior under diverse scenarios, including error handling and edge cases.