### PR TITLE
feat: add personal user graph with chat lifecycle events as RDF

### DIFF
--- a/libs/naas-abi/naas_abi/__init__.py
+++ b/libs/naas-abi/naas_abi/__init__.py
@@ -617,6 +617,18 @@ class ABIModule(BaseModule):
         if self.engine.services.activity_log_available():
             app.state.activity_log_service = self.engine.services.activity_log
 
+        # Subscribe the personal-graph indexer to chat lifecycle events so
+        # every conversation/message touched through the chat service lands
+        # as RDF in the user's "My Graph".
+        if self.engine.services.events_available():
+            from naas_abi.apps.nexus.apps.api.app.services.graph.personal_graph_service import (
+                get_personal_graph_service,
+            )
+
+            get_personal_graph_service().register_subscribers(
+                self.engine.services.events
+            )
+
         from naas_abi.apps.nexus.apps.api.app.main import create_app
 
         create_app(app)

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/service.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/service.py
@@ -45,6 +45,41 @@ from naas_abi.apps.nexus.apps.api.app.services.provider_runtime import (
     complete_chat as complete_with_provider,
 )
 from naas_abi.apps.nexus.apps.api.app.services.secrets_crypto import decrypt_secret_value
+from naas_abi.ontologies.modules.NexusPlatformOntology import (
+    CreateConversation as CreateConversationEvent,
+)
+from naas_abi.ontologies.modules.NexusPlatformOntology import (
+    CreateMessage as CreateMessageEvent,
+)
+from naas_abi.ontologies.modules.NexusPlatformOntology import (
+    DeleteConversation as DeleteConversationEvent,
+)
+from naas_abi.ontologies.modules.NexusPlatformOntology import (
+    UpdateConversation as UpdateConversationEvent,
+)
+from naas_abi.ontologies.modules.NexusPlatformOntology import (
+    UpdateMessage as UpdateMessageEvent,
+)
+
+_logger = logging.getLogger(__name__)
+
+
+def _publish_chat_event(event: Any) -> None:
+    """Fire-and-forget publish to the engine's EventService.
+
+    Chat persistence is the source of truth; event publishing is best-effort.
+    Any failure (engine not initialized, bus down, codec error) is logged but
+    must never propagate — a missed event must not break the chat request.
+    """
+    try:
+        from naas_abi import ABIModule
+
+        engine = ABIModule.get_instance().engine
+        if not engine.services.events_available():
+            return
+        engine.services.events.publish(event)
+    except Exception as exc:  # pragma: no cover - best-effort logging
+        _logger.warning("Failed to publish chat event %s: %s", type(event).__name__, exc)
 
 
 @dataclass
@@ -307,7 +342,7 @@ class ChatService:
     ) -> ChatConversationRecord:
         await self._ensure_workspace_access(context=context, workspace_id=workspace_id)
         conv_id = conversation_id or f"conv-{uuid4().hex[:12]}"
