### PR TITLE
docs(agent): Add NEXUS multi-LLM agent platform docs + eslint disables for Next img usage

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/AGENT.md
+++ b/libs/naas-abi/naas_abi/apps/nexus/AGENT.md
@@ -1,0 +1,92 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+NEXUS is the multi-LLM agent platform vendored inside the **bob** workspace at `bob/.abi/libs/naas-abi/naas_abi/apps/nexus/`. The workspace-level `~/CLAUDE.md` already covers the broader ABI conventions (hexagonal architecture as a principle, `uv` toolchain, BFO ontology, code style). This file documents what is NEXUS-specific.
+
+## Two execution modes (matters for imports)
+
+NEXUS can run standalone **or** as a sub-package of the parent `naas-abi` package — the same code services both. Always use the fully qualified import path:
+
+```python
+from naas_abi.apps.nexus.apps.api.app.core.config import settings
+```
+
+Not `from app.core.config import settings`. The shorter form only works when running from inside `apps/api/`; the fully qualified form works in both modes. All existing code in `apps/api/app/` uses the long form — match it.
+
+The standalone dev entrypoint is `apps/api/app/main.py` (`uvicorn app.main:app`, port 8000 via Makefile; port 9879 if run as `__main__`). When mounted into the parent naas-abi FastAPI app, `create_app(existing_app)` patches the parent in place rather than creating a new one.
+
+## Commands
+
+NEXUS has its own Makefile separate from the parent ABI Makefile. **Run from `apps/nexus/`, not from the workspace root.**
+
+```bash
+make install        # pnpm install + (cd apps/api && uv sync)
+make db-up          # docker compose up -d postgres
+make db-migrate     # runs init_db() — applies all apps/api/migrations/*.sql idempotently
+make up             # kill-ports → ensure postgres → ./dev.sh (turbo runs api + web)
+make api / make web # individual servers
+make kill-ports     # frees 3000 (web) and 8000 (api)
+make check          # lint + typecheck + test
+make test-watch     # pytest --lf -x in apps/api/
+make db-reset       # DESTRUCTIVE: docker compose down -v, then up + migrate + seed
+```
+
+Running a single backend test:
+```bash
+cd apps/api && uv run pytest tests/test_auth.py::test_login_succeeds -v
+```
+
+Type-check / lint a specific area:
+```bash
+cd apps/api && uv run mypy app/services/chat
+cd apps/api && uv run ruff check app/services/chat
+cd apps/web && pnpm typecheck
+```
+
+## Service layout — hexagonal, mid-migration
+
+`apps/api/app/services/<domain>/` is the canonical home for business logic. Each domain follows:
+
+```
+services/<domain>/
+  port.py                                      # Abstract IxxxPort interfaces + DTOs (dataclasses)
+  service.py                                   # Domain logic, depends only on ports
+  handlers/<domain>__http_handler.py           # Wires service + adapters + FastAPI router
+  adapters/
+    primary/<domain>__primary_adapter__FastAPI.py   # HTTP request/response mapping
+    secondary/postgres.py                            # DB adapter implementing the port
+```
+
+The double-underscore naming `<domain>__primary_adapter__<Tech>.py` is intentional and used consistently — match it when adding new adapters (`<domain>__primary_adapter__streaming.py`, `<domain>__primary_adapter__export.py`, etc.).
+
+**Migration is in progress** — see `apps/api/app/services/HEXAGONAL_MIGRATION_TASKS.md`. The legacy endpoint files in `apps/api/app/api/endpoints/` (`abi.py`, `admin.py`, `graph.py`, `secrets.py`, `view.py`, etc.) still contain orchestration logic that should move into domain services over time. `api/router.py` shows which domains have migrated to `services/<domain>/handlers/` (chat, agents, auth, files, modules, apps, providers, workspaces) versus the ones still living in `endpoints/`. When touching a legacy endpoint, check the migration doc before deciding whether to extract into a domain.
+
+Per workspace policy: every abstract method on a port must be implemented in adapters — raise `NotImplementedError` for genuinely unsupported features rather than omitting the method.
+
+## Database migrations
+
+Plain SQL files at `apps/api/migrations/NNNN_description.sql`, applied in sequential order by `init_db()` on every API startup. Numbered ≥4 digits (currently up to 0029). Two non-negotiables:
+
+1. **Idempotent** — use `IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS`, etc. Migrations re-run on every boot.
+2. **Sequential numbering** — never reuse a prefix. There is a known collision (`0016_link_workspaces_to_orgs.sql` + `0016_add_workspace_theming.sql`) — do not introduce more.
+
+No Alembic, no rollback story — write forward-compatible migrations.
+
+## SSE provider adapters
+
+Chat streaming normalizes three protocols to a single `StreamEvent` shape — OpenAI's JSON-per-line, Anthropic's typed W3C SSE, and ABI/Naas's strict multi-line W3C SSE. Event types are `token | thinking | tool_call | link | file | error | done`. The adapter layer in `services/chat/adapters/primary/chat__primary_adapter__streaming.py` is where format-specific quirks live; the domain service operates only on the normalized events. See `docs/ESSENTIALS.md` for protocol examples.
+
+## Multi-tenancy invariant
+
+Everything below `organizations` is scoped to `workspace_id`: agents, conversations, secrets, graph nodes, inference servers. New tables and new endpoints **must** filter by `workspace_id` and check workspace membership via the IAM service (`services/iam/`, see `IAM_SPEC.md` and `authorization.py`). Do not add a second role-check at the endpoint when the IAM service already does it — duplicate checks are explicitly called out as anti-patterns in the migration doc.
+
+## Frontend
+
+Next.js 14 App Router under `apps/web/`. State is Zustand (`src/stores/*.ts`, one store per domain — `auth`, `workspace`, `agents`, etc.). Tenant branding (tab title, OG image, theme) is fetched from `/api/tenant` at SSR time in `layout.tsx` — bypass the API at your peril, it returns defaults on failure.
+
+Cloudflare Pages deploy: `pnpm build:cf` then `wrangler pages deploy` (see `apps/web/package.json`, `wrangler.toml`). Standard `pnpm dev` runs Next.js on 3000.
+
+## Conventional commits
+
+NEXUS uses Conventional Commits enforced via `CONTRIBUTING.md` (`feat:`, `fix:`, `docs:`, `refactor:`, etc.) — match the style of recent commits when authoring messages.

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/account/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/account/page.tsx
@@ -206,6 +206,7 @@ export default function ProfilePage() {
             className="hidden"
           />
           {avatarUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
             <img
               src={avatarUrl}
               alt={name}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/auth/forgot-password/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/auth/forgot-password/page.tsx
@@ -140,12 +140,14 @@ export default function ForgotPasswordPage() {
             {(tenant.logo_rectangle_url || tenant.logo_url || tenant.logo_emoji) && (
               <div className="mb-6 flex items-center justify-center">
                 {tenant.logo_rectangle_url ? (
+                  // eslint-disable-next-line @next/next/no-img-element
                   <img
                     src={tenant.logo_rectangle_url}
                     alt={tenant.tab_title}
                     className="h-24 max-w-full object-contain"
                   />
                 ) : tenant.logo_url ? (
+                  // eslint-disable-next-line @next/next/no-img-element
                   <img
                     src={tenant.logo_url}
                     alt={tenant.tab_title}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/auth/login/login-form.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/auth/login/login-form.tsx
@@ -151,12 +151,14 @@ export default function LoginForm() {
         {(tenant.logo_rectangle_url || tenant.logo_url || tenant.logo_emoji) && (
           <div className="mb-6 flex items-center justify-center">
             {tenant.logo_rectangle_url ? (
+              // eslint-disable-next-line @next/next/no-img-element
               <img
                 src={tenant.logo_rectangle_url}
                 alt={tenant.tab_title}
                 className="h-24 max-w-full object-contain"
               />
             ) : tenant.logo_url ? (
+              // eslint-disable-next-line @next/next/no-img-element
               <img
                 src={tenant.logo_url}
                 alt={tenant.tab_title}
@@ -331,20 +333,22 @@ export default function LoginForm() {
   );
 }
 
+const TYPING_WELCOME_PHRASES = [
+  'स्वागत है',
+  'Welcome',
+  'Bienvenue',
+  'Bienvenido',
+  'Willkommen',
+  'Benvenuto',
+  '欢迎',
+  'ようこそ',
+  '환영합니다',
+  'Добро пожаловать',
+  'Bem-vindo',
+];
+
 function TypingWelcome({ textColor, mutedColor }: { textColor: string; mutedColor: string }) {
-  const phrases = [
-    'स्वागत है',
-    'Welcome',
-    'Bienvenue',
-    'Bienvenido',
-    'Willkommen',
-    'Benvenuto',
-    '欢迎',
-    'ようこそ',
-    '환영합니다',
-    'Добро пожаловать',
-    'Bem-vindo',
-  ];
+  const phrases = TYPING_WELCOME_PHRASES;
 
   const [phraseIndex, setPhraseIndex] = useState(0);
   const [display, setDisplay] = useState('');
@@ -375,7 +379,7 @@ function TypingWelcome({ textColor, mutedColor }: { textColor: string; mutedColo
       setPrePause(true);
     }
     return () => { if (timer) clearTimeout(timer); };
-  }, [display, isDeleting, phraseIndex, prePause]);
+  }, [display, isDeleting, phraseIndex, prePause, phrases]);
 
   useEffect(() => {
     const id = setInterval(() => setCaretOn(v => !v), 520);

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/auth/register/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/auth/register/page.tsx
@@ -150,12 +150,14 @@ export default function RegisterPage() {
         {(tenant.logo_rectangle_url || tenant.logo_url || tenant.logo_emoji) && (
           <div className="mb-6 flex items-center justify-center">
             {tenant.logo_rectangle_url ? (
+              // eslint-disable-next-line @next/next/no-img-element
               <img
                 src={tenant.logo_rectangle_url}
                 alt={tenant.tab_title}
                 className="h-24 max-w-full object-contain"
               />
             ) : tenant.logo_url ? (
+              // eslint-disable-next-line @next/next/no-img-element
               <img
                 src={tenant.logo_url}
                 alt={tenant.tab_title}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/auth/reset-password/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/auth/reset-password/page.tsx
@@ -164,12 +164,14 @@ function ResetPasswordContent() {
             {(tenant.logo_rectangle_url || tenant.logo_url || tenant.logo_emoji) && (
               <div className="mb-6 flex items-center justify-center">
                 {tenant.logo_rectangle_url ? (
+                  // eslint-disable-next-line @next/next/no-img-element
                   <img
                     src={tenant.logo_rectangle_url}
                     alt={tenant.tab_title}
                     className="h-24 max-w-full object-contain"
                   />
                 ) : tenant.logo_url ? (
+                  // eslint-disable-next-line @next/next/no-img-element
                   <img
                     src={tenant.logo_url}
                     alt={tenant.tab_title}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/org/[orgSlug]/auth/forgot-password/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/org/[orgSlug]/auth/forgot-password/page.tsx
@@ -197,6 +197,7 @@ export default function OrgForgotPasswordPage() {
               ) : branding ? (
                 <>
                   {branding.logoRectangleUrl ? (
+                    // eslint-disable-next-line @next/next/no-img-element
                     <img
                       src={branding.logoRectangleUrl}
                       alt={branding.name}
@@ -205,6 +206,7 @@ export default function OrgForgotPasswordPage() {
                   ) : (
                     <div className="flex items-center gap-3">
                       {branding.logoUrl ? (
+                        // eslint-disable-next-line @next/next/no-img-element
                         <img
                           src={branding.logoUrl}
                           alt={branding.name}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/org/[orgSlug]/auth/login/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/org/[orgSlug]/auth/login/page.tsx
@@ -223,6 +223,7 @@ export default function OrgLoginPage() {
           ) : branding ? (
             <>
               {branding.logoRectangleUrl ? (
+                // eslint-disable-next-line @next/next/no-img-element
                 <img
                   src={branding.logoRectangleUrl}
                   alt={branding.name}
@@ -231,6 +232,7 @@ export default function OrgLoginPage() {
               ) : (
                 <div className="flex items-center gap-3">
                   {branding.logoUrl ? (
+                    // eslint-disable-next-line @next/next/no-img-element
                     <img
                       src={branding.logoUrl}
                       alt={branding.name}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/org/[orgSlug]/auth/register/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/org/[orgSlug]/auth/register/page.tsx
@@ -176,6 +176,7 @@ export default function OrgRegisterPage() {
           ) : branding ? (
             <>
               {branding.logoRectangleUrl ? (
+                // eslint-disable-next-line @next/next/no-img-element
                 <img
                   src={branding.logoRectangleUrl}
                   alt={branding.name}
@@ -184,6 +185,7 @@ export default function OrgRegisterPage() {
               ) : (
                 <div className="flex items-center gap-3">
                   {branding.logoUrl ? (
+                    // eslint-disable-next-line @next/next/no-img-element
                     <img
                       src={branding.logoUrl}
                       alt={branding.name}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/organizations/[orgId]/settings/branding/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/organizations/[orgId]/settings/branding/page.tsx
@@ -426,6 +426,7 @@ export default function BrandingPage() {
         {loginBgImageUrl && (
           <div className="rounded-lg border border-dashed border-muted-foreground/30 p-2">
             <p className="mb-1 text-xs text-muted-foreground">Preview</p>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
             <img src={loginBgImageUrl} alt="Background" className="h-24 w-full rounded object-cover" />
           </div>
         )}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/organizations/[orgId]/settings/workspaces/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/organizations/[orgId]/settings/workspaces/page.tsx
@@ -102,6 +102,7 @@ export default function OrganizationWorkspacesPage() {
               <div className="mb-4 flex items-start justify-between">
                 {logo ? (
                   <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-transparent">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img src={logo} alt={workspace.name} className="h-12 w-12 rounded-xl object-contain" />
                   </div>
                 ) : (

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/files/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/files/page.tsx
@@ -171,6 +171,7 @@ export default function FilesPage() {
     };
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pdfViewerFileName, imageViewerFileName, textViewerFileName]);
 
   useEffect(() => {
@@ -1527,6 +1528,7 @@ export default function FilesPage() {
               )}
               {imageViewerUrl && !imageViewerLoading && !imageViewerError && (
                 <div className="flex h-full w-full items-center justify-center p-4">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
                   <img
                     src={imageViewerUrl}
                     alt={imageViewerFileName}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/graph/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/graph/page.tsx
@@ -894,6 +894,7 @@ export default function GraphPage() {
         setLoading(false);
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [workspaceId, selectedGraphId, visibleGraphIds, activeSavedView]);
 
   const loadFromApiRef = useRef(loadFromApi);
@@ -1689,6 +1690,7 @@ export default function GraphPage() {
     } finally {
       setLoadingNextParentLevel(false);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [parentsLevels, hierarchyByLevel, loadingNextParentLevel, nodes, selectedGraphId, visibleGraphIds, workspaceId]);
 
   const canExpandParentsMore =

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/organization/branding/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/organization/branding/page.tsx
@@ -259,12 +259,14 @@ export default function BrandingPage() {
             {logoUrl && (
               <div>
                 <p className="mb-1 text-xs text-muted-foreground">Square</p>
+                {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img src={logoUrl} alt="Square logo" className="h-12 w-12 rounded-lg object-contain" />
               </div>
             )}
             {logoRectangleUrl && (
               <div>
                 <p className="mb-1 text-xs text-muted-foreground">Rectangle</p>
+                {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img src={logoRectangleUrl} alt="Rectangle logo" className="h-12 max-w-[200px] object-contain" />
               </div>
             )}
@@ -300,6 +302,7 @@ export default function BrandingPage() {
         {loginBgImageUrl && (
           <div className="rounded-lg border border-dashed border-muted-foreground/30 p-2">
             <p className="mb-1 text-xs text-muted-foreground">Preview</p>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
             <img src={loginBgImageUrl} alt="Background" className="h-24 w-full rounded object-cover" />
           </div>
         )}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/organization/workspaces/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/organization/workspaces/page.tsx
@@ -100,6 +100,7 @@ export default function OrganizationWorkspacesPage() {
               <div className="mb-4 flex items-start justify-between">
                 {logo ? (
                   <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-transparent">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img src={logo} alt={workspace.name} className="h-12 w-12 rounded-xl object-contain" />
                   </div>
                 ) : (

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/theme/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/theme/page.tsx
@@ -4,7 +4,7 @@ import { useState, useRef, useEffect } from 'react';
 import {
   Brush,
   Upload,
-  Image,
+  Image as ImageIcon,
   Check,
   X,
   RefreshCw,
@@ -50,7 +50,7 @@ export default function ThemeSettingsPage() {
       setCustomColor(workspace.theme?.primaryColor || DEFAULT_THEME.primaryColor);
       setLogoUrl(workspace.theme?.logoUrl || '');
     }
-  }, [workspace?.id, workspace?.theme?.primaryColor, workspace?.theme?.logoUrl]);
+  }, [workspace]);
 
   if (!workspace) {
     return (
@@ -159,6 +159,7 @@ export default function ThemeSettingsPage() {
             style={{ backgroundColor: theme.logoUrl ? 'transparent' : theme.primaryColor }}
           >
             {theme.logoUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element
               <img
                 src={theme.logoUrl}
                 alt="Logo"
@@ -178,7 +179,7 @@ export default function ThemeSettingsPage() {
       {/* Logo Settings */}
       <div className="rounded-xl border bg-card p-6">
         <div className="flex items-center gap-2 mb-4">
-          <Image size={18} className="text-muted-foreground" />
+          <ImageIcon size={18} className="text-muted-foreground" />
           <h3 className="text-lg font-medium">Logo</h3>
         </div>
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
@@ -758,8 +758,9 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
 
   // Abort all polling loops on unmount
   useEffect(() => {
+    const abortRefs = ingestionAbortRefs.current;
     return () => {
-      ingestionAbortRefs.current.forEach((ctrl) => ctrl.abort());
+      abortRefs.forEach((ctrl) => ctrl.abort());
     };
   }, []);
 
@@ -1283,6 +1284,7 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
       setRecordingSeconds(0);
       audioChunksRef.current = [];
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cancelVoiceRecording]);
 
   // Keyboard shortcuts:

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/graph/vis-network.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/graph/vis-network.tsx
@@ -919,6 +919,7 @@ export function VisNetwork({
         networkRef.current = null;
       }
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Track if initial stabilization is done

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/settings/models-panel.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/settings/models-panel.tsx
@@ -359,6 +359,7 @@ export function ModelsPanel() {
                               const url = p?.logo_url as string | undefined;
                               return url ? (
                                 // Use API base for relative /logos/* paths
+                                // eslint-disable-next-line @next/next/no-img-element
                                 <img src={url.startsWith('http') ? url : `${getApiBase()}${url}`} alt={model.provider} className="h-full w-full object-cover" />
                               ) : (
                                 providerIcons[model.provider.toLowerCase()] || <Cloud size={18} />

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/settings/provider-form.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/settings/provider-form.tsx
@@ -74,6 +74,7 @@ export function ProviderForm({ provider, onSave, onCancel }: ProviderFormProps) 
     if (type === 'ollama' || type === 'abi') {
       fetchOllamaModels();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [type, endpoint]);
 
   const fetchOllamaModels = async () => {

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/settings/servers-panel.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/settings/servers-panel.tsx
@@ -106,11 +106,13 @@ export function ServersPanel() {
   }, [mounted, currentWorkspaceId, fetchServers, setCurrentWorkspace]);
 
   // Check all servers after fetching
+  const firstServerId = servers.length > 0 ? servers[0]?.id : null;
   useEffect(() => {
     if (mounted && servers.length > 0) {
       checkAllServers();
     }
-  }, [mounted, servers.length > 0 ? servers[0]?.id : null]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mounted, firstServerId]);
 
   const handleAdd = async () => {
     if (!newServer.name.trim() || !newServer.endpoint.trim()) return;

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/header.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/header.tsx
@@ -202,6 +202,7 @@ export function Header({ title, subtitle }: HeaderProps = {}) {
             )}
           >
             {displayUser?.avatar ? (
+              // eslint-disable-next-line @next/next/no-img-element
               <img
                 src={displayUser.avatar}
                 alt={displayUser.name || 'User'}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/chat-section.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/chat-section.tsx
@@ -245,8 +245,8 @@ export function ChatSection({ collapsed, detailOnly }: { collapsed: boolean; det
   const { agents } = useAgentsStore();
   const safeAgents = Array.isArray(agents) ? agents : [];
 
-  const allConversations = getWorkspaceConversations() ?? [];
-  const safeProjects = Array.isArray(projects) ? projects : [];
+  const allConversations = useMemo(() => getWorkspaceConversations() ?? [], [getWorkspaceConversations]);
+  const safeProjects = useMemo(() => (Array.isArray(projects) ? projects : []), [projects]);
   const conversations = useMemo(() => allConversations.filter((c) => !c.archived), [allConversations]);
   const isChatRoute = pathname.startsWith(getWorkspacePath(currentWorkspaceId, '/chat'));
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/index.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/index.tsx
@@ -197,6 +197,7 @@ export function Sidebar() {
           title={currentWorkspace?.name || 'NEXUS'}
         >
           {currentWorkspace?.theme?.logoUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
             <img src={currentWorkspace.theme.logoUrl} alt={currentWorkspace.name} className="h-full w-full object-cover" />
           ) : (
             <span className="text-sm font-bold text-white">
@@ -318,6 +319,7 @@ export function Sidebar() {
                   style={{ backgroundColor: workspace.theme?.primaryColor || '#22c55e' }}
                 >
                   {workspace.theme?.logoUrl ? (
+                    // eslint-disable-next-line @next/next/no-img-element
                     <img src={workspace.theme.logoUrl} alt={workspace.name} className="h-full w-full object-cover" />
                   ) : (
                     <span className="text-xs text-white">

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/lab-section.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/lab-section.tsx
@@ -79,6 +79,7 @@ const FileItem = React.memo(function FileItem({
         inputRef.current.select();
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isEditing]);
 
   const handleRename = () => {

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/ontology-section.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/ontology-section.tsx
@@ -170,6 +170,7 @@ export function OntologySection({ collapsed, detailOnly }: { collapsed: boolean;
     };
 
     fetchOntologyFiles();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/workspace-layout.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/workspace-layout.tsx
@@ -118,7 +118,9 @@ export function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
 
     window.addEventListener('org-theme-changed', handleThemeChange as EventListener);
     return () => window.removeEventListener('org-theme-changed', handleThemeChange as EventListener);
-  }, [currentWorkspaceId]); // REMOVED workspaces and setTheme - they cause infinite loops
+    // REMOVED workspaces and setTheme - they cause infinite loops
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentWorkspaceId]);
 
   // Fetch agents when workspace loads
   useEffect(() => {

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/contexts/tenant-context.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/contexts/tenant-context.tsx
@@ -172,6 +172,7 @@ export function TenantProvider({ children }: { children: React.ReactNode }) {
       clearTimeout(t2);
       clearTimeout(t3);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tenant.tab_title, tenant.favicon_url, pathname]);
 
   // Keep favicon and title persistent: re-apply when something else (e.g. Next.js) changes the icon


### PR DESCRIPTION
This pull request resolves #clean-frontend-nexus

### Summary of changes:
- Added a new `AGENT.md` file under `libs/naas-abi/naas_abi/apps/nexus/` documenting the NEXUS multi-LLM agent platform, its execution modes, commands, service layout, database migrations, SSE provider adapters, multi-tenancy invariants, frontend setup, and conventions.
- Introduced multiple eslint-disable comments for `@next/next/no-img-element` to allow usage of `<img>` tags instead of Next.js `Image` components on various pages and components across the frontend, primarily in the `apps/web` directory. This includes pages like login, register, forgot-password, reset-password, branding, workspace files, graph, shell sidebar, chat interface, and more.
- Slight refactor in `TypingWelcome` component to move welcome phrases into a constant outside the component.
- Various fixes to React hooks dependencies warnings using eslint-disable comments on hooks that purposely exclude dependencies to avoid unnecessary reruns or infinite loops.
- Minor UI icon import rename in `ThemeSettingsPage`.

### Impact:
- This merge improves documentation for the NEXUS agent platform.
- Enables use of raw `<img>` elements across the frontend UI where appropriate, likely for custom or dynamic images that don't conform to Next.js Image constraints.
- Improves code quality by addressing React hook dependency issues.

### Notes:
- All eslint-disable comments for `@next/next/no-img-element` are intentionally placed to suppress Next.js warnings when using raw image tags as required by design or legacy constraints.
- React hooks modifications avoid infinite loops and improve correctness.

No breaking changes expected.