### PR TITLE
fix(module-model-loader): use f-strings so loguru interpolates values

### DIFF
--- a/libs/naas-abi-core/naas_abi_core/module/ModuleModelLoader.py
+++ b/libs/naas-abi-core/naas_abi_core/module/ModuleModelLoader.py
@@ -54,9 +54,7 @@ class ModuleModelLoader:
                 model_module = importlib.import_module(model_module_path)
             except Exception as exc:
                 logger.warning(
-                    "ModuleModelLoader: failed to import %s: %s — skipping.",
-                    model_module_path,
-                    exc,
+                    f"ModuleModelLoader: failed to import {model_module_path}: {exc} — skipping."
                 )
                 continue
 
@@ -74,11 +72,9 @@ class ModuleModelLoader:
                 model = getattr(value, "model", None)
                 if canonical_id is None or not isinstance(model, Model):
                     logger.warning(
-                        "ModuleModelLoader: %s.%s is a ModelDefinition but is "
-                        "missing CANONICAL_ID or a Model instance on ``model`` "
-                        "— skipped.",
-                        model_module_path,
-                        value.__name__,
+                        f"ModuleModelLoader: {model_module_path}.{value.__name__} "
+                        "is a ModelDefinition but is missing CANONICAL_ID or a "
+                        "Model instance on ``model`` — skipped."
                     )
                     continue
 
@@ -86,20 +82,15 @@ class ModuleModelLoader:
                     registry.register(canonical_id, model)
                     registered += 1
                     logger.debug(
-                        "ModuleModelLoader: registered %s.%s as %r (provider=%s).",
-                        model_module_path,
-                        value.__name__,
-                        str(canonical_id),
-                        model.provider,
+                        f"ModuleModelLoader: registered {model_module_path}."
+                        f"{value.__name__} as {str(canonical_id)!r} "
+                        f"(provider={model.provider})."
                     )
                 except Exception as exc:
                     logger.warning(
-                        "ModuleModelLoader: registration failed for %s.%s "
-                        "(canonical_id=%r): %s",
-                        model_module_path,
-                        value.__name__,
-                        str(canonical_id),
-                        exc,
+                        f"ModuleModelLoader: registration failed for "
+                        f"{model_module_path}.{value.__name__} "
+                        f"(canonical_id={str(canonical_id)!r}): {exc}"
                     )
 
         return registered


### PR DESCRIPTION
## Summary

The four `logger.*` calls in `ModuleModelLoader` were using stdlib `%s`-style format strings with positional args. loguru doesn't substitute `%s` placeholders, so output looked like:

```
ModuleModelLoader: registered %s.%s as %r (provider=%s).
```

…with the module path / class name / canonical id / provider silently dropped.

## Changes

Switched all four calls (one debug, three warnings) to f-strings, matching the loguru style already used at line 40 of the same file.

## Test plan

- [ ] Run `abi chat` (or anything that boots the engine with the model registry) and confirm log lines now show real values, e.g.:
      `ModuleModelLoader: registered naas_abi_marketplace.ai.chatgpt.models.gpt_4_1_mini.Gpt41Mini as 'gpt-4.1-mini' (provider=openai).`
- [ ] No behavior change beyond log formatting.