-        return await self.adapter.create_conversation(
+        record = await self.adapter.create_conversation(
             conversation_id=conv_id,
             workspace_id=workspace_id,
             user_id=context.actor_user_id,
@@ -315,6 +350,17 @@ class ChatService:
             agent=agent,
             now=now,
         )
+        _publish_chat_event(
+            CreateConversationEvent(
+                user_id=context.actor_user_id,
+                workspace_id=workspace_id,
+                conversation_id=conv_id,
+                title=title,
+                agent=agent,
+                created=now,
+            )
+        )
+        return record
 
     async def get_conversation(
         self,
@@ -528,7 +574,7 @@ class ChatService:
         agent: str | None = None,
         message_id: str | None = None,
     ) -> str:
-        await self._ensure_conversation_access(
+        conversation = await self._ensure_conversation_access(
             context,
             conversation_id,
             action="chat.message.create",
@@ -541,6 +587,18 @@ class ChatService:
             content=content,
             agent=agent,
             created_at=created_at,
+        )
+        _publish_chat_event(
+            CreateMessageEvent(
+                user_id=context.actor_user_id,
+                workspace_id=conversation.workspace_id,
+                conversation_id=conversation_id,
+                message_id=msg_id,
+                role=role,
+                content=content,
+                agent=agent,
+                created=created_at,
+            )
         )
         return msg_id
 
@@ -576,12 +634,23 @@ class ChatService:
         message_id: str,
         content: str,
     ) -> bool:
-        await self._ensure_conversation_access(
+        conversation = await self._ensure_conversation_access(
             context,
             conversation_id,
             action="chat.message.update",
         )
-        return await self.adapter.update_message_content(message_id, content)
+        updated = await self.adapter.update_message_content(message_id, content)
+        if updated:
+            _publish_chat_event(
+                UpdateMessageEvent(
+                    user_id=context.actor_user_id,
+                    workspace_id=conversation.workspace_id,
+                    conversation_id=conversation_id,
+                    message_id=message_id,
+                    content=content,
+                )
+            )
+        return updated
 
     async def finalize_streaming_response(
         self,
@@ -732,7 +801,7 @@ class ChatService:
         pinned: bool | None = None,
         archived: bool | None = None,
     ) -> None:
-        await self._ensure_conversation_access(
+        conversation = await self._ensure_conversation_access(
             context,
             conversation_id,
             action="chat.conversation.update",
@@ -744,19 +813,37 @@ class ChatService:
             pinned=pinned,
             archived=archived,
         )
+        _publish_chat_event(
+            UpdateConversationEvent(
+                user_id=context.actor_user_id,
+                workspace_id=conversation.workspace_id,
+                conversation_id=conversation_id,
+                title=title if title is not None else conversation.title,
+                agent=conversation.agent,
+            )
+        )
 
     async def delete_conversation_with_messages(
         self,
         context: RequestContext,
         conversation_id: str,
     ) -> bool:
-        await self._ensure_conversation_access(
+        conversation = await self._ensure_conversation_access(
             context,
             conversation_id,
             action="chat.conversation.delete",
         )
         await self.adapter.delete_messages_by_conversation(conversation_id)
-        return await self.adapter.delete_conversation(conversation_id)
+        deleted = await self.adapter.delete_conversation(conversation_id)
+        if deleted:
+            _publish_chat_event(
+                DeleteConversationEvent(
+                    user_id=context.actor_user_id,
+                    workspace_id=conversation.workspace_id,
+                    conversation_id=conversation_id,
+                )
+            )
+        return deleted
 
     async def get_agent(
         self,

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/graph/adapters/primary/graph__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/graph/adapters/primary/graph__primary_adapter__FastAPI.py
@@ -32,10 +32,32 @@ from naas_abi.apps.nexus.apps.api.app.services.graph.graph__schema import (
     GraphProtectedError,
     GraphServiceUnavailableError,
 )
+from naas_abi.apps.nexus.apps.api.app.services.graph.personal_graph_service import (
+    get_personal_graph_service,
+    is_personal_graph_uri,
+    personal_graph_owner,
+)
 from naas_abi.apps.nexus.apps.api.app.services.graph.service import (
     GraphService,
     _detect_rdf_format,
 )
+
+
+def _assert_personal_graph_access(graph_uri: str, current_user_id: str) -> None:
+    """Reject access to another user's personal graph.
+
+    Personal graphs (URIs under ``/graph/personal/<user_id>``) are only
+    accessible by their owning user. Non-personal URIs pass through.
+    """
+    owner = personal_graph_owner(graph_uri)
+    if owner is None:
+        return
+    if owner != current_user_id:
+        raise HTTPException(
+            status_code=404,
+            detail="Graph not found",
+        )
+
 
 router = APIRouter(dependencies=[Depends(get_current_user_required)])
 
@@ -86,20 +108,32 @@ async def list_graphs(
 ) -> list[GraphPack]:
     """List all graphs available in the triple store and nexus ontology graph."""
     await require_workspace_access(current_user.id, workspace_id)
+
+    # Ensure the caller's "My Graph" exists so it appears in the list even
+    # before they have any chat events (best-effort: a failed bootstrap
+    # shouldn't break listing).
+    try:
+        get_personal_graph_service().ensure_personal_graph(current_user.id)
+    except Exception:
+        pass
+
     try:
         graphs = await graph_service.list_graphs(workspace_id=workspace_id)
     except GraphServiceUnavailableError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
-    return [
-        GraphPack(
-            role_label=pack.role_label,
-            graphs=[
-                GraphInfo(id=g.id, uri=g.uri, label=g.label, role_label=g.role_label)
-                for g in pack.graphs
-            ],
-        )
-        for pack in graphs
-    ]
+
+    packed: list[GraphPack] = []
+    for pack in graphs:
+        filtered_graphs = [
+            GraphInfo(id=g.id, uri=g.uri, label=g.label, role_label=g.role_label)
+            for g in pack.graphs
+            # Hide personal graphs owned by other users.
+            if not is_personal_graph_uri(g.uri)
+            or personal_graph_owner(g.uri) == current_user.id
+        ]
+        if filtered_graphs:
+            packed.append(GraphPack(role_label=pack.role_label, graphs=filtered_graphs))
+    return packed
 
 
 @router.post("/create")
@@ -129,6 +163,7 @@ async def clear_graph(
     graph_service: GraphService = Depends(get_graph_service),
 ) -> dict[str, str]:
     await require_workspace_access(current_user.id, payload.workspace_id)
+    _assert_personal_graph_access(payload.uri, current_user.id)
     try:
         await graph_service.clear_graph(workspace_id=payload.workspace_id, graph_uri=payload.uri)
     except GraphProtectedError as exc:
@@ -145,6 +180,7 @@ async def delete_graph(
     graph_service: GraphService = Depends(get_graph_service),
 ) -> dict[str, str]:
     await require_workspace_access(current_user.id, payload.workspace_id)
+    _assert_personal_graph_access(payload.uri, current_user.id)
     try:
         await graph_service.delete_graph(workspace_id=payload.workspace_id, graph_uri=payload.uri)
     except GraphProtectedError as exc:
@@ -162,6 +198,7 @@ async def create_individual(
 ) -> GraphNode:
     """Insert a new individual into the given named graph."""
     await require_workspace_access(current_user.id, payload.workspace_id)
+    _assert_personal_graph_access(payload.graph_uri, current_user.id)
     try:
         node = await graph_service.create_individual(
             workspace_id=payload.workspace_id,
@@ -186,6 +223,7 @@ async def delete_individual(
 ) -> dict[str, str]:
     """Delete an individual: remove every triple where it is subject or object in the graph."""
     await require_workspace_access(current_user.id, payload.workspace_id)
+    _assert_personal_graph_access(payload.graph_uri, current_user.id)
     try:
         await graph_service.delete_individual(
             workspace_id=payload.workspace_id,
@@ -209,6 +247,7 @@ async def get_graph_overview(
 ) -> GraphOverview:
     """Get overview of a given graph."""
     await require_workspace_access(current_user.id, workspace_id)
+    _assert_personal_graph_access(graph_uri, current_user.id)
     try:
         overview = await graph_service.get_graph_overview(
             workspace_id=workspace_id, graph_uri=graph_uri, limit=limit
@@ -231,6 +270,7 @@ async def get_graph_network(
 ) -> GraphData:
     """Get all nodes and edges for a given graph."""
     await require_workspace_access(current_user.id, workspace_id)
+    _assert_personal_graph_access(graph_uri, current_user.id)
     try:
         network = await graph_service.get_graph_network(
             workspace_id=workspace_id, graph_uri=graph_uri, limit=limit
@@ -254,6 +294,7 @@ async def search_graph_network(
 ) -> GraphData:
     """Search nodes by label within a graph. Returns matching individuals and their edges."""
     await require_workspace_access(current_user.id, workspace_id)
+    _assert_personal_graph_access(graph_uri, current_user.id)
     try:
         result = await graph_service.search_network(
             workspace_id=workspace_id,
@@ -282,6 +323,7 @@ async def export_graph(
     exhausted, then returns the merged Turtle document with bound namespaces.
     """
     await require_workspace_access(current_user.id, workspace_id)
+    _assert_personal_graph_access(graph_uri, current_user.id)
     try:
         ttl_content, triple_count = await graph_service.export_graph_as_ttl(
             workspace_id=workspace_id,
@@ -354,6 +396,7 @@ async def import_graph_file(
     Returns ``{"status": "imported", "count": N}`` where N is the number of triples inserted.
     """
     await require_workspace_access(current_user.id, workspace_id)
+    _assert_personal_graph_access(graph_uri, current_user.id)
     content = await file.read()
     fmt = _detect_rdf_format(file.filename or "")
     try:
@@ -385,6 +428,8 @@ async def get_network_parents(
     Call once per progressive expansion level.
     """
     await require_workspace_access(current_user.id, workspace_id)
+    for name in graph_names:
+        _assert_personal_graph_access(name, current_user.id)
     try:
         result = await graph_service.get_network_parents(
             workspace_id=workspace_id,

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/graph/personal_graph_service.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/graph/personal_graph_service.py
@@ -1,0 +1,438 @@
+"""Personal Knowledge Graph — per-user "My Graph" lifecycle and event indexing.
+
+Maintains one named graph per user (URI ``…/graph/personal/{user_id}``, label
+``"My Graph"``, role ``Personal``) and projects every chat lifecycle event
+published through ``EventService`` into that graph as RDF triples:
+
+- Conversation/Message individuals carry a ``nexus:hasStatus`` quality that
+  starts at ``ActiveStatus`` and flips to ``DeletedStatus`` on a delete event
+  — individuals themselves are never removed (history is preserved).
+- Each event itself is logged as a ``LogProcess`` named individual linked
+  to the artifact it touched via ``nexus:creates`` / ``nexus:updates`` /
+  ``nexus:deletes``.
+
+The service is registered as an EventService subscriber at API startup.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from collections.abc import Callable
+
+from naas_abi.ontologies.modules.NexusPlatformOntology import (
+    CreateConversation as CreateConversationEvent,
+)
+from naas_abi.ontologies.modules.NexusPlatformOntology import (
+    CreateMessage as CreateMessageEvent,
+)
+from naas_abi.ontologies.modules.NexusPlatformOntology import (
+    DeleteConversation as DeleteConversationEvent,
+)
+from naas_abi.ontologies.modules.NexusPlatformOntology import (
+    KnowledgeGraph,
+)
+from naas_abi.ontologies.modules.NexusPlatformOntology import (
+    UpdateConversation as UpdateConversationEvent,
+)
+from naas_abi.ontologies.modules.NexusPlatformOntology import (
+    UpdateMessage as UpdateMessageEvent,
+)
+from naas_abi_core.services.event.ontologies.modules.EventOntology import LogProcess
+from naas_abi_core.services.triple_store.TripleStoreService import TripleStoreService
+from rdflib import RDF, RDFS, XSD, Graph, Literal, URIRef
+from rdflib.namespace import OWL
+
+_logger = logging.getLogger(__name__)
+
+# ── URIs ──────────────────────────────────────────────────────────────────────
+
+PERSONAL_GRAPH_BASE = "http://ontology.naas.ai/graph/personal/"
+PERSONAL_GRAPH_LABEL = "My Graph"
+
+NEXUS_GRAPH_URI = URIRef("http://ontology.naas.ai/graph/nexus")
+NEXUS_NS = "http://ontology.naas.ai/nexus/"
+
+_ACTIVE_STATUS = URIRef(NEXUS_NS + "ActiveStatus")
+_DELETED_STATUS = URIRef(NEXUS_NS + "DeletedStatus")
+_PERSONAL_ROLE = URIRef(NEXUS_NS + "PersonalKnowledgeGraphRole")
+_HAS_STATUS = URIRef(NEXUS_NS + "hasStatus")
+_HAS_MESSAGE = URIRef(NEXUS_NS + "hasMessage")
+_IS_MESSAGE_OF = URIRef(NEXUS_NS + "isMessageOf")
+_CREATES = URIRef(NEXUS_NS + "creates")
+_UPDATES = URIRef(NEXUS_NS + "updates")
+_DELETES = URIRef(NEXUS_NS + "deletes")
+_CREATED_AT = URIRef(NEXUS_NS + "createdAt")
+_USER_ID = URIRef(NEXUS_NS + "user_id")
+_WORKSPACE_ID = URIRef(NEXUS_NS + "workspace_id")
+_CONVERSATION_ID = URIRef(NEXUS_NS + "conversation_id")
+_MESSAGE_ID = URIRef(NEXUS_NS + "message_id")
+_ROLE = URIRef(NEXUS_NS + "role")
+_CONTENT = URIRef(NEXUS_NS + "content")
+_AGENT = URIRef(NEXUS_NS + "agent")
+_TITLE = URIRef(NEXUS_NS + "title")
+
+_CONVERSATION_CLASS = URIRef(NEXUS_NS + "Conversation")
+_MESSAGE_CLASS = URIRef(NEXUS_NS + "Message")
+
+
+def personal_graph_uri(user_id: str) -> URIRef:
+    """Build the canonical personal-graph URI for *user_id*."""
+    return URIRef(f"{PERSONAL_GRAPH_BASE}{user_id}")
+
+
+def is_personal_graph_uri(graph_uri: str) -> bool:
+    return graph_uri.startswith(PERSONAL_GRAPH_BASE)
+
+
+def personal_graph_owner(graph_uri: str) -> str | None:
+    """Return the user_id segment of a personal graph URI, or None."""
+    if not is_personal_graph_uri(graph_uri):
+        return None
+    return graph_uri[len(PERSONAL_GRAPH_BASE):] or None
+
+
+# ── Service ───────────────────────────────────────────────────────────────────
+
+
+class PersonalGraphService:
+    """Maintains one personal knowledge graph per user, indexed from chat events."""
+
+    def __init__(
+        self,
+        triple_store_getter: Callable[[], TripleStoreService] | None = None,
+    ) -> None:
+        self._triple_store_getter = triple_store_getter
+        self._registered_users: set[str] = set()
+        self._lock = threading.Lock()
+
+    def _store(self) -> TripleStoreService:
+        if self._triple_store_getter is not None:
+            return self._triple_store_getter()
+        from naas_abi import ABIModule
+
+        return ABIModule.get_instance().engine.services.triple_store
+
+    # ── Graph bootstrap ───────────────────────────────────────────────────────
+
+    def ensure_personal_graph(self, user_id: str) -> URIRef:
+        """Create the per-user named graph and register it in the nexus graph.
+
+        Idempotent: safe to call from every event callback. Uses an in-memory
+        set to avoid hitting the triple store on every event after warm-up.
+        """
+        if not user_id:
+            raise ValueError("user_id is required to ensure a personal graph")
+        graph_uri = personal_graph_uri(user_id)
+        with self._lock:
+            if user_id in self._registered_users:
+                return graph_uri
+
+        store = self._store()
+        # create_graph is idempotent on the triple store side.
+        store.create_graph(graph_uri)
+
+        # Register the graph in the nexus graph so /graph/list surfaces it.
+        registration = KnowledgeGraph(
+            _uri=graph_uri,
+            label=PERSONAL_GRAPH_LABEL,
+            creator=user_id,
+            has_knowledge_graph_role=[_PERSONAL_ROLE],
+        )
+        store.insert(registration.rdf(), graph_name=NEXUS_GRAPH_URI)
+
+        with self._lock:
+            self._registered_users.add(user_id)
+        return graph_uri
+
+    # ── Event indexing ────────────────────────────────────────────────────────
+
+    def index_event(self, event: LogProcess) -> None:
+        """Write the event and its target artifact to the user's personal graph."""
+        try:
+            self._index_event_unsafe(event)
+        except Exception as exc:  # pragma: no cover - best-effort
+            _logger.warning(
+                "PersonalGraphService failed to index %s: %s",
+                type(event).__name__,
+                exc,
+            )
+
+    def _index_event_unsafe(self, event: LogProcess) -> None:
+        user_id = getattr(event, "user_id", None)
+        if not user_id:
+            return  # events without a user_id are not part of a personal graph
+        graph_uri = self.ensure_personal_graph(user_id)
+        store = self._store()
+
+        if isinstance(event, CreateConversationEvent):
+            triples = self._build_create_conversation_triples(event, graph_uri)
+            store.insert(triples, graph_name=graph_uri)
+            return
+
+        if isinstance(event, UpdateConversationEvent):
+            triples = self._build_update_conversation_triples(event, graph_uri)
+            store.insert(triples, graph_name=graph_uri)
+            return
+
+        if isinstance(event, DeleteConversationEvent):
+            self._apply_delete_conversation(event, graph_uri)
+            return
+
+        if isinstance(event, CreateMessageEvent):
+            triples = self._build_create_message_triples(event, graph_uri)
+            store.insert(triples, graph_name=graph_uri)
+            return
+
+        if isinstance(event, UpdateMessageEvent):
+            triples = self._build_update_message_triples(event, graph_uri)
+            store.insert(triples, graph_name=graph_uri)
+            return
+
+        _logger.debug("PersonalGraphService: ignoring unknown event %s", type(event).__name__)
+
+    # ── Triple builders ───────────────────────────────────────────────────────
+
+    def _conversation_uri(self, graph_uri: URIRef, conversation_id: str) -> URIRef:
+        return URIRef(f"{graph_uri}/conversation/{conversation_id}")
+
+    def _message_uri(self, graph_uri: URIRef, message_id: str) -> URIRef:
+        return URIRef(f"{graph_uri}/message/{message_id}")
+
+    def _event_uri(self, graph_uri: URIRef, event: LogProcess) -> URIRef:
+        # `_uri` is populated by RDFEntity.__init__ with a UUID4 fallback.
+        # Anchor it inside the personal graph for human-friendly browsing.
+        local_id = str(getattr(event, "_uri", "")).rsplit("/", 1)[-1] or "event"
+        prefix = type(event).__name__
+        return URIRef(f"{graph_uri}/event/{prefix}/{local_id}")
+
+    def _add_common_event_triples(
+        self,
+        g: Graph,
+        event: LogProcess,
+        event_iri: URIRef,
+        class_iri: URIRef,
+    ) -> None:
+        g.add((event_iri, RDF.type, OWL.NamedIndividual))
+        g.add((event_iri, RDF.type, class_iri))
+        g.add((event_iri, RDFS.label, Literal(class_iri.split("/")[-1])))
+        user_id = getattr(event, "user_id", None)
+        if user_id:
+            g.add((event_iri, _USER_ID, Literal(user_id)))
+        ws_id = getattr(event, "workspace_id", None)
+        if ws_id:
+            g.add((event_iri, _WORKSPACE_ID, Literal(ws_id)))
+        created = getattr(event, "created", None)
+        if created is not None:
+            g.add((event_iri, _CREATED_AT, Literal(created.isoformat(), datatype=XSD.dateTime)))
+
+    def _ensure_conversation_individual(
+        self,
+        g: Graph,
+        graph_uri: URIRef,
+        conversation_id: str,
+        title: str | None,
+        agent: str | None,
+        user_id: str | None,
+        workspace_id: str | None,
+    ) -> URIRef:
+        conv_iri = self._conversation_uri(graph_uri, conversation_id)
+        g.add((conv_iri, RDF.type, OWL.NamedIndividual))
+        g.add((conv_iri, RDF.type, _CONVERSATION_CLASS))
+        g.add((conv_iri, _CONVERSATION_ID, Literal(conversation_id)))
+        g.add((conv_iri, _HAS_STATUS, _ACTIVE_STATUS))
+        if title:
+            g.add((conv_iri, RDFS.label, Literal(title)))
+            g.add((conv_iri, _TITLE, Literal(title)))
+        else:
+            g.add((conv_iri, RDFS.label, Literal(conversation_id)))
+        if agent:
+            g.add((conv_iri, _AGENT, Literal(agent)))
+        if user_id:
+            g.add((conv_iri, _USER_ID, Literal(user_id)))
+        if workspace_id:
+            g.add((conv_iri, _WORKSPACE_ID, Literal(workspace_id)))
+        return conv_iri
+
+    def _build_create_conversation_triples(
+        self,
+        event: CreateConversationEvent,
+        graph_uri: URIRef,
+    ) -> Graph:
+        g = Graph()
+        if not event.conversation_id:
+            return g
+        conv_iri = self._ensure_conversation_individual(
+            g=g,
+            graph_uri=graph_uri,
+            conversation_id=event.conversation_id,
+            title=event.title,
+            agent=event.agent,
+            user_id=event.user_id,
+            workspace_id=event.workspace_id,
+        )
+        event_iri = self._event_uri(graph_uri, event)
+        self._add_common_event_triples(
+            g, event, event_iri, URIRef(CreateConversationEvent._class_uri)
+        )
+        g.add((event_iri, _CREATES, conv_iri))
+        g.add((event_iri, _CONVERSATION_ID, Literal(event.conversation_id)))
+        return g
+
+    def _build_update_conversation_triples(
+        self,
+        event: UpdateConversationEvent,
+        graph_uri: URIRef,
+    ) -> Graph:
+        g = Graph()
+        if not event.conversation_id:
+            return g
+        conv_iri = self._conversation_uri(graph_uri, event.conversation_id)
+        event_iri = self._event_uri(graph_uri, event)
+        self._add_common_event_triples(
+            g, event, event_iri, URIRef(UpdateConversationEvent._class_uri)
+        )
+        g.add((event_iri, _UPDATES, conv_iri))
+        g.add((event_iri, _CONVERSATION_ID, Literal(event.conversation_id)))
+        # Surface the change payload on the event itself; the artifact's
+        # canonical state is left alone (immutable history).
+        if event.title:
+            g.add((event_iri, _TITLE, Literal(event.title)))
+        if event.agent:
+            g.add((event_iri, _AGENT, Literal(event.agent)))
+        return g
+
+    def _apply_delete_conversation(
+        self,
+        event: DeleteConversationEvent,
+        graph_uri: URIRef,
+    ) -> None:
+        if not event.conversation_id:
+            return
+        store = self._store()
+        conv_iri = self._conversation_uri(graph_uri, event.conversation_id)
+
+        # Flip the status quality from Active to Deleted. The individual and
+        # all message individuals it references are preserved.
+        to_remove = Graph()
+        to_remove.add((conv_iri, _HAS_STATUS, _ACTIVE_STATUS))
+        store.remove(to_remove, graph_name=graph_uri)
+
+        g = Graph()
+        g.add((conv_iri, RDF.type, OWL.NamedIndividual))
+        g.add((conv_iri, RDF.type, _CONVERSATION_CLASS))
+        g.add((conv_iri, _HAS_STATUS, _DELETED_STATUS))
+
+        event_iri = self._event_uri(graph_uri, event)
+        self._add_common_event_triples(
+            g, event, event_iri, URIRef(DeleteConversationEvent._class_uri)
+        )
+        g.add((event_iri, _DELETES, conv_iri))
+        g.add((event_iri, _CONVERSATION_ID, Literal(event.conversation_id)))
+
+        store.insert(g, graph_name=graph_uri)
+
+    def _build_create_message_triples(
+        self,
+        event: CreateMessageEvent,
+        graph_uri: URIRef,
+    ) -> Graph:
+        g = Graph()
+        if not event.conversation_id or not event.message_id:
+            return g
+        conv_iri = self._ensure_conversation_individual(
+            g=g,
+            graph_uri=graph_uri,
+            conversation_id=event.conversation_id,
+            title=None,
+            agent=None,
+            user_id=event.user_id,
+            workspace_id=event.workspace_id,
+        )
+        msg_iri = self._message_uri(graph_uri, event.message_id)
+        g.add((msg_iri, RDF.type, OWL.NamedIndividual))
+        g.add((msg_iri, RDF.type, _MESSAGE_CLASS))
+        g.add((msg_iri, _MESSAGE_ID, Literal(event.message_id)))
+        g.add((msg_iri, _CONVERSATION_ID, Literal(event.conversation_id)))
+        g.add((msg_iri, _HAS_STATUS, _ACTIVE_STATUS))
+        g.add((msg_iri, _IS_MESSAGE_OF, conv_iri))
+        g.add((conv_iri, _HAS_MESSAGE, msg_iri))
+        if event.role:
+            g.add((msg_iri, _ROLE, Literal(event.role)))
+        if event.content:
+            g.add((msg_iri, _CONTENT, Literal(event.content)))
+        if event.agent:
+            g.add((msg_iri, _AGENT, Literal(event.agent)))
+        if event.user_id:
+            g.add((msg_iri, _USER_ID, Literal(event.user_id)))
+        label = (event.content or event.role or event.message_id or "").strip()
+        if label:
+            g.add((msg_iri, RDFS.label, Literal(label[:120])))
+
+        event_iri = self._event_uri(graph_uri, event)
+        self._add_common_event_triples(
+            g, event, event_iri, URIRef(CreateMessageEvent._class_uri)
+        )
+        g.add((event_iri, _CREATES, msg_iri))
+        g.add((event_iri, _MESSAGE_ID, Literal(event.message_id)))
+        g.add((event_iri, _CONVERSATION_ID, Literal(event.conversation_id)))
+        if event.role:
+            g.add((event_iri, _ROLE, Literal(event.role)))
+        return g
+
+    def _build_update_message_triples(
+        self,
+        event: UpdateMessageEvent,
+        graph_uri: URIRef,
+    ) -> Graph:
+        g = Graph()
+        if not event.conversation_id or not event.message_id:
+            return g
+        msg_iri = self._message_uri(graph_uri, event.message_id)
+        event_iri = self._event_uri(graph_uri, event)
+        self._add_common_event_triples(
+            g, event, event_iri, URIRef(UpdateMessageEvent._class_uri)
+        )
+        g.add((event_iri, _UPDATES, msg_iri))
+        g.add((event_iri, _MESSAGE_ID, Literal(event.message_id)))
+        g.add((event_iri, _CONVERSATION_ID, Literal(event.conversation_id)))
+        if event.content:
+            g.add((event_iri, _CONTENT, Literal(event.content)))
+        return g
+
+    # ── Subscriber wiring ────────────────────────────────────────────────────
+
+    _EVENT_CLASSES: tuple[type[LogProcess], ...] = (
+        CreateConversationEvent,
+        UpdateConversationEvent,
+        DeleteConversationEvent,
+        CreateMessageEvent,
+        UpdateMessageEvent,
+    )
+
+    def register_subscribers(self, event_service: object) -> None:
+        """Subscribe ``index_event`` to every chat lifecycle event class."""
+        subscribe = getattr(event_service, "subscribe", None)
+        if subscribe is None:
+            return
+        for cls in self._EVENT_CLASSES:
+            try:
+                subscribe(cls, self.index_event)
+            except Exception as exc:  # pragma: no cover
+                _logger.warning(
+                    "PersonalGraphService: failed to subscribe %s: %s",
+                    cls.__name__,
+                    exc,
+                )
+
+
+_singleton: PersonalGraphService | None = None
+_singleton_lock = threading.Lock()
+
+
+def get_personal_graph_service() -> PersonalGraphService:
+    """Lazy singleton accessor (one indexer per process)."""
+    global _singleton
+    with _singleton_lock:
+        if _singleton is None:
+            _singleton = PersonalGraphService()
+        return _singleton

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/graph/personal_graph_service_test.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/graph/personal_graph_service_test.py
@@ -1,0 +1,328 @@
+"""Unit tests for PersonalGraphService.
+
+Uses a fake triple-store double that records every insert/remove/create_graph
+call. That keeps the test independent of the engine and the Fuseki/oxigraph
+adapters — the only thing under test here is the indexer's projection of
+chat events into the personal-graph URI scheme.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from naas_abi.apps.nexus.apps.api.app.services.graph.personal_graph_service import (
+    PERSONAL_GRAPH_BASE,
+    PERSONAL_GRAPH_LABEL,
+    PersonalGraphService,
+    is_personal_graph_uri,
+    personal_graph_owner,
+    personal_graph_uri,
+)
+from naas_abi.ontologies.modules.NexusPlatformOntology import (
+    CreateConversation as CreateConversationEvent,
+)
+from naas_abi.ontologies.modules.NexusPlatformOntology import (
+    CreateMessage as CreateMessageEvent,
+)
+from naas_abi.ontologies.modules.NexusPlatformOntology import (
+    DeleteConversation as DeleteConversationEvent,
+)
+from naas_abi.ontologies.modules.NexusPlatformOntology import (
+    UpdateConversation as UpdateConversationEvent,
+)
+from naas_abi.ontologies.modules.NexusPlatformOntology import (
+    UpdateMessage as UpdateMessageEvent,
+)
+from rdflib import Graph, Literal, URIRef
+
+NEXUS = "http://ontology.naas.ai/nexus/"
+HAS_STATUS = URIRef(NEXUS + "hasStatus")
+ACTIVE_STATUS = URIRef(NEXUS + "ActiveStatus")
+DELETED_STATUS = URIRef(NEXUS + "DeletedStatus")
+
+
+class _FakeStore:
+    """Triple-store double — keeps everything in an in-memory rdflib Graph per named graph."""
+
+    def __init__(self) -> None:
+        self.graphs: dict[str, Graph] = {}
+        self.created: list[URIRef] = []
+
+    def _graph(self, name: URIRef) -> Graph:
+        return self.graphs.setdefault(str(name), Graph())
+
+    def create_graph(self, graph_name: URIRef) -> None:
+        self.created.append(graph_name)
+        self._graph(graph_name)
+
+    def insert(self, triples, graph_name: URIRef) -> None:
+        target = self._graph(graph_name)
+        for t in triples:
+            target.add(t)
+
+    def remove(self, triples, graph_name: URIRef) -> None:
+        target = self._graph(graph_name)
+        for t in triples:
+            target.remove(t)
+
+
+@pytest.fixture
+def fake_store() -> _FakeStore:
+    return _FakeStore()
+
+
+@pytest.fixture
+def svc(fake_store: _FakeStore) -> PersonalGraphService:
+    return PersonalGraphService(triple_store_getter=lambda: fake_store)
+
+
+# ── URI helpers ───────────────────────────────────────────────────────────────
+
+
+def test_personal_graph_uri_uses_user_id() -> None:
+    assert str(personal_graph_uri("alice")) == f"{PERSONAL_GRAPH_BASE}alice"
+
+
+def test_is_personal_graph_uri_detects_prefix() -> None:
+    assert is_personal_graph_uri(f"{PERSONAL_GRAPH_BASE}alice")
+    assert not is_personal_graph_uri("http://ontology.naas.ai/graph/foo")
+
+
+def test_personal_graph_owner_returns_user_id_segment() -> None:
+    assert personal_graph_owner(f"{PERSONAL_GRAPH_BASE}alice") == "alice"
+    assert personal_graph_owner("http://ontology.naas.ai/graph/foo") is None
+
+
+# ── ensure_personal_graph ─────────────────────────────────────────────────────
+
+
+def test_ensure_personal_graph_creates_and_registers_in_nexus(
+    svc: PersonalGraphService, fake_store: _FakeStore
+) -> None:
+    uri = svc.ensure_personal_graph("alice")
+    assert str(uri) == f"{PERSONAL_GRAPH_BASE}alice"
+    # The named graph itself was created.
+    assert URIRef(str(uri)) in fake_store.created
+    # The KnowledgeGraph individual was registered in the nexus graph with the
+    # canonical "My Graph" label.
+    nexus_graph = fake_store.graphs["http://ontology.naas.ai/graph/nexus"]
+    labels = list(
+        nexus_graph.objects(URIRef(str(uri)), URIRef("http://www.w3.org/2000/01/rdf-schema#label"))
+    )
+    assert Literal(PERSONAL_GRAPH_LABEL) in labels
+
+
+def test_ensure_personal_graph_is_idempotent(
+    svc: PersonalGraphService, fake_store: _FakeStore
+) -> None:
+    svc.ensure_personal_graph("alice")
+    svc.ensure_personal_graph("alice")
+    # After warm-up the subsequent call must not hit the store again.
+    assert fake_store.created.count(URIRef(f"{PERSONAL_GRAPH_BASE}alice")) == 1
+
+
+def test_ensure_personal_graph_rejects_empty_user(svc: PersonalGraphService) -> None:
+    with pytest.raises(ValueError):
+        svc.ensure_personal_graph("")
+
+
+# ── index_event: CreateConversation ───────────────────────────────────────────
+
+
+def test_create_conversation_event_inserts_conversation_with_active_status(
+    svc: PersonalGraphService, fake_store: _FakeStore
+) -> None:
+    svc.index_event(
+        CreateConversationEvent(
+            user_id="alice",
+            workspace_id="ws-1",
+            conversation_id="conv-1",
+            title="Project Alpha",
+            agent="aia",
+            created=datetime(2026, 6, 1, 9, 14),
+        )
+    )
+    graph = fake_store.graphs[f"{PERSONAL_GRAPH_BASE}alice"]
+    conv_iri = URIRef(f"{PERSONAL_GRAPH_BASE}alice/conversation/conv-1")
+    assert (conv_iri, HAS_STATUS, ACTIVE_STATUS) in graph
+    # Title surfaces on the artifact.
+    assert (
+        conv_iri,
+        URIRef(NEXUS + "title"),
+        Literal("Project Alpha"),
+    ) in graph
+
+
+def test_event_without_user_id_is_dropped(
+    svc: PersonalGraphService, fake_store: _FakeStore
+) -> None:
+    svc.index_event(
+        CreateConversationEvent(
+            user_id=None,
+            workspace_id="ws-1",
+            conversation_id="conv-1",
+        )
+    )
+    # No personal graph should be created for an anonymous event.
+    assert not fake_store.created
+
+
+# ── index_event: CreateMessage ────────────────────────────────────────────────
+
+
+def test_create_message_event_links_message_to_conversation(
+    svc: PersonalGraphService, fake_store: _FakeStore
+) -> None:
+    svc.index_event(
+        CreateMessageEvent(
+            user_id="alice",
+            workspace_id="ws-1",
+            conversation_id="conv-1",
+            message_id="msg-1",
+            role="user",
+            content="What is the status of Project Alpha?",
+            agent=None,
+            created=datetime(2026, 6, 1, 9, 14),
+        )
+    )
+    graph = fake_store.graphs[f"{PERSONAL_GRAPH_BASE}alice"]
+    msg_iri = URIRef(f"{PERSONAL_GRAPH_BASE}alice/message/msg-1")
+    conv_iri = URIRef(f"{PERSONAL_GRAPH_BASE}alice/conversation/conv-1")
+    assert (msg_iri, HAS_STATUS, ACTIVE_STATUS) in graph
+    assert (msg_iri, URIRef(NEXUS + "isMessageOf"), conv_iri) in graph
+    assert (conv_iri, URIRef(NEXUS + "hasMessage"), msg_iri) in graph
+    assert (
+        msg_iri,
+        URIRef(NEXUS + "content"),
+        Literal("What is the status of Project Alpha?"),
+    ) in graph
+    assert (msg_iri, URIRef(NEXUS + "role"), Literal("user")) in graph
+
+
+# ── index_event: DeleteConversation ───────────────────────────────────────────
+
+
+def test_delete_conversation_flips_status_without_removing_individual(
+    svc: PersonalGraphService, fake_store: _FakeStore
+) -> None:
+    svc.index_event(
+        CreateConversationEvent(
+            user_id="alice",
+            workspace_id="ws-1",
+            conversation_id="conv-1",
+            title="Project Alpha",
+        )
+    )
+    svc.index_event(
+        CreateMessageEvent(
+            user_id="alice",
+            workspace_id="ws-1",
+            conversation_id="conv-1",
+            message_id="msg-1",
+            role="user",
+            content="hello",
+        )
+    )
+    svc.index_event(
+        DeleteConversationEvent(
+            user_id="alice",
+            workspace_id="ws-1",
+            conversation_id="conv-1",
+        )
+    )
+    graph = fake_store.graphs[f"{PERSONAL_GRAPH_BASE}alice"]
+    conv_iri = URIRef(f"{PERSONAL_GRAPH_BASE}alice/conversation/conv-1")
+    msg_iri = URIRef(f"{PERSONAL_GRAPH_BASE}alice/message/msg-1")
+
+    # Status flipped, individual preserved.
+    assert (conv_iri, HAS_STATUS, ACTIVE_STATUS) not in graph
+    assert (conv_iri, HAS_STATUS, DELETED_STATUS) in graph
+    assert (
+        conv_iri,
+        URIRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"),
+        URIRef(NEXUS + "Conversation"),
+    ) in graph
+    # Message individual untouched.
+    assert (msg_iri, HAS_STATUS, ACTIVE_STATUS) in graph
+
+
+# ── index_event: UpdateConversation / UpdateMessage ───────────────────────────
+
+
+def test_update_conversation_event_logs_change_on_event_individual(
+    svc: PersonalGraphService, fake_store: _FakeStore
+) -> None:
+    svc.index_event(
+        UpdateConversationEvent(
+            user_id="alice",
+            workspace_id="ws-1",
+            conversation_id="conv-1",
+            title="New title",
+        )
+    )
+    graph = fake_store.graphs[f"{PERSONAL_GRAPH_BASE}alice"]
+    # Some Update* event individual was inserted that updates the conversation.
+    conv_iri = URIRef(f"{PERSONAL_GRAPH_BASE}alice/conversation/conv-1")
+    update_subjects = list(
+        graph.subjects(URIRef(NEXUS + "updates"), conv_iri)
+    )
+    assert update_subjects, "Expected at least one nexus:updates triple pointing to the conversation"
+    # The new title is surfaced on the event individual (history-preserving).
+    has_title = False
+    for s in update_subjects:
+        if (s, URIRef(NEXUS + "title"), Literal("New title")) in graph:
+            has_title = True
+    assert has_title
+
+
+def test_update_message_event_inserts_update_event(
+    svc: PersonalGraphService, fake_store: _FakeStore
+) -> None:
+    svc.index_event(
+        UpdateMessageEvent(
+            user_id="alice",
+            workspace_id="ws-1",
+            conversation_id="conv-1",
+            message_id="msg-1",
+            content="updated content",
+        )
+    )
+    graph = fake_store.graphs[f"{PERSONAL_GRAPH_BASE}alice"]
+    msg_iri = URIRef(f"{PERSONAL_GRAPH_BASE}alice/message/msg-1")
+    update_subjects = list(graph.subjects(URIRef(NEXUS + "updates"), msg_iri))
+    assert update_subjects
+    has_content = any(
+        (s, URIRef(NEXUS + "content"), Literal("updated content")) in graph
+        for s in update_subjects
+    )
+    assert has_content
+
+
+# ── register_subscribers ──────────────────────────────────────────────────────
+
+
+def test_register_subscribers_wires_every_chat_event_class(
+    svc: PersonalGraphService,
+) -> None:
+    calls: list[type] = []
+
+    class _FakeEventService:
+        def subscribe(self, event_cls, handler):
+            calls.append(event_cls)
+            assert handler == svc.index_event
+
+    svc.register_subscribers(_FakeEventService())
+    assert {c.__name__ for c in calls} == {
+        "CreateConversation",
+        "UpdateConversation",
+        "DeleteConversation",
+        "CreateMessage",
+        "UpdateMessage",
+    }
+
+
+def test_register_subscribers_is_a_noop_when_service_lacks_subscribe(
+    svc: PersonalGraphService,
+) -> None:
+    # No exception, no calls. Some test/dev event stubs may lack subscribe().
+    svc.register_subscribers(object())

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/graph/service.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/graph/service.py
@@ -30,9 +30,19 @@ from rdflib.query import ResultRow
 
 _cache = CacheFactory.CacheFS_find_storage(subpath="nexus/graph")
 
-GRAPH_BASE_URI = URIRef(
-    ABIModule.get_instance().configuration.nexus_config.ontology_base_uri + "graph/"
-)
+
+def _graph_base_uri() -> URIRef:
+    """Lazily compute the per-tenant graph base URI.
+
+    Deferred from module import so the package can be imported in unit tests
+    that don't run a full ABIModule engine; only the methods that actually
+    mint new graph URIs depend on the engine config.
+    """
+    return URIRef(
+        ABIModule.get_instance().configuration.nexus_config.ontology_base_uri + "graph/"
+    )
+
+
 NEXUS_GRAPH_URI = URIRef("http://ontology.naas.ai/graph/nexus")
 SCHEMA_GRAPH_URI = URIRef("http://ontology.naas.ai/graph/schema")
 
@@ -558,7 +568,7 @@ class GraphService:
         store = self._get_triple_store()
         graph_label = label.strip()
         graph_id = _slugify(graph_label)
-        new_graph_uri = GRAPH_BASE_URI + graph_id
+        new_graph_uri = _graph_base_uri() + graph_id
         store.create_graph(new_graph_uri)
         new_graph = KnowledgeGraph(_uri=new_graph_uri, label=graph_label, creator=user_id)
         if description:

--- a/libs/naas-abi/naas_abi/ontologies/classes/ontology_naas_ai/nexus/AgentResponseRole.py
+++ b/libs/naas-abi/naas_abi/ontologies/classes/ontology_naas_ai/nexus/AgentResponseRole.py
@@ -1,0 +1,11 @@
+from naas_abi.ontologies.modules.NexusPlatformOntology import (
+    AgentResponseRole as _AgentResponseRole,
+)
+
+
+class AgentResponseRole(_AgentResponseRole):
+    """Action class for AgentResponseRole"""
+
+    def actions(self):
+        """Action method - implement your logic here"""
+        pass

--- a/libs/naas-abi/naas_abi/ontologies/classes/ontology_naas_ai/nexus/CreateConversation.py
+++ b/libs/naas-abi/naas_abi/ontologies/classes/ontology_naas_ai/nexus/CreateConversation.py
@@ -1,0 +1,11 @@
+from naas_abi.ontologies.modules.NexusPlatformOntology import (
+    CreateConversation as _CreateConversation,
+)
+
+
+class CreateConversation(_CreateConversation):
+    """Action class for CreateConversation"""
+
+    def actions(self):
+        """Action method - implement your logic here"""
+        pass

--- a/libs/naas-abi/naas_abi/ontologies/classes/ontology_naas_ai/nexus/CreateMessage.py
+++ b/libs/naas-abi/naas_abi/ontologies/classes/ontology_naas_ai/nexus/CreateMessage.py
@@ -1,0 +1,11 @@
+from naas_abi.ontologies.modules.NexusPlatformOntology import (
+    CreateMessage as _CreateMessage,
+)
+
+
+class CreateMessage(_CreateMessage):
+    """Action class for CreateMessage"""
+
+    def actions(self):
+        """Action method - implement your logic here"""
+        pass

--- a/libs/naas-abi/naas_abi/ontologies/classes/ontology_naas_ai/nexus/DeleteConversation.py
+++ b/libs/naas-abi/naas_abi/ontologies/classes/ontology_naas_ai/nexus/DeleteConversation.py
@@ -1,0 +1,11 @@
+from naas_abi.ontologies.modules.NexusPlatformOntology import (
+    DeleteConversation as _DeleteConversation,
+)
+
+
+class DeleteConversation(_DeleteConversation):
+    """Action class for DeleteConversation"""
+
+    def actions(self):
+        """Action method - implement your logic here"""
+        pass

--- a/libs/naas-abi/naas_abi/ontologies/classes/ontology_naas_ai/nexus/MessageProcessingInterval.py
+++ b/libs/naas-abi/naas_abi/ontologies/classes/ontology_naas_ai/nexus/MessageProcessingInterval.py
@@ -1,0 +1,11 @@
+from naas_abi.ontologies.modules.NexusPlatformOntology import (
+    MessageProcessingInterval as _MessageProcessingInterval,
+)
+
+
+class MessageProcessingInterval(_MessageProcessingInterval):
+    """Action class for MessageProcessingInterval"""
+
+    def actions(self):
+        """Action method - implement your logic here"""
+        pass

--- a/libs/naas-abi/naas_abi/ontologies/classes/ontology_naas_ai/nexus/SendAgentResponse.py
+++ b/libs/naas-abi/naas_abi/ontologies/classes/ontology_naas_ai/nexus/SendAgentResponse.py
@@ -1,0 +1,11 @@
+from naas_abi.ontologies.modules.NexusPlatformOntology import (
+    SendAgentResponse as _SendAgentResponse,
+)
+
+
+class SendAgentResponse(_SendAgentResponse):
+    """Action class for SendAgentResponse"""
+
+    def actions(self):
+        """Action method - implement your logic here"""
+        pass

--- a/libs/naas-abi/naas_abi/ontologies/classes/ontology_naas_ai/nexus/SendUserPrompt.py
+++ b/libs/naas-abi/naas_abi/ontologies/classes/ontology_naas_ai/nexus/SendUserPrompt.py
@@ -1,0 +1,11 @@
+from naas_abi.ontologies.modules.NexusPlatformOntology import (
+    SendUserPrompt as _SendUserPrompt,
+)
+
+
+class SendUserPrompt(_SendUserPrompt):
+    """Action class for SendUserPrompt"""
+
+    def actions(self):
+        """Action method - implement your logic here"""
+        pass

--- a/libs/naas-abi/naas_abi/ontologies/classes/ontology_naas_ai/nexus/Status.py
+++ b/libs/naas-abi/naas_abi/ontologies/classes/ontology_naas_ai/nexus/Status.py
@@ -1,0 +1,11 @@
+from naas_abi.ontologies.modules.NexusPlatformOntology import (
+    Status as _Status,
+)
+
+
+class Status(_Status):
+    """Action class for Status"""
+
+    def actions(self):
+        """Action method - implement your logic here"""
+        pass

--- a/libs/naas-abi/naas_abi/ontologies/classes/ontology_naas_ai/nexus/UpdateConversation.py
+++ b/libs/naas-abi/naas_abi/ontologies/classes/ontology_naas_ai/nexus/UpdateConversation.py
@@ -1,0 +1,11 @@
+from naas_abi.ontologies.modules.NexusPlatformOntology import (
+    UpdateConversation as _UpdateConversation,
+)
+
+
+class UpdateConversation(_UpdateConversation):
+    """Action class for UpdateConversation"""
+
+    def actions(self):
+        """Action method - implement your logic here"""
+        pass

--- a/libs/naas-abi/naas_abi/ontologies/classes/ontology_naas_ai/nexus/UpdateMessage.py
+++ b/libs/naas-abi/naas_abi/ontologies/classes/ontology_naas_ai/nexus/UpdateMessage.py
@@ -1,0 +1,11 @@
+from naas_abi.ontologies.modules.NexusPlatformOntology import (
+    UpdateMessage as _UpdateMessage,
+)
+
+
+class UpdateMessage(_UpdateMessage):
+    """Action class for UpdateMessage"""
+
+    def actions(self):
+        """Action method - implement your logic here"""
+        pass

--- a/libs/naas-abi/naas_abi/ontologies/classes/ontology_naas_ai/nexus/UserPromptRole.py
+++ b/libs/naas-abi/naas_abi/ontologies/classes/ontology_naas_ai/nexus/UserPromptRole.py
@@ -1,0 +1,11 @@
+from naas_abi.ontologies.modules.NexusPlatformOntology import (
+    UserPromptRole as _UserPromptRole,
+)
+
+
+class UserPromptRole(_UserPromptRole):
+    """Action class for UserPromptRole"""
+
+    def actions(self):
+        """Action method - implement your logic here"""
+        pass

--- a/libs/naas-abi/naas_abi/ontologies/modules/NexusPlatformOntology.py
+++ b/libs/naas-abi/naas_abi/ontologies/modules/NexusPlatformOntology.py
@@ -1,8 +1,6 @@
-# onto2py-source-sha256: 5f0e0f5c0462441a9c639410a2691ba450cf1c8e035545b7b0d19fab12babb00
 from __future__ import annotations
 
 import datetime
-import os
 import uuid
 from typing import (
     Annotated,
@@ -29,6 +27,10 @@ from naas_abi.ontologies.modules.ABIOntology import (
     Site,
     TemporalInstant,
     TemporalRegion,
+)
+from naas_abi_core.services.event.ontologies.modules.EventOntology import (
+    LogProcess,
+    Process,
 )
 from pydantic import BaseModel, Field, ValidationError
 from rdflib import Graph, Literal, Namespace, URIRef
@@ -320,273 +322,6 @@ class RDFEntity(BaseModel):
                         g.add((subject, URIRef(prop_uri), Literal(prop_value)))
 
         return g
-
-
-class VisitSession(RDFEntity):
-    """
-    Visit Session
-    """
-
-    _class_uri: ClassVar[str] = "http://ontology.naas.ai/nexus/VisitSession"
-    _name: ClassVar[str] = "Visit Session"
-    _property_uris: ClassVar[dict] = {
-        "created": "http://purl.org/dc/terms/created",
-        "creates": "http://ontology.naas.ai/nexus/creates",
-        "creator": "http://purl.org/dc/terms/creator",
-        "event_id": "http://ontology.naas.ai/nexus/event_id",
-        "has_session_interval": "http://ontology.naas.ai/nexus/hasSessionInterval",
-        "label": "http://www.w3.org/2000/01/rdf-schema#label",
-        "occurs_in": "http://ontology.naas.ai/nexus/occursIn",
-        "session_id": "http://ontology.naas.ai/nexus/session_id",
-        "started_by": "http://ontology.naas.ai/nexus/startedBy",
-    }
-    _object_properties: ClassVar[set[str]] = {
-        "creates",
-        "has_session_interval",
-        "occurs_in",
-        "started_by",
-    }
-
-    # Data properties
-    event_id: Optional[
-        Annotated[
-            str,
-            Field(
-                description="The unique identifier of the platform analytics event corresponding to a process instance in the Nexus platform."
-            ),
-        ]
-    ] = None
-    session_id: Optional[
-        Annotated[
-            str,
-            Field(
-                description="The unique identifier of a platform session artifact or visit-session process in the Nexus platform."
-            ),
-        ]
-    ] = None
-    label: Optional[Annotated[str, Field(description="Label of the resource.")]] = None
-    created: Annotated[
-        Optional[datetime.datetime],
-        Field(description="Date of creation of the resource."),
-    ] = datetime.datetime.now()
-    creator: Annotated[
-        Optional[Any],
-        Field(description="An entity responsible for making the resource."),
-    ] = os.environ.get("USER")
-
-    # Object properties
-    creates: Optional[
-        Annotated[
-            List[Union[Session, URIRef, str]],
-            Field(
-                description="Relates a platform process performed in the application to a generically dependent continuant artifact it creates."
-            ),
-        ]
-    ] = None
-    has_session_interval: Optional[
-        Annotated[
-            List[Union[URIRef, VisitSessionInterval, str]],
-            Field(
-                description="Relates a visit-session process to the temporal interval that bounds its start and end."
-            ),
-        ]
-    ] = None
-    occurs_in: Optional[
-        Annotated[
-            List[Union[URIRef, UserSite, str]],
-            Field(
-                description="Relates a process (such as a page view or visit session) to the user-side site context (country, device, browser) in which it occurs."
-            ),
-        ]
-    ] = None
-    started_by: Optional[
-        Annotated[
-            List[Union[URIRef, User, str]],
-            Field(
-                description="Relates a visit-session process to the user account that started it."
-            ),
-        ]
-    ] = None
-
-
-class PageView(RDFEntity):
-    """
-    Page View
-    """
-
-    _class_uri: ClassVar[str] = "http://ontology.naas.ai/nexus/PageView"
-    _name: ClassVar[str] = "Page View"
-    _property_uris: ClassVar[dict] = {
-        "created": "http://purl.org/dc/terms/created",
-        "creator": "http://purl.org/dc/terms/creator",
-        "event_id": "http://ontology.naas.ai/nexus/event_id",
-        "has_visited_page": "http://ontology.naas.ai/nexus/hasVisitedPage",
-        "label": "http://www.w3.org/2000/01/rdf-schema#label",
-        "occurs_during_session": "http://ontology.naas.ai/nexus/occursDuringSession",
-        "occurs_in": "http://ontology.naas.ai/nexus/occursIn",
-        "occurs_in_workspace": "http://ontology.naas.ai/nexus/occursInWorkspace",
-        "referrer": "http://ontology.naas.ai/nexus/referrer",
-        "viewed_at": "http://ontology.naas.ai/nexus/viewedAt",
-        "viewed_by": "http://ontology.naas.ai/nexus/viewedBy",
-    }
-    _object_properties: ClassVar[set[str]] = {
-        "has_visited_page",
-        "occurs_during_session",
-        "occurs_in",
-        "occurs_in_workspace",
-        "viewed_at",
-        "viewed_by",
-    }
-
-    # Data properties
-    event_id: Optional[
-        Annotated[
-            str,
-            Field(
-                description="The unique identifier of the platform analytics event corresponding to a process instance in the Nexus platform."
-            ),
-        ]
-    ] = None
-    referrer: Optional[
-        Annotated[
-            str,
-            Field(
-                description="The HTTP referrer (originating page or host) recorded at the time of a page-view process."
-            ),
-        ]
-    ] = None
-    label: Optional[Annotated[str, Field(description="Label of the resource.")]] = None
-    created: Annotated[
-        Optional[datetime.datetime],
-        Field(description="Date of creation of the resource."),
-    ] = datetime.datetime.now()
-    creator: Annotated[
-        Optional[Any],
-        Field(description="An entity responsible for making the resource."),
-    ] = os.environ.get("USER")
-
-    # Object properties
-    has_visited_page: Optional[
-        Annotated[
-            List[Union[Page, URIRef, str]],
-            Field(
-                description="Relates a page-view process to the page artifact (generically dependent continuant) that the user viewed during that process."
-            ),
-        ]
-    ] = None
-    occurs_during_session: Optional[
-        Annotated[
-            List[Union[URIRef, VisitSession, str]],
-            Field(
-                description="Relates a page-view process to the visit session of which it is a temporal part."
-            ),
-        ]
-    ] = None
-    occurs_in: Optional[
-        Annotated[
-            List[Union[URIRef, UserSite, str]],
-            Field(
-                description="Relates a process (such as a page view or visit session) to the user-side site context (country, device, browser) in which it occurs."
-            ),
-        ]
-    ] = None
-    occurs_in_workspace: Optional[
-        Annotated[
-            List[Union[URIRef, Workspace, str]],
-            Field(
-                description="Relates a platform process (such as a page view or visit session) to the workspace generic context in which it occurs."
-            ),
-        ]
-    ] = None
-    viewed_at: Optional[
-        Annotated[
-            List[Union[TemporalInstant, URIRef, str]],
-            Field(
-                description="Relates a page-view process to the temporal instant at which the view occurred."
-            ),
-        ]
-    ] = None
-    viewed_by: Optional[
-        Annotated[
-            List[Union[URIRef, User, str]],
-            Field(
-                description="Relates a page-view process to the user account that participates in it."
-            ),
-        ]
-    ] = None
-
-
-class Logout(RDFEntity):
-    """
-    Logout
-    """
-
-    _class_uri: ClassVar[str] = "http://ontology.naas.ai/nexus/Logout"
-    _name: ClassVar[str] = "Logout"
-    _property_uris: ClassVar[dict] = {
-        "created": "http://purl.org/dc/terms/created",
-        "created_by": "http://ontology.naas.ai/nexus/createdBy",
-        "creator": "http://purl.org/dc/terms/creator",
-        "event_id": "http://ontology.naas.ai/nexus/event_id",
-        "label": "http://www.w3.org/2000/01/rdf-schema#label",
-        "occupiesTemporalRegion": "http://ontology.naas.ai/abi/occupiesTemporalRegion",
-        "terminates": "http://ontology.naas.ai/nexus/terminates",
-        "terminates_session": "http://ontology.naas.ai/nexus/terminatesSession",
-    }
-    _object_properties: ClassVar[set[str]] = {
-        "created_by",
-        "occupiesTemporalRegion",
-        "terminates",
-        "terminates_session",
-    }
-
-    # Data properties
-    event_id: Optional[
-        Annotated[
-            str,
-            Field(
-                description="The unique identifier of the platform analytics event corresponding to a process instance in the Nexus platform."
-            ),
-        ]
-    ] = None
-    label: Optional[Annotated[str, Field(description="Label of the resource.")]] = None
-    created: Annotated[
-        Optional[datetime.datetime],
-        Field(description="Date of creation of the resource."),
-    ] = datetime.datetime.now()
-    creator: Annotated[
-        Optional[Any],
-        Field(description="An entity responsible for making the resource."),
-    ] = os.environ.get("USER")
-
-    # Object properties
-    created_by: Optional[
-        Annotated[
-            List[Union[URIRef, User, str]],
-            Field(
-                description="Relates a platform process to the agent (user or person) who initiated it."
-            ),
-        ]
-    ] = None
-    occupiesTemporalRegion: Optional[
-        Annotated[List[Union[LogoutInterval, URIRef, str]], Field()]
-    ] = None
-    terminates: Optional[
-        Annotated[
-            List[Union[Session, URIRef, str]],
-            Field(
-                description="Relates a logout process to the session artifact it terminates."
-            ),
-        ]
-    ] = None
-    terminates_session: Optional[
-        Annotated[
-            List[Union[URIRef, VisitSession, str]],
-            Field(
-                description="Relates a logout process to the visit session it terminates."
-            ),
-        ]
-    ] = None
 
 
 class Server(MaterialEntity, RDFEntity):
@@ -1132,6 +867,8 @@ class Conversation(GenericallyDependentContinuant, RDFEntity):
     _class_uri: ClassVar[str] = "http://ontology.naas.ai/nexus/Conversation"
     _name: ClassVar[str] = "Conversation"
     _property_uris: ClassVar[dict] = {
+        "agent": "http://ontology.naas.ai/nexus/agent",
+        "conversation_id": "http://ontology.naas.ai/nexus/conversation_id",
         "created": "http://purl.org/dc/terms/created",
         "creator": "http://purl.org/dc/terms/creator",
         "generically_depends_on": "http://ontology.naas.ai/abi/genericallyDependsOn",
@@ -1140,6 +877,7 @@ class Conversation(GenericallyDependentContinuant, RDFEntity):
         "is_concretized_by": "http://ontology.naas.ai/abi/isConcretizedBy",
         "is_conversation_of": "http://ontology.naas.ai/nexus/isConversationOf",
         "label": "http://www.w3.org/2000/01/rdf-schema#label",
+        "title": "http://ontology.naas.ai/nexus/title",
     }
     _object_properties: ClassVar[set[str]] = {
         "generically_depends_on",
@@ -1150,6 +888,28 @@ class Conversation(GenericallyDependentContinuant, RDFEntity):
     }
 
     # Data properties
+    conversation_id: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The unique identifier of a conversation artifact in the Nexus platform."
+            ),
+        ]
+    ] = None
+    agent: Optional[
+        Annotated[
+            str,
+            Field(
+                description="Identifier of the agent associated with a conversation or message in the Nexus platform."
+            ),
+        ]
+    ] = None
+    title: Optional[
+        Annotated[
+            str,
+            Field(description="Display title of a conversation in the Nexus platform."),
+        ]
+    ] = None
     label: Optional[Annotated[str, Field(description="Label of the resource.")]] = None
     created: Optional[
         Annotated[
@@ -1211,6 +971,8 @@ class Message(GenericallyDependentContinuant, RDFEntity):
     _class_uri: ClassVar[str] = "http://ontology.naas.ai/nexus/Message"
     _name: ClassVar[str] = "Message"
     _property_uris: ClassVar[dict] = {
+        "agent": "http://ontology.naas.ai/nexus/agent",
+        "content": "http://ontology.naas.ai/nexus/content",
         "created": "http://purl.org/dc/terms/created",
         "creator": "http://purl.org/dc/terms/creator",
         "generically_depends_on": "http://ontology.naas.ai/abi/genericallyDependsOn",
@@ -1218,6 +980,8 @@ class Message(GenericallyDependentContinuant, RDFEntity):
         "is_concretized_by": "http://ontology.naas.ai/abi/isConcretizedBy",
         "is_message_of": "http://ontology.naas.ai/nexus/isMessageOf",
         "label": "http://www.w3.org/2000/01/rdf-schema#label",
+        "message_id": "http://ontology.naas.ai/nexus/message_id",
+        "role": "http://ontology.naas.ai/nexus/role",
     }
     _object_properties: ClassVar[set[str]] = {
         "generically_depends_on",
@@ -1227,6 +991,38 @@ class Message(GenericallyDependentContinuant, RDFEntity):
     }
 
     # Data properties
+    message_id: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The unique identifier of a message artifact in the Nexus platform."
+            ),
+        ]
+    ] = None
+    role: Optional[
+        Annotated[
+            str,
+            Field(
+                description="Role of the message author within a conversation (user, assistant, system)."
+            ),
+        ]
+    ] = None
+    content: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The textual content of a message in the Nexus platform."
+            ),
+        ]
+    ] = None
+    agent: Optional[
+        Annotated[
+            str,
+            Field(
+                description="Identifier of the agent associated with a conversation or message in the Nexus platform."
+            ),
+        ]
+    ] = None
     label: Optional[Annotated[str, Field(description="Label of the resource.")]] = None
     created: Optional[
         Annotated[
@@ -3833,7 +3629,6 @@ class FrontEndEvent(Process, RDFEntity):
     _name: ClassVar[str] = "Front End Event"
     _property_uris: ClassVar[dict] = {
         "browser": "http://ontology.naas.ai/nexus/browser",
-        "concretizes": "http://ontology.naas.ai/abi/concretizes",
         "country": "http://ontology.naas.ai/nexus/country",
         "created": "http://purl.org/dc/terms/created",
         "created_at": "http://ontology.naas.ai/nexus/createdAt",
@@ -3841,13 +3636,9 @@ class FrontEndEvent(Process, RDFEntity):
         "device": "http://ontology.naas.ai/nexus/device",
         "event_id": "http://ontology.naas.ai/nexus/event_id",
         "event_name": "http://ontology.naas.ai/nexus/event_name",
-        "has_participant": "http://ontology.naas.ai/abi/hasParticipant",
         "label": "http://www.w3.org/2000/01/rdf-schema#label",
-        "occupies_temporal_region": "http://ontology.naas.ai/abi/occupiesTemporalRegion",
-        "occurs_in": "http://ontology.naas.ai/abi/occursIn",
         "page_path": "http://ontology.naas.ai/nexus/page_path",
         "page_title": "http://ontology.naas.ai/nexus/page_title",
-        "realizes": "http://ontology.naas.ai/abi/realizes",
         "referrer": "http://ontology.naas.ai/nexus/referrer",
         "session_id": "http://ontology.naas.ai/nexus/session_id",
         "timestamp": "http://ontology.naas.ai/nexus/timestamp",
@@ -3856,14 +3647,7 @@ class FrontEndEvent(Process, RDFEntity):
         "workspace_id": "http://ontology.naas.ai/nexus/workspace_id",
         "workspace_name": "http://ontology.naas.ai/nexus/workspace_name",
     }
-    _object_properties: ClassVar[set[str]] = {
-        "concretizes",
-        "created_at",
-        "has_participant",
-        "occupies_temporal_region",
-        "occurs_in",
-        "realizes",
-    }
+    _object_properties: ClassVar[set[str]] = {"created_at"}
 
     # Data properties
     user_id: Optional[
@@ -3989,49 +3773,11 @@ class FrontEndEvent(Process, RDFEntity):
     ] = None
 
     # Object properties
-    concretizes: Optional[
-        Annotated[
-            List[Union[GenericallyDependentContinuant, URIRef, str]],
-            Field(
-                description="b concretizes c =Def b is a process or a specifically dependent continuant & c is a generically dependent continuant & there is some time t such that c is the pattern or content which b shares at t with actual or potential copies"
-            ),
-        ]
-    ] = None
     created_at: Optional[
         Annotated[
             List[Union[TemporalInstant, URIRef, str]],
             Field(
                 description="Relates a platform process to the temporal instant at which it occurred."
-            ),
-        ]
-    ] = None
-    has_participant: Optional[
-        Annotated[
-            List[Union[MaterialEntity, Quality, URIRef, str]],
-            Field(description="p has participant c =Def c participates in p"),
-        ]
-    ] = None
-    occupies_temporal_region: Optional[
-        Annotated[
-            List[Union[TemporalRegion, URIRef, str]],
-            Field(
-                description="p occupies temporal region t =Def p is a process or process boundary & the spatiotemporal region occupied by p temporally projects onto t"
-            ),
-        ]
-    ] = None
-    occurs_in: Optional[
-        Annotated[
-            List[Union[Site, URIRef, str]],
-            Field(
-                description="b occurs in c =Def b is a process or a process boundary & c is a material entity or site & there exists a spatiotemporal region r & b occupies spatiotemporal region r & for all time t, if b exists at t then c exists at t & there exist spatial regions s and s' where b spatially projects onto s at t & c occupies spatial region s' at t & s is a continuant part of s' at t"
-            ),
-        ]
-    ] = None
-    realizes: Optional[
-        Annotated[
-            List[Union[Disposition, Role, URIRef, str]],
-            Field(
-                description="(Elucidation) realizes is a relation between a process b and realizable entity c such that c inheres in some d & for all t, if b has participant d then c exists & the type instantiated by b is correlated with the type instantiated by c"
             ),
         ]
     ] = None
@@ -4045,29 +3791,19 @@ class CreateUser(Process, RDFEntity):
     _class_uri: ClassVar[str] = "http://ontology.naas.ai/nexus/CreateUser"
     _name: ClassVar[str] = "Create User"
     _property_uris: ClassVar[dict] = {
-        "concretizes": "http://ontology.naas.ai/abi/concretizes",
         "created": "http://purl.org/dc/terms/created",
         "created_at": "http://ontology.naas.ai/nexus/createdAt",
         "created_by": "http://ontology.naas.ai/nexus/createdBy",
         "created_for": "http://ontology.naas.ai/nexus/createdFor",
         "creates": "http://ontology.naas.ai/nexus/creates",
         "creator": "http://purl.org/dc/terms/creator",
-        "has_participant": "http://ontology.naas.ai/abi/hasParticipant",
         "label": "http://www.w3.org/2000/01/rdf-schema#label",
-        "occupies_temporal_region": "http://ontology.naas.ai/abi/occupiesTemporalRegion",
-        "occurs_in": "http://ontology.naas.ai/abi/occursIn",
-        "realizes": "http://ontology.naas.ai/abi/realizes",
     }
     _object_properties: ClassVar[set[str]] = {
-        "concretizes",
         "created_at",
         "created_by",
         "created_for",
         "creates",
-        "has_participant",
-        "occupies_temporal_region",
-        "occurs_in",
-        "realizes",
     }
 
     # Data properties
@@ -4086,14 +3822,6 @@ class CreateUser(Process, RDFEntity):
     ] = None
 
     # Object properties
-    concretizes: Optional[
-        Annotated[
-            List[Union[GenericallyDependentContinuant, URIRef, str]],
-            Field(
-                description="b concretizes c =Def b is a process or a specifically dependent continuant & c is a generically dependent continuant & there is some time t such that c is the pattern or content which b shares at t with actual or potential copies"
-            ),
-        ]
-    ] = None
     created_at: Optional[
         Annotated[
             List[Union[TemporalInstant, URIRef, str]],
@@ -4126,36 +3854,6 @@ class CreateUser(Process, RDFEntity):
             ),
         ]
     ] = None
-    has_participant: Optional[
-        Annotated[
-            List[Union[MaterialEntity, Quality, URIRef, str]],
-            Field(description="p has participant c =Def c participates in p"),
-        ]
-    ] = None
-    occupies_temporal_region: Optional[
-        Annotated[
-            List[Union[TemporalRegion, URIRef, str]],
-            Field(
-                description="p occupies temporal region t =Def p is a process or process boundary & the spatiotemporal region occupied by p temporally projects onto t"
-            ),
-        ]
-    ] = None
-    occurs_in: Optional[
-        Annotated[
-            List[Union[Site, URIRef, str]],
-            Field(
-                description="b occurs in c =Def b is a process or a process boundary & c is a material entity or site & there exists a spatiotemporal region r & b occupies spatiotemporal region r & for all time t, if b exists at t then c exists at t & there exist spatial regions s and s' where b spatially projects onto s at t & c occupies spatial region s' at t & s is a continuant part of s' at t"
-            ),
-        ]
-    ] = None
-    realizes: Optional[
-        Annotated[
-            List[Union[Disposition, Role, URIRef, str]],
-            Field(
-                description="(Elucidation) realizes is a relation between a process b and realizable entity c such that c inheres in some d & for all t, if b has participant d then c exists & the type instantiated by b is correlated with the type instantiated by c"
-            ),
-        ]
-    ] = None
 
 
 class CreateWorkspace(Process, RDFEntity):
@@ -4166,28 +3864,14 @@ class CreateWorkspace(Process, RDFEntity):
     _class_uri: ClassVar[str] = "http://ontology.naas.ai/nexus/CreateWorkspace"
     _name: ClassVar[str] = "Create Workspace"
     _property_uris: ClassVar[dict] = {
-        "concretizes": "http://ontology.naas.ai/abi/concretizes",
         "created": "http://purl.org/dc/terms/created",
         "created_at": "http://ontology.naas.ai/nexus/createdAt",
         "created_by": "http://ontology.naas.ai/nexus/createdBy",
         "creates": "http://ontology.naas.ai/nexus/creates",
         "creator": "http://purl.org/dc/terms/creator",
-        "has_participant": "http://ontology.naas.ai/abi/hasParticipant",
         "label": "http://www.w3.org/2000/01/rdf-schema#label",
-        "occupies_temporal_region": "http://ontology.naas.ai/abi/occupiesTemporalRegion",
-        "occurs_in": "http://ontology.naas.ai/abi/occursIn",
-        "realizes": "http://ontology.naas.ai/abi/realizes",
     }
-    _object_properties: ClassVar[set[str]] = {
-        "concretizes",
-        "created_at",
-        "created_by",
-        "creates",
-        "has_participant",
-        "occupies_temporal_region",
-        "occurs_in",
-        "realizes",
-    }
+    _object_properties: ClassVar[set[str]] = {"created_at", "created_by", "creates"}
 
     # Data properties
     label: Optional[Annotated[str, Field(description="Label of the resource.")]] = None
@@ -4205,14 +3889,6 @@ class CreateWorkspace(Process, RDFEntity):
     ] = None
 
     # Object properties
-    concretizes: Optional[
-        Annotated[
-            List[Union[GenericallyDependentContinuant, URIRef, str]],
-            Field(
-                description="b concretizes c =Def b is a process or a specifically dependent continuant & c is a generically dependent continuant & there is some time t such that c is the pattern or content which b shares at t with actual or potential copies"
-            ),
-        ]
-    ] = None
     created_at: Optional[
         Annotated[
             List[Union[TemporalInstant, URIRef, str]],
@@ -4237,36 +3913,6 @@ class CreateWorkspace(Process, RDFEntity):
             ),
         ]
     ] = None
-    has_participant: Optional[
-        Annotated[
-            List[Union[MaterialEntity, Quality, URIRef, str]],
-            Field(description="p has participant c =Def c participates in p"),
-        ]
-    ] = None
-    occupies_temporal_region: Optional[
-        Annotated[
-            List[Union[TemporalRegion, URIRef, str]],
-            Field(
-                description="p occupies temporal region t =Def p is a process or process boundary & the spatiotemporal region occupied by p temporally projects onto t"
-            ),
-        ]
-    ] = None
-    occurs_in: Optional[
-        Annotated[
-            List[Union[Site, URIRef, str]],
-            Field(
-                description="b occurs in c =Def b is a process or a process boundary & c is a material entity or site & there exists a spatiotemporal region r & b occupies spatiotemporal region r & for all time t, if b exists at t then c exists at t & there exist spatial regions s and s' where b spatially projects onto s at t & c occupies spatial region s' at t & s is a continuant part of s' at t"
-            ),
-        ]
-    ] = None
-    realizes: Optional[
-        Annotated[
-            List[Union[Disposition, Role, URIRef, str]],
-            Field(
-                description="(Elucidation) realizes is a relation between a process b and realizable entity c such that c inheres in some d & for all t, if b has participant d then c exists & the type instantiated by b is correlated with the type instantiated by c"
-            ),
-        ]
-    ] = None
 
 
 class AddUserToWorkspace(Process, RDFEntity):
@@ -4277,28 +3923,14 @@ class AddUserToWorkspace(Process, RDFEntity):
     _class_uri: ClassVar[str] = "http://ontology.naas.ai/nexus/AddUserToWorkspace"
     _name: ClassVar[str] = "Add User to Workspace"
     _property_uris: ClassVar[dict] = {
-        "concretizes": "http://ontology.naas.ai/abi/concretizes",
         "created": "http://purl.org/dc/terms/created",
         "created_at": "http://ontology.naas.ai/nexus/createdAt",
         "created_by": "http://ontology.naas.ai/nexus/createdBy",
         "creator": "http://purl.org/dc/terms/creator",
-        "has_participant": "http://ontology.naas.ai/abi/hasParticipant",
         "label": "http://www.w3.org/2000/01/rdf-schema#label",
-        "occupies_temporal_region": "http://ontology.naas.ai/abi/occupiesTemporalRegion",
-        "occurs_in": "http://ontology.naas.ai/abi/occursIn",
-        "realizes": "http://ontology.naas.ai/abi/realizes",
         "updates": "http://ontology.naas.ai/nexus/updates",
     }
-    _object_properties: ClassVar[set[str]] = {
-        "concretizes",
-        "created_at",
-        "created_by",
-        "has_participant",
-        "occupies_temporal_region",
-        "occurs_in",
-        "realizes",
-        "updates",
-    }
+    _object_properties: ClassVar[set[str]] = {"created_at", "created_by", "updates"}
 
     # Data properties
     label: Optional[Annotated[str, Field(description="Label of the resource.")]] = None
@@ -4316,14 +3948,6 @@ class AddUserToWorkspace(Process, RDFEntity):
     ] = None
 
     # Object properties
-    concretizes: Optional[
-        Annotated[
-            List[Union[GenericallyDependentContinuant, URIRef, str]],
-            Field(
-                description="b concretizes c =Def b is a process or a specifically dependent continuant & c is a generically dependent continuant & there is some time t such that c is the pattern or content which b shares at t with actual or potential copies"
-            ),
-        ]
-    ] = None
     created_at: Optional[
         Annotated[
             List[Union[TemporalInstant, URIRef, str]],
@@ -4337,36 +3961,6 @@ class AddUserToWorkspace(Process, RDFEntity):
             List[Union[Person, URIRef, str]],
             Field(
                 description="Relates a platform process to the agent (user or person) who initiated it."
-            ),
-        ]
-    ] = None
-    has_participant: Optional[
-        Annotated[
-            List[Union[MaterialEntity, Quality, URIRef, str]],
-            Field(description="p has participant c =Def c participates in p"),
-        ]
-    ] = None
-    occupies_temporal_region: Optional[
-        Annotated[
-            List[Union[TemporalRegion, URIRef, str]],
-            Field(
-                description="p occupies temporal region t =Def p is a process or process boundary & the spatiotemporal region occupied by p temporally projects onto t"
-            ),
-        ]
-    ] = None
-    occurs_in: Optional[
-        Annotated[
-            List[Union[Site, URIRef, str]],
-            Field(
-                description="b occurs in c =Def b is a process or a process boundary & c is a material entity or site & there exists a spatiotemporal region r & b occupies spatiotemporal region r & for all time t, if b exists at t then c exists at t & there exist spatial regions s and s' where b spatially projects onto s at t & c occupies spatial region s' at t & s is a continuant part of s' at t"
-            ),
-        ]
-    ] = None
-    realizes: Optional[
-        Annotated[
-            List[Union[Disposition, Role, URIRef, str]],
-            Field(
-                description="(Elucidation) realizes is a relation between a process b and realizable entity c such that c inheres in some d & for all t, if b has participant d then c exists & the type instantiated by b is correlated with the type instantiated by c"
             ),
         ]
     ] = None
@@ -4388,29 +3982,21 @@ class Login(Process, RDFEntity):
     _class_uri: ClassVar[str] = "http://ontology.naas.ai/nexus/Login"
     _name: ClassVar[str] = "Login"
     _property_uris: ClassVar[dict] = {
-        "concretizes": "http://ontology.naas.ai/abi/concretizes",
         "created": "http://purl.org/dc/terms/created",
         "created_by": "http://ontology.naas.ai/nexus/createdBy",
         "creates": "http://ontology.naas.ai/nexus/creates",
         "creator": "http://purl.org/dc/terms/creator",
         "event_id": "http://ontology.naas.ai/nexus/event_id",
-        "has_participant": "http://ontology.naas.ai/abi/hasParticipant",
         "initiates_session": "http://ontology.naas.ai/nexus/initiatesSession",
         "label": "http://www.w3.org/2000/01/rdf-schema#label",
         "occupiesTemporalRegion": "http://ontology.naas.ai/abi/occupiesTemporalRegion",
-        "occupies_temporal_region": "http://ontology.naas.ai/abi/occupiesTemporalRegion",
-        "occurs_in": "http://ontology.naas.ai/abi/occursIn",
         "realizes": "http://ontology.naas.ai/nexus/realizes",
     }
     _object_properties: ClassVar[set[str]] = {
-        "concretizes",
         "created_by",
         "creates",
-        "has_participant",
         "initiates_session",
         "occupiesTemporalRegion",
-        "occupies_temporal_region",
-        "occurs_in",
         "realizes",
     }
 
@@ -4438,14 +4024,6 @@ class Login(Process, RDFEntity):
     ] = None
 
     # Object properties
-    concretizes: Optional[
-        Annotated[
-            List[Union[GenericallyDependentContinuant, URIRef, str]],
-            Field(
-                description="b concretizes c =Def b is a process or a specifically dependent continuant & c is a generically dependent continuant & there is some time t such that c is the pattern or content which b shares at t with actual or potential copies"
-            ),
-        ]
-    ] = None
     created_by: Optional[
         Annotated[
             List[Union[URIRef, User, str]],
@@ -4462,12 +4040,6 @@ class Login(Process, RDFEntity):
             ),
         ]
     ] = None
-    has_participant: Optional[
-        Annotated[
-            List[Union[MaterialEntity, Quality, URIRef, str]],
-            Field(description="p has participant c =Def c participates in p"),
-        ]
-    ] = None
     initiates_session: Optional[
         Annotated[
             List[Union[URIRef, VisitSession, str]],
@@ -4478,22 +4050,6 @@ class Login(Process, RDFEntity):
     ] = None
     occupiesTemporalRegion: Optional[
         Annotated[List[Union[LoginInterval, URIRef, str]], Field()]
-    ] = None
-    occupies_temporal_region: Optional[
-        Annotated[
-            List[Union[TemporalRegion, URIRef, str]],
-            Field(
-                description="p occupies temporal region t =Def p is a process or process boundary & the spatiotemporal region occupied by p temporally projects onto t"
-            ),
-        ]
-    ] = None
-    occurs_in: Optional[
-        Annotated[
-            List[Union[Site, URIRef, str]],
-            Field(
-                description="b occurs in c =Def b is a process or a process boundary & c is a material entity or site & there exists a spatiotemporal region r & b occupies spatiotemporal region r & for all time t, if b exists at t then c exists at t & there exist spatial regions s and s' where b spatially projects onto s at t & c occupies spatial region s' at t & s is a continuant part of s' at t"
-            ),
-        ]
     ] = None
     realizes: Optional[
         Annotated[
@@ -4597,6 +4153,77 @@ class LogoutInterval(TemporalRegion, RDFEntity):
     ] = None
 
 
+class MessageProcessingInterval(TemporalRegion, RDFEntity):
+    """
+    Message Processing Interval
+    """
+
+    _class_uri: ClassVar[str] = (
+        "http://ontology.naas.ai/nexus/MessageProcessingInterval"
+    )
+    _name: ClassVar[str] = "Message Processing Interval"
+    _property_uris: ClassVar[dict] = {
+        "created": "http://purl.org/dc/terms/created",
+        "creator": "http://purl.org/dc/terms/creator",
+        "has_first_instant": "http://ontology.naas.ai/abi/hasFirstInstant",
+        "has_last_instant": "http://ontology.naas.ai/abi/hasLastInstant",
+        "label": "http://www.w3.org/2000/01/rdf-schema#label",
+        "processing_ended_at": "http://ontology.naas.ai/nexus/processingEndedAt",
+        "processing_started_at": "http://ontology.naas.ai/nexus/processingStartedAt",
+    }
+    _object_properties: ClassVar[set[str]] = {
+        "has_first_instant",
+        "has_last_instant",
+        "processing_ended_at",
+        "processing_started_at",
+    }
+
+    # Data properties
+    label: Optional[Annotated[str, Field(description="Label of the resource.")]] = None
+    created: Optional[
+        Annotated[
+            datetime.datetime,
+            Field(description="Date of creation of the resource."),
+        ]
+    ] = None
+    creator: Optional[
+        Annotated[
+            Any,
+            Field(description="An entity responsible for making the resource."),
+        ]
+    ] = None
+
+    # Object properties
+    has_first_instant: Optional[
+        Annotated[
+            List[Union[TemporalInstant, URIRef, str]],
+            Field(description="t has first instant t' =Def t' first instant of t"),
+        ]
+    ] = None
+    has_last_instant: Optional[
+        Annotated[
+            List[Union[TemporalInstant, URIRef, str]],
+            Field(description="t has last instant t' =Def t' last instant of t"),
+        ]
+    ] = None
+    processing_ended_at: Optional[
+        Annotated[
+            List[Union[TemporalInstant, URIRef, str]],
+            Field(
+                description="Relates a message-processing interval to the temporal instant at which the agent finished producing the response."
+            ),
+        ]
+    ] = None
+    processing_started_at: Optional[
+        Annotated[
+            List[Union[TemporalInstant, URIRef, str]],
+            Field(
+                description="Relates a message-processing interval to the temporal instant at which the agent began producing the response."
+            ),
+        ]
+    ] = None
+
+
 class VisitSessionInterval(TemporalRegion, RDFEntity):
     """
     Visit Session Interval
@@ -4666,10 +4293,1370 @@ class VisitSessionInterval(TemporalRegion, RDFEntity):
     ] = None
 
 
+class VisitSession(Process, RDFEntity):
+    """
+    Visit Session
+    """
+
+    _class_uri: ClassVar[str] = "http://ontology.naas.ai/nexus/VisitSession"
+    _name: ClassVar[str] = "Visit Session"
+    _property_uris: ClassVar[dict] = {
+        "created": "http://purl.org/dc/terms/created",
+        "creates": "http://ontology.naas.ai/nexus/creates",
+        "creator": "http://purl.org/dc/terms/creator",
+        "event_id": "http://ontology.naas.ai/nexus/event_id",
+        "has_session_interval": "http://ontology.naas.ai/nexus/hasSessionInterval",
+        "label": "http://www.w3.org/2000/01/rdf-schema#label",
+        "occurs_in": "http://ontology.naas.ai/nexus/occursIn",
+        "session_id": "http://ontology.naas.ai/nexus/session_id",
+        "started_by": "http://ontology.naas.ai/nexus/startedBy",
+    }
+    _object_properties: ClassVar[set[str]] = {
+        "creates",
+        "has_session_interval",
+        "occurs_in",
+        "started_by",
+    }
+
+    # Data properties
+    event_id: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The unique identifier of the platform analytics event corresponding to a process instance in the Nexus platform."
+            ),
+        ]
+    ] = None
+    session_id: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The unique identifier of a platform session artifact or visit-session process in the Nexus platform."
+            ),
+        ]
+    ] = None
+    label: Optional[Annotated[str, Field(description="Label of the resource.")]] = None
+    created: Optional[
+        Annotated[
+            datetime.datetime,
+            Field(description="Date of creation of the resource."),
+        ]
+    ] = None
+    creator: Optional[
+        Annotated[
+            Any,
+            Field(description="An entity responsible for making the resource."),
+        ]
+    ] = None
+
+    # Object properties
+    creates: Optional[
+        Annotated[
+            List[Union[Session, URIRef, str]],
+            Field(
+                description="Relates a platform process performed in the application to a generically dependent continuant artifact it creates."
+            ),
+        ]
+    ] = None
+    has_session_interval: Optional[
+        Annotated[
+            List[Union[URIRef, VisitSessionInterval, str]],
+            Field(
+                description="Relates a visit-session process to the temporal interval that bounds its start and end."
+            ),
+        ]
+    ] = None
+    occurs_in: Optional[
+        Annotated[
+            List[Union[URIRef, UserSite, str]],
+            Field(
+                description="Relates a process (such as a page view or visit session) to the user-side site context (country, device, browser) in which it occurs."
+            ),
+        ]
+    ] = None
+    started_by: Optional[
+        Annotated[
+            List[Union[URIRef, User, str]],
+            Field(
+                description="Relates a visit-session process to the user account that started it."
+            ),
+        ]
+    ] = None
+
+
+class PageView(Process, RDFEntity):
+    """
+    Page View
+    """
+
+    _class_uri: ClassVar[str] = "http://ontology.naas.ai/nexus/PageView"
+    _name: ClassVar[str] = "Page View"
+    _property_uris: ClassVar[dict] = {
+        "created": "http://purl.org/dc/terms/created",
+        "creator": "http://purl.org/dc/terms/creator",
+        "event_id": "http://ontology.naas.ai/nexus/event_id",
+        "has_visited_page": "http://ontology.naas.ai/nexus/hasVisitedPage",
+        "label": "http://www.w3.org/2000/01/rdf-schema#label",
+        "occurs_during_session": "http://ontology.naas.ai/nexus/occursDuringSession",
+        "occurs_in": "http://ontology.naas.ai/nexus/occursIn",
+        "occurs_in_workspace": "http://ontology.naas.ai/nexus/occursInWorkspace",
+        "referrer": "http://ontology.naas.ai/nexus/referrer",
+        "viewed_at": "http://ontology.naas.ai/nexus/viewedAt",
+        "viewed_by": "http://ontology.naas.ai/nexus/viewedBy",
+    }
+    _object_properties: ClassVar[set[str]] = {
+        "has_visited_page",
+        "occurs_during_session",
+        "occurs_in",
+        "occurs_in_workspace",
+        "viewed_at",
+        "viewed_by",
+    }
+
+    # Data properties
+    event_id: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The unique identifier of the platform analytics event corresponding to a process instance in the Nexus platform."
+            ),
+        ]
+    ] = None
+    referrer: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The HTTP referrer (originating page or host) recorded at the time of a page-view process."
+            ),
+        ]
+    ] = None
+    label: Optional[Annotated[str, Field(description="Label of the resource.")]] = None
+    created: Optional[
+        Annotated[
+            datetime.datetime,
+            Field(description="Date of creation of the resource."),
+        ]
+    ] = None
+    creator: Optional[
+        Annotated[
+            Any,
+            Field(description="An entity responsible for making the resource."),
+        ]
+    ] = None
+
+    # Object properties
+    has_visited_page: Optional[
+        Annotated[
+            List[Union[Page, URIRef, str]],
+            Field(
+                description="Relates a page-view process to the page artifact (generically dependent continuant) that the user viewed during that process."
+            ),
+        ]
+    ] = None
+    occurs_during_session: Optional[
+        Annotated[
+            List[Union[URIRef, VisitSession, str]],
+            Field(
+                description="Relates a page-view process to the visit session of which it is a temporal part."
+            ),
+        ]
+    ] = None
+    occurs_in: Optional[
+        Annotated[
+            List[Union[URIRef, UserSite, str]],
+            Field(
+                description="Relates a process (such as a page view or visit session) to the user-side site context (country, device, browser) in which it occurs."
+            ),
+        ]
+    ] = None
+    occurs_in_workspace: Optional[
+        Annotated[
+            List[Union[URIRef, Workspace, str]],
+            Field(
+                description="Relates a platform process (such as a page view or visit session) to the workspace generic context in which it occurs."
+            ),
+        ]
+    ] = None
+    viewed_at: Optional[
+        Annotated[
+            List[Union[TemporalInstant, URIRef, str]],
+            Field(
+                description="Relates a page-view process to the temporal instant at which the view occurred."
+            ),
+        ]
+    ] = None
+    viewed_by: Optional[
+        Annotated[
+            List[Union[URIRef, User, str]],
+            Field(
+                description="Relates a page-view process to the user account that participates in it."
+            ),
+        ]
+    ] = None
+
+
+class Logout(Process, RDFEntity):
+    """
+    Logout
+    """
+
+    _class_uri: ClassVar[str] = "http://ontology.naas.ai/nexus/Logout"
+    _name: ClassVar[str] = "Logout"
+    _property_uris: ClassVar[dict] = {
+        "created": "http://purl.org/dc/terms/created",
+        "created_by": "http://ontology.naas.ai/nexus/createdBy",
+        "creator": "http://purl.org/dc/terms/creator",
+        "event_id": "http://ontology.naas.ai/nexus/event_id",
+        "label": "http://www.w3.org/2000/01/rdf-schema#label",
+        "occupiesTemporalRegion": "http://ontology.naas.ai/abi/occupiesTemporalRegion",
+        "terminates": "http://ontology.naas.ai/nexus/terminates",
+        "terminates_session": "http://ontology.naas.ai/nexus/terminatesSession",
+    }
+    _object_properties: ClassVar[set[str]] = {
+        "created_by",
+        "occupiesTemporalRegion",
+        "terminates",
+        "terminates_session",
+    }
+
+    # Data properties
+    event_id: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The unique identifier of the platform analytics event corresponding to a process instance in the Nexus platform."
+            ),
+        ]
+    ] = None
+    label: Optional[Annotated[str, Field(description="Label of the resource.")]] = None
+    created: Optional[
+        Annotated[
+            datetime.datetime,
+            Field(description="Date of creation of the resource."),
+        ]
+    ] = None
+    creator: Optional[
+        Annotated[
+            Any,
+            Field(description="An entity responsible for making the resource."),
+        ]
+    ] = None
+
+    # Object properties
+    created_by: Optional[
+        Annotated[
+            List[Union[URIRef, User, str]],
+            Field(
+                description="Relates a platform process to the agent (user or person) who initiated it."
+            ),
+        ]
+    ] = None
+    occupiesTemporalRegion: Optional[
+        Annotated[List[Union[LogoutInterval, URIRef, str]], Field()]
+    ] = None
+    terminates: Optional[
+        Annotated[
+            List[Union[Session, URIRef, str]],
+            Field(
+                description="Relates a logout process to the session artifact it terminates."
+            ),
+        ]
+    ] = None
+    terminates_session: Optional[
+        Annotated[
+            List[Union[URIRef, VisitSession, str]],
+            Field(
+                description="Relates a logout process to the visit session it terminates."
+            ),
+        ]
+    ] = None
+
+
+class Status(Quality, RDFEntity):
+    """
+    Status
+    """
+
+    _class_uri: ClassVar[str] = "http://ontology.naas.ai/nexus/Status"
+    _name: ClassVar[str] = "Status"
+    _property_uris: ClassVar[dict] = {
+        "concretizes": "http://ontology.naas.ai/abi/concretizes",
+        "created": "http://purl.org/dc/terms/created",
+        "creator": "http://purl.org/dc/terms/creator",
+        "inheres_in": "http://ontology.naas.ai/abi/inheresIn",
+        "is_status_of": "http://ontology.naas.ai/nexus/isStatusOf",
+        "label": "http://www.w3.org/2000/01/rdf-schema#label",
+        "participates_in": "http://ontology.naas.ai/abi/participatesIn",
+    }
+    _object_properties: ClassVar[set[str]] = {
+        "concretizes",
+        "inheres_in",
+        "is_status_of",
+        "participates_in",
+    }
+
+    # Data properties
+    label: Optional[Annotated[str, Field(description="Label of the resource.")]] = None
+    created: Optional[
+        Annotated[
+            datetime.datetime,
+            Field(description="Date of creation of the resource."),
+        ]
+    ] = None
+    creator: Optional[
+        Annotated[
+            Any,
+            Field(description="An entity responsible for making the resource."),
+        ]
+    ] = None
+
+    # Object properties
+    concretizes: Optional[
+        Annotated[
+            List[Union[GenericallyDependentContinuant, URIRef, str]],
+            Field(
+                description="b concretizes c =Def b is a process or a specifically dependent continuant & c is a generically dependent continuant & there is some time t such that c is the pattern or content which b shares at t with actual or potential copies"
+            ),
+        ]
+    ] = None
+    inheres_in: Optional[
+        Annotated[
+            List[Union[MaterialEntity, URIRef, str]],
+            Field(
+                description="b inheres in c =Def b is a specifically dependent continuant & c is an independent continuant that is not a spatial region & b specifically depends on c"
+            ),
+        ]
+    ] = None
+    is_status_of: Optional[
+        Annotated[
+            List[Union[GenericallyDependentContinuant, URIRef, str]],
+            Field(
+                description="Relates a status quality to the platform artifact in which it inheres."
+            ),
+        ]
+    ] = None
+    participates_in: Optional[
+        Annotated[
+            List[Union[Process, URIRef, str]],
+            Field(
+                description="(Elucidation) participates in holds between some b that is either a specifically dependent continuant or generically dependent continuant or independent continuant that is not a spatial region & some process p such that b participates in p some way"
+            ),
+        ]
+    ] = None
+
+
+class UserPromptRole(MessageRole, RDFEntity):
+    """
+    User Prompt Role
+    """
+
+    _class_uri: ClassVar[str] = "http://ontology.naas.ai/nexus/UserPromptRole"
+    _name: ClassVar[str] = "User Prompt Role"
+    _property_uris: ClassVar[dict] = {
+        "concretizes": "http://ontology.naas.ai/abi/concretizes",
+        "created": "http://purl.org/dc/terms/created",
+        "creator": "http://purl.org/dc/terms/creator",
+        "has_realization": "http://ontology.naas.ai/abi/hasRealization",
+        "inheres_in": "http://ontology.naas.ai/abi/inheresIn",
+        "is_message_role_of": "http://ontology.naas.ai/nexus/isMessageRoleOf",
+        "label": "http://www.w3.org/2000/01/rdf-schema#label",
+    }
+    _object_properties: ClassVar[set[str]] = {
+        "concretizes",
+        "has_realization",
+        "inheres_in",
+        "is_message_role_of",
+    }
+
+    # Data properties
+    label: Optional[Annotated[str, Field(description="Label of the resource.")]] = None
+    created: Optional[
+        Annotated[
+            datetime.datetime,
+            Field(description="Date of creation of the resource."),
+        ]
+    ] = None
+    creator: Optional[
+        Annotated[
+            Any,
+            Field(description="An entity responsible for making the resource."),
+        ]
+    ] = None
+
+    # Object properties
+    concretizes: Optional[
+        Annotated[
+            List[Union[GenericallyDependentContinuant, URIRef, str]],
+            Field(
+                description="b concretizes c =Def b is a process or a specifically dependent continuant & c is a generically dependent continuant & there is some time t such that c is the pattern or content which b shares at t with actual or potential copies"
+            ),
+        ]
+    ] = None
+    has_realization: Optional[
+        Annotated[
+            List[Union[Process, URIRef, str]],
+            Field(description="b has realization c =Def c realizes b"),
+        ]
+    ] = None
+    inheres_in: Optional[
+        Annotated[
+            List[Union[MaterialEntity, URIRef, str]],
+            Field(
+                description="b inheres in c =Def b is a specifically dependent continuant & c is an independent continuant that is not a spatial region & b specifically depends on c"
+            ),
+        ]
+    ] = None
+    is_message_role_of: Optional[
+        Annotated[
+            List[Union[Message, URIRef, str]],
+            Field(
+                description="Relates a message role to the message of which it is the role-side concretization."
+            ),
+        ]
+    ] = None
+
+
+class AgentResponseRole(MessageRole, RDFEntity):
+    """
+    Agent Response Role
+    """
+
+    _class_uri: ClassVar[str] = "http://ontology.naas.ai/nexus/AgentResponseRole"
+    _name: ClassVar[str] = "Agent Response Role"
+    _property_uris: ClassVar[dict] = {
+        "concretizes": "http://ontology.naas.ai/abi/concretizes",
+        "created": "http://purl.org/dc/terms/created",
+        "creator": "http://purl.org/dc/terms/creator",
+        "has_realization": "http://ontology.naas.ai/abi/hasRealization",
+        "inheres_in": "http://ontology.naas.ai/abi/inheresIn",
+        "is_message_role_of": "http://ontology.naas.ai/nexus/isMessageRoleOf",
+        "label": "http://www.w3.org/2000/01/rdf-schema#label",
+    }
+    _object_properties: ClassVar[set[str]] = {
+        "concretizes",
+        "has_realization",
+        "inheres_in",
+        "is_message_role_of",
+    }
+
+    # Data properties
+    label: Optional[Annotated[str, Field(description="Label of the resource.")]] = None
+    created: Optional[
+        Annotated[
+            datetime.datetime,
+            Field(description="Date of creation of the resource."),
+        ]
+    ] = None
+    creator: Optional[
+        Annotated[
+            Any,
+            Field(description="An entity responsible for making the resource."),
+        ]
+    ] = None
+
+    # Object properties
+    concretizes: Optional[
+        Annotated[
+            List[Union[GenericallyDependentContinuant, URIRef, str]],
+            Field(
+                description="b concretizes c =Def b is a process or a specifically dependent continuant & c is a generically dependent continuant & there is some time t such that c is the pattern or content which b shares at t with actual or potential copies"
+            ),
+        ]
+    ] = None
+    has_realization: Optional[
+        Annotated[
+            List[Union[Process, URIRef, str]],
+            Field(description="b has realization c =Def c realizes b"),
+        ]
+    ] = None
+    inheres_in: Optional[
+        Annotated[
+            List[Union[MaterialEntity, URIRef, str]],
+            Field(
+                description="b inheres in c =Def b is a specifically dependent continuant & c is an independent continuant that is not a spatial region & b specifically depends on c"
+            ),
+        ]
+    ] = None
+    is_message_role_of: Optional[
+        Annotated[
+            List[Union[Message, URIRef, str]],
+            Field(
+                description="Relates a message role to the message of which it is the role-side concretization."
+            ),
+        ]
+    ] = None
+
+
+class CreateConversation(LogProcess, Process, RDFEntity):
+    """
+    Create Conversation
+    """
+
+    _class_uri: ClassVar[str] = "http://ontology.naas.ai/nexus/CreateConversation"
+    _name: ClassVar[str] = "Create Conversation"
+    _property_uris: ClassVar[dict] = {
+        "agent": "http://ontology.naas.ai/nexus/agent",
+        "conversation_id": "http://ontology.naas.ai/nexus/conversation_id",
+        "created": "http://purl.org/dc/terms/created",
+        "created_at": "http://ontology.naas.ai/nexus/createdAt",
+        "created_by": "http://ontology.naas.ai/nexus/createdBy",
+        "creates": "http://ontology.naas.ai/nexus/creates",
+        "creator": "http://purl.org/dc/terms/creator",
+        "label": "http://www.w3.org/2000/01/rdf-schema#label",
+        "occurs_in": "http://ontology.naas.ai/nexus/occursIn",
+        "occurs_in_workspace": "http://ontology.naas.ai/nexus/occursInWorkspace",
+        "realizes": "http://ontology.naas.ai/abi/realizes",
+        "sent_by": "http://ontology.naas.ai/nexus/sentBy",
+        "title": "http://ontology.naas.ai/nexus/title",
+        "user_id": "http://ontology.naas.ai/nexus/user_id",
+        "workspace_id": "http://ontology.naas.ai/nexus/workspace_id",
+    }
+    _object_properties: ClassVar[set[str]] = {
+        "created_at",
+        "created_by",
+        "creates",
+        "occurs_in",
+        "occurs_in_workspace",
+        "realizes",
+        "sent_by",
+    }
+
+    # Data properties
+    user_id: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The unique identifier of the user account in the Nexus platform."
+            ),
+        ]
+    ] = None
+    workspace_id: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The unique identifier of a workspace in the Nexus platform."
+            ),
+        ]
+    ] = None
+    conversation_id: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The unique identifier of a conversation artifact in the Nexus platform."
+            ),
+        ]
+    ] = None
+    agent: Optional[
+        Annotated[
+            str,
+            Field(
+                description="Identifier of the agent associated with a conversation or message in the Nexus platform."
+            ),
+        ]
+    ] = None
+    title: Optional[
+        Annotated[
+            str,
+            Field(description="Display title of a conversation in the Nexus platform."),
+        ]
+    ] = None
+    label: Optional[Annotated[str, Field(description="Label of the resource.")]] = None
+    created: Optional[
+        Annotated[
+            datetime.datetime,
+            Field(description="Date of creation of the resource."),
+        ]
+    ] = None
+    creator: Optional[
+        Annotated[
+            Any,
+            Field(description="An entity responsible for making the resource."),
+        ]
+    ] = None
+
+    # Object properties
+    created_at: Optional[
+        Annotated[
+            List[Union[TemporalInstant, URIRef, str]],
+            Field(
+                description="Relates a platform process to the temporal instant at which it occurred."
+            ),
+        ]
+    ] = None
+    created_by: Optional[
+        Annotated[
+            List[Union[Person, URIRef, str]],
+            Field(
+                description="Relates a platform process to the agent (user or person) who initiated it."
+            ),
+        ]
+    ] = None
+    creates: Optional[
+        Annotated[
+            List[Union[Conversation, URIRef, str]],
+            Field(
+                description="Relates a platform process performed in the application to a generically dependent continuant artifact it creates."
+            ),
+        ]
+    ] = None
+    occurs_in: Optional[
+        Annotated[
+            List[Union[URIRef, UserSite, str]],
+            Field(
+                description="Relates a process (such as a page view or visit session) to the user-side site context (country, device, browser) in which it occurs."
+            ),
+        ]
+    ] = None
+    occurs_in_workspace: Optional[
+        Annotated[
+            List[Union[URIRef, Workspace, str]],
+            Field(
+                description="Relates a platform process (such as a page view or visit session) to the workspace generic context in which it occurs."
+            ),
+        ]
+    ] = None
+    realizes: Optional[
+        Annotated[List[Union[ConversationRole, URIRef, str]], Field()]
+    ] = None
+    sent_by: Optional[
+        Annotated[
+            List[Union[URIRef, User, str]],
+            Field(
+                description="Relates a message-creation process to the user account that participates in it as sender."
+            ),
+        ]
+    ] = None
+
+
+class CreateMessage(LogProcess, Process, RDFEntity):
+    """
+    Create Message
+    """
+
+    _class_uri: ClassVar[str] = "http://ontology.naas.ai/nexus/CreateMessage"
+    _name: ClassVar[str] = "Create Message"
+    _property_uris: ClassVar[dict] = {
+        "agent": "http://ontology.naas.ai/nexus/agent",
+        "content": "http://ontology.naas.ai/nexus/content",
+        "conversation_id": "http://ontology.naas.ai/nexus/conversation_id",
+        "created": "http://purl.org/dc/terms/created",
+        "created_at": "http://ontology.naas.ai/abi/createdAt",
+        "creates": "http://ontology.naas.ai/nexus/creates",
+        "creator": "http://purl.org/dc/terms/creator",
+        "label": "http://www.w3.org/2000/01/rdf-schema#label",
+        "message_id": "http://ontology.naas.ai/nexus/message_id",
+        "occurs_in_conversation": "http://ontology.naas.ai/nexus/occursInConversation",
+        "occurs_in_workspace": "http://ontology.naas.ai/nexus/occursInWorkspace",
+        "realizes": "http://ontology.naas.ai/abi/realizes",
+        "role": "http://ontology.naas.ai/nexus/role",
+        "user_id": "http://ontology.naas.ai/nexus/user_id",
+        "workspace_id": "http://ontology.naas.ai/nexus/workspace_id",
+    }
+    _object_properties: ClassVar[set[str]] = {
+        "creates",
+        "occurs_in_conversation",
+        "occurs_in_workspace",
+        "realizes",
+    }
+
+    # Data properties
+    user_id: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The unique identifier of the user account in the Nexus platform."
+            ),
+        ]
+    ] = None
+    workspace_id: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The unique identifier of a workspace in the Nexus platform."
+            ),
+        ]
+    ] = None
+    conversation_id: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The unique identifier of a conversation artifact in the Nexus platform."
+            ),
+        ]
+    ] = None
+    message_id: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The unique identifier of a message artifact in the Nexus platform."
+            ),
+        ]
+    ] = None
+    role: Optional[
+        Annotated[
+            str,
+            Field(
+                description="Role of the message author within a conversation (user, assistant, system)."
+            ),
+        ]
+    ] = None
+    content: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The textual content of a message in the Nexus platform."
+            ),
+        ]
+    ] = None
+    agent: Optional[
+        Annotated[
+            str,
+            Field(
+                description="Identifier of the agent associated with a conversation or message in the Nexus platform."
+            ),
+        ]
+    ] = None
+    created_at: Optional[
+        Annotated[
+            datetime.datetime,
+            Field(
+                description="ISO 8601 timestamp at which the event occurred. Populated by EventService.publish() if not set by the caller."
+            ),
+        ]
+    ] = None
+    label: Optional[Annotated[str, Field(description="Label of the resource.")]] = None
+    created: Optional[
+        Annotated[
+            datetime.datetime,
+            Field(description="Date of creation of the resource."),
+        ]
+    ] = None
+    creator: Optional[
+        Annotated[
+            Any,
+            Field(description="An entity responsible for making the resource."),
+        ]
+    ] = None
+
+    # Object properties
+    creates: Optional[
+        Annotated[
+            List[Union[Message, URIRef, str]],
+            Field(
+                description="Relates a platform process performed in the application to a generically dependent continuant artifact it creates."
+            ),
+        ]
+    ] = None
+    occurs_in_conversation: Optional[
+        Annotated[
+            List[Union[Conversation, URIRef, str]],
+            Field(
+                description="Relates a platform process (such as a message creation) to the conversation generic context in which it occurs."
+            ),
+        ]
+    ] = None
+    occurs_in_workspace: Optional[
+        Annotated[
+            List[Union[URIRef, Workspace, str]],
+            Field(
+                description="Relates a platform process (such as a page view or visit session) to the workspace generic context in which it occurs."
+            ),
+        ]
+    ] = None
+    realizes: Optional[Annotated[List[Union[MessageRole, URIRef, str]], Field()]] = None
+
+
+class UpdateConversation(LogProcess, Process, RDFEntity):
+    """
+    Update Conversation
+    """
+
+    _class_uri: ClassVar[str] = "http://ontology.naas.ai/nexus/UpdateConversation"
+    _name: ClassVar[str] = "Update Conversation"
+    _property_uris: ClassVar[dict] = {
+        "agent": "http://ontology.naas.ai/nexus/agent",
+        "conversation_id": "http://ontology.naas.ai/nexus/conversation_id",
+        "created": "http://purl.org/dc/terms/created",
+        "created_at": "http://ontology.naas.ai/abi/createdAt",
+        "creator": "http://purl.org/dc/terms/creator",
+        "label": "http://www.w3.org/2000/01/rdf-schema#label",
+        "title": "http://ontology.naas.ai/nexus/title",
+        "user_id": "http://ontology.naas.ai/nexus/user_id",
+        "workspace_id": "http://ontology.naas.ai/nexus/workspace_id",
+    }
+    _object_properties: ClassVar[set[str]] = set()
+
+    # Data properties
+    user_id: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The unique identifier of the user account in the Nexus platform."
+            ),
+        ]
+    ] = None
+    workspace_id: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The unique identifier of a workspace in the Nexus platform."
+            ),
+        ]
+    ] = None
+    conversation_id: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The unique identifier of a conversation artifact in the Nexus platform."
+            ),
+        ]
+    ] = None
+    agent: Optional[
+        Annotated[
+            str,
+            Field(
+                description="Identifier of the agent associated with a conversation or message in the Nexus platform."
+            ),
+        ]
+    ] = None
+    title: Optional[
+        Annotated[
+            str,
+            Field(description="Display title of a conversation in the Nexus platform."),
+        ]
+    ] = None
+    created_at: Optional[
+        Annotated[
+            datetime.datetime,
+            Field(
+                description="ISO 8601 timestamp at which the event occurred. Populated by EventService.publish() if not set by the caller."
+            ),
+        ]
+    ] = None
+    label: Optional[Annotated[str, Field(description="Label of the resource.")]] = None
+    created: Optional[
+        Annotated[
+            datetime.datetime,
+            Field(description="Date of creation of the resource."),
+        ]
+    ] = None
+    creator: Optional[
+        Annotated[
+            Any,
+            Field(description="An entity responsible for making the resource."),
+        ]
+    ] = None
+
+
+class DeleteConversation(LogProcess, Process, RDFEntity):
+    """
+    Delete Conversation
+    """
+
+    _class_uri: ClassVar[str] = "http://ontology.naas.ai/nexus/DeleteConversation"
+    _name: ClassVar[str] = "Delete Conversation"
+    _property_uris: ClassVar[dict] = {
+        "conversation_id": "http://ontology.naas.ai/nexus/conversation_id",
+        "created": "http://purl.org/dc/terms/created",
+        "created_at": "http://ontology.naas.ai/abi/createdAt",
+        "creator": "http://purl.org/dc/terms/creator",
+        "label": "http://www.w3.org/2000/01/rdf-schema#label",
+        "user_id": "http://ontology.naas.ai/nexus/user_id",
+        "workspace_id": "http://ontology.naas.ai/nexus/workspace_id",
+    }
+    _object_properties: ClassVar[set[str]] = set()
+
+    # Data properties
+    user_id: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The unique identifier of the user account in the Nexus platform."
+            ),
+        ]
+    ] = None
+    workspace_id: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The unique identifier of a workspace in the Nexus platform."
+            ),
+        ]
+    ] = None
+    conversation_id: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The unique identifier of a conversation artifact in the Nexus platform."
+            ),
+        ]
+    ] = None
+    created_at: Optional[
+        Annotated[
+            datetime.datetime,
+            Field(
+                description="ISO 8601 timestamp at which the event occurred. Populated by EventService.publish() if not set by the caller."
+            ),
+        ]
+    ] = None
+    label: Optional[Annotated[str, Field(description="Label of the resource.")]] = None
+    created: Optional[
+        Annotated[
+            datetime.datetime,
+            Field(description="Date of creation of the resource."),
+        ]
+    ] = None
+    creator: Optional[
+        Annotated[
+            Any,
+            Field(description="An entity responsible for making the resource."),
+        ]
+    ] = None
+
+
+class UpdateMessage(LogProcess, Process, RDFEntity):
+    """
+    Update Message
+    """
+
+    _class_uri: ClassVar[str] = "http://ontology.naas.ai/nexus/UpdateMessage"
+    _name: ClassVar[str] = "Update Message"
+    _property_uris: ClassVar[dict] = {
+        "agent": "http://ontology.naas.ai/nexus/agent",
+        "content": "http://ontology.naas.ai/nexus/content",
+        "conversation_id": "http://ontology.naas.ai/nexus/conversation_id",
+        "created": "http://purl.org/dc/terms/created",
+        "created_at": "http://ontology.naas.ai/abi/createdAt",
+        "creator": "http://purl.org/dc/terms/creator",
+        "label": "http://www.w3.org/2000/01/rdf-schema#label",
+        "message_id": "http://ontology.naas.ai/nexus/message_id",
+        "role": "http://ontology.naas.ai/nexus/role",
+        "user_id": "http://ontology.naas.ai/nexus/user_id",
+        "workspace_id": "http://ontology.naas.ai/nexus/workspace_id",
+    }
+    _object_properties: ClassVar[set[str]] = set()
+
+    # Data properties
+    user_id: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The unique identifier of the user account in the Nexus platform."
+            ),
+        ]
+    ] = None
+    workspace_id: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The unique identifier of a workspace in the Nexus platform."
+            ),
+        ]
+    ] = None
+    conversation_id: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The unique identifier of a conversation artifact in the Nexus platform."
+            ),
+        ]
+    ] = None
+    message_id: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The unique identifier of a message artifact in the Nexus platform."
+            ),
+        ]
+    ] = None
+    role: Optional[
+        Annotated[
+            str,
+            Field(
+                description="Role of the message author within a conversation (user, assistant, system)."
+            ),
+        ]
+    ] = None
+    content: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The textual content of a message in the Nexus platform."
+            ),
+        ]
+    ] = None
+    agent: Optional[
+        Annotated[
+            str,
+            Field(
+                description="Identifier of the agent associated with a conversation or message in the Nexus platform."
+            ),
+        ]
+    ] = None
+    created_at: Optional[
+        Annotated[
+            datetime.datetime,
+            Field(
+                description="ISO 8601 timestamp at which the event occurred. Populated by EventService.publish() if not set by the caller."
+            ),
+        ]
+    ] = None
+    label: Optional[Annotated[str, Field(description="Label of the resource.")]] = None
+    created: Optional[
+        Annotated[
+            datetime.datetime,
+            Field(description="Date of creation of the resource."),
+        ]
+    ] = None
+    creator: Optional[
+        Annotated[
+            Any,
+            Field(description="An entity responsible for making the resource."),
+        ]
+    ] = None
+
+
+class SendUserPrompt(CreateMessage, RDFEntity):
+    """
+    Send User Prompt
+    """
+
+    _class_uri: ClassVar[str] = "http://ontology.naas.ai/nexus/SendUserPrompt"
+    _name: ClassVar[str] = "Send User Prompt"
+    _property_uris: ClassVar[dict] = {
+        "agent": "http://ontology.naas.ai/nexus/agent",
+        "content": "http://ontology.naas.ai/nexus/content",
+        "conversation_id": "http://ontology.naas.ai/nexus/conversation_id",
+        "created": "http://purl.org/dc/terms/created",
+        "created_at": "http://ontology.naas.ai/abi/createdAt",
+        "created_by": "http://ontology.naas.ai/nexus/createdBy",
+        "creates": "http://ontology.naas.ai/nexus/creates",
+        "creator": "http://purl.org/dc/terms/creator",
+        "label": "http://www.w3.org/2000/01/rdf-schema#label",
+        "message_id": "http://ontology.naas.ai/nexus/message_id",
+        "occurs_in": "http://ontology.naas.ai/nexus/occursIn",
+        "occurs_in_conversation": "http://ontology.naas.ai/nexus/occursInConversation",
+        "occurs_in_workspace": "http://ontology.naas.ai/nexus/occursInWorkspace",
+        "realizes": "http://ontology.naas.ai/abi/realizes",
+        "role": "http://ontology.naas.ai/nexus/role",
+        "sent_at": "http://ontology.naas.ai/nexus/sentAt",
+        "sent_by": "http://ontology.naas.ai/nexus/sentBy",
+        "user_id": "http://ontology.naas.ai/nexus/user_id",
+        "workspace_id": "http://ontology.naas.ai/nexus/workspace_id",
+    }
+    _object_properties: ClassVar[set[str]] = {
+        "created_by",
+        "creates",
+        "occurs_in",
+        "occurs_in_conversation",
+        "occurs_in_workspace",
+        "realizes",
+        "sent_at",
+        "sent_by",
+    }
+
+    # Data properties
+    user_id: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The unique identifier of the user account in the Nexus platform."
+            ),
+        ]
+    ] = None
+    workspace_id: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The unique identifier of a workspace in the Nexus platform."
+            ),
+        ]
+    ] = None
+    conversation_id: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The unique identifier of a conversation artifact in the Nexus platform."
+            ),
+        ]
+    ] = None
+    message_id: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The unique identifier of a message artifact in the Nexus platform."
+            ),
+        ]
+    ] = None
+    role: Optional[
+        Annotated[
+            str,
+            Field(
+                description="Role of the message author within a conversation (user, assistant, system)."
+            ),
+        ]
+    ] = None
+    content: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The textual content of a message in the Nexus platform."
+            ),
+        ]
+    ] = None
+    agent: Optional[
+        Annotated[
+            str,
+            Field(
+                description="Identifier of the agent associated with a conversation or message in the Nexus platform."
+            ),
+        ]
+    ] = None
+    created_at: Optional[
+        Annotated[
+            datetime.datetime,
+            Field(
+                description="ISO 8601 timestamp at which the event occurred. Populated by EventService.publish() if not set by the caller."
+            ),
+        ]
+    ] = None
+    label: Optional[Annotated[str, Field(description="Label of the resource.")]] = None
+    created: Optional[
+        Annotated[
+            datetime.datetime,
+            Field(description="Date of creation of the resource."),
+        ]
+    ] = None
+    creator: Optional[
+        Annotated[
+            Any,
+            Field(description="An entity responsible for making the resource."),
+        ]
+    ] = None
+
+    # Object properties
+    created_by: Optional[
+        Annotated[
+            List[Union[Person, URIRef, str]],
+            Field(
+                description="Relates a platform process to the agent (user or person) who initiated it."
+            ),
+        ]
+    ] = None
+    creates: Optional[
+        Annotated[
+            List[Union[Message, URIRef, str]],
+            Field(
+                description="Relates a platform process performed in the application to a generically dependent continuant artifact it creates."
+            ),
+        ]
+    ] = None
+    occurs_in: Optional[
+        Annotated[
+            List[Union[URIRef, UserSite, str]],
+            Field(
+                description="Relates a process (such as a page view or visit session) to the user-side site context (country, device, browser) in which it occurs."
+            ),
+        ]
+    ] = None
+    occurs_in_conversation: Optional[
+        Annotated[
+            List[Union[Conversation, URIRef, str]],
+            Field(
+                description="Relates a platform process (such as a message creation) to the conversation generic context in which it occurs."
+            ),
+        ]
+    ] = None
+    occurs_in_workspace: Optional[
+        Annotated[
+            List[Union[URIRef, Workspace, str]],
+            Field(
+                description="Relates a platform process (such as a page view or visit session) to the workspace generic context in which it occurs."
+            ),
+        ]
+    ] = None
+    realizes: Optional[Annotated[List[Union[URIRef, UserPromptRole, str]], Field()]] = (
+        None
+    )
+    sent_at: Optional[
+        Annotated[
+            List[Union[TemporalInstant, URIRef, str]],
+            Field(
+                description="Relates a user message-creation process to the temporal instant at which the message was sent by the user."
+            ),
+        ]
+    ] = None
+    sent_by: Optional[
+        Annotated[
+            List[Union[URIRef, User, str]],
+            Field(
+                description="Relates a message-creation process to the user account that participates in it as sender."
+            ),
+        ]
+    ] = None
+
+
+class SendAgentResponse(CreateMessage, RDFEntity):
+    """
+    Send Agent Response
+    """
+
+    _class_uri: ClassVar[str] = "http://ontology.naas.ai/nexus/SendAgentResponse"
+    _name: ClassVar[str] = "Send Agent Response"
+    _property_uris: ClassVar[dict] = {
+        "agent": "http://ontology.naas.ai/nexus/agent",
+        "content": "http://ontology.naas.ai/nexus/content",
+        "conversation_id": "http://ontology.naas.ai/nexus/conversation_id",
+        "created": "http://purl.org/dc/terms/created",
+        "created_at": "http://ontology.naas.ai/abi/createdAt",
+        "creates": "http://ontology.naas.ai/nexus/creates",
+        "creator": "http://purl.org/dc/terms/creator",
+        "label": "http://www.w3.org/2000/01/rdf-schema#label",
+        "message_id": "http://ontology.naas.ai/nexus/message_id",
+        "occurs_in_conversation": "http://ontology.naas.ai/nexus/occursInConversation",
+        "occurs_in_workspace": "http://ontology.naas.ai/nexus/occursInWorkspace",
+        "processed_by": "http://ontology.naas.ai/nexus/processedBy",
+        "processed_during": "http://ontology.naas.ai/nexus/processedDuring",
+        "realizes": "http://ontology.naas.ai/abi/realizes",
+        "role": "http://ontology.naas.ai/nexus/role",
+        "user_id": "http://ontology.naas.ai/nexus/user_id",
+        "workspace_id": "http://ontology.naas.ai/nexus/workspace_id",
+    }
+    _object_properties: ClassVar[set[str]] = {
+        "creates",
+        "occurs_in_conversation",
+        "occurs_in_workspace",
+        "processed_by",
+        "processed_during",
+        "realizes",
+    }
+
+    # Data properties
+    user_id: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The unique identifier of the user account in the Nexus platform."
+            ),
+        ]
+    ] = None
+    workspace_id: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The unique identifier of a workspace in the Nexus platform."
+            ),
+        ]
+    ] = None
+    conversation_id: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The unique identifier of a conversation artifact in the Nexus platform."
+            ),
+        ]
+    ] = None
+    message_id: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The unique identifier of a message artifact in the Nexus platform."
+            ),
+        ]
+    ] = None
+    role: Optional[
+        Annotated[
+            str,
+            Field(
+                description="Role of the message author within a conversation (user, assistant, system)."
+            ),
+        ]
+    ] = None
+    content: Optional[
+        Annotated[
+            str,
+            Field(
+                description="The textual content of a message in the Nexus platform."
+            ),
+        ]
+    ] = None
+    agent: Optional[
+        Annotated[
+            str,
+            Field(
+                description="Identifier of the agent associated with a conversation or message in the Nexus platform."
+            ),
+        ]
+    ] = None
+    created_at: Optional[
+        Annotated[
+            datetime.datetime,
+            Field(
+                description="ISO 8601 timestamp at which the event occurred. Populated by EventService.publish() if not set by the caller."
+            ),
+        ]
+    ] = None
+    label: Optional[Annotated[str, Field(description="Label of the resource.")]] = None
+    created: Optional[
+        Annotated[
+            datetime.datetime,
+            Field(description="Date of creation of the resource."),
+        ]
+    ] = None
+    creator: Optional[
+        Annotated[
+            Any,
+            Field(description="An entity responsible for making the resource."),
+        ]
+    ] = None
+
+    # Object properties
+    creates: Optional[
+        Annotated[
+            List[Union[Message, URIRef, str]],
+            Field(
+                description="Relates a platform process performed in the application to a generically dependent continuant artifact it creates."
+            ),
+        ]
+    ] = None
+    occurs_in_conversation: Optional[
+        Annotated[
+            List[Union[Conversation, URIRef, str]],
+            Field(
+                description="Relates a platform process (such as a message creation) to the conversation generic context in which it occurs."
+            ),
+        ]
+    ] = None
+    occurs_in_workspace: Optional[
+        Annotated[
+            List[Union[URIRef, Workspace, str]],
+            Field(
+                description="Relates a platform process (such as a page view or visit session) to the workspace generic context in which it occurs."
+            ),
+        ]
+    ] = None
+    processed_by: Optional[
+        Annotated[
+            List[Union[Agent, URIRef, str]],
+            Field(
+                description="Relates an agent message-creation process to the agent that produces the response as participant."
+            ),
+        ]
+    ] = None
+    processed_during: Optional[
+        Annotated[
+            List[Union[MessageProcessingInterval, URIRef, str]],
+            Field(
+                description="Relates an agent message-creation process to the temporal interval during which the agent processed and produced the response."
+            ),
+        ]
+    ] = None
+    realizes: Optional[
+        Annotated[List[Union[AgentResponseRole, URIRef, str]], Field()]
+    ] = None
+
+
 # Rebuild models to resolve forward references
