### PR TITLE
feat(chat): enhance negative feedback with detailed subtype, severity, and description

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/analytics/adapters/primary/analytics__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/analytics/adapters/primary/analytics__primary_adapter__FastAPI.py
@@ -282,10 +282,18 @@ class ChatFeedbackUpdate(BaseModel):
     """Body for ``PATCH /chats/{cid}/messages/{mid}/feedback``.
 
     ``feedback=None`` clears any previously set value, so the UI can toggle a
-    thumbs-up off by sending ``{"feedback": null}``.
+    thumbs-up off by sending ``{"feedback": null}``. The optional details
+    fields (``feedback_type``, ``feedback_detail``, ``feedback_severity``)
+    are only persisted alongside a ``dislike`` and are cleared on like / null.
     """
 
     feedback: Literal["like", "dislike"] | None = None
+    feedback_type: str | None = None
+    feedback_detail: str | None = None
+    feedback_severity: int | None = None
+
+
+_FEEDBACK_DETAIL_KEYS = ("feedback_type", "feedback_detail", "feedback_severity")
 
 
 @router.patch("/chats/{conversation_id}/messages/{message_id}/feedback")
@@ -311,8 +319,26 @@ async def update_chat_message_feedback(
     existing = _parse_message_metadata(target.metadata_) or {}
     if payload.feedback is None:
         existing.pop("feedback", None)
+        for key in _FEEDBACK_DETAIL_KEYS:
+            existing.pop(key, None)
     else:
         existing["feedback"] = payload.feedback
+        if payload.feedback == "dislike":
+            if payload.feedback_type:
+                existing["feedback_type"] = payload.feedback_type
+            else:
+                existing.pop("feedback_type", None)
+            if payload.feedback_detail:
+                existing["feedback_detail"] = payload.feedback_detail
+            else:
+                existing.pop("feedback_detail", None)
+            if payload.feedback_severity is not None:
+                existing["feedback_severity"] = payload.feedback_severity
+            else:
+                existing.pop("feedback_severity", None)
+        else:
+            for key in _FEEDBACK_DETAIL_KEYS:
+                existing.pop(key, None)
 
     updated = await chat_service.adapter.update_message_metadata(
         message_id=message_id,
@@ -320,7 +346,13 @@ async def update_chat_message_feedback(
     )
     if not updated:
         raise HTTPException(status_code=404, detail="Message not found")
-    return {"status": "updated", "feedback": payload.feedback}
+    return {
+        "status": "updated",
+        "feedback": payload.feedback,
+        "feedback_type": existing.get("feedback_type"),
+        "feedback_detail": existing.get("feedback_detail"),
+        "feedback_severity": existing.get("feedback_severity"),
+    }
 
 
 @router.get("/chats/{conversation_id}/export")

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__export.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__export.py
@@ -55,6 +55,16 @@ def export_conversation_as_response(
             feedback = meta.get("feedback")
             if feedback in ("like", "dislike"):
                 content += f"Feedback: {feedback}\n"
+                if feedback == "dislike":
+                    fb_type = meta.get("feedback_type")
+                    if fb_type:
+                        content += f"Feedback type: {fb_type}\n"
+                    fb_severity = meta.get("feedback_severity")
+                    if fb_severity is not None:
+                        content += f"Feedback severity: {fb_severity}/5\n"
+                    fb_detail = meta.get("feedback_detail")
+                    if fb_detail:
+                        content += f"Feedback detail: {fb_detail}\n"
             steps = meta.get("steps", [])
             if steps:
                 content += "Steps:\n"
@@ -136,6 +146,19 @@ def export_conversation_as_response(
         meta = _parse_metadata(msg, (messages_metadata or {}).get(msg.id))
         if meta.get("execution_time") is not None:
             content += f"⏱ **Execution time:** {meta['execution_time']:.1f}s\n\n"
+        feedback = meta.get("feedback")
+        if feedback in ("like", "dislike"):
+            content += f"**Feedback:** {feedback}\n\n"
+            if feedback == "dislike":
+                fb_type = meta.get("feedback_type")
+                if fb_type:
+                    content += f"**Feedback type:** {fb_type}\n\n"
+                fb_severity = meta.get("feedback_severity")
+                if fb_severity is not None:
+                    content += f"**Feedback severity:** {fb_severity}/5\n\n"
+                fb_detail = meta.get("feedback_detail")
+                if fb_detail:
+                    content += f"**Feedback detail:** {fb_detail}\n\n"
         steps = meta.get("steps", [])
         if steps:
             content += f"🔧 **Steps ({len(steps)}):** " + ", ".join(

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/secondary/postgres.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/secondary/postgres.py
@@ -17,7 +17,7 @@ from naas_abi.apps.nexus.apps.api.app.services.chat.port import (
     ChatPersistencePort,
     ChatSecretRecord,
 )
-from sqlalchemy import delete, func, select
+from sqlalchemy import case, delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 AsyncSessionGetter = Callable[[], AsyncSession | None]
@@ -172,10 +172,18 @@ class ChatSecondaryAdapterPostgres(ChatPersistencePort):
         return True
 
     async def list_messages_by_conversation(self, conversation_id: str) -> list[ChatMessageRecord]:
+        # Streaming writes the user row and the paired assistant row with the
+        # same ``created_at``; without a deterministic tie-breaker the pair can
+        # surface assistant-first. Order user < assistant < system on ties.
+        role_order = case(
+            (MessageModel.role == "user", 0),
+            (MessageModel.role == "assistant", 1),
+            else_=2,
+        )
         result = await self.db.execute(
             select(MessageModel)
             .where(MessageModel.conversation_id == conversation_id)
-            .order_by(MessageModel.created_at)
+            .order_by(MessageModel.created_at, role_order, MessageModel.id)
         )
         return [self._to_message_record(row) for row in result.scalars().all()]
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/lib/types.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/lib/types.ts
@@ -161,6 +161,9 @@ export interface ChatMessageMetadata {
   steps?: ChatMessageStep[];
   sources?: string[];
   feedback?: ChatMessageFeedback | null;
+  feedback_type?: string | null;
+  feedback_detail?: string | null;
+  feedback_severity?: number | null;
   [key: string]: unknown;
 }
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/page.tsx
@@ -1200,6 +1200,20 @@ function buildChatExportText(conversation: ChatDetail): string {
     const fb = msg.metadata?.feedback;
     if (fb === 'like' || fb === 'dislike') {
       out += `Feedback: ${fb}\n`;
+      if (fb === 'dislike') {
+        const fbType = msg.metadata?.feedback_type;
+        if (typeof fbType === 'string' && fbType) {
+          out += `Feedback type: ${fbType}\n`;
+        }
+        const fbSeverity = msg.metadata?.feedback_severity;
+        if (typeof fbSeverity === 'number') {
+          out += `Feedback severity: ${fbSeverity}/5\n`;
+        }
+        const fbDetail = msg.metadata?.feedback_detail;
+        if (typeof fbDetail === 'string' && fbDetail) {
+          out += `Feedback detail: ${fbDetail}\n`;
+        }
+      }
     }
     const steps = msg.metadata?.steps ?? [];
     if (steps.length > 0) {
@@ -1240,6 +1254,15 @@ function ChatMessageBubble({ message }: { message: ChatMessage }) {
   const steps = message.metadata?.steps ?? [];
   const executionTime = message.metadata?.execution_time;
   const feedback = message.metadata?.feedback;
+  const feedbackType = message.metadata?.feedback_type;
+  const feedbackDetail = message.metadata?.feedback_detail;
+  const feedbackSeverity = message.metadata?.feedback_severity;
+  const hasFeedbackDetails =
+    isAssistant &&
+    feedback === 'dislike' &&
+    ((typeof feedbackType === 'string' && feedbackType) ||
+      (typeof feedbackDetail === 'string' && feedbackDetail) ||
+      typeof feedbackSeverity === 'number');
 
   return (
     <div className={cn('flex flex-col gap-1', align)}>
@@ -1265,9 +1288,42 @@ function ChatMessageBubble({ message }: { message: ChatMessage }) {
       </div>
       {steps.length > 0 && <ChatStepsList steps={steps} alignEnd={isUser} />}
       <div className={bubble}>{message.content || <span className="opacity-50">(empty)</span>}</div>
+      {hasFeedbackDetails && (
+        <div className="max-w-[85%] space-y-1 border border-red-200 bg-red-50/40 px-3 py-2 text-xs text-red-900">
+          {typeof feedbackType === 'string' && feedbackType && (
+            <div>
+              <span className="font-semibold uppercase tracking-wide text-[10px]">Type:</span>{' '}
+              {ANALYTICS_FEEDBACK_TYPE_LABELS[feedbackType] ?? feedbackType}
+            </div>
+          )}
+          {typeof feedbackSeverity === 'number' && (
+            <div>
+              <span className="font-semibold uppercase tracking-wide text-[10px]">Severity:</span>{' '}
+              {feedbackSeverity}/5
+            </div>
+          )}
+          {typeof feedbackDetail === 'string' && feedbackDetail && (
+            <div className="whitespace-pre-wrap">
+              <span className="font-semibold uppercase tracking-wide text-[10px]">Detail:</span>{' '}
+              {feedbackDetail}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }
+
+const ANALYTICS_FEEDBACK_TYPE_LABELS: Record<string, string> = {
+  inaccurate: 'Inaccurate response',
+  off_topic: 'Off topic',
+  hallucination: 'Hallucination / made-up information',
+  incomplete: 'Incomplete response',
+  unjustified_refusal: 'Unjustified refusal',
+  tone: 'Inappropriate style or tone',
+  harmful: 'Harmful or problematic content',
+  other: 'Other',
+};
 
 function ChatStepsList({ steps, alignEnd }: { steps: ChatMessageStep[]; alignEnd: boolean }) {
   return (

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
@@ -8,7 +8,7 @@ import { usePathname, useRouter } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { cn } from '@/lib/utils';
-import { useWorkspaceStore, type AgentType, type Message, type MessageFeedback, type SidebarSection, type ToolCall } from '@/stores/workspace';
+import { useWorkspaceStore, type AgentType, type Message, type MessageFeedback, type MessageFeedbackDetails, type SidebarSection, type ToolCall } from '@/stores/workspace';
 import { useIntegrationsStore } from '@/stores/integrations';
 import { useAgentsStore } from '@/stores/agents';
 import { useSecretsStore } from '@/stores/secrets';
@@ -3656,19 +3656,179 @@ function UserMessageActions({ message }: { message: Message }) {
   );
 }
 
+const FEEDBACK_TYPE_OPTIONS = [
+  { value: 'inaccurate', label: 'Inaccurate response' },
+  { value: 'off_topic', label: 'Off topic' },
+  { value: 'hallucination', label: 'Hallucination / made-up information' },
+  { value: 'incomplete', label: 'Incomplete response' },
+  { value: 'unjustified_refusal', label: 'Unjustified refusal' },
+  { value: 'tone', label: 'Inappropriate style or tone' },
+  { value: 'harmful', label: 'Harmful or problematic content' },
+  { value: 'other', label: 'Other' },
+] as const;
+
+function FeedbackDislikeDialog({
+  open,
+  initialDetails,
+  submitting,
+  onSubmit,
+  onCancel,
+}: {
+  open: boolean;
+  initialDetails: MessageFeedbackDetails | null;
+  submitting: boolean;
+  onSubmit: (details: MessageFeedbackDetails) => void;
+  onCancel: () => void;
+}) {
+  const [type, setType] = useState<string>('');
+  const [detail, setDetail] = useState<string>('');
+  const [severity, setSeverity] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setType(initialDetails?.type ?? '');
+      setDetail(initialDetails?.detail ?? '');
+      setSeverity(initialDetails?.severity ?? null);
+    }
+  }, [open, initialDetails]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !submitting) onCancel();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [open, submitting, onCancel]);
+
+  if (!open) return null;
+
+  const handleSubmit = () => {
+    onSubmit({
+      type: type.trim() ? type : null,
+      detail: detail.trim() ? detail.trim() : null,
+      severity: severity ?? null,
+    });
+  };
+
+  return createPortal(
+    <div className="fixed inset-0 z-[9999] flex items-center justify-center">
+      <div
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm animate-in fade-in duration-200"
+        onClick={() => !submitting && onCancel()}
+      />
+      <div className="relative z-10 mx-4 w-full max-w-md animate-in zoom-in-95 fade-in duration-200">
+        <div className="rounded-xl border border-border bg-background p-6 shadow-2xl">
+          <h3 className="text-base font-semibold text-foreground">Provide negative feedback</h3>
+
+          <div className="mt-4 space-y-1">
+            <label className="text-sm text-foreground">
+              What type of issue would you like to report? (optional)
+            </label>
+            <select
+              value={type}
+              onChange={(e) => setType(e.target.value)}
+              className="w-full rounded-lg border border-border bg-muted/50 px-3 py-2 text-sm text-foreground outline-none focus-visible:ring-2 focus-visible:ring-workspace-accent focus-visible:ring-offset-2 ring-offset-background"
+            >
+              <option value="">Select...</option>
+              {FEEDBACK_TYPE_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="mt-4 space-y-1">
+            <label className="text-sm text-foreground">
+              Please provide details: (optional)
+            </label>
+            <textarea
+              value={detail}
+              onChange={(e) => setDetail(e.target.value)}
+              rows={4}
+              className="w-full resize-none rounded-lg border border-border bg-muted/50 px-3 py-2 text-sm text-foreground outline-none focus-visible:ring-2 focus-visible:ring-workspace-accent focus-visible:ring-offset-2 ring-offset-background"
+              placeholder="Describe the issue you encountered..."
+            />
+          </div>
+
+          <div className="mt-4 space-y-2">
+            <label className="text-sm text-foreground">
+              How unsatisfactory was this response?
+            </label>
+            <div className="flex items-center gap-1">
+              {[1, 2, 3, 4, 5].map((value) => {
+                const active = severity !== null && value <= severity;
+                return (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => setSeverity(severity === value ? null : value)}
+                    className={cn(
+                      'flex h-8 w-8 items-center justify-center rounded-md border text-sm transition-colors',
+                      active
+                        ? 'border-red-600/40 bg-red-50/40 text-red-600'
+                        : 'border-border text-muted-foreground hover:bg-muted/40',
+                    )}
+                    aria-label={`Severity ${value}`}
+                  >
+                    {value}
+                  </button>
+                );
+              })}
+            </div>
+            <p className="text-[11px] text-muted-foreground">
+              1 = slightly unsatisfactory · 5 = completely unsatisfactory
+            </p>
+          </div>
+
+          <p className="mt-4 text-xs text-muted-foreground">
+            By submitting this report, you send the entire current conversation to our team to help
+            us improve our models.
+          </p>
+
+          <div className="mt-6 flex justify-end gap-2">
+            <button
+              onClick={onCancel}
+              disabled={submitting}
+              className="rounded-lg px-4 py-2 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-60"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleSubmit}
+              disabled={submitting}
+              className="inline-flex items-center gap-2 rounded-lg bg-workspace-accent px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-workspace-accent/90 disabled:opacity-60"
+            >
+              {submitting && <Loader2 size={12} className="animate-spin" />}
+              Submit
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
 function AssistantMessageActions({ message }: { message: Message }) {
   const updateMessageFeedback = useWorkspaceStore((s) => s.updateMessageFeedback);
   const activeConversationId = useWorkspaceStore((s) => s.activeConversationId);
   const [busy, setBusy] = useState<null | 'like' | 'dislike'>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
   const feedback = message.feedback ?? null;
+  const feedbackDetails = message.feedbackDetails ?? null;
 
-  const sendFeedback = async (next: MessageFeedback | null) => {
-    if (!activeConversationId) return;
+  const sendFeedback = async (
+    next: MessageFeedback | null,
+    details: MessageFeedbackDetails | null,
+  ) => {
+    if (!activeConversationId) return false;
     const prev = feedback;
+    const prevDetails = feedbackDetails;
     const which: 'like' | 'dislike' = next ?? (prev === 'like' ? 'like' : 'dislike');
     setBusy(which);
-    // Optimistic local update; rolled back on failure.
-    updateMessageFeedback(activeConversationId, message.id, next);
+    updateMessageFeedback(activeConversationId, message.id, next, details);
     try {
       const { authFetch } = await import('@/stores/auth');
       const res = await authFetch(
@@ -3676,62 +3836,97 @@ function AssistantMessageActions({ message }: { message: Message }) {
         {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ feedback: next }),
+          body: JSON.stringify({
+            feedback: next,
+            feedback_type: details?.type ?? null,
+            feedback_detail: details?.detail ?? null,
+            feedback_severity: details?.severity ?? null,
+          }),
         },
       );
       if (!res.ok) throw new Error(`Save failed (${res.status})`);
+      return true;
     } catch (error) {
       console.error('Failed to save feedback:', error);
-      updateMessageFeedback(activeConversationId, message.id, prev);
+      updateMessageFeedback(activeConversationId, message.id, prev, prevDetails);
+      return false;
     } finally {
       setBusy(null);
     }
   };
 
-  const toggle = (value: MessageFeedback) => {
-    void sendFeedback(feedback === value ? null : value);
+  const handleLikeClick = () => {
+    if (feedback === 'like') {
+      void sendFeedback(null, null);
+    } else {
+      void sendFeedback('like', null);
+    }
+  };
+
+  const handleDislikeClick = () => {
+    if (feedback === 'dislike') {
+      void sendFeedback(null, null);
+      return;
+    }
+    setDialogOpen(true);
+  };
+
+  const handleDialogSubmit = async (details: MessageFeedbackDetails) => {
+    const ok = await sendFeedback('dislike', details);
+    if (ok) setDialogOpen(false);
   };
 
   return (
-    <div className="mt-1 flex items-center text-muted-foreground">
-      <CopyMessageButton content={message.content} />
-      <button
-        onClick={() => toggle('like')}
-        disabled={busy !== null}
-        title={feedback === 'like' ? 'Remove like' : 'Like'}
-        className={`flex h-6 w-6 items-center justify-center rounded border border-transparent transition-colors hover:border-border hover:bg-muted/40 disabled:opacity-60 ${
-          feedback === 'like' ? 'text-emerald-600 border-emerald-600/40 bg-emerald-50/40' : ''
-        }`}
-      >
-        {busy === 'like' ? (
-          <Loader2 size={12} className="animate-spin" />
-        ) : (
-          <ThumbsUp
-            size={12}
-            fill={feedback === 'like' ? 'currentColor' : 'none'}
-            strokeWidth={feedback === 'like' ? 1.5 : 2}
-          />
-        )}
-      </button>
-      <button
-        onClick={() => toggle('dislike')}
-        disabled={busy !== null}
-        title={feedback === 'dislike' ? 'Remove dislike' : 'Dislike'}
-        className={`flex h-6 w-6 items-center justify-center rounded border border-transparent transition-colors hover:border-border hover:bg-muted/40 disabled:opacity-60 ${
-          feedback === 'dislike' ? 'text-red-600 border-red-600/40 bg-red-50/40' : ''
-        }`}
-      >
-        {busy === 'dislike' ? (
-          <Loader2 size={12} className="animate-spin" />
-        ) : (
-          <ThumbsDown
-            size={12}
-            fill={feedback === 'dislike' ? 'currentColor' : 'none'}
-            strokeWidth={feedback === 'dislike' ? 1.5 : 2}
-          />
-        )}
-      </button>
-    </div>
+    <>
+      <div className="mt-1 flex items-center text-muted-foreground">
+        <CopyMessageButton content={message.content} />
+        <button
+          onClick={handleLikeClick}
+          disabled={busy !== null}
+          title={feedback === 'like' ? 'Remove like' : 'Like'}
+          className={`flex h-6 w-6 items-center justify-center rounded border border-transparent transition-colors hover:border-border hover:bg-muted/40 disabled:opacity-60 ${
+            feedback === 'like' ? 'text-emerald-600 border-emerald-600/40 bg-emerald-50/40' : ''
+          }`}
+        >
+          {busy === 'like' ? (
+            <Loader2 size={12} className="animate-spin" />
+          ) : (
+            <ThumbsUp
+              size={12}
+              fill={feedback === 'like' ? 'currentColor' : 'none'}
+              strokeWidth={feedback === 'like' ? 1.5 : 2}
+            />
+          )}
+        </button>
+        <button
+          onClick={handleDislikeClick}
+          disabled={busy !== null}
+          title={feedback === 'dislike' ? 'Remove dislike' : 'Dislike'}
+          className={`flex h-6 w-6 items-center justify-center rounded border border-transparent transition-colors hover:border-border hover:bg-muted/40 disabled:opacity-60 ${
+            feedback === 'dislike' ? 'text-red-600 border-red-600/40 bg-red-50/40' : ''
+          }`}
+        >
+          {busy === 'dislike' ? (
+            <Loader2 size={12} className="animate-spin" />
+          ) : (
+            <ThumbsDown
+              size={12}
+              fill={feedback === 'dislike' ? 'currentColor' : 'none'}
+              strokeWidth={feedback === 'dislike' ? 1.5 : 2}
+            />
+          )}
+        </button>
+      </div>
+      <FeedbackDislikeDialog
+        open={dialogOpen}
+        initialDetails={feedbackDetails}
+        submitting={busy === 'dislike'}
+        onSubmit={handleDialogSubmit}
+        onCancel={() => {
+          if (busy !== 'dislike') setDialogOpen(false);
+        }}
+      />
+    </>
   );
 }
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
@@ -59,6 +59,12 @@ export interface ToolCall {
 
 export type MessageFeedback = 'like' | 'dislike';
 
+export interface MessageFeedbackDetails {
+  type?: string | null;
+  detail?: string | null;
+  severity?: number | null;
+}
+
 export interface Message {
   id: string;
   role: 'user' | 'assistant' | 'system';
@@ -73,6 +79,7 @@ export interface Message {
   executionTime?: number; // Total seconds from request sent to response complete
   sources?: string[]; // filenames of RAG documents used to answer
   feedback?: MessageFeedback | null; // Reviewer thumbs up/down, persisted on metadata_
+  feedbackDetails?: MessageFeedbackDetails | null; // Extended dislike details (type/detail/severity)
   // Author attribution (preserved across sessions and users)
   authorId?: string;
   authorName?: string;
@@ -235,6 +242,7 @@ interface WorkspaceState {
     conversationId: string,
     messageId: string,
     feedback: MessageFeedback | null,
+    details?: MessageFeedbackDetails | null,
   ) => void;
   renameMessageId: (
     conversationId: string,
@@ -311,7 +319,15 @@ type ApiConversation = {
 };
 
 const mapApiMessage = (message: ApiChatMessage): Message => {
-  const fb = message.metadata?.feedback;
+  const meta = message.metadata ?? {};
+  const fb = meta.feedback;
+  const fbType = meta.feedback_type;
+  const fbDetail = meta.feedback_detail;
+  const fbSeverity = meta.feedback_severity;
+  const hasDetails =
+    typeof fbType === 'string' ||
+    typeof fbDetail === 'string' ||
+    typeof fbSeverity === 'number';
   return {
     id: message.id,
     role: message.role,
@@ -319,6 +335,13 @@ const mapApiMessage = (message: ApiChatMessage): Message => {
     timestamp: new Date(message.created_at || Date.now()),
     agent: message.agent || undefined,
     feedback: fb === 'like' || fb === 'dislike' ? fb : null,
+    feedbackDetails: hasDetails
+      ? {
+          type: typeof fbType === 'string' ? fbType : null,
+          detail: typeof fbDetail === 'string' ? fbDetail : null,
+          severity: typeof fbSeverity === 'number' ? fbSeverity : null,
+        }
+      : null,
   };
 };
 
@@ -457,14 +480,21 @@ export const useWorkspaceStore = create<WorkspaceState>()(
     }));
   },
 
-  updateMessageFeedback: (conversationId, messageId, feedback) => {
+  updateMessageFeedback: (conversationId, messageId, feedback, details) => {
     set((state) => ({
       conversations: state.conversations.map((conv) =>
         conv.id === conversationId
           ? {
               ...conv,
               messages: conv.messages.map((msg) =>
-                msg.id === messageId ? { ...msg, feedback } : msg,
+                msg.id === messageId
+                  ? {
+                      ...msg,
+                      feedback,
+                      feedbackDetails:
+                        details === undefined ? msg.feedbackDetails : details,
+                    }
+                  : msg,
               ),
             }
           : conv,

--- a/uv.lock
+++ b/uv.lock
@@ -3453,7 +3453,7 @@ wheels = [
 
 [[package]]
 name = "naas-abi"
-version = "2.11.0"
+version = "2.12.0"
 source = { editable = "libs/naas-abi" }
 dependencies = [
     { name = "aiosqlite" },
@@ -3561,7 +3561,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-core"
-version = "1.51.0"
+version = "1.52.0"
 source = { editable = "libs/naas-abi-core" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
This pull request resolves #fix-feedbacks-analytics

### Summary

This PR enhances the feedback functionality in the chat and analytics components by adding support for detailed negative feedback. It allows users to provide extended feedback when marking a message as "dislike", including specifying a feedback type, detailed textual information, and a severity rating.

### Details

- **API Changes:**
  - The PATCH endpoint for updating chat message feedback has been extended to accept and persist `feedback_type`, `feedback_detail`, and `feedback_severity` fields when the feedback is "dislike".
  - These detailed fields are cleared when feedback is "like" or null.

- **Backend Storage and Query:**
  - The secondary Postgres adapter ensures messages are ordered deterministically by `created_at` and role to prevent ordering issues.

- **Chat Export:**
  - The conversation export now includes the detailed dislike feedback fields when present.

- **Frontend Enhancements:**
  - The types for message metadata in analytics and message feedback in workspace store have been extended to handle the new feedback detail fields.
  - The chat message UI displays additional dislike feedback details (type, severity, detail) visually in a styled box.
  - A new dialog component (`FeedbackDislikeDialog`) allows users to input extended dislike feedback details before submitting.
  - User message action buttons have been updated to trigger the dialog on dislike clicks, enabling input of detailed feedback.
  - Redux-like update in the workspace store supports optimistic updates including these extended feedback details.

- **UX Improvements:**
  - Feedback dislike requires an optional form for the user to specify type, severity (rating 1-5), and a textual detail.

### Impact

This update improves the quality of feedback collected from users, providing richer data to analyze and improve chat responses. It also enhances transparency for users by showing detailed negative feedback information in the UI and export.

### Additional Notes

- The feedback type includes predefined options such as "inaccurate", "off_topic", "hallucination", etc.
- The severity rating is from 1 (slightly unsatisfactory) to 5 (completely unsatisfactory).
- The dialog seamlessly integrates with the existing feedback buttons and handles optimistic UI updates.
