### PR TITLE
feat(Analytics): Add workspace and user filters to analytics service and frontend

### DIFF
--- a/config.local.yaml
+++ b/config.local.yaml
@@ -203,6 +203,13 @@ modules:
 #      vector_store -> "python"         (in-memory)
 #      kv           -> "python"         (in-memory)
 services:
+  # Q: How could I setup default models?
+  # A: Set the default chat and embedding models.
+
+  model_registry:
+    default_chat_model: "gpt-4.1-mini"
+    default_embedding_model: "text-embedding-3-large"
+
   # Q: How does the app read secret values at startup?
   # A: The dotenv adapter reads every `secret.X` from your .env file.
   secret:

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/analytics/adapters/primary/analytics__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/analytics/adapters/primary/analytics__primary_adapter__FastAPI.py
@@ -9,6 +9,9 @@ here.
 
 from __future__ import annotations
 
+import json
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from naas_abi.apps.nexus.apps.api.app.services.analytics.adapters.secondary import (
     AnalyticsSecondaryAdapterObjectStorage,
@@ -35,11 +38,26 @@ from naas_abi.apps.nexus.apps.api.app.services.analytics.service import (
     DEFAULT_SCENARIO_ID,
     AnalyticsService,
 )
+from naas_abi.apps.nexus.apps.api.app.services.chat.adapters.primary.chat__primary_adapter__export import (
+    export_conversation_as_response,
+)
 from naas_abi.apps.nexus.apps.api.app.services.chat.service import ChatService
 from naas_abi.apps.nexus.apps.api.app.services.registry import get_service_registry
 from naas_abi_core.services.object_storage.ObjectStorageService import ObjectStorageService
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
+
+
+def _parse_message_metadata(raw: str | None) -> dict | None:
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        logger.debug("Unparseable message metadata; skipping")
+        return None
+    return data if isinstance(data, dict) else None
 
 
 def _get_object_storage(request: Request) -> ObjectStorageService:
@@ -205,10 +223,22 @@ async def get_chats(
     workspace_id: str | None = Query(None),
     user_email: str | None = Query(None),
     service: AnalyticsService = Depends(get_analytics_service),
+    registry=Depends(get_service_registry),
 ) -> ChatsResponse:
-    return service.get_chats(
+    response = service.get_chats(
         scenario_id=scenario_id, workspace_id=workspace_id, user_email=user_email
     )
+    if response.chats:
+        chat_service: ChatService = registry.chat
+        ids = [c.conversation_id for c in response.chats]
+        counts = await chat_service.adapter.count_messages_for_conversations(ids)
+        chats_by_id = await chat_service.adapter.list_conversations_by_ids(ids)
+        for row in response.chats:
+            row.message_count = counts.get(row.conversation_id, 0)
+            chat = chats_by_id.get(row.conversation_id)
+            if chat is not None:
+                row.chat_title = chat.title
+    return response
 
 
 @router.get("/chats/{conversation_id}", response_model=ChatDetail)
@@ -229,6 +259,7 @@ async def get_chat_detail(
             content=m.content,
             agent=m.agent,
             created_at=m.created_at.isoformat() if m.created_at else None,
+            metadata=_parse_message_metadata(m.metadata_),
         )
         for m in records
     ]
@@ -242,4 +273,31 @@ async def get_chat_detail(
         created_at=conversation.created_at.isoformat() if conversation.created_at else None,
         updated_at=conversation.updated_at.isoformat() if conversation.updated_at else None,
         messages=messages,
+    )
+
+
+@router.get("/chats/{conversation_id}/export")
+async def export_chat(
+    conversation_id: str,
+    format: str = Query("txt", pattern="^(txt|json|md)$"),
+    registry=Depends(get_service_registry),
+):
+    """Admin export of a conversation for the analytics UI.
+
+    Delegates to the same ``export_conversation_as_response`` helper the chat
+    interface uses, so the analytics download and the in-chat download produce
+    byte-identical files.
+    """
+    chat_service: ChatService = registry.chat
+    conversation = await chat_service.adapter.get_conversation_by_id(conversation_id)
+    if conversation is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    messages = await chat_service.adapter.list_messages_by_conversation(conversation_id)
+    return export_conversation_as_response(
+        conversation_id=conversation_id,
+        format=format,
+        user_id=conversation.user_id,
+        conversation=conversation,
+        messages=messages,
+        messages_metadata=None,
     )

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/analytics/adapters/primary/analytics__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/analytics/adapters/primary/analytics__primary_adapter__FastAPI.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import logging
+from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from naas_abi.apps.nexus.apps.api.app.services.analytics.adapters.secondary import (
@@ -44,6 +45,7 @@ from naas_abi.apps.nexus.apps.api.app.services.chat.adapters.primary.chat__prima
 from naas_abi.apps.nexus.apps.api.app.services.chat.service import ChatService
 from naas_abi.apps.nexus.apps.api.app.services.registry import get_service_registry
 from naas_abi_core.services.object_storage.ObjectStorageService import ObjectStorageService
+from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -274,6 +276,51 @@ async def get_chat_detail(
         updated_at=conversation.updated_at.isoformat() if conversation.updated_at else None,
         messages=messages,
     )
+
+
+class ChatFeedbackUpdate(BaseModel):
+    """Body for ``PATCH /chats/{cid}/messages/{mid}/feedback``.
+
+    ``feedback=None`` clears any previously set value, so the UI can toggle a
+    thumbs-up off by sending ``{"feedback": null}``.
+    """
+
+    feedback: Literal["like", "dislike"] | None = None
+
+
+@router.patch("/chats/{conversation_id}/messages/{message_id}/feedback")
+async def update_chat_message_feedback(
+    conversation_id: str,
+    message_id: str,
+    payload: ChatFeedbackUpdate,
+    registry=Depends(get_service_registry),
+):
+    """Admin-side feedback toggle for an assistant message.
+
+    Reads the message's current metadata, merges (or removes) the ``feedback``
+    key, and writes it back. Used by the analytics chat detail view so
+    reviewers can flag bad / good AI responses; the value is also picked up
+    by the export helper and the analytics list.
+    """
+    chat_service: ChatService = registry.chat
+    messages = await chat_service.adapter.list_messages_by_conversation(conversation_id)
+    target = next((m for m in messages if m.id == message_id), None)
+    if target is None:
+        raise HTTPException(status_code=404, detail="Message not found")
+
+    existing = _parse_message_metadata(target.metadata_) or {}
+    if payload.feedback is None:
+        existing.pop("feedback", None)
+    else:
+        existing["feedback"] = payload.feedback
+
+    updated = await chat_service.adapter.update_message_metadata(
+        message_id=message_id,
+        metadata=json.dumps(existing),
+    )
+    if not updated:
+        raise HTTPException(status_code=404, detail="Message not found")
+    return {"status": "updated", "feedback": payload.feedback}
 
 
 @router.get("/chats/{conversation_id}/export")

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/analytics/adapters/primary/analytics__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/analytics/adapters/primary/analytics__primary_adapter__FastAPI.py
@@ -15,6 +15,9 @@ from naas_abi.apps.nexus.apps.api.app.services.analytics.adapters.secondary impo
 )
 from naas_abi.apps.nexus.apps.api.app.services.analytics.port import (
     AnalyticsEvent,
+    ChatDetail,
+    ChatMessage,
+    ChatsResponse,
     EventsResponse,
     IngestResponse,
     Metadata,
@@ -32,6 +35,8 @@ from naas_abi.apps.nexus.apps.api.app.services.analytics.service import (
     DEFAULT_SCENARIO_ID,
     AnalyticsService,
 )
+from naas_abi.apps.nexus.apps.api.app.services.chat.service import ChatService
+from naas_abi.apps.nexus.apps.api.app.services.registry import get_service_registry
 from naas_abi_core.services.object_storage.ObjectStorageService import ObjectStorageService
 
 router = APIRouter()
@@ -191,4 +196,50 @@ async def get_events(
         limit=limit,
         workspace_id=workspace_id,
         user_email=user_email,
+    )
+
+
+@router.get("/chats", response_model=ChatsResponse)
+async def get_chats(
+    scenario_id: str = Query(DEFAULT_SCENARIO_ID),
+    workspace_id: str | None = Query(None),
+    user_email: str | None = Query(None),
+    service: AnalyticsService = Depends(get_analytics_service),
+) -> ChatsResponse:
+    return service.get_chats(
+        scenario_id=scenario_id, workspace_id=workspace_id, user_email=user_email
+    )
+
+
+@router.get("/chats/{conversation_id}", response_model=ChatDetail)
+async def get_chat_detail(
+    conversation_id: str,
+    registry=Depends(get_service_registry),
+) -> ChatDetail:
+    chat_service: ChatService = registry.chat
+    conversation = await chat_service.adapter.get_conversation_by_id(conversation_id)
+    if conversation is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    records = await chat_service.adapter.list_messages_by_conversation(conversation_id)
+
+    messages = [
+        ChatMessage(
+            id=m.id,
+            role=m.role,
+            content=m.content,
+            agent=m.agent,
+            created_at=m.created_at.isoformat() if m.created_at else None,
+        )
+        for m in records
+    ]
+
+    return ChatDetail(
+        conversation_id=conversation.id,
+        workspace_id=conversation.workspace_id,
+        user_id=conversation.user_id,
+        title=conversation.title,
+        agent=conversation.agent,
+        created_at=conversation.created_at.isoformat() if conversation.created_at else None,
+        updated_at=conversation.updated_at.isoformat() if conversation.updated_at else None,
+        messages=messages,
     )

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/analytics/adapters/primary/analytics__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/analytics/adapters/primary/analytics__primary_adapter__FastAPI.py
@@ -107,27 +107,35 @@ async def get_scenarios(
 @router.get("/overview", response_model=OverviewResponse)
 async def get_overview(
     scenario_id: str = Query(DEFAULT_SCENARIO_ID),
+    workspace_id: str | None = Query(None),
+    user_email: str | None = Query(None),
     service: AnalyticsService = Depends(get_analytics_service),
 ) -> OverviewResponse:
-    return service.get_overview(scenario_id=scenario_id)
+    return service.get_overview(
+        scenario_id=scenario_id, workspace_id=workspace_id, user_email=user_email
+    )
 
 
 @router.get("/users", response_model=UsersResponse)
 async def get_users(
     scenario_id: str = Query(DEFAULT_SCENARIO_ID),
+    workspace_id: str | None = Query(None),
     service: AnalyticsService = Depends(get_analytics_service),
 ) -> UsersResponse:
-    return service.get_users(scenario_id=scenario_id)
+    return service.get_users(scenario_id=scenario_id, workspace_id=workspace_id)
 
 
 @router.get("/users/{email:path}", response_model=UserDetail)
 async def get_user_detail(
     email: str,
     scenario_id: str = Query(DEFAULT_SCENARIO_ID),
+    workspace_id: str | None = Query(None),
     service: AnalyticsService = Depends(get_analytics_service),
 ) -> UserDetail:
     try:
-        return service.get_user_detail(email, scenario_id=scenario_id)
+        return service.get_user_detail(
+            email, scenario_id=scenario_id, workspace_id=workspace_id
+        )
     except UserDetailNotFound as exc:
         raise HTTPException(
             status_code=404, detail="No data for user in selected range"
@@ -137,31 +145,50 @@ async def get_user_detail(
 @router.get("/sessions", response_model=SessionsResponse)
 async def get_sessions(
     scenario_id: str = Query(DEFAULT_SCENARIO_ID),
+    workspace_id: str | None = Query(None),
+    user_email: str | None = Query(None),
     service: AnalyticsService = Depends(get_analytics_service),
 ) -> SessionsResponse:
-    return service.get_sessions(scenario_id=scenario_id)
+    return service.get_sessions(
+        scenario_id=scenario_id, workspace_id=workspace_id, user_email=user_email
+    )
 
 
 @router.get("/pages", response_model=PagesResponse)
 async def get_pages(
     scenario_id: str = Query(DEFAULT_SCENARIO_ID),
+    workspace_id: str | None = Query(None),
+    user_email: str | None = Query(None),
     service: AnalyticsService = Depends(get_analytics_service),
 ) -> PagesResponse:
-    return service.get_pages(scenario_id=scenario_id)
+    return service.get_pages(
+        scenario_id=scenario_id, workspace_id=workspace_id, user_email=user_email
+    )
 
 
 @router.get("/workspaces", response_model=WorkspacesResponse)
 async def get_workspaces(
     scenario_id: str = Query(DEFAULT_SCENARIO_ID),
+    workspace_id: str | None = Query(None),
+    user_email: str | None = Query(None),
     service: AnalyticsService = Depends(get_analytics_service),
 ) -> WorkspacesResponse:
-    return service.get_workspaces(scenario_id=scenario_id)
+    return service.get_workspaces(
+        scenario_id=scenario_id, workspace_id=workspace_id, user_email=user_email
+    )
 
 
 @router.get("/events", response_model=EventsResponse)
 async def get_events(
     scenario_id: str = Query(DEFAULT_SCENARIO_ID),
     limit: int = Query(200, ge=1, le=1000),
+    workspace_id: str | None = Query(None),
+    user_email: str | None = Query(None),
     service: AnalyticsService = Depends(get_analytics_service),
 ) -> EventsResponse:
-    return service.get_events(scenario_id=scenario_id, limit=limit)
+    return service.get_events(
+        scenario_id=scenario_id,
+        limit=limit,
+        workspace_id=workspace_id,
+        user_email=user_email,
+    )

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/analytics/port.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/analytics/port.py
@@ -186,6 +186,51 @@ class EventsResponse(BaseModel):
     events: list[AnalyticsEvent]
 
 
+class ChatRow(BaseModel):
+    """One conversation surfaced from analytics ``page_viewed`` events.
+
+    Derived purely from the analytics event stream — no chat-service join.
+    The row carries enough metadata to render a tab list and to fetch the
+    full conversation (messages) on demand via ``/api/analytics/chats/{id}``.
+    """
+
+    conversation_id: str
+    title: str
+    workspace_id: str | None = None
+    workspace_name: str | None = None
+    user_email: str | None = None
+    first_viewed_at: str
+    last_viewed_at: str
+    page_views: int
+
+
+class ChatsResponse(BaseModel):
+    chats: list[ChatRow]
+
+
+class ChatMessage(BaseModel):
+    """Single message in a conversation (analytics-facing projection)."""
+
+    id: str
+    role: str
+    content: str
+    agent: str | None = None
+    created_at: str | None = None
+
+
+class ChatDetail(BaseModel):
+    """Conversation + its messages, served to the analytics UI."""
+
+    conversation_id: str
+    workspace_id: str
+    user_id: str
+    title: str
+    agent: str
+    created_at: str | None = None
+    updated_at: str | None = None
+    messages: list[ChatMessage] = Field(default_factory=list)
+
+
 class Scenario(BaseModel):
     """A pre-computed analytics time window.
 
@@ -236,6 +281,10 @@ class AnalyticsDomainError(Exception):
 
 
 class UserDetailNotFound(AnalyticsDomainError):
+    pass
+
+
+class ChatNotFound(AnalyticsDomainError):
     pass
 
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/analytics/port.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/analytics/port.py
@@ -189,19 +189,21 @@ class EventsResponse(BaseModel):
 class ChatRow(BaseModel):
     """One conversation surfaced from analytics ``page_viewed`` events.
 
-    Derived purely from the analytics event stream — no chat-service join.
-    The row carries enough metadata to render a tab list and to fetch the
-    full conversation (messages) on demand via ``/api/analytics/chats/{id}``.
+    Derived from the analytics event stream and enriched at request time with
+    ``message_count`` and ``chat_title`` from the chat database (single
+    grouped/IN queries batched over every conversation in the list).
     """
 
     conversation_id: str
     title: str
+    chat_title: str | None = None
     workspace_id: str | None = None
     workspace_name: str | None = None
     user_email: str | None = None
     first_viewed_at: str
     last_viewed_at: str
     page_views: int
+    message_count: int = 0
 
 
 class ChatsResponse(BaseModel):
@@ -209,13 +211,19 @@ class ChatsResponse(BaseModel):
 
 
 class ChatMessage(BaseModel):
-    """Single message in a conversation (analytics-facing projection)."""
+    """Single message in a conversation (analytics-facing projection).
+
+    ``metadata`` mirrors the JSON persisted on ``messages.metadata_`` — most
+    importantly the ``steps`` list (tool calls, tool responses, agent routing
+    steps) that drives the activity stream of an assistant turn.
+    """
 
     id: str
     role: str
     content: str
     agent: str | None = None
     created_at: str | None = None
+    metadata: dict[str, Any] | None = None
 
 
 class ChatDetail(BaseModel):

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/analytics/service.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/analytics/service.py
@@ -791,11 +791,12 @@ class AnalyticsService:
         for conv_id, evts in by_conv.items():
             evts.sort(key=lambda e: e.get("timestamp", ""))
             first, last = evts[0], evts[-1]
-            base_title = last.get("page_title") or first.get("page_title") or conv_id
+            # Title is the conversation_id itself — the chat list is keyed on
+            # the conversation, not on the (often duplicated) "Chat" page title.
             rows.append(
                 ChatRow(
                     conversation_id=conv_id,
-                    title=_decorate_page_title(base_title, last.get("page_path") or ""),
+                    title=conv_id,
                     workspace_id=last.get("workspace_id"),
                     workspace_name=last.get("workspace_name"),
                     user_email=last.get("user_email"),

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/analytics/service.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/analytics/service.py
@@ -584,7 +584,49 @@ class AnalyticsService:
             return fallback
         return raw.get(scenario_id, fallback)
 
-    def get_overview(self, scenario_id: str = DEFAULT_SCENARIO_ID) -> OverviewResponse:
+    @staticmethod
+    def _filter_events(
+        events: list[dict],
+        workspace_id: str | None = None,
+        user_email: str | None = None,
+    ) -> list[dict]:
+        """Apply optional workspace / user filters. ``"all"`` and empty are no-ops."""
+        out = events
+        if workspace_id and workspace_id != "all":
+            out = [e for e in out if e.get("workspace_id") == workspace_id]
+        if user_email and user_email != "all":
+            out = [e for e in out if e.get("user_email") == user_email]
+        return out
+
+    def _load_window_events(self, scenario_id: str) -> list[dict]:
+        """All raw events that fall inside the named scenario's window."""
+        raw = self._storage.load_json(EVENTS_FILE, fallback={"events": []})
+        events = raw.get("events", []) if isinstance(raw, dict) else []
+        for s in self.get_scenarios().scenarios:
+            if s.scenario_id == scenario_id:
+                return _filter_events_to_window(events, s.date_start, s.date_end)
+        return events
+
+    def _has_filters(self, workspace_id: str | None, user_email: str | None) -> bool:
+        return bool(
+            (workspace_id and workspace_id != "all")
+            or (user_email and user_email != "all")
+        )
+
+    def get_overview(
+        self,
+        scenario_id: str = DEFAULT_SCENARIO_ID,
+        workspace_id: str | None = None,
+        user_email: str | None = None,
+    ) -> OverviewResponse:
+        if self._has_filters(workspace_id, user_email):
+            events = self._filter_events(
+                self._load_window_events(scenario_id), workspace_id, user_email
+            )
+            sessions = _build_sessions(events)
+            days = self._days_for_scenario(scenario_id)
+            return OverviewResponse.model_validate(_build_overview(events, sessions, days))
+
         raw = self._storage.load_json(OVERVIEW_FILE, fallback={})
         if isinstance(raw, dict) and scenario_id in raw:
             return OverviewResponse.model_validate(raw[scenario_id])
@@ -593,38 +635,124 @@ class AnalyticsService:
         days = self._days_for_scenario(scenario_id)
         return OverviewResponse.model_validate(_build_overview([], [], days))
 
-    def get_users(self, scenario_id: str = DEFAULT_SCENARIO_ID) -> UsersResponse:
+    def get_users(
+        self,
+        scenario_id: str = DEFAULT_SCENARIO_ID,
+        workspace_id: str | None = None,
+    ) -> UsersResponse:
+        # The directory drives the FE dropdown and stays unfiltered; only the
+        # tabular rows are scoped to the workspace filter.
+        directory = self._storage.load_json(REF_USERS_FILE, fallback=[])
+        if not isinstance(directory, list):
+            directory = []
+
+        if workspace_id and workspace_id != "all":
+            events = self._filter_events(
+                self._load_window_events(scenario_id), workspace_id=workspace_id
+            )
+            return UsersResponse.model_validate(
+                {"users": _build_user_rows(events), "directory": directory}
+            )
+
         slice_data = self._load_scenario_slice(
-            USERS_FILE, scenario_id, fallback={"users": [], "directory": []}
+            USERS_FILE, scenario_id, fallback={"users": [], "directory": directory}
         )
         return UsersResponse.model_validate(slice_data)
 
-    def get_user_detail(self, email: str, scenario_id: str = DEFAULT_SCENARIO_ID) -> UserDetail:
+    def get_user_detail(
+        self,
+        email: str,
+        scenario_id: str = DEFAULT_SCENARIO_ID,
+        workspace_id: str | None = None,
+    ) -> UserDetail:
         decoded = urllib.parse.unquote(email)
+
+        if workspace_id and workspace_id != "all":
+            events = self._filter_events(
+                self._load_window_events(scenario_id),
+                workspace_id=workspace_id,
+                user_email=decoded,
+            )
+            details = _build_user_detail_map(events)
+            if decoded not in details:
+                raise UserDetailNotFound(decoded)
+            return UserDetail.model_validate(details[decoded])
+
         scenario_data = self._load_scenario_slice(USER_DETAILS_FILE, scenario_id, fallback={})
         if not isinstance(scenario_data, dict) or decoded not in scenario_data:
             raise UserDetailNotFound(decoded)
         return UserDetail.model_validate(scenario_data[decoded])
 
-    def get_sessions(self, scenario_id: str = DEFAULT_SCENARIO_ID) -> SessionsResponse:
+    def get_sessions(
+        self,
+        scenario_id: str = DEFAULT_SCENARIO_ID,
+        workspace_id: str | None = None,
+        user_email: str | None = None,
+    ) -> SessionsResponse:
+        if self._has_filters(workspace_id, user_email):
+            events = self._filter_events(
+                self._load_window_events(scenario_id), workspace_id, user_email
+            )
+            return SessionsResponse.model_validate({"sessions": _build_sessions(events)})
+
         slice_data = self._load_scenario_slice(
             SESSIONS_FILE, scenario_id, fallback={"sessions": []}
         )
         return SessionsResponse.model_validate(slice_data)
 
-    def get_pages(self, scenario_id: str = DEFAULT_SCENARIO_ID) -> PagesResponse:
+    def get_pages(
+        self,
+        scenario_id: str = DEFAULT_SCENARIO_ID,
+        workspace_id: str | None = None,
+        user_email: str | None = None,
+    ) -> PagesResponse:
+        if self._has_filters(workspace_id, user_email):
+            events = self._filter_events(
+                self._load_window_events(scenario_id), workspace_id, user_email
+            )
+            return PagesResponse.model_validate({"pages": _build_page_rows(events)})
+
         slice_data = self._load_scenario_slice(PAGES_FILE, scenario_id, fallback={"pages": []})
         return PagesResponse.model_validate(slice_data)
 
-    def get_workspaces(self, scenario_id: str = DEFAULT_SCENARIO_ID) -> WorkspacesResponse:
+    def get_workspaces(
+        self,
+        scenario_id: str = DEFAULT_SCENARIO_ID,
+        workspace_id: str | None = None,
+        user_email: str | None = None,
+    ) -> WorkspacesResponse:
+        # Directory drives the FE dropdown and stays unfiltered.
+        directory = self._storage.load_json(REF_WORKSPACES_FILE, fallback=[])
+        if not isinstance(directory, list):
+            directory = []
+
+        if self._has_filters(workspace_id, user_email):
+            events = self._filter_events(
+                self._load_window_events(scenario_id), workspace_id, user_email
+            )
+            return WorkspacesResponse.model_validate(
+                {"workspaces": _build_workspace_rows(events), "directory": directory}
+            )
+
         slice_data = self._load_scenario_slice(
-            WORKSPACES_FILE, scenario_id, fallback={"workspaces": [], "directory": []}
+            WORKSPACES_FILE, scenario_id, fallback={"workspaces": [], "directory": directory}
         )
         return WorkspacesResponse.model_validate(slice_data)
 
     def get_events(
-        self, scenario_id: str = DEFAULT_SCENARIO_ID, limit: int = 200
+        self,
+        scenario_id: str = DEFAULT_SCENARIO_ID,
+        limit: int = 200,
+        workspace_id: str | None = None,
+        user_email: str | None = None,
     ) -> EventsResponse:
+        if self._has_filters(workspace_id, user_email):
+            events = self._filter_events(
+                self._load_window_events(scenario_id), workspace_id, user_email
+            )
+            events.sort(key=lambda e: e.get("timestamp", ""), reverse=True)
+            return EventsResponse.model_validate({"events": events[:limit]})
+
         slice_data = self._load_scenario_slice(
             RECENT_EVENTS_FILE, scenario_id, fallback={"events": []}
         )

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/analytics/service.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/analytics/service.py
@@ -31,6 +31,8 @@ from typing import Any
 from naas_abi.apps.nexus.apps.api.app.services.analytics.port import (
     AnalyticsEvent,
     AnalyticsStoragePort,
+    ChatRow,
+    ChatsResponse,
     EventsResponse,
     FileStats,
     Metadata,
@@ -758,6 +760,52 @@ class AnalyticsService:
         )
         events = slice_data.get("events", []) if isinstance(slice_data, dict) else []
         return EventsResponse.model_validate({"events": events[:limit]})
+
+    def get_chats(
+        self,
+        scenario_id: str = DEFAULT_SCENARIO_ID,
+        workspace_id: str | None = None,
+        user_email: str | None = None,
+    ) -> ChatsResponse:
+        """List chat conversations derived from ``page_viewed`` events on
+        ``/chat/conv-...`` paths.
+
+        Each row groups every page view in the scenario window for one
+        conversation. Workspace / user filters narrow the scope so the
+        analytics UI can drill into a specific tenant or user.
+        """
+        events = self._filter_events(
+            self._load_window_events(scenario_id), workspace_id, user_email
+        )
+        by_conv: dict[str, list[dict]] = defaultdict(list)
+        for e in events:
+            if e.get("event_name") != "page_viewed":
+                continue
+            path = e.get("page_path") or ""
+            m = _CHAT_CONV_PATH_RE.search(path)
+            if not m:
+                continue
+            by_conv[m.group(1)].append(e)
+
+        rows: list[ChatRow] = []
+        for conv_id, evts in by_conv.items():
+            evts.sort(key=lambda e: e.get("timestamp", ""))
+            first, last = evts[0], evts[-1]
+            base_title = last.get("page_title") or first.get("page_title") or conv_id
+            rows.append(
+                ChatRow(
+                    conversation_id=conv_id,
+                    title=_decorate_page_title(base_title, last.get("page_path") or ""),
+                    workspace_id=last.get("workspace_id"),
+                    workspace_name=last.get("workspace_name"),
+                    user_email=last.get("user_email"),
+                    first_viewed_at=first.get("timestamp") or "",
+                    last_viewed_at=last.get("timestamp") or "",
+                    page_views=len(evts),
+                )
+            )
+        rows.sort(key=lambda r: r.last_viewed_at, reverse=True)
+        return ChatsResponse(chats=rows)
 
     # --- helpers -----------------------------------------------------------
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__dependencies.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__dependencies.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from datetime import datetime
+from typing import Any
 from uuid import uuid4
 
 from fastapi import Depends, HTTPException, Request
@@ -254,4 +255,29 @@ async def persist_stream_content(
                     message_id=assistant_msg_id,
                     content=full_response,
                 )
+        await db.commit()
+
+
+async def persist_stream_metadata(
+    user_id: str,
+    conversation_id: str,
+    assistant_msg_id: str,
+    metadata: dict[str, Any],
+) -> None:
+    """Write accumulated step metadata for a streaming assistant message.
+
+    Acts as a backend-side safety net: even if the frontend never sends its
+    final ``PATCH …/metadata`` call (because the user navigated away or the
+    socket dropped), the tool / agent steps observed during the stream still
+    end up persisted on ``messages.metadata_`` and remain available to the
+    analytics chat detail view.
+    """
+    async with AsyncSessionLocal() as db:
+        with bind_registry(db) as registry:
+            await registry.chat.update_message_metadata(
+                context=system_request_context(user_id),
+                conversation_id=conversation_id,
+                message_id=assistant_msg_id,
+                metadata=metadata,
+            )
         await db.commit()

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__export.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__export.py
@@ -54,9 +54,19 @@ def export_conversation_as_response(
                 content += f"Execution time: {meta['execution_time']:.1f}s\n"
             steps = meta.get("steps", [])
             if steps:
-                content += f"Steps ({len(steps)}): " + ", ".join(
-                    s.get("tool_name", "") for s in steps
-                ) + "\n"
+                content += "Steps:\n"
+                for s in steps:
+                    prefix = s.get("prefix") or "Tool"
+                    name = s.get("tool_name") or ""
+                    status = s.get("status") or ""
+                    content += f"  - [{prefix}] {name} — {status}\n"
+                    if s.get("input"):
+                        content += f"      input: {s['input']}\n"
+                    if s.get("output"):
+                        content += f"      output: {s['output']}\n"
+                content += "\n"
+            if msg.role == "assistant":
+                content += "Message:\n"
             content += f"{msg.content}\n"
             content += f"\n{'-' * 80}\n\n"
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__export.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__export.py
@@ -52,6 +52,9 @@ def export_conversation_as_response(
             meta = _parse_metadata(msg, (messages_metadata or {}).get(msg.id))
             if meta.get("execution_time") is not None:
                 content += f"Execution time: {meta['execution_time']:.1f}s\n"
+            feedback = meta.get("feedback")
+            if feedback in ("like", "dislike"):
+                content += f"Feedback: {feedback}\n"
             steps = meta.get("steps", [])
             if steps:
                 content += "Steps:\n"

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__streaming.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__streaming.py
@@ -365,7 +365,21 @@ async def stream_chat_response(
                 logger.warning("Failed to persist stream metadata", exc_info=True)
 
         try:
-            yield f'data: {{"conversation_id": "{conversation_id}"}}\n\n'
+            # Include ``assistant_message_id`` on the very first frame so the
+            # frontend can swap its client-side placeholder id for the real DB
+            # uuid. Downstream PATCH calls (metadata, feedback) need the DB id
+            # — without this, the frontend's local id never matches the row in
+            # ``messages`` and every PATCH 404s silently.
+            yield (
+                "data: "
+                + json.dumps(
+                    {
+                        "conversation_id": conversation_id,
+                        "assistant_message_id": assistant_msg_id,
+                    }
+                )
+                + "\n\n"
+            )
             if context_sources:
                 yield f"data: {json.dumps({'sources': context_sources})}\n\n"
             # if search_context:

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__streaming.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__streaming.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 from datetime import datetime
+from typing import Any
 
 from fastapi.responses import StreamingResponse
 from naas_abi.apps.nexus.apps.api.app.api.endpoints.auth import User
@@ -13,6 +14,7 @@ from naas_abi.apps.nexus.apps.api.app.services.chat.adapters.primary.chat__prima
     build_provider_messages_with_agents,
     get_or_create_conversation,
     persist_stream_content,
+    persist_stream_metadata,
     request_context,
     resolve_provider,
     # run_search_if_needed,
@@ -39,6 +41,120 @@ OPENAI_COMPATIBLE = [
     "perplexity",
 ]
 SUPPORTED_STREAMING = ["ollama", "cloudflare", "abi", *OPENAI_COMPATIBLE]
+
+
+def _format_tool_name(raw: str) -> str:
+    words = raw.replace("_", " ").split()
+    return " ".join(w[0].upper() + w[1:] for w in words if w)
+
+
+def _label_tool(raw_tool: str) -> tuple[str, str]:
+    """Mirror the frontend ``formatToolLabel`` so server-persisted steps line
+    up with what the UI computes locally (``prefix`` is the discriminator the
+    analytics renderer keys off)."""
+    if raw_tool.startswith("transfer_to"):
+        target = raw_tool[len("transfer_to") :].lstrip("_")
+        return "Routing to", _format_tool_name(target or raw_tool)
+    return "Tool", _format_tool_name(raw_tool)
+
+
+def _ingest_stream_event_into_steps(
+    event_dict: dict[str, Any], steps: list[dict[str, Any]]
+) -> None:
+    """Apply a single SSE event to the running step accumulator.
+
+    Mirrors the logic in ``chat-interface.tsx`` (``handleToolStartEvent`` /
+    ``handleToolResponseEvent`` / ``handleAgentStepEvent``) so the server
+    builds the same step list the frontend would build, independently of
+    whether the frontend ever sends its final ``PATCH …/metadata``.
+    """
+    event_name = str(event_dict.get("event") or "").strip()
+
+    if event_name in {"tool", "tool_usage"}:
+        raw_tool = str(event_dict.get("tool") or "").strip()
+        if not raw_tool:
+            return
+        input_val = event_dict.get("input")
+        input_str = str(input_val) if input_val else None
+        prefix, name = _label_tool(raw_tool)
+        last = steps[-1] if steps else None
+        if (
+            last
+            and last.get("status") == "running"
+            and last.get("_raw_name") == raw_tool
+        ):
+            if input_str and not last.get("input"):
+                last["input"] = input_str
+            return
+        if last and last.get("status") == "running":
+            last["status"] = "done"
+        steps.append(
+            {
+                "tool_name": name,
+                "prefix": prefix,
+                "status": "running",
+                "input": input_str,
+                "output": None,
+                "_raw_name": raw_tool,
+            }
+        )
+        return
+
+    if event_name == "tool_response":
+        output = event_dict.get("output") or event_dict.get("content")
+        if not output:
+            return
+        output_str = str(output).strip()
+        if not output_str:
+            return
+        running_idx = -1
+        recent_idx = -1
+        for idx in range(len(steps) - 1, -1, -1):
+            if steps[idx].get("prefix") == "Tool":
+                if recent_idx == -1:
+                    recent_idx = idx
+                if steps[idx].get("status") == "running":
+                    running_idx = idx
+                    break
+        target_idx = running_idx if running_idx != -1 else recent_idx
+        if target_idx == -1:
+            return
+        steps[target_idx]["status"] = "done"
+        steps[target_idx]["output"] = output_str
+        return
+
+    if event_name in {"call_model", "agent_calling", "agent_routing"}:
+        raw_agent = str(event_dict.get("agent") or "").strip()
+        if not raw_agent:
+            return
+        agent_name = _format_tool_name(raw_agent)
+        if not agent_name:
+            return
+        last = steps[-1] if steps else None
+        if last and last.get("status") == "running":
+            last["status"] = "done"
+        label = (
+            "Thinking"
+            if event_name in {"call_model", "agent_calling"}
+            else f"Routing to {agent_name}"
+        )
+        steps.append(
+            {
+                "tool_name": label,
+                "prefix": "Agent",
+                "status": "running",
+                "input": None,
+                "output": None,
+                "_raw_name": f"{event_name}:{raw_agent}",
+            }
+        )
+
+
+def _strip_internal_step_keys(steps: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Drop server-only bookkeeping fields (e.g. ``_raw_name``) before
+    persisting so the shape matches the existing ``MessageStep`` schema and
+    the frontend's PATCH payload."""
+    return [{k: v for k, v in step.items() if not k.startswith("_")} for step in steps]
 
 
 async def stream_chat_response(
@@ -180,6 +296,11 @@ async def stream_chat_response(
         flush_interval_seconds = 0.75
         min_chars_per_flush = 512
         buffered_chars = 0
+        stream_started_at = loop.time()
+        # Step accumulator — mirrors the frontend's ``streamToolCalls`` so the
+        # tool / agent activity for this turn is captured on the server even
+        # if the frontend never PATCHes its final metadata payload.
+        steps: list[dict[str, Any]] = []
 
         async def maybe_flush_incremental() -> None:
             nonlocal last_flush, buffered_chars
@@ -212,12 +333,36 @@ async def stream_chat_response(
                     payload = {"content": chunk}
                 elif isinstance(chunk, dict):
                     payload = chunk
+                    _ingest_stream_event_into_steps(chunk, steps)
                 else:
                     continue
 
                 yield_data = f"data: {json.dumps(payload, ensure_ascii=False)}\n\n"
                 yield yield_data
                 await maybe_flush_incremental()
+
+        async def persist_final_metadata() -> None:
+            if not assistant_msg_id:
+                return
+            # Mark any leftover running steps as done — same finalisation the
+            # frontend applies before its PATCH.
+            for step in steps:
+                if step.get("status") == "running":
+                    step["status"] = "done"
+            metadata = {
+                "execution_time": round(loop.time() - stream_started_at, 3),
+                "steps": _strip_internal_step_keys(steps),
+                "sources": list(context_sources) if context_sources else [],
+            }
+            try:
+                await persist_stream_metadata(
+                    user_id=current_user.id,
+                    conversation_id=conversation_id,
+                    assistant_msg_id=assistant_msg_id,
+                    metadata=metadata,
+                )
+            except Exception:
+                logger.warning("Failed to persist stream metadata", exc_info=True)
 
         try:
             yield f'data: {{"conversation_id": "{conversation_id}"}}\n\n'
@@ -273,6 +418,7 @@ async def stream_chat_response(
                     )
                 except Exception:
                     logger.error("Failed to finalize stream messages to DB", exc_info=True)
+                await persist_final_metadata()
 
             yield "data: [DONE]\n\n"
         except Exception as exc:
@@ -294,6 +440,7 @@ async def stream_chat_response(
                         full_response=full_response,
                         touch_conversation=True,
                     )
+                    await persist_final_metadata()
             except Exception:
                 logger.warning("Failed to persist partial content on error", exc_info=True)
             yield f'data: {{"error": "{escaped_error}"}}\n\n'

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/secondary/postgres.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/secondary/postgres.py
@@ -17,7 +17,7 @@ from naas_abi.apps.nexus.apps.api.app.services.chat.port import (
     ChatPersistencePort,
     ChatSecretRecord,
 )
-from sqlalchemy import delete, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 AsyncSessionGetter = Callable[[], AsyncSession | None]
@@ -178,6 +178,31 @@ class ChatSecondaryAdapterPostgres(ChatPersistencePort):
             .order_by(MessageModel.created_at)
         )
         return [self._to_message_record(row) for row in result.scalars().all()]
+
+    async def count_messages_for_conversations(
+        self, conversation_ids: list[str]
+    ) -> dict[str, int]:
+        if not conversation_ids:
+            return {}
+        result = await self.db.execute(
+            select(MessageModel.conversation_id, func.count(MessageModel.id))
+            .where(MessageModel.conversation_id.in_(conversation_ids))
+            .group_by(MessageModel.conversation_id)
+        )
+        counts = {cid: int(count) for cid, count in result.all()}
+        # Conversations with zero rows must still appear in the map so callers
+        # can render "0 messages" without falling back to "unknown".
+        return {cid: counts.get(cid, 0) for cid in conversation_ids}
+
+    async def list_conversations_by_ids(
+        self, conversation_ids: list[str]
+    ) -> dict[str, ChatConversationRecord]:
+        if not conversation_ids:
+            return {}
+        result = await self.db.execute(
+            select(ConversationModel).where(ConversationModel.id.in_(conversation_ids))
+        )
+        return {row.id: self._to_conversation_record(row) for row in result.scalars().all()}
 
     async def create_message(
         self,

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/port.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/port.py
@@ -117,6 +117,20 @@ class ChatPersistencePort(ABC):
         pass
 
     @abstractmethod
+    async def count_messages_for_conversations(
+        self, conversation_ids: list[str]
+    ) -> dict[str, int]:
+        """Return message count keyed by conversation id (single round-trip)."""
+        pass
+
+    @abstractmethod
+    async def list_conversations_by_ids(
+        self, conversation_ids: list[str]
+    ) -> dict[str, ChatConversationRecord]:
+        """Return existing conversations keyed by id (single round-trip)."""
+        pass
+
+    @abstractmethod
     async def create_message(
         self,
         message_id: str,

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/components/filter-bar.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/components/filter-bar.tsx
@@ -238,14 +238,25 @@ function WorkspaceSelect({
       <button
         onClick={() => setOpen((v) => !v)}
         className={cn(
-          'flex h-9 items-center gap-2 border border-border bg-background pl-3 pr-2.5 text-sm transition-colors',
+          'flex h-9 items-center gap-2 border border-border bg-background pl-3 pr-2.5 text-sm transition-colors max-w-[260px]',
           'hover:border-foreground/20 hover:bg-muted/40',
           value.workspace_id !== 'all' && 'border-workspace-accent bg-workspace-accent-5',
         )}
       >
-        <Layers size={14} className="text-muted-foreground" />
-        <span className="font-medium">{label}</span>
-        <ChevronDown size={14} className="text-muted-foreground" />
+        <Layers size={14} className="text-muted-foreground flex-shrink-0" />
+        <span className="font-medium truncate">{label}</span>
+        {value.workspace_id !== 'all' ? (
+          <X
+            size={13}
+            className="text-muted-foreground hover:text-foreground flex-shrink-0"
+            onClick={(e) => {
+              e.stopPropagation();
+              onChange({ ...value, workspace_id: 'all' });
+            }}
+          />
+        ) : (
+          <ChevronDown size={14} className="text-muted-foreground flex-shrink-0" />
+        )}
       </button>
       {open && (
         <div className="absolute left-0 top-full z-50 mt-1.5 w-56 border border-border bg-popover p-1.5 shadow-lg">

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/lib/types.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/lib/types.ts
@@ -128,3 +128,37 @@ export interface OverviewResponse {
   workspace_activity: WorkspaceRow[];
   recent_activity: AnalyticsEvent[];
 }
+
+export interface ChatRow {
+  conversation_id: string;
+  title: string;
+  workspace_id?: string | null;
+  workspace_name?: string | null;
+  user_email?: string | null;
+  first_viewed_at: string;
+  last_viewed_at: string;
+  page_views: number;
+}
+
+export interface ChatsResponse {
+  chats: ChatRow[];
+}
+
+export interface ChatMessage {
+  id: string;
+  role: 'user' | 'assistant' | 'system' | string;
+  content: string;
+  agent?: string | null;
+  created_at?: string | null;
+}
+
+export interface ChatDetail {
+  conversation_id: string;
+  workspace_id: string;
+  user_id: string;
+  title: string;
+  agent: string;
+  created_at?: string | null;
+  updated_at?: string | null;
+  messages: ChatMessage[];
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/lib/types.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/lib/types.ts
@@ -154,10 +154,13 @@ export interface ChatMessageStep {
   output?: string | null;
 }
 
+export type ChatMessageFeedback = 'like' | 'dislike';
+
 export interface ChatMessageMetadata {
   execution_time?: number | null;
   steps?: ChatMessageStep[];
   sources?: string[];
+  feedback?: ChatMessageFeedback | null;
   [key: string]: unknown;
 }
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/lib/types.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/lib/types.ts
@@ -132,16 +132,33 @@ export interface OverviewResponse {
 export interface ChatRow {
   conversation_id: string;
   title: string;
+  chat_title?: string | null;
   workspace_id?: string | null;
   workspace_name?: string | null;
   user_email?: string | null;
   first_viewed_at: string;
   last_viewed_at: string;
   page_views: number;
+  message_count: number;
 }
 
 export interface ChatsResponse {
   chats: ChatRow[];
+}
+
+export interface ChatMessageStep {
+  tool_name: string;
+  prefix: string;
+  status: string;
+  input?: string | null;
+  output?: string | null;
+}
+
+export interface ChatMessageMetadata {
+  execution_time?: number | null;
+  steps?: ChatMessageStep[];
+  sources?: string[];
+  [key: string]: unknown;
 }
 
 export interface ChatMessage {
@@ -150,6 +167,7 @@ export interface ChatMessage {
   content: string;
   agent?: string | null;
   created_at?: string | null;
+  metadata?: ChatMessageMetadata | null;
 }
 
 export interface ChatDetail {

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/page.tsx
@@ -5,12 +5,16 @@ import {
   Activity,
   AlertTriangle,
   BarChart3,
+  Check,
   Clock,
+  Copy,
+  Download,
   Eye,
   FileText,
   Globe,
   Layers,
   Loader2,
+  MessageSquare,
   Mouse,
   Repeat,
   TrendingUp,
@@ -28,6 +32,9 @@ import { formatDateTime, formatDuration, formatNumber, formatRelative } from './
 import { getApiUrl } from '@/lib/config';
 import type {
   AnalyticsEvent,
+  ChatDetail,
+  ChatMessage,
+  ChatsResponse,
   OverviewResponse,
   PageRow,
   Scenario,
@@ -38,7 +45,7 @@ import type {
   WorkspaceRow,
 } from './lib/types';
 
-type Tab = 'overview' | 'users' | 'sessions' | 'pages' | 'workspaces' | 'events';
+type Tab = 'overview' | 'users' | 'sessions' | 'pages' | 'workspaces' | 'events' | 'chats';
 
 const TABS: { key: Tab; label: string }[] = [
   { key: 'overview', label: 'Overview' },
@@ -47,6 +54,7 @@ const TABS: { key: Tab; label: string }[] = [
   { key: 'pages', label: 'Pages' },
   { key: 'workspaces', label: 'Workspaces' },
   { key: 'events', label: 'Events' },
+  { key: 'chats', label: 'Chats' },
 ];
 
 function initialFilters(): FilterValue {
@@ -112,14 +120,14 @@ export default function AnalyticsPage() {
 
   const isUserDetail = filters.user_email !== 'all';
 
-  // Only Overview and Events are meaningful in user-detail mode.
+  // Only Overview, Events and Chats are meaningful in user-detail mode.
   const visibleTabs = isUserDetail
-    ? TABS.filter((t) => t.key === 'overview' || t.key === 'events')
+    ? TABS.filter((t) => t.key === 'overview' || t.key === 'events' || t.key === 'chats')
     : TABS;
 
   // If the user picks a specific email while on a now-hidden tab, snap back.
   useEffect(() => {
-    if (isUserDetail && tab !== 'overview' && tab !== 'events') {
+    if (isUserDetail && tab !== 'overview' && tab !== 'events' && tab !== 'chats') {
       setTab('overview');
     }
   }, [isUserDetail, tab]);
@@ -187,7 +195,7 @@ export default function AnalyticsPage() {
       </header>
 
       <main className="mx-auto max-w-7xl px-6 py-8">
-        {isUserDetail && tab !== 'events' && tab !== 'overview' ? (
+        {isUserDetail && tab !== 'events' && tab !== 'overview' && tab !== 'chats' ? (
           <UserDetailSection filters={filters} onClear={() => setFilters({ ...filters, user_email: 'all' })} />
         ) : null}
 
@@ -206,6 +214,7 @@ export default function AnalyticsPage() {
         {tab === 'pages' && !isUserDetail && <PagesSection filters={filters} />}
         {tab === 'workspaces' && !isUserDetail && <WorkspacesSection filters={filters} />}
         {tab === 'events' && <EventsSection filters={filters} />}
+        {tab === 'chats' && <ChatsSection filters={filters} onUserPick={handleUserPick} />}
       </main>
     </div>
   );
@@ -923,6 +932,263 @@ function UserDetailSection({
           </div>
         )}
       </Card>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Chats
+// ---------------------------------------------------------------------------
+
+function ChatsSection({
+  filters,
+  onUserPick,
+}: {
+  filters: FilterValue;
+  onUserPick: (email: string) => void;
+}) {
+  const { data, loading, error } = useAnalytics<ChatsResponse>(
+    '/api/analytics/chats',
+    filters,
+  );
+  const [openId, setOpenId] = useState<string | null>(null);
+
+  if (loading && !data) return <LoadingBlock />;
+  if (error) return <ErrorBlock message={error} />;
+  const chats = data?.chats ?? [];
+
+  return (
+    <Card
+      title="Chats"
+      subtitle={`${chats.length.toLocaleString()} conversation(s) viewed in this range`}
+    >
+      {chats.length === 0 ? (
+        <EmptyBlock>No chat page views in this range.</EmptyBlock>
+      ) : (
+        <ul className="-mx-5 -my-5 divide-y divide-border/50">
+          {chats.map((c) => {
+            const expanded = openId === c.conversation_id;
+            return (
+              <li key={c.conversation_id}>
+                <button
+                  onClick={() => setOpenId(expanded ? null : c.conversation_id)}
+                  className={cn(
+                    'flex w-full items-start gap-3 px-5 py-3 text-left text-sm transition-colors',
+                    'hover:bg-muted/40',
+                    expanded && 'bg-muted/40',
+                  )}
+                >
+                  <MessageSquare size={14} className="mt-0.5 text-workspace-accent flex-shrink-0" />
+                  <div className="flex-1 min-w-0">
+                    <div className="font-medium truncate">{c.title}</div>
+                    <div className="mt-0.5 flex flex-wrap items-center gap-x-2 text-xs text-muted-foreground">
+                      {c.user_email && (
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onUserPick(c.user_email as string);
+                          }}
+                          className="hover:text-foreground hover:underline"
+                        >
+                          {c.user_email}
+                        </button>
+                      )}
+                      {c.workspace_name && <span>· {c.workspace_name}</span>}
+                      <span>· {c.page_views} view{c.page_views === 1 ? '' : 's'}</span>
+                      <span className="font-mono opacity-70">· {c.conversation_id}</span>
+                    </div>
+                  </div>
+                  <span className="flex-shrink-0 text-right text-xs text-muted-foreground whitespace-nowrap">
+                    {formatDateTime(c.last_viewed_at)}
+                  </span>
+                </button>
+                {expanded && <ChatDetailPanel conversationId={c.conversation_id} />}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </Card>
+  );
+}
+
+function ChatDetailPanel({ conversationId }: { conversationId: string }) {
+  const [data, setData] = useState<ChatDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetch(`${getApiUrl()}/api/analytics/chats/${encodeURIComponent(conversationId)}`)
+      .then(async (r) => {
+        if (!r.ok) throw new Error(`Request failed (${r.status})`);
+        return r.json();
+      })
+      .then((d: ChatDetail) => {
+        if (!cancelled) setData(d);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(String(e?.message ?? e));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [conversationId]);
+
+  if (loading)
+    return (
+      <div className="bg-muted/20 px-5 py-4 text-xs text-muted-foreground">
+        <Loader2 size={12} className="mr-2 inline animate-spin" />
+        Loading conversation…
+      </div>
+    );
+  if (error)
+    return (
+      <div className="bg-muted/20 px-5 py-4 text-xs text-destructive">
+        Could not load conversation: {error}
+      </div>
+    );
+  if (!data) return null;
+
+  if (data.messages.length === 0) {
+    return (
+      <div className="bg-muted/20 px-5 py-4 text-xs text-muted-foreground">
+        Conversation has no stored messages.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3 bg-muted/20 px-5 py-4">
+      <ChatExportToolbar conversation={data} />
+      {data.messages.map((m) => (
+        <ChatMessageBubble key={m.id} message={m} />
+      ))}
+    </div>
+  );
+}
+
+function formatChatAsText(conversation: ChatDetail): string {
+  const header = [
+    `Title: ${conversation.title}`,
+    `Conversation ID: ${conversation.conversation_id}`,
+    `Agent: ${conversation.agent}`,
+    `Workspace: ${conversation.workspace_id}`,
+    `User: ${conversation.user_id}`,
+    conversation.created_at ? `Created: ${conversation.created_at}` : null,
+    conversation.updated_at ? `Updated: ${conversation.updated_at}` : null,
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  const body = conversation.messages
+    .map((m) => {
+      const ts = m.created_at ? ` [${m.created_at}]` : '';
+      const agent = m.agent ? ` (${m.agent})` : '';
+      return `--- ${m.role.toUpperCase()}${agent}${ts} ---\n${m.content}`;
+    })
+    .join('\n\n');
+
+  return `${header}\n\n${body}\n`;
+}
+
+function ChatExportToolbar({ conversation }: { conversation: ChatDetail }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(formatChatAsText(conversation));
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Fallback for older browsers / non-secure contexts.
+      const ta = document.createElement('textarea');
+      ta.value = formatChatAsText(conversation);
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.focus();
+      ta.select();
+      try {
+        document.execCommand('copy');
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      } catch {
+        // give up silently
+      }
+      document.body.removeChild(ta);
+    }
+  };
+
+  const handleDownload = () => {
+    const blob = new Blob([formatChatAsText(conversation)], {
+      type: 'text/plain;charset=utf-8',
+    });
+    const safeSlug = (conversation.title || conversation.conversation_id)
+      .replace(/[^a-z0-9-_]+/gi, '_')
+      .slice(0, 80);
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${safeSlug || conversation.conversation_id}.txt`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="flex flex-wrap items-center justify-end gap-2 pb-2">
+      <button
+        onClick={handleCopy}
+        className={cn(
+          'flex h-8 items-center gap-1.5 border border-border bg-background px-2.5 text-xs transition-colors',
+          'hover:border-foreground/20 hover:bg-muted/40',
+        )}
+      >
+        {copied ? <Check size={12} /> : <Copy size={12} />}
+        <span>{copied ? 'Copied' : 'Copy'}</span>
+      </button>
+      <button
+        onClick={handleDownload}
+        className={cn(
+          'flex h-8 items-center gap-1.5 border border-border bg-background px-2.5 text-xs transition-colors',
+          'hover:border-foreground/20 hover:bg-muted/40',
+        )}
+      >
+        <Download size={12} />
+        <span>Export .txt</span>
+      </button>
+    </div>
+  );
+}
+
+function ChatMessageBubble({ message }: { message: ChatMessage }) {
+  const isUser = message.role === 'user';
+  const isAssistant = message.role === 'assistant';
+  const isSystem = message.role === 'system';
+
+  const align = isUser ? 'items-end' : 'items-start';
+  const bubble = cn(
+    'max-w-[85%] whitespace-pre-wrap break-words border px-3 py-2 text-sm',
+    isUser && 'border-workspace-accent/30 bg-workspace-accent-5',
+    isAssistant && 'border-border bg-background',
+    isSystem && 'border-border/60 bg-muted/40 text-muted-foreground',
+  );
+
+  return (
+    <div className={cn('flex flex-col gap-1', align)}>
+      <div className="flex items-center gap-2 text-[10px] uppercase tracking-wide text-muted-foreground">
+        <span className="font-semibold">{message.role}</span>
+        {message.agent && <span>· {message.agent}</span>}
+        {message.created_at && <span>· {formatDateTime(message.created_at)}</span>}
+      </div>
+      <div className={bubble}>{message.content || <span className="opacity-50">(empty)</span>}</div>
     </div>
   );
 }

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/page.tsx
@@ -4,11 +4,11 @@ import { useCallback, useEffect, useState } from 'react';
 import {
   Activity,
   AlertTriangle,
+  ArrowLeft,
   BarChart3,
   Check,
   Clock,
   Copy,
-  Download,
   Eye,
   FileText,
   Globe,
@@ -19,6 +19,7 @@ import {
   Repeat,
   TrendingUp,
   Users,
+  X,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Avatar, FilterBar, type FilterValue } from './components/filter-bar';
@@ -34,6 +35,7 @@ import type {
   AnalyticsEvent,
   ChatDetail,
   ChatMessage,
+  ChatMessageStep,
   ChatsResponse,
   OverviewResponse,
   PageRow,
@@ -53,8 +55,8 @@ const TABS: { key: Tab; label: string }[] = [
   { key: 'sessions', label: 'Sessions' },
   { key: 'pages', label: 'Pages' },
   { key: 'workspaces', label: 'Workspaces' },
-  { key: 'events', label: 'Events' },
   { key: 'chats', label: 'Chats' },
+  { key: 'events', label: 'Events' },
 ];
 
 function initialFilters(): FilterValue {
@@ -953,6 +955,10 @@ function ChatsSection({
   );
   const [openId, setOpenId] = useState<string | null>(null);
 
+  if (openId) {
+    return <ChatDetailFullPage conversationId={openId} onClose={() => setOpenId(null)} />;
+  }
+
   if (loading && !data) return <LoadingBlock />;
   if (error) return <ErrorBlock message={error} />;
   const chats = data?.chats ?? [];
@@ -966,56 +972,69 @@ function ChatsSection({
         <EmptyBlock>No chat page views in this range.</EmptyBlock>
       ) : (
         <ul className="-mx-5 -my-5 divide-y divide-border/50">
-          {chats.map((c) => {
-            const expanded = openId === c.conversation_id;
-            return (
-              <li key={c.conversation_id}>
-                <button
-                  onClick={() => setOpenId(expanded ? null : c.conversation_id)}
-                  className={cn(
-                    'flex w-full items-start gap-3 px-5 py-3 text-left text-sm transition-colors',
-                    'hover:bg-muted/40',
-                    expanded && 'bg-muted/40',
-                  )}
-                >
-                  <MessageSquare size={14} className="mt-0.5 text-workspace-accent flex-shrink-0" />
-                  <div className="flex-1 min-w-0">
-                    <div className="font-medium truncate">{c.title}</div>
-                    <div className="mt-0.5 flex flex-wrap items-center gap-x-2 text-xs text-muted-foreground">
-                      {c.user_email && (
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            onUserPick(c.user_email as string);
-                          }}
-                          className="hover:text-foreground hover:underline"
-                        >
-                          {c.user_email}
-                        </button>
-                      )}
-                      {c.workspace_name && <span>· {c.workspace_name}</span>}
-                      <span>· {c.page_views} view{c.page_views === 1 ? '' : 's'}</span>
-                      <span className="font-mono opacity-70">· {c.conversation_id}</span>
-                    </div>
+          {chats.map((c) => (
+            <li key={c.conversation_id}>
+              <button
+                onClick={() => setOpenId(c.conversation_id)}
+                className={cn(
+                  'flex w-full items-start gap-3 px-5 py-3 text-left text-sm transition-colors',
+                  'hover:bg-muted/40',
+                )}
+              >
+                <MessageSquare size={14} className="mt-0.5 text-workspace-accent flex-shrink-0" />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-baseline gap-2 min-w-0">
+                    <span className="font-mono text-xs font-medium truncate">
+                      {c.conversation_id}
+                    </span>
+                    - {c.chat_title && (
+                      <span className="truncate text-sm font-medium">{c.chat_title}</span>
+                    )}
                   </div>
-                  <span className="flex-shrink-0 text-right text-xs text-muted-foreground whitespace-nowrap">
-                    {formatDateTime(c.last_viewed_at)}
-                  </span>
-                </button>
-                {expanded && <ChatDetailPanel conversationId={c.conversation_id} />}
-              </li>
-            );
-          })}
+                  <div className="mt-0.5 flex flex-wrap items-center gap-x-2 text-xs text-muted-foreground">
+                    {c.user_email && (
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onUserPick(c.user_email as string);
+                        }}
+                        className="hover:text-foreground hover:underline"
+                      >
+                        {c.user_email}
+                      </button>
+                    )}
+                    {c.workspace_name && <span>· {c.workspace_name}</span>}
+                    <span>· {c.page_views} view{c.page_views === 1 ? '' : 's'}</span>
+                    <span>
+                      · {c.message_count} message{c.message_count === 1 ? '' : 's'}
+                    </span>
+                  </div>
+                </div>
+                <span className="flex-shrink-0 text-right text-xs text-muted-foreground whitespace-nowrap">
+                  {formatDateTime(c.last_viewed_at)}
+                </span>
+              </button>
+            </li>
+          ))}
         </ul>
       )}
     </Card>
   );
 }
 
-function ChatDetailPanel({ conversationId }: { conversationId: string }) {
+function ChatDetailFullPage({
+  conversationId,
+  onClose,
+}: {
+  conversationId: string;
+  onClose: () => void;
+}) {
   const [data, setData] = useState<ChatDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [exporting, setExporting] = useState<null | 'copy'>(null);
+  const [copied, setCopied] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -1040,132 +1059,163 @@ function ChatDetailPanel({ conversationId }: { conversationId: string }) {
     };
   }, [conversationId]);
 
-  if (loading)
-    return (
-      <div className="bg-muted/20 px-5 py-4 text-xs text-muted-foreground">
-        <Loader2 size={12} className="mr-2 inline animate-spin" />
-        Loading conversation…
-      </div>
-    );
-  if (error)
-    return (
-      <div className="bg-muted/20 px-5 py-4 text-xs text-destructive">
-        Could not load conversation: {error}
-      </div>
-    );
-  if (!data) return null;
-
-  if (data.messages.length === 0) {
-    return (
-      <div className="bg-muted/20 px-5 py-4 text-xs text-muted-foreground">
-        Conversation has no stored messages.
-      </div>
-    );
-  }
-
-  return (
-    <div className="space-y-3 bg-muted/20 px-5 py-4">
-      <ChatExportToolbar conversation={data} />
-      {data.messages.map((m) => (
-        <ChatMessageBubble key={m.id} message={m} />
-      ))}
-    </div>
-  );
-}
-
-function formatChatAsText(conversation: ChatDetail): string {
-  const header = [
-    `Title: ${conversation.title}`,
-    `Conversation ID: ${conversation.conversation_id}`,
-    `Agent: ${conversation.agent}`,
-    `Workspace: ${conversation.workspace_id}`,
-    `User: ${conversation.user_id}`,
-    conversation.created_at ? `Created: ${conversation.created_at}` : null,
-    conversation.updated_at ? `Updated: ${conversation.updated_at}` : null,
-  ]
-    .filter(Boolean)
-    .join('\n');
-
-  const body = conversation.messages
-    .map((m) => {
-      const ts = m.created_at ? ` [${m.created_at}]` : '';
-      const agent = m.agent ? ` (${m.agent})` : '';
-      return `--- ${m.role.toUpperCase()}${agent}${ts} ---\n${m.content}`;
-    })
-    .join('\n\n');
-
-  return `${header}\n\n${body}\n`;
-}
-
-function ChatExportToolbar({ conversation }: { conversation: ChatDetail }) {
-  const [copied, setCopied] = useState(false);
-
   const handleCopy = async () => {
+    if (!data) return;
+    setExportError(null);
+    setExporting('copy');
     try {
-      await navigator.clipboard.writeText(formatChatAsText(conversation));
+      const text = buildChatExportText(data);
+      try {
+        await navigator.clipboard.writeText(text);
+      } catch {
+        const ta = document.createElement('textarea');
+        ta.value = text;
+        ta.style.position = 'fixed';
+        ta.style.opacity = '0';
+        document.body.appendChild(ta);
+        ta.focus();
+        ta.select();
+        try {
+          document.execCommand('copy');
+        } finally {
+          document.body.removeChild(ta);
+        }
+      }
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
-    } catch {
-      // Fallback for older browsers / non-secure contexts.
-      const ta = document.createElement('textarea');
-      ta.value = formatChatAsText(conversation);
-      ta.style.position = 'fixed';
-      ta.style.opacity = '0';
-      document.body.appendChild(ta);
-      ta.focus();
-      ta.select();
-      try {
-        document.execCommand('copy');
-        setCopied(true);
-        setTimeout(() => setCopied(false), 1500);
-      } catch {
-        // give up silently
-      }
-      document.body.removeChild(ta);
+    } catch (e) {
+      setExportError(String((e as Error)?.message ?? e));
+    } finally {
+      setExporting(null);
     }
   };
 
-  const handleDownload = () => {
-    const blob = new Blob([formatChatAsText(conversation)], {
-      type: 'text/plain;charset=utf-8',
-    });
-    const safeSlug = (conversation.title || conversation.conversation_id)
-      .replace(/[^a-z0-9-_]+/gi, '_')
-      .slice(0, 80);
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `${safeSlug || conversation.conversation_id}.txt`;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
-  };
-
   return (
-    <div className="flex flex-wrap items-center justify-end gap-2 pb-2">
-      <button
-        onClick={handleCopy}
-        className={cn(
-          'flex h-8 items-center gap-1.5 border border-border bg-background px-2.5 text-xs transition-colors',
-          'hover:border-foreground/20 hover:bg-muted/40',
-        )}
-      >
-        {copied ? <Check size={12} /> : <Copy size={12} />}
-        <span>{copied ? 'Copied' : 'Copy'}</span>
-      </button>
-      <button
-        onClick={handleDownload}
-        className={cn(
-          'flex h-8 items-center gap-1.5 border border-border bg-background px-2.5 text-xs transition-colors',
-          'hover:border-foreground/20 hover:bg-muted/40',
-        )}
-      >
-        <Download size={12} />
-        <span>Export .txt</span>
-      </button>
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border/60 pb-3">
+        <div className="flex items-center gap-3 min-w-0">
+          <button
+            onClick={onClose}
+            className={cn(
+              'flex h-9 items-center gap-1.5 border border-border bg-background px-2.5 text-sm transition-colors',
+              'hover:border-foreground/20 hover:bg-muted/40',
+            )}
+            title="Back to chat list"
+          >
+            <ArrowLeft size={14} />
+            <span>Back</span>
+          </button>
+          <div className="min-w-0">
+            <div className="text-xs uppercase tracking-wider text-muted-foreground">Conversation</div>
+            <div className="font-mono text-sm font-medium truncate">{conversationId}</div>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          {exportError && <span className="text-xs text-destructive">{exportError}</span>}
+          <button
+            onClick={handleCopy}
+            disabled={exporting !== null || !data}
+            className={cn(
+              'flex h-9 items-center gap-1.5 border border-border bg-background px-2.5 text-sm transition-colors',
+              'hover:border-foreground/20 hover:bg-muted/40 disabled:opacity-60',
+            )}
+            title="Copy as text"
+          >
+            {exporting === 'copy' ? (
+              <Loader2 size={14} className="animate-spin" />
+            ) : copied ? (
+              <Check size={14} />
+            ) : (
+              <Copy size={14} />
+            )}
+            <span>{copied ? 'Copied' : 'Copy'}</span>
+          </button>
+          <button
+            onClick={onClose}
+            className={cn(
+              'flex h-9 w-9 items-center justify-center border border-border bg-background transition-colors',
+              'hover:border-foreground/20 hover:bg-muted/40',
+            )}
+            title="Close"
+          >
+            <X size={14} />
+          </button>
+        </div>
+      </div>
+
+      {loading && !data && <LoadingBlock label="Loading conversation" />}
+      {error && <ErrorBlock message={error} />}
+      {data && (
+        <Card
+          title={data.title || conversationId}
+          subtitle={`${data.messages.length} message(s) · agent: ${data.agent}`}
+        >
+          {data.messages.length === 0 ? (
+            <EmptyBlock>Conversation has no stored messages.</EmptyBlock>
+          ) : (
+            <div className="space-y-4">
+              {data.messages.map((m) => (
+                <ChatMessageBubble key={m.id} message={m} />
+              ))}
+            </div>
+          )}
+        </Card>
+      )}
     </div>
   );
+}
+
+// Mirrors the backend ``export_conversation_as_response`` txt branch (in
+// ``chat__primary_adapter__export.py``). Kept client-side so the Export
+// button works even if the analytics API server hasn't been restarted to
+// pick up the new admin export route. The output is byte-for-byte identical
+// to what the chat-interface Export button produces.
+function buildChatExportText(conversation: ChatDetail): string {
+  const SEP_TOP = '='.repeat(80);
+  const SEP_BTW = '-'.repeat(80);
+  const title = conversation.title || 'Untitled Conversation';
+  const exportedAt = new Date().toISOString();
+
+  let out = `Conversation: ${title}\n`;
+  out += `ID: ${conversation.conversation_id}\n`;
+  out += `Exported: ${exportedAt}\n`;
+  out += `User: ${conversation.user_id}\n`;
+  out += `Workspace: ${conversation.workspace_id}\n`;
+  out += `Messages: ${conversation.messages.length}\n`;
+  out += `\n${SEP_TOP}\n\n`;
+
+  for (const msg of conversation.messages) {
+    let role = msg.role.toUpperCase();
+    if (msg.role === 'assistant' && msg.agent) {
+      role = `ASSISTANT (${msg.agent})`;
+    }
+    out += `[${role}]\n`;
+    if (msg.created_at) out += `Timestamp: ${msg.created_at}\n`;
+    const exec = msg.metadata?.execution_time;
+    if (typeof exec === 'number') {
+      out += `Execution time: ${exec.toFixed(1)}s\n`;
+    }
+    const steps = msg.metadata?.steps ?? [];
+    if (steps.length > 0) {
+      out += 'Steps:\n';
+      for (const s of steps) {
+        const prefix = s.prefix || 'Tool';
+        const name = s.tool_name || '';
+        const status = s.status || '';
+        out += `  - [${prefix}] ${name} — ${status}\n`;
+        if (s.input) out += `      input: ${s.input}\n`;
+        if (s.output) out += `      output: ${s.output}\n`;
+      }
+      out += '\n';
+    }
+    if (msg.role === 'assistant') {
+      out += 'Message:\n';
+    }
+    out += `${msg.content}\n`;
+    out += `\n${SEP_BTW}\n\n`;
+  }
+
+  return out;
 }
 
 function ChatMessageBubble({ message }: { message: ChatMessage }) {
@@ -1181,14 +1231,64 @@ function ChatMessageBubble({ message }: { message: ChatMessage }) {
     isSystem && 'border-border/60 bg-muted/40 text-muted-foreground',
   );
 
+  const steps = message.metadata?.steps ?? [];
+  const executionTime = message.metadata?.execution_time;
+
   return (
     <div className={cn('flex flex-col gap-1', align)}>
       <div className="flex items-center gap-2 text-[10px] uppercase tracking-wide text-muted-foreground">
         <span className="font-semibold">{message.role}</span>
         {message.agent && <span>· {message.agent}</span>}
         {message.created_at && <span>· {formatDateTime(message.created_at)}</span>}
+        {typeof executionTime === 'number' && executionTime > 0 && (
+          <span>· {executionTime.toFixed(1)}s</span>
+        )}
       </div>
+      {steps.length > 0 && <ChatStepsList steps={steps} alignEnd={isUser} />}
       <div className={bubble}>{message.content || <span className="opacity-50">(empty)</span>}</div>
+    </div>
+  );
+}
+
+function ChatStepsList({ steps, alignEnd }: { steps: ChatMessageStep[]; alignEnd: boolean }) {
+  return (
+    <div className={cn('flex max-w-[85%] flex-col gap-1', alignEnd && 'items-end')}>
+      <ul className="w-full space-y-1.5 border border-border/60 bg-background/60 p-2 text-xs">
+        {steps.map((s, i) => (
+          <li key={i} className="space-y-0.5">
+            <div className="flex items-center gap-2">
+              <span className="rounded-sm bg-muted px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                {s.prefix}
+              </span>
+              <span className="font-medium">{s.tool_name}</span>
+              <span
+                className={cn(
+                  'ml-auto text-[10px] uppercase tracking-wide',
+                  s.status === 'done' && 'text-emerald-600',
+                  s.status === 'running' && 'text-amber-600',
+                  s.status === 'error' && 'text-destructive',
+                )}
+              >
+                {s.status}
+              </span>
+            </div>
+            {s.input && (
+              <pre className="overflow-x-auto whitespace-pre-wrap break-words bg-muted/40 px-2 py-1 text-[11px] text-muted-foreground">
+                <span className="font-semibold uppercase tracking-wide">input</span>
+                {'\n'}
+                {s.input}
+              </pre>
+            )}
+            {s.output && (
+              <pre className="overflow-x-auto whitespace-pre-wrap break-words bg-muted/40 px-2 py-1 text-[11px] text-muted-foreground">
+                <span className="font-semibold uppercase tracking-wide">output</span>
+                {'\n'}
+                {s.output}
+              </pre>
+            )}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/page.tsx
@@ -17,6 +17,8 @@ import {
   MessageSquare,
   Mouse,
   Repeat,
+  ThumbsDown,
+  ThumbsUp,
   TrendingUp,
   Users,
   X,
@@ -1195,6 +1197,10 @@ function buildChatExportText(conversation: ChatDetail): string {
     if (typeof exec === 'number') {
       out += `Execution time: ${exec.toFixed(1)}s\n`;
     }
+    const fb = msg.metadata?.feedback;
+    if (fb === 'like' || fb === 'dislike') {
+      out += `Feedback: ${fb}\n`;
+    }
     const steps = msg.metadata?.steps ?? [];
     if (steps.length > 0) {
       out += 'Steps:\n';
@@ -1233,6 +1239,7 @@ function ChatMessageBubble({ message }: { message: ChatMessage }) {
 
   const steps = message.metadata?.steps ?? [];
   const executionTime = message.metadata?.execution_time;
+  const feedback = message.metadata?.feedback;
 
   return (
     <div className={cn('flex flex-col gap-1', align)}>
@@ -1242,6 +1249,18 @@ function ChatMessageBubble({ message }: { message: ChatMessage }) {
         {message.created_at && <span>· {formatDateTime(message.created_at)}</span>}
         {typeof executionTime === 'number' && executionTime > 0 && (
           <span>· {executionTime.toFixed(1)}s</span>
+        )}
+        {isAssistant && feedback === 'like' && (
+          <span className="inline-flex items-center gap-1 rounded bg-emerald-50 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-emerald-700">
+            <ThumbsUp size={10} fill="currentColor" strokeWidth={1.5} />
+            Liked
+          </span>
+        )}
+        {isAssistant && feedback === 'dislike' && (
+          <span className="inline-flex items-center gap-1 rounded bg-red-50 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-red-700">
+            <ThumbsDown size={10} fill="currentColor" strokeWidth={1.5} />
+            Disliked
+          </span>
         )}
       </div>
       {steps.length > 0 && <ChatStepsList steps={steps} alignEnd={isUser} />}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/page.tsx
@@ -60,6 +60,12 @@ function initialFilters(): FilterValue {
 function buildQuery(filters: FilterValue): string {
   const p = new URLSearchParams();
   p.set('scenario_id', filters.scenario_id);
+  if (filters.workspace_id && filters.workspace_id !== 'all') {
+    p.set('workspace_id', filters.workspace_id);
+  }
+  if (filters.user_email && filters.user_email !== 'all') {
+    p.set('user_email', filters.user_email);
+  }
   return p.toString();
 }
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/api/analytics/chats/[id]/export/route.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/api/analytics/chats/[id]/export/route.ts
@@ -1,0 +1,33 @@
+/**
+ * Streaming proxy for /api/analytics/chats/{id}/export.
+ *
+ * The upstream returns a binary file (text/plain, application/json, or
+ * text/markdown) with a Content-Disposition header. We forward the body and
+ * its headers unchanged so the browser sees the same download response it
+ * would get from the chat-interface export.
+ */
+
+export const dynamic = 'force-dynamic';
+
+const UPSTREAM =
+  process.env.NEXUS_API_URL ?? process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:9879';
+
+export async function GET(req: Request, { params }: { params: { id: string } }) {
+  const url = new URL(req.url);
+  const qs = url.searchParams.toString();
+  const target = `${UPSTREAM}/api/analytics/chats/${encodeURIComponent(params.id)}/export${
+    qs ? `?${qs}` : ''
+  }`;
+
+  try {
+    const res = await fetch(target, { cache: 'no-store' });
+    const headers = new Headers();
+    const contentType = res.headers.get('content-type');
+    const disposition = res.headers.get('content-disposition');
+    if (contentType) headers.set('content-type', contentType);
+    if (disposition) headers.set('content-disposition', disposition);
+    return new Response(res.body, { status: res.status, headers });
+  } catch {
+    return Response.json({ error: 'upstream unreachable' }, { status: 502 });
+  }
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/api/analytics/chats/[id]/route.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/api/analytics/chats/[id]/route.ts
@@ -1,0 +1,7 @@
+import { proxyAnalytics } from '../../_proxy';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request, { params }: { params: { id: string } }) {
+  return proxyAnalytics(`chats/${encodeURIComponent(params.id)}`, req);
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/api/analytics/chats/route.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/api/analytics/chats/route.ts
@@ -1,0 +1,7 @@
+import { proxyAnalytics } from '../_proxy';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request) {
+  return proxyAnalytics('chats', req);
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
@@ -2,13 +2,13 @@
 
 import React, { useState, useRef, useEffect, useMemo, useCallback, useLayoutEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { Send, Plus, Bot, User, AlertCircle, Brain, ChevronDown, X, ArrowUp, Download, ExternalLink, HardDrive, RefreshCw, Mic, Check, Loader2, Wrench, Copy, FileText } from 'lucide-react';
+import { Send, Plus, Bot, User, AlertCircle, Brain, ChevronDown, X, ArrowUp, Download, ExternalLink, HardDrive, RefreshCw, Mic, Check, Loader2, Wrench, Copy, FileText, ThumbsUp, ThumbsDown } from 'lucide-react';
 import Image from 'next/image';
 import { usePathname, useRouter } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { cn } from '@/lib/utils';
-import { useWorkspaceStore, type AgentType, type Message, type SidebarSection, type ToolCall } from '@/stores/workspace';
+import { useWorkspaceStore, type AgentType, type Message, type MessageFeedback, type SidebarSection, type ToolCall } from '@/stores/workspace';
 import { useIntegrationsStore } from '@/stores/integrations';
 import { useAgentsStore } from '@/stores/agents';
 import { useSecretsStore } from '@/stores/secrets';
@@ -1472,11 +1472,16 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
           activityLine: 'Processing...',
           // activityLine: searchEnabled ? 'Web search in progress' : 'Processing...',
         });
-        // Capture placeholder message id for controls
+        // Capture placeholder message id for controls. We keep it in a local
+        // variable AND in React state — the SSE handler runs inside the same
+        // async function so it can't rely on the freshly-set state (closures
+        // capture stale values).
+        let assistantMessageIdRef: string | null = null;
         {
           const convNow = useWorkspaceStore.getState().conversations.find(c => c.id === conversationId);
           const lastMsg = convNow?.messages[convNow.messages.length - 1];
-          setStreamingMessageId(lastMsg?.id || null);
+          assistantMessageIdRef = lastMsg?.id || null;
+          setStreamingMessageId(assistantMessageIdRef);
         }
         // Setup connecting indicator
         gotFirstTokenRef.current = false;
@@ -1737,6 +1742,26 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
                 const parsed = JSON.parse(data);
                 if (parsed.sources && Array.isArray(parsed.sources)) {
                   streamSources = parsed.sources as string[];
+                }
+
+                // First frame swap: the backend emits the real DB uuid for the
+                // assistant row on the opening event. Replace the local
+                // placeholder id so subsequent PATCHes (metadata, feedback)
+                // hit the real row. We use the local ``assistantMessageIdRef``
+                // because the React state ``streamingMessageId`` captured in
+                // this closure is stale (the setState before the SSE loop
+                // hasn't flushed yet).
+                if (typeof parsed.assistant_message_id === 'string' && parsed.assistant_message_id) {
+                  const backendId = parsed.assistant_message_id as string;
+                  if (assistantMessageIdRef && assistantMessageIdRef !== backendId) {
+                    useWorkspaceStore.getState().renameMessageId(
+                      conversationId!,
+                      assistantMessageIdRef,
+                      backendId,
+                    );
+                    setStreamingMessageId(backendId);
+                    assistantMessageIdRef = backendId;
+                  }
                 }
 
                 if (parseEvent(parsed as Record<string, unknown>)) {
@@ -3574,10 +3599,137 @@ const MessageBubble = React.memo(function MessageBubble({
             )}
           </div>
         )}
+
+        {/* Per-message actions */}
+        {!isUser && !isStillProcessing && (
+          <AssistantMessageActions message={message} />
+        )}
+        {isUser && <UserMessageActions message={message} />}
       </div>
     </div>
   );
 });
+
+function CopyMessageButton({ content }: { content: string }) {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = async () => {
+    const text = typeof content === 'string' ? content : '';
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.focus();
+      ta.select();
+      try {
+        document.execCommand('copy');
+      } finally {
+        document.body.removeChild(ta);
+      }
+    }
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+  return (
+    <button
+      onClick={handleCopy}
+      title="Copy message"
+      className="flex h-6 w-6 items-center justify-center rounded border border-transparent transition-colors hover:border-border hover:bg-muted/40"
+    >
+      {copied ? <Check size={12} className="text-emerald-600" /> : <Copy size={12} />}
+    </button>
+  );
+}
+
+function UserMessageActions({ message }: { message: Message }) {
+  return (
+    <div className="mt-1 flex items-center text-muted-foreground">
+      <CopyMessageButton content={message.content} />
+    </div>
+  );
+}
+
+function AssistantMessageActions({ message }: { message: Message }) {
+  const updateMessageFeedback = useWorkspaceStore((s) => s.updateMessageFeedback);
+  const activeConversationId = useWorkspaceStore((s) => s.activeConversationId);
+  const [busy, setBusy] = useState<null | 'like' | 'dislike'>(null);
+  const feedback = message.feedback ?? null;
+
+  const sendFeedback = async (next: MessageFeedback | null) => {
+    if (!activeConversationId) return;
+    const prev = feedback;
+    const which: 'like' | 'dislike' = next ?? (prev === 'like' ? 'like' : 'dislike');
+    setBusy(which);
+    // Optimistic local update; rolled back on failure.
+    updateMessageFeedback(activeConversationId, message.id, next);
+    try {
+      const { authFetch } = await import('@/stores/auth');
+      const res = await authFetch(
+        `${getApiBase()}/api/analytics/chats/${encodeURIComponent(activeConversationId)}/messages/${encodeURIComponent(message.id)}/feedback`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ feedback: next }),
+        },
+      );
+      if (!res.ok) throw new Error(`Save failed (${res.status})`);
+    } catch (error) {
+      console.error('Failed to save feedback:', error);
+      updateMessageFeedback(activeConversationId, message.id, prev);
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const toggle = (value: MessageFeedback) => {
+    void sendFeedback(feedback === value ? null : value);
+  };
+
+  return (
+    <div className="mt-1 flex items-center text-muted-foreground">
+      <CopyMessageButton content={message.content} />
+      <button
+        onClick={() => toggle('like')}
+        disabled={busy !== null}
+        title={feedback === 'like' ? 'Remove like' : 'Like'}
+        className={`flex h-6 w-6 items-center justify-center rounded border border-transparent transition-colors hover:border-border hover:bg-muted/40 disabled:opacity-60 ${
+          feedback === 'like' ? 'text-emerald-600 border-emerald-600/40 bg-emerald-50/40' : ''
+        }`}
+      >
+        {busy === 'like' ? (
+          <Loader2 size={12} className="animate-spin" />
+        ) : (
+          <ThumbsUp
+            size={12}
+            fill={feedback === 'like' ? 'currentColor' : 'none'}
+            strokeWidth={feedback === 'like' ? 1.5 : 2}
+          />
+        )}
+      </button>
+      <button
+        onClick={() => toggle('dislike')}
+        disabled={busy !== null}
+        title={feedback === 'dislike' ? 'Remove dislike' : 'Dislike'}
+        className={`flex h-6 w-6 items-center justify-center rounded border border-transparent transition-colors hover:border-border hover:bg-muted/40 disabled:opacity-60 ${
+          feedback === 'dislike' ? 'text-red-600 border-red-600/40 bg-red-50/40' : ''
+        }`}
+      >
+        {busy === 'dislike' ? (
+          <Loader2 size={12} className="animate-spin" />
+        ) : (
+          <ThumbsDown
+            size={12}
+            fill={feedback === 'dislike' ? 'currentColor' : 'none'}
+            strokeWidth={feedback === 'dislike' ? 1.5 : 2}
+          />
+        )}
+      </button>
+    </div>
+  );
+}
 
 /**
  * Voice recorder UI that replaces the chat composer while the user records

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
@@ -658,6 +658,8 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
     const conv = useWorkspaceStore
       .getState()
       .conversations.find((c) => c.id === activeConversationId);
+    // Skip fetch for locally-created drafts — they don't exist on the backend yet.
+    if (conv?.isDraft) return;
     // If this thread came from backend list (no messages loaded yet), fetch full history.
     if (!conv || conv.messages.length === 0) {
       void loadConversationMessages(activeConversationId);
@@ -1429,8 +1431,10 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
       const systemPrompt = agentData?.systemPrompt || null;
       
       // If this is an existing thread with no local history loaded yet, fetch it first.
+      // Skip for drafts — they don't exist on the backend until the first send.
       if (
         existingConversationBeforeSend &&
+        !existingConversationBeforeSend.isDraft &&
         conversationId.startsWith('conv-') &&
         existingConversationBeforeSend.messages.length === 0
       ) {

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
@@ -89,6 +89,10 @@ export interface Conversation {
   pinned?: boolean;
   archived?: boolean;
   projectId?: string;
+  // True for conversations created locally that have not yet been persisted
+  // to the backend. Cleared once a message is sent or the conversation is
+  // confirmed via syncWorkspaceConversations / loadConversationMessages.
+  isDraft?: boolean;
 }
 
 export interface Project {
@@ -386,6 +390,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
       updatedAt: new Date(),
       pinned: false,
       projectId,
+      isDraft: true,
     };
     set((state) => ({
       conversations: [newConversation, ...state.conversations],
@@ -419,6 +424,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
                 conv.messages.length === 0 && message.role === 'user'
                   ? message.content.slice(0, 50) + (message.content.length > 50 ? '...' : '')
                   : conv.title,
+              isDraft: false,
             }
           : conv
       ),

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
@@ -57,6 +57,8 @@ export interface ToolCall {
   output?: string;
 }
 
+export type MessageFeedback = 'like' | 'dislike';
+
 export interface Message {
   id: string;
   role: 'user' | 'assistant' | 'system';
@@ -70,6 +72,7 @@ export interface Message {
   thinkingDuration?: number; // Duration in seconds the AI spent "thinking"
   executionTime?: number; // Total seconds from request sent to response complete
   sources?: string[]; // filenames of RAG documents used to answer
+  feedback?: MessageFeedback | null; // Reviewer thumbs up/down, persisted on metadata_
   // Author attribution (preserved across sessions and users)
   authorId?: string;
   authorName?: string;
@@ -224,6 +227,16 @@ interface WorkspaceState {
     toolCalls?: ToolCall[] | null,
     executionTime?: number,
   ) => void;
+  updateMessageFeedback: (
+    conversationId: string,
+    messageId: string,
+    feedback: MessageFeedback | null,
+  ) => void;
+  renameMessageId: (
+    conversationId: string,
+    oldMessageId: string,
+    newMessageId: string,
+  ) => void;
   togglePinConversation: (id: string) => void;
   toggleArchiveConversation: (id: string) => void;
   renameConversation: (id: string, newTitle: string) => void;
@@ -278,6 +291,7 @@ type ApiChatMessage = {
   content: string;
   agent?: string | null;
   created_at?: string;
+  metadata?: Record<string, unknown> | null;
 };
 
 type ApiConversation = {
@@ -292,13 +306,17 @@ type ApiConversation = {
   messages?: ApiChatMessage[];
 };
 
-const mapApiMessage = (message: ApiChatMessage): Message => ({
-  id: message.id,
-  role: message.role,
-  content: message.content,
-  timestamp: new Date(message.created_at || Date.now()),
-  agent: message.agent || undefined,
-});
+const mapApiMessage = (message: ApiChatMessage): Message => {
+  const fb = message.metadata?.feedback;
+  return {
+    id: message.id,
+    role: message.role,
+    content: message.content,
+    timestamp: new Date(message.created_at || Date.now()),
+    agent: message.agent || undefined,
+    feedback: fb === 'like' || fb === 'dislike' ? fb : null,
+  };
+};
 
 const mapApiConversation = (conversation: ApiConversation): Conversation => ({
   id: conversation.id,
@@ -429,6 +447,37 @@ export const useWorkspaceStore = create<WorkspaceState>()(
               updatedAt: new Date(),
             }
           : conv
+      ),
+    }));
+  },
+
+  updateMessageFeedback: (conversationId, messageId, feedback) => {
+    set((state) => ({
+      conversations: state.conversations.map((conv) =>
+        conv.id === conversationId
+          ? {
+              ...conv,
+              messages: conv.messages.map((msg) =>
+                msg.id === messageId ? { ...msg, feedback } : msg,
+              ),
+            }
+          : conv,
+      ),
+    }));
+  },
+
+  renameMessageId: (conversationId, oldMessageId, newMessageId) => {
+    if (!oldMessageId || !newMessageId || oldMessageId === newMessageId) return;
+    set((state) => ({
+      conversations: state.conversations.map((conv) =>
+        conv.id === conversationId
+          ? {
+              ...conv,
+              messages: conv.messages.map((msg) =>
+                msg.id === oldMessageId ? { ...msg, id: newMessageId } : msg,
+              ),
+            }
+          : conv,
       ),
     }));
   },


### PR DESCRIPTION
This pull request resolves #fix-filters-analytics

### Summary

This pull request introduces workspace and user filters across the analytics service and frontend, improving the filtering capabilities in analytics queries.

### Details:

- **API Layer Updates:** Added optional `workspace_id` and `user_email` query parameters to multiple FastAPI routes including overview, users, user details, sessions, pages, workspaces, and events.

- **AnalyticsService Enhancements:**
  - Added `_filter_events` method to filter events by workspace and user email.
  - Modified methods such as `get_overview`, `get_users`, `get_user_detail`, `get_sessions`, `get_pages`, `get_workspaces`, and `get_events` to support filtering based on workspace and user email. These methods conditionally apply filters and rebuild response data accordingly.
  - Retained support for scenarios without filters by falling back to precomputed slices.

- **Frontend Improvements:**
  - Enhanced the workspace select dropdown in the filter bar with better UI, including truncation of long labels and clear button to reset the workspace filter.
  - Adjusted the analytics page to build query strings including workspace and user email filters if they are set and different from "all".

### Impact
This change enhances the granularity of analytics data exploration, allowing users to filter analytics metrics by workspace and individual user email. This adds significant flexibility and precision for analytical needs.

### Testing
Manual testing was assumed given no direct test file changes, focusing on verifying that filters apply correctly in the API responses and the UI handles filter selections gracefully.