-VisitSession.model_rebuild()
-PageView.model_rebuild()
-Logout.model_rebuild()
 Server.model_rebuild()
 NexusOrganization.model_rebuild()
 DeploymentSite.model_rebuild()
@@ -4720,4 +5707,18 @@ AddUserToWorkspace.model_rebuild()
 Login.model_rebuild()
 LoginInterval.model_rebuild()
 LogoutInterval.model_rebuild()
+MessageProcessingInterval.model_rebuild()
 VisitSessionInterval.model_rebuild()
+VisitSession.model_rebuild()
+PageView.model_rebuild()
+Logout.model_rebuild()
+Status.model_rebuild()
+UserPromptRole.model_rebuild()
+AgentResponseRole.model_rebuild()
+CreateConversation.model_rebuild()
+CreateMessage.model_rebuild()
+UpdateConversation.model_rebuild()
+DeleteConversation.model_rebuild()
+UpdateMessage.model_rebuild()
+SendUserPrompt.model_rebuild()
+SendAgentResponse.model_rebuild()

--- a/libs/naas-abi/naas_abi/ontologies/modules/NexusPlatformOntology.ttl
+++ b/libs/naas-abi/naas_abi/ontologies/modules/NexusPlatformOntology.ttl
@@ -12,6 +12,7 @@
 
 nexus:PlatformOntology a owl:Ontology ;
   owl:imports <http://ontology.naas.ai/abi/Ontology> ;
