### PR TITLE
fix: Remove unused agent functions from default_tools.py

### DIFF
--- a/libs/naas-abi-core/naas_abi_core/services/agent/tools/default_tools.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/tools/default_tools.py
@@ -10,20 +10,6 @@ def default_tools(self) -> list[Tool | BaseTool]:
 
         return datetime.now(ZoneInfo(timezone)).strftime("%H:%M:%S %Y-%m-%d")
 
-    @tool(return_direct=True)
-    def get_current_active_agent() -> str:
-        """Returns the current active agent."""
-        return "The current active agent is: " + (
-            self._state.current_active_agent or self.name
-        )
-
-    @tool(return_direct=True)
-    def get_supervisor_agent() -> str:
-        """Returns the supervisor agent."""
-        if self._state.supervisor_agent is None:
-            return "I don't have a supervisor agent."
-        return "The supervisor agent is: " + self._state.supervisor_agent
-
     # @tool(return_direct=True)
     # def list_tools_available() -> str:
     #     """Displays a formatted list of all available tools."""
@@ -95,7 +81,4 @@ def default_tools(self) -> list[Tool | BaseTool]:
         # list_subagents_available,
         # list_intents_available,
     ]
-    if self.state.supervisor_agent is not None or len(self._agents) > 0:
-        tools.append(get_current_active_agent)
-        tools.append(get_supervisor_agent)
     return tools


### PR DESCRIPTION
Removed get_current_active_agent and get_supervisor_agent functions from default_tools.py.