### PR TITLE
fix(shared-agent): prevent cross-conversation response leakage by duplicating singleton agent in in-process runtime

### DIFF
--- a/libs/naas-abi-core/naas_abi_core/models/Model.py
+++ b/libs/naas-abi-core/naas_abi_core/models/Model.py
@@ -83,6 +83,9 @@ class CanonicalModelId(StrEnum):
     # Chat — OpenAI open-weights
     GPT_OSS_120B = "gpt-oss-120b"
 
+    # Chat - Qwen family
+    QWEN_3_6 = "qwen-3.6"
+
 
 # Type aliases for registry call sites — accept enum or raw string.
 CanonicalModelIdLike = Union[CanonicalModelId, str]

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/analytics/service.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/analytics/service.py
@@ -64,7 +64,7 @@ REF_WORKSPACES_FILE = "ref-workspaces.json"
 
 RECENT_EVENTS_LIMIT = 100
 
-_REBUILD_DEBOUNCE_SECONDS = 10
+_REBUILD_DEBOUNCE_SECONDS = 60
 
 _CHAT_CONV_PATH_RE = re.compile(r"/chat/(conv-[^/?#]+)")
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/provider_runtime.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/provider_runtime.py
@@ -686,13 +686,16 @@ async def complete_with_abi(
 
     endpoint = (config.endpoint or "").rstrip("/")
     if endpoint.startswith("inprocess://"):
-        agent = _resolve_inprocess_abi_agent(config.model)
-        if agent is None:
+        template_agent = _resolve_inprocess_abi_agent(config.model)
+        if template_agent is None:
             raise ValueError(f"In-process ABI agent not found: {config.model}")
 
         latest_user_message = next((m.content for m in reversed(messages) if m.role == "user"), "")
         if not latest_user_message:
             return ""
+
+        # Per-request isolation: never execute against the cached singleton.
+        agent = _duplicate_inprocess_agent(template_agent, thread_id)
 
         if hasattr(agent, "ainvoke"):
             return await agent.ainvoke(latest_user_message, thread_id=thread_id)
@@ -1248,6 +1251,38 @@ def _resolve_inprocess_abi_agent(agent_name: str):
         return instance
 
 
+def _duplicate_inprocess_agent(template: Any, thread_id: str | None) -> Any:
+    """Return a per-request copy of the cached template agent.
+
+    The resolver in ``_resolve_inprocess_abi_agent`` caches a single shared
+    instance per factory. Executing requests against that shared instance
+    causes cross-conversation contamination: ``agent.state`` and the
+    ``_event_queue`` are instance attributes, so two overlapping requests
+    clobber each other's thread_id and read each other's events. This helper
+    mirrors what ``Agent.as_api`` does for the regular HTTP route — build a
+    fresh ``AgentSharedState`` and ``Queue`` per request, then ``duplicate``
+    the template. The template stays warm; only the execution context is
+    isolated.
+
+    Falls back to the template itself if duplication is not available
+    (defensive — every Agent class in naas_abi_core implements ``duplicate``).
+    """
+    from queue import Queue
+
+    from naas_abi_core.services.agent.Agent import AgentSharedState
+
+    if not hasattr(template, "duplicate"):
+        return template
+
+    fresh_state = AgentSharedState(thread_id=str(thread_id) if thread_id else None)
+    fresh_queue: Queue = Queue()
+    try:
+        return template.duplicate(queue=fresh_queue, agent_shared_state=fresh_state)
+    except TypeError:
+        # Some agent classes ignore the queue kwarg or have a narrower signature.
+        return template.duplicate(agent_shared_state=fresh_state)
+
+
 def _extract_opencode_ui_event(event: dict[str, Any]) -> dict[str, Any] | None:
     event_type = str(event.get("type") or "")
     properties = event.get("properties") or {}
@@ -1333,8 +1368,8 @@ async def stream_with_abi_inprocess(
         latest_user_message = f"{user_context_preamble.strip()}\n\n{latest_user_message}"
 
     agent_name = config.model
-    agent = _resolve_inprocess_abi_agent(agent_name)
-    if agent is None:
+    template_agent = _resolve_inprocess_abi_agent(agent_name)
+    if template_agent is None:
         with _INPROCESS_AGENT_LOCK:
             available_hint = ", ".join(_INPROCESS_AGENT_HINTS[:20]) or "unavailable"
         yield (
@@ -1343,15 +1378,14 @@ async def stream_with_abi_inprocess(
         )
         return
 
-    # Keep ABI memory continuity aligned with Nexus conversation.
+    # Per-request isolation: duplicate the cached template so this request gets
+    # its own AgentSharedState and _event_queue. Mutating the shared singleton
+    # (the previous behaviour) caused cross-conversation response leakage when
+    # two requests overlapped — see jupyter-naas/abi#991.
     assert thread_id is not None, "thread_id is required"
-    if thread_id and hasattr(agent, "state") and hasattr(agent.state, "set_thread_id"):
-        try:
-            agent.state.set_thread_id(str(thread_id))
-        except Exception as exc:
-            logger.error(f"Failed to set thread_id: {str(exc)}")
+    agent = _duplicate_inprocess_agent(template_agent, thread_id)
 
-    logger.debug(f"Agent.state.thread_id: {agent.state.thread_id}")
+    logger.debug(f"Agent.state.thread_id: {getattr(getattr(agent, 'state', None), 'thread_id', None)}")
 
     # New OpencodeAgent path: async event stream method.
     if hasattr(agent, "astream"):

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/account/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/account/page.tsx
@@ -6,6 +6,29 @@ import { cn } from '@/lib/utils';
 import { getApiUrl } from '@/lib/config';
 import { useAuthStore } from '@/stores/auth';
 
+type FastApiValidationError = {
+  loc?: (string | number)[];
+  msg?: string;
+};
+
+function formatApiError(err: unknown, fallback: string): string {
+  if (!err || typeof err !== 'object') return fallback;
+  const detail = (err as { detail?: unknown }).detail;
+  if (typeof detail === 'string') return detail;
+  if (Array.isArray(detail)) {
+    const messages = (detail as FastApiValidationError[])
+      .map((d) => {
+        const field = Array.isArray(d?.loc)
+          ? d.loc.filter((p) => p !== 'body').join('.')
+          : '';
+        return field ? `${field}: ${d?.msg ?? ''}`.trim() : (d?.msg ?? '');
+      })
+      .filter(Boolean);
+    if (messages.length) return messages.join('\n');
+  }
+  return fallback;
+}
+
 export default function ProfilePage() {
   const authUser = useAuthStore((s) => s.user);
   const setUser = useAuthStore((s) => s.setUser);
@@ -72,8 +95,8 @@ export default function ProfilePage() {
           setUser({ ...authUser, avatar: fullUrl });
         }
       } else {
-        const error = await response.json();
-        alert(`Upload failed: ${error.detail || 'Unknown error'}`);
+        const error = await response.json().catch(() => ({}));
+        alert(`Upload failed: ${formatApiError(error, 'Unknown error')}`);
       }
     } catch (error) {
       console.error('Upload error:', error);
@@ -98,8 +121,8 @@ export default function ProfilePage() {
           setUser({ ...authUser, avatar: undefined });
         }
       } else {
-        const error = await response.json();
-        alert(`Remove failed: ${error.detail || 'Unknown error'}`);
+        const error = await response.json().catch(() => ({}));
+        alert(`Remove failed: ${formatApiError(error, 'Unknown error')}`);
       }
     } catch (error) {
       console.error('Remove avatar error:', error);
@@ -110,16 +133,28 @@ export default function ProfilePage() {
   const handleSave = async () => {
     try {
       const { authFetch } = await import('@/stores/auth');
+      // Only include fields the user actually filled in. The backend's
+      // UserUpdate enforces min_length on name/email, so sending "" would
+      // fail validation even when the user only wanted to update bio/role.
+      const payload: Record<string, string> = {};
+      const trimmedName = name.trim();
+      const trimmedEmail = email.trim();
+      if (trimmedName) payload.name = trimmedName;
+      if (trimmedEmail) payload.email = trimmedEmail;
+      payload.company = company.trim();
+      payload.role = role.trim();
+      payload.bio = bio.trim();
+
       const response = await authFetch('/api/auth/me', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name, email, company, role, bio }),
+        body: JSON.stringify(payload),
       });
 
       if (!response.ok) {
-        const err = await response.json();
-          alert(err.detail || 'Failed to save profile');
-          return;
+        const err = await response.json().catch(() => ({}));
+        alert(formatApiError(err, 'Failed to save profile'));
+        return;
       }
 
       const updated = await response.json();

--- a/uv.lock
+++ b/uv.lock
@@ -3453,7 +3453,7 @@ wheels = [
 
 [[package]]
 name = "naas-abi"
-version = "2.7.1"
+version = "2.10.0"
 source = { editable = "libs/naas-abi" }
 dependencies = [
     { name = "aiosqlite" },
@@ -3535,7 +3535,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-cli"
-version = "1.42.2"
+version = "1.43.1"
 source = { editable = "libs/naas-abi-cli" }
 dependencies = [
     { name = "naas-abi" },
@@ -3561,7 +3561,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-core"
-version = "1.47.0"
+version = "1.50.1"
 source = { editable = "libs/naas-abi-core" }
 dependencies = [
     { name = "click" },
@@ -3689,7 +3689,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-marketplace"
-version = "1.25.0"
+version = "1.28.0"
 source = { editable = "libs/naas-abi-marketplace" }
 dependencies = [
     { name = "naas-abi-core" },


### PR DESCRIPTION
This pull request resolves #991

### Summary
- Added support for a new model identifier `QWEN_3_6` in `CanonicalModelId`.
- Increased debounce time for rebuild events in the analytics service from 10 to 60 seconds.
- Fixed critical issue causing cross-conversation response leakage in in-process ABI agents by duplicating the cached singleton agent per request. This ensures each request has its own `AgentSharedState` and event queue, preventing overlapping requests from affecting each other.
- Enhanced error handling in the Nexus web profile page to better parse and display API validation errors from FastAPI, providing clearer error messages for the user.
- Improved the PATCH request payload construction for updating user profile info by only sending fields that were actually modified by the user.

### Details
- In `provider_runtime.py`, the function `_duplicate_inprocess_agent` duplicates the shared in-process ABI agent instance to ensure thread-safety and prevent state leakage across conversations.
- Updated usages of the in-process agent resolver to use the duplicated agent instead of the shared singleton.
- Added helper function `formatApiError` in `page.tsx` to handle and format various shapes of FastAPI validation errors.
- Modified avatar upload and removal error handling to use the new formatter.
- Made the profile save handler send only trimmed, non-empty fields to reduce validation failures on the backend.

These changes improve stability, security, and user experience in handling ABI agents and user profile management.