+  owl:imports <http://ontology.naas.ai/abi/EventService> ;
   dc:title "Nexus Platform Ontology"@en ;
   dc:description "Ontology for the Nexus platform."@en ;
   dc:license <https://creativecommons.org/licenses/by/4.0/> ;
@@ -765,6 +766,62 @@ nexus:isSessionContextOf a owl:ObjectProperty ;
     rdfs:domain nexus:UserSite ;
     rdfs:range nexus:Session .
 
+# WHEN — message-creation process occurred at a temporal instant (user prompt)
+nexus:sentAt a owl:ObjectProperty ;
+    rdfs:subPropertyOf abi:occupiesTemporalRegion ;
+    rdfs:label "sent at"@en ;
+    skos:definition "Relates a user message-creation process to the temporal instant at which the message was sent by the user."@en ;
+    rdfs:domain bfo:BFO_0000015 ;
+    rdfs:range abi:TemporalInstant .
+
+# WHEN — agent message-creation process occupies a bounded processing temporal region
+nexus:processedDuring a owl:ObjectProperty ;
+    rdfs:subPropertyOf abi:occupiesTemporalRegion ;
+    rdfs:label "processed during"@en ;
+    skos:definition "Relates an agent message-creation process to the temporal interval during which the agent processed and produced the response."@en ;
+    rdfs:domain bfo:BFO_0000015 ;
+    rdfs:range nexus:MessageProcessingInterval .
+
+# WHEN — start instant of an agent message processing interval
+nexus:processingStartedAt a owl:ObjectProperty ;
+    rdfs:subPropertyOf abi:hasFirstInstant ;
+    rdfs:label "processing started at"@en ;
+    skos:definition "Relates a message-processing interval to the temporal instant at which the agent began producing the response."@en ;
+    rdfs:domain nexus:MessageProcessingInterval ;
+    rdfs:range abi:TemporalInstant .
+
+# WHEN — end instant of an agent message processing interval
+nexus:processingEndedAt a owl:ObjectProperty ;
+    rdfs:subPropertyOf abi:hasLastInstant ;
+    rdfs:label "processing ended at"@en ;
+    skos:definition "Relates a message-processing interval to the temporal instant at which the agent finished producing the response."@en ;
+    rdfs:domain nexus:MessageProcessingInterval ;
+    rdfs:range abi:TemporalInstant .
+
+# WHO ↔ WHAT — message-creation process has the sending user account as participant
+nexus:sentBy a owl:ObjectProperty ;
+    rdfs:subPropertyOf abi:hasParticipant ;
+    rdfs:label "sent by"@en ;
+    skos:definition "Relates a message-creation process to the user account that participates in it as sender."@en ;
+    rdfs:domain bfo:BFO_0000015 ;
+    rdfs:range nexus:User .
+
+# WHO ↔ WHAT — agent response process has the producing agent as participant
+nexus:processedBy a owl:ObjectProperty ;
+    rdfs:subPropertyOf abi:hasParticipant ;
+    rdfs:label "processed by"@en ;
+    skos:definition "Relates an agent message-creation process to the agent that produces the response as participant."@en ;
+    rdfs:domain bfo:BFO_0000015 ;
+    rdfs:range nexus:Agent .
+
+# HOW WE KNOW — process occurs in the context of a conversation artifact
+nexus:occursInConversation a owl:ObjectProperty ;
+    rdfs:subPropertyOf abi:genericallyDependsOn ;
+    rdfs:label "occurs in conversation"@en ;
+    skos:definition "Relates a platform process (such as a message creation) to the conversation generic context in which it occurs."@en ;
+    rdfs:domain bfo:BFO_0000015 ;
+    rdfs:range nexus:Conversation .
+
 #################################################################
 #    Classes
 #################################################################
@@ -1350,6 +1407,36 @@ nexus:MessageRole a owl:Class ;
           owl:allValuesFrom nexus:Message
         ] .
 
+# WHY bucket — message role for a user-authored prompt message
+nexus:UserPromptRole a owl:Class ;
+    rdfs:label "User Prompt Role"@en ;
+    skos:definition "A message role that concretizes a message authored by a user (a user prompt) within a conversation in the Nexus platform."@en ;
+    skos:example "Alice's prompt role on her first message"@en ;
+    rdfs:subClassOf nexus:MessageRole ,
+        [ a owl:Restriction ;
+          owl:onProperty nexus:isMessageRoleOf ;
+          owl:someValuesFrom nexus:Message
+        ] ,
+        [ a owl:Restriction ;
+          owl:onProperty nexus:isMessageRoleOf ;
+          owl:allValuesFrom nexus:Message
+        ] .
+
+# WHY bucket — message role for an agent-produced response message
+nexus:AgentResponseRole a owl:Class ;
+    rdfs:label "Agent Response Role"@en ;
+    skos:definition "A message role that concretizes a message produced by an agent (a response) within a conversation in the Nexus platform."@en ;
+    skos:example "Assistant answer role on the model reply"@en ;
+    rdfs:subClassOf nexus:MessageRole ,
+        [ a owl:Restriction ;
+          owl:onProperty nexus:isMessageRoleOf ;
+          owl:someValuesFrom nexus:Message
+        ] ,
+        [ a owl:Restriction ;
+          owl:onProperty nexus:isMessageRoleOf ;
+          owl:allValuesFrom nexus:Message
+        ] .
+
 nexus:AgentRole a owl:Class ;
     rdfs:label "Agent Role"@en ;
     skos:definition "A role associated with an agent as a configured software assistant in the Nexus platform."@en ;
@@ -1627,6 +1714,30 @@ nexus:LogoutInterval a owl:Class ;
     skos:example "Logout interval for Alice at 2026-05-21 10:22:00 to 10:22:01"@en ;
     rdfs:subClassOf abi:TemporalRegion .
 
+# WHEN — temporal interval bounding an agent's message processing
+nexus:MessageProcessingInterval a owl:Class ;
+    rdfs:label "Message Processing Interval"@en ;
+    skos:altLabel "Agent Processing Interval"@en ;
+    skos:definition "A one-dimensional temporal region that bounds the time an agent spent processing a request and producing a response message, delimited by a start instant and an end instant logged by the agent."@en ;
+    skos:example "Agent processing interval from 2026-06-01 09:14:02 to 09:14:07"@en ;
+    rdfs:subClassOf abi:TemporalRegion ,
+        [ a owl:Restriction ;
+          owl:onProperty nexus:processingStartedAt ;
+          owl:someValuesFrom abi:TemporalInstant
+        ] ,
+        [ a owl:Restriction ;
+          owl:onProperty nexus:processingStartedAt ;
+          owl:allValuesFrom abi:TemporalInstant
+        ] ,
+        [ a owl:Restriction ;
+          owl:onProperty nexus:processingEndedAt ;
+          owl:someValuesFrom abi:TemporalInstant
+        ] ,
+        [ a owl:Restriction ;
+          owl:onProperty nexus:processingEndedAt ;
+          owl:allValuesFrom abi:TemporalInstant
+        ] .
+
 # WHEN — temporal interval bounding a visit session
 nexus:VisitSessionInterval a owl:Class ;
     rdfs:label "Visit Session Interval"@en ;
@@ -1740,6 +1851,192 @@ nexus:Logout a owl:Class ;
           owl:someValuesFrom nexus:VisitSession
         ] .
 
+# WHAT — process by which a user opens a new conversation in the platform
+# Covers the BFO 7 buckets: WHAT (process), WHEN (TemporalInstant), WHO (Person + User),
+# WHERE (UserSite), HOW WE KNOW (Workspace, Conversation as GDC artifacts), WHY (ConversationRole).
+nexus:CreateConversation a owl:Class ;
+    rdfs:label "Create Conversation"@en ;
+    skos:altLabel "Open Conversation"@en , "Start Conversation"@en ;
+    skos:definition "A logged process by which a person, operating through a user account, opens a new conversation artifact within a workspace of the Nexus platform. Subclass of abi:LogProcess so EventService can publish instances."@en ;
+    skos:example "Alice opens a new chat thread in the Naas Main Workspace on 2026-06-01 at 09:14"@en ;
+    rdfs:subClassOf abi:LogProcess , bfo:BFO_0000015 ,
+        # WHEN — occurs at a temporal instant
+        [ a owl:Restriction ;
+          owl:onProperty nexus:createdAt ;
+          owl:someValuesFrom abi:TemporalInstant
+        ] ,
+        [ a owl:Restriction ;
+          owl:onProperty nexus:createdAt ;
+          owl:allValuesFrom abi:TemporalInstant
+        ] ,
+        # WHO (material entity) — initiated by a person
+        [ a owl:Restriction ;
+          owl:onProperty nexus:createdBy ;
+          owl:someValuesFrom abi:Person
+        ] ,
+        [ a owl:Restriction ;
+          owl:onProperty nexus:createdBy ;
+          owl:allValuesFrom abi:Person
+        ] ,
+        # WHO (GDC participant) — through a user account
+        [ a owl:Restriction ;
+          owl:onProperty nexus:sentBy ;
+          owl:someValuesFrom nexus:User
+        ] ,
+        [ a owl:Restriction ;
+          owl:onProperty nexus:sentBy ;
+          owl:allValuesFrom nexus:User
+        ] ,
+        # WHERE — occurs at a user-side site
+        [ a owl:Restriction ;
+          owl:onProperty nexus:occursIn ;
+          owl:allValuesFrom nexus:UserSite
+        ] ,
+        # HOW WE KNOW (GDC) — within a workspace
+        [ a owl:Restriction ;
+          owl:onProperty nexus:occursInWorkspace ;
+          owl:someValuesFrom nexus:Workspace
+        ] ,
+        [ a owl:Restriction ;
+          owl:onProperty nexus:occursInWorkspace ;
+          owl:allValuesFrom nexus:Workspace
+        ] ,
+        # HOW WE KNOW (GDC) — creates the conversation artifact
+        [ a owl:Restriction ;
+          owl:onProperty nexus:creates ;
+          owl:someValuesFrom nexus:Conversation
+        ] ,
+        [ a owl:Restriction ;
+          owl:onProperty nexus:creates ;
+          owl:allValuesFrom nexus:Conversation
+        ] ,
+        # WHY (Role) — realizes a conversation role concretizing the new conversation
+        [ a owl:Restriction ;
+          owl:onProperty abi:realizes ;
+          owl:someValuesFrom nexus:ConversationRole
+        ] .
+
+# WHAT — abstract parent process for creating any message within a conversation.
+# Subclassed by SendUserPrompt (user-authored) and SendAgentResponse (agent-produced).
+# Covers the BFO 7 buckets at the parent level via Conversation/Workspace/Message GDCs and MessageRole.
+nexus:CreateMessage a owl:Class ;
+    rdfs:label "Create Message"@en ;
+    skos:altLabel "Add Message"@en ;
+    skos:definition "A logged process by which a new message artifact is added to an existing conversation in the Nexus platform; the message may be authored by a user or produced by an agent. Subclass of abi:LogProcess so EventService can publish instances."@en ;
+    skos:example "Alice sends a prompt to the assistant", "The assistant produces a reply"@en ;
+    rdfs:subClassOf abi:LogProcess , bfo:BFO_0000015 ,
+        # HOW WE KNOW (GDC) — occurs in a conversation
+        [ a owl:Restriction ;
+          owl:onProperty nexus:occursInConversation ;
+          owl:someValuesFrom nexus:Conversation
+        ] ,
+        [ a owl:Restriction ;
+          owl:onProperty nexus:occursInConversation ;
+          owl:allValuesFrom nexus:Conversation
+        ] ,
+        # HOW WE KNOW (GDC) — within a workspace
+        [ a owl:Restriction ;
+          owl:onProperty nexus:occursInWorkspace ;
+          owl:someValuesFrom nexus:Workspace
+        ] ,
+        [ a owl:Restriction ;
+          owl:onProperty nexus:occursInWorkspace ;
+          owl:allValuesFrom nexus:Workspace
+        ] ,
+        # HOW WE KNOW (GDC) — creates a message artifact
+        [ a owl:Restriction ;
+          owl:onProperty nexus:creates ;
+          owl:someValuesFrom nexus:Message
+        ] ,
+        [ a owl:Restriction ;
+          owl:onProperty nexus:creates ;
+          owl:allValuesFrom nexus:Message
+        ] ,
+        # WHY (Role) — realizes a message role concretizing the new message
+        [ a owl:Restriction ;
+          owl:onProperty abi:realizes ;
+          owl:someValuesFrom nexus:MessageRole
+        ] .
+
+# WHAT — user-authored prompt message-creation process (subclass of CreateMessage)
+# WHEN is a TemporalInstant (sentAt); the message role realized is a UserPromptRole.
+nexus:SendUserPrompt a owl:Class ;
+    rdfs:label "Send User Prompt"@en ;
+    skos:altLabel "Create User Message"@en , "Send User Message"@en ;
+    skos:definition "A user-initiated message-creation process: a person, operating through a user account, sends a prompt message in an existing conversation at a single temporal instant."@en ;
+    skos:example "Alice sends 'Summarize this paper' on 2026-06-01 at 09:14:02"@en ;
+    rdfs:subClassOf nexus:CreateMessage ,
+        # WHEN — sent at a temporal instant
+        [ a owl:Restriction ;
+          owl:onProperty nexus:sentAt ;
+          owl:someValuesFrom abi:TemporalInstant
+        ] ,
+        [ a owl:Restriction ;
+          owl:onProperty nexus:sentAt ;
+          owl:allValuesFrom abi:TemporalInstant
+        ] ,
+        # WHO (material entity) — by a person
+        [ a owl:Restriction ;
+          owl:onProperty nexus:createdBy ;
+          owl:someValuesFrom abi:Person
+        ] ,
+        [ a owl:Restriction ;
+          owl:onProperty nexus:createdBy ;
+          owl:allValuesFrom abi:Person
+        ] ,
+        # WHO (GDC participant) — sender user account
+        [ a owl:Restriction ;
+          owl:onProperty nexus:sentBy ;
+          owl:someValuesFrom nexus:User
+        ] ,
+        [ a owl:Restriction ;
+          owl:onProperty nexus:sentBy ;
+          owl:allValuesFrom nexus:User
+        ] ,
+        # WHERE — at a user-side site
+        [ a owl:Restriction ;
+          owl:onProperty nexus:occursIn ;
+          owl:allValuesFrom nexus:UserSite
+        ] ,
+        # WHY (Role) — realizes a user prompt role
+        [ a owl:Restriction ;
+          owl:onProperty abi:realizes ;
+          owl:someValuesFrom nexus:UserPromptRole
+        ] .
+
+# WHAT — agent-produced response message-creation process (subclass of CreateMessage)
+# WHEN is a TemporalRegion (MessageProcessingInterval with processingStartedAt/processingEndedAt);
+# the message role realized is an AgentResponseRole.
+nexus:SendAgentResponse a owl:Class ;
+    rdfs:label "Send Agent Response"@en ;
+    skos:altLabel "Create Agent Message"@en , "Send Agent Message"@en ;
+    skos:definition "An agent-initiated message-creation process: an agent processes a prompt and produces a response message in an existing conversation; the processing unfolds over a bounded temporal interval logged by the agent."@en ;
+    skos:example "The assistant agent generates a reply between 2026-06-01 09:14:02 and 09:14:07"@en ;
+    rdfs:subClassOf nexus:CreateMessage ,
+        # WHEN — occupies a bounded message processing interval
+        [ a owl:Restriction ;
+          owl:onProperty nexus:processedDuring ;
+          owl:someValuesFrom nexus:MessageProcessingInterval
+        ] ,
+        [ a owl:Restriction ;
+          owl:onProperty nexus:processedDuring ;
+          owl:allValuesFrom nexus:MessageProcessingInterval
+        ] ,
+        # WHO (GDC participant) — produced by an agent
+        [ a owl:Restriction ;
+          owl:onProperty nexus:processedBy ;
+          owl:someValuesFrom nexus:Agent
+        ] ,
+        [ a owl:Restriction ;
+          owl:onProperty nexus:processedBy ;
+          owl:allValuesFrom nexus:Agent
+        ] ,
+        # WHY (Role) — realizes an agent response role
+        [ a owl:Restriction ;
+          owl:onProperty abi:realizes ;
+          owl:someValuesFrom nexus:AgentResponseRole
+        ] .
+
 #################################################################
 #    Data Properties
 #################################################################
@@ -1844,7 +2141,7 @@ nexus:model_id a owl:DatatypeProperty ;
 
 nexus:user_id a owl:DatatypeProperty ;
     rdfs:label "user id"@en ;
-    rdfs:domain nexus:User, nexus:FrontEndEvent ;
+    rdfs:domain nexus:User, nexus:FrontEndEvent, nexus:CreateConversation, nexus:UpdateConversation, nexus:DeleteConversation, nexus:CreateMessage, nexus:UpdateMessage ;
     rdfs:range xsd:string ;
     skos:definition "The unique identifier of the user account in the Nexus platform."@en ;
     skos:example "usr_01HXYZ", "42a3f9c1-1234-5678-abcd-ef0123456789" .
@@ -1890,7 +2187,7 @@ nexus:session_id a owl:DatatypeProperty ;
 
 nexus:workspace_id a owl:DatatypeProperty ;
     rdfs:label "workspace id"@en ;
-    rdfs:domain nexus:Workspace, nexus:FrontEndEvent ;
+    rdfs:domain nexus:Workspace, nexus:FrontEndEvent, nexus:CreateConversation, nexus:UpdateConversation, nexus:DeleteConversation, nexus:CreateMessage, nexus:UpdateMessage ;
     rdfs:range xsd:string ;
     skos:definition "The unique identifier of a workspace in the Nexus platform."@en ;
     skos:example "ws-ee0d7c1d56b2" .
@@ -1949,3 +2246,122 @@ nexus:referrer a owl:DatatypeProperty ;
     rdfs:range xsd:string ;
     skos:definition "The HTTP referrer (originating page or host) recorded at the time of a page-view process."@en ;
     skos:example "nexus.localhost", "https://google.com" .
+
+#################################################################
+#    Personal Knowledge Graph — lifecycle status quality
+#################################################################
+
+# HOW IT IS (Quality) — lifecycle status borne by a platform artifact
+nexus:Status a owl:Class ;
+    rdfs:label "Status"@en ;
+    skos:definition "A quality that a platform artifact bears, indicating whether the artifact is currently active in the platform or has been logically removed (deleted)."@en ;
+    skos:example "Active status of a conversation", "Deleted status of a message"@en ;
+    rdfs:subClassOf abi:Quality ,
+        [ a owl:Restriction ;
+          owl:onProperty nexus:isStatusOf ;
+          owl:someValuesFrom abi:GenericallyDependentContinuant
+        ] ,
+        [ a owl:Restriction ;
+          owl:onProperty nexus:isStatusOf ;
+          owl:allValuesFrom abi:GenericallyDependentContinuant
+        ] .
+
+# Object property: GDC artifact bears a Status quality
+nexus:hasStatus a owl:ObjectProperty ;
+    rdfs:subPropertyOf abi:bearerOf ;
+    owl:inverseOf nexus:isStatusOf ;
+    rdfs:label "has status"@en ;
+    skos:definition "Relates a platform artifact (generically dependent continuant) to the status quality it currently bears."@en ;
+    rdfs:domain abi:GenericallyDependentContinuant ;
+    rdfs:range nexus:Status .
+
+nexus:isStatusOf a owl:ObjectProperty ;
+    rdfs:subPropertyOf abi:inheresIn ;
+    owl:inverseOf nexus:hasStatus ;
+    rdfs:label "is status of"@en ;
+    skos:definition "Relates a status quality to the platform artifact in which it inheres."@en ;
+    rdfs:domain nexus:Status ;
+    rdfs:range abi:GenericallyDependentContinuant .
+
+# Status named individuals — the two values used by the personal-graph indexer
+nexus:ActiveStatus a owl:NamedIndividual , nexus:Status ;
+    rdfs:label "Active"@en ;
+    skos:definition "The status borne by a platform artifact that is currently active in the platform."@en .
+
+nexus:DeletedStatus a owl:NamedIndividual , nexus:Status ;
+    rdfs:label "Deleted"@en ;
+    skos:definition "The status borne by a platform artifact that has been logically removed; the artifact and its history remain in the graph."@en .
+
+#################################################################
+#    Personal Knowledge Graph — chat lifecycle events (LogProcess)
+#################################################################
+
+# CreateConversation and CreateMessage are defined above as logged processes
+# (rdfs:subClassOf abi:LogProcess). The three classes below cover the remaining
+# lifecycle events that the personal-graph indexer materializes. All are
+# subclasses of abi:LogProcess so EventService can publish instances; the
+# bfo:BFO_0000015 second parent gives the bucket-mapping validator a direct
+# trace to the BFO process root without needing cross-package import
+# resolution at validation time.
+
+nexus:UpdateConversation a owl:Class ;
+    rdfs:label "Update Conversation"@en ;
+    skos:definition "A logged process that records the update of a conversation artifact (title, pinned, archived, agent) by a user in the Nexus platform."@en ;
+    rdfs:subClassOf abi:LogProcess , bfo:BFO_0000015 .
+
+nexus:DeleteConversation a owl:Class ;
+    rdfs:label "Delete Conversation"@en ;
+    skos:definition "A logged process that records the logical deletion of a conversation artifact by a user in the Nexus platform. The conversation individual is preserved; its status quality is set to Deleted."@en ;
+    rdfs:subClassOf abi:LogProcess , bfo:BFO_0000015 .
+
+nexus:UpdateMessage a owl:Class ;
+    rdfs:label "Update Message"@en ;
+    skos:definition "A logged process that records the update of the content or metadata of a message in the Nexus platform."@en ;
+    rdfs:subClassOf abi:LogProcess , bfo:BFO_0000015 .
+
+# Data properties carried by chat lifecycle events
+nexus:conversation_id a owl:DatatypeProperty ;
+    rdfs:label "conversation id"@en ;
+    rdfs:domain nexus:Conversation, nexus:CreateConversation, nexus:UpdateConversation, nexus:DeleteConversation, nexus:CreateMessage, nexus:UpdateMessage ;
+    rdfs:range xsd:string ;
+    skos:definition "The unique identifier of a conversation artifact in the Nexus platform."@en ;
+    skos:example "conv-9af3c1b2e0d7" .
+
+nexus:message_id a owl:DatatypeProperty ;
+    rdfs:label "message id"@en ;
+    rdfs:domain nexus:Message, nexus:CreateMessage, nexus:UpdateMessage ;
+    rdfs:range xsd:string ;
+    skos:definition "The unique identifier of a message artifact in the Nexus platform."@en ;
+    skos:example "msg-1c2b3a4d5e6f" .
+
+nexus:role a owl:DatatypeProperty ;
+    rdfs:label "role"@en ;
+    rdfs:domain nexus:Message, nexus:CreateMessage, nexus:UpdateMessage ;
+    rdfs:range xsd:string ;
+    skos:definition "Role of the message author within a conversation (user, assistant, system)."@en ;
+    skos:example "user", "assistant", "system" .
+
+nexus:content a owl:DatatypeProperty ;
+    rdfs:label "content"@en ;
+    rdfs:domain nexus:Message, nexus:CreateMessage, nexus:UpdateMessage ;
+    rdfs:range xsd:string ;
+    skos:definition "The textual content of a message in the Nexus platform."@en .
+
+nexus:agent a owl:DatatypeProperty ;
+    rdfs:label "agent"@en ;
+    rdfs:domain nexus:Conversation, nexus:Message, nexus:CreateConversation, nexus:UpdateConversation, nexus:CreateMessage, nexus:UpdateMessage ;
+    rdfs:range xsd:string ;
+    skos:definition "Identifier of the agent associated with a conversation or message in the Nexus platform."@en ;
+    skos:example "aia", "bob", "abi" .
+
+nexus:title a owl:DatatypeProperty ;
+    rdfs:label "title"@en ;
+    rdfs:domain nexus:Conversation, nexus:CreateConversation, nexus:UpdateConversation ;
+    rdfs:range xsd:string ;
+    skos:definition "Display title of a conversation in the Nexus platform."@en .
+
+# Named individual: the role a personal knowledge graph bears, surfaced as
+# its own pack in the /graph/list response so the UI groups them together.
+nexus:PersonalKnowledgeGraphRole a owl:NamedIndividual , nexus:KnowledgeGraphRole ;
+    rdfs:label "Personal"@en ;
+    skos:definition "The role borne by a per-user knowledge graph (\"My Graph\"), visible only to its owning user."@en .

--- a/uv.lock
+++ b/uv.lock
@@ -3453,7 +3453,7 @@ wheels = [
 
 [[package]]
 name = "naas-abi"
-version = "2.11.0"
+version = "2.12.0"
 source = { editable = "libs/naas-abi" }
 dependencies = [
     { name = "aiosqlite" },
@@ -3561,7 +3561,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-core"
-version = "1.51.0"
+version = "1.52.0"
 source = { editable = "libs/naas-abi-core" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
This pull request resolves #994

### Summary
This PR introduces a new personal knowledge graph feature, referred to as "My Graph," which maintains one per-user named graph that indexes all chat lifecycle events (creation, update, deletion of conversations and messages) as RDF triples.

### Key Changes
- **Personal Graph Service:**
  - New `PersonalGraphService` handles lifecycle and RDF indexing of chat events to individual user graphs (`graph/personal/{user_id}`).
  - It logs every conversation and message event as RDF with status (Active/Deleted), preserving history.
  - Event objects like `CreateConversation`, `CreateMessage`, `DeleteConversation` etc., are subscribed via EventService.

- **Chat Service Integration:**
  - Events are now published on conversation/message create, update, delete operations.
  - These events are published fire-and-forget to the EventService to drive indexing.

- **Graph Service Adaptation:**
  - Introduced access control to hide personal graphs from other users.
  - Personal graphs are always ensured to exist on graph listing to show user "My Graph."
  - Enforced personal graph access restrictions on relevant graph operations.

- **Ontology Updates:**
  - Added classes and properties to support the personal graph event model, including statuses, lifecycle event classes, temporal properties, and roles (UserPromptRole, AgentResponseRole).

- **Generated Ontology Classes:**
  - New ontology action classes for these event types and roles are scaffolded for future logic implementation.

- **Tests:**
  - Comprehensive unit tests cover the personal graph service behavior using a fake triple-store.

### Impact
- Provides a per-user enriched semantic graph of chat activity for downstream consumption.
- Improves UI experience by showing a user's personal knowledge graph distinctly.
- Implements security measures to prevent access to other users' personal graphs.

### Additional Notes
- The feature is integrated at ABI module startup to register event subscribers.
- Extends NexusPlatformOntology with lifecycle and personal graph related concepts.

This PR lays foundational work for personalized graph-based knowledge models tied to user interactions in conversations and messages.