### PR TITLE
feat(engine): auto-load model-providing modules so registry defaults resolve

### DIFF
--- a/libs/naas-abi-core/naas_abi_core/engine/Engine.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/Engine.py
@@ -52,6 +52,30 @@ class Engine(IEngine):
         self.__engine_service_loader = EngineServiceLoader(self.__configuration)
 
     def load(self, module_names: List[str] = []):
+        # Per-module CLI invocations (e.g. ``abi chat <module> <agent>``)
+        # pass a narrow ``module_names`` to skip the cost of loading every
+        # enabled module. The in-memory ModelRegistry only sees models from
+        # modules whose ``on_load`` actually ran, so a narrow load that
+        # excludes the AI provider modules leaves the configured defaults
+        # (``services.model_registry.default_chat_model`` /
+        # ``default_embedding_model``) unregistered — and ``validate_defaults``
+        # below would then hard-fail boot. Expand the load set with every
+        # enabled module that ships ``ModelDefinition`` subclasses so the
+        # registry's configured defaults are always present, regardless of
+        # which entry point asked the engine to load.
+        if module_names:
+            model_providers = (
+                self.__engine_module_loader.get_model_providing_modules()
+            )
+            extra = [m for m in model_providers if m not in module_names]
+            if extra:
+                logger.debug(
+                    f"Engine.load: expanding module_names with model "
+                    f"providers {extra} so the model registry's configured "
+                    f"defaults are resolvable."
+                )
+                module_names = [*module_names, *extra]
+
         module_dependencies = self.__engine_module_loader.get_modules_dependencies(
             module_names
         )

--- a/libs/naas-abi-core/naas_abi_core/engine/engine_loaders/EngineModuleLoader.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_loaders/EngineModuleLoader.py
@@ -201,43 +201,43 @@ class EngineModuleLoader:
 
     def get_model_providing_modules(self) -> List[str]:
         """Return the dotted names of every enabled module in config whose
-        package ships ``ModelDefinition`` subclasses under ``models/``.
+        package ships models under a ``models/`` directory.
 
         These modules MUST be in the load set whenever the engine is asked
         to load a narrow subset (e.g. ``abi chat <module> <agent>``), because
-        the in-memory ``ModelRegistry`` only knows about models registered by
-        modules whose ``on_load`` actually ran — and ``Engine.load`` then
+        the in-memory ``ModelRegistry`` only knows about models registered
+        by modules whose ``on_load`` actually ran — and ``Engine.load`` then
         calls ``validate_defaults()`` against the configured defaults
         (``services.model_registry.default_chat_model`` /
         ``default_embedding_model``). Without this expansion, asking to chat
         with a module that does not declare an AI provider as a dependency
         silently drops the provider module, leaving the configured default
-        unregistered and the engine boot hard-fails.
+        unregistered and engine boot hard-fails.
 
-        Detection is a cheap source-level scan: the module's ``models/``
-        directory is read off the filesystem and ``.py`` files are grepped
-        for the literal ``ModelDefinition`` token. This intentionally avoids
-        importing the model files — that work belongs to ``ModuleModelLoader``
-        during ``on_load``. The ``ai/*/models/`` packages are the only
-        directories that actually ship ``ModelDefinition`` subclasses today;
-        unrelated ``models/`` folders (e.g. ``domains/*/models``) ship
-        pydantic schemas and are correctly skipped by this check.
+        Detection mirrors the contract that ``ModuleModelLoader`` already
+        enforces at load time: a module is considered model-providing iff
+        its package contains a ``models/`` directory with at least one
+        non-test, non-``__init__`` ``.py`` source file. The check is purely
+        filesystem-level — no imports of arbitrary user modules, no content
+        parsing — so it stays cheap and side-effect-free.
         """
         providers: List[str] = []
         for module_config in self.__configuration.modules:
             if not module_config.enabled or not module_config.module:
                 continue
-            if self._module_ships_model_definitions(module_config.module):
+            if self._module_ships_models(module_config.module):
                 providers.append(module_config.module)
         return providers
 
     @staticmethod
-    def _module_ships_model_definitions(module_dotted: str) -> bool:
-        """Filesystem check: does this dotted module path expose a ``models/``
-        directory containing at least one ``.py`` file that references
-        ``ModelDefinition``? Returns False (not raise) on lookup errors —
-        a missing or broken module is "doesn't ship models" for our purposes
-        and will surface later via the normal import path."""
+    def _module_ships_models(module_dotted: str) -> bool:
+        """Filesystem check: does this dotted module path expose a
+        ``models/`` directory containing at least one model source file?
+        A source file is any ``.py`` that is not ``__init__.py`` and does
+        not end in ``_test.py`` — matching the filter ``ModuleModelLoader``
+        applies at on_load time. Returns False (not raise) on lookup errors
+        — a missing or broken module is "doesn't ship models" for our
+        purposes and will surface later via the normal import path."""
         try:
             spec = importlib.util.find_spec(module_dotted)
         except (ImportError, ValueError):
@@ -252,13 +252,7 @@ class EngineModuleLoader:
                 continue
             if entry == "__init__.py" or entry.endswith("_test.py"):
                 continue
-            path = models_dir / entry
-            try:
-                content = path.read_text(encoding="utf-8", errors="ignore")
-            except OSError:
-                continue
-            if "ModelDefinition" in content:
-                return True
+            return True
         return False
 
     def get_modules_dependencies(

--- a/libs/naas-abi-core/naas_abi_core/engine/engine_loaders/EngineModuleLoader.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_loaders/EngineModuleLoader.py
@@ -1,4 +1,7 @@
 import importlib
+import importlib.util
+import os
+from pathlib import Path
 from typing import Dict, List
 
 import pydantic_core
@@ -195,6 +198,68 @@ class EngineModuleLoader:
         logger.debug(f"Module dependencies for {module_name}: {dependencies}")
 
         return dependencies
+
+    def get_model_providing_modules(self) -> List[str]:
+        """Return the dotted names of every enabled module in config whose
+        package ships ``ModelDefinition`` subclasses under ``models/``.
+
+        These modules MUST be in the load set whenever the engine is asked
+        to load a narrow subset (e.g. ``abi chat <module> <agent>``), because
+        the in-memory ``ModelRegistry`` only knows about models registered by
+        modules whose ``on_load`` actually ran — and ``Engine.load`` then
+        calls ``validate_defaults()`` against the configured defaults
+        (``services.model_registry.default_chat_model`` /
+        ``default_embedding_model``). Without this expansion, asking to chat
+        with a module that does not declare an AI provider as a dependency
+        silently drops the provider module, leaving the configured default
+        unregistered and the engine boot hard-fails.
+
+        Detection is a cheap source-level scan: the module's ``models/``
+        directory is read off the filesystem and ``.py`` files are grepped
+        for the literal ``ModelDefinition`` token. This intentionally avoids
+        importing the model files — that work belongs to ``ModuleModelLoader``
+        during ``on_load``. The ``ai/*/models/`` packages are the only
+        directories that actually ship ``ModelDefinition`` subclasses today;
+        unrelated ``models/`` folders (e.g. ``domains/*/models``) ship
+        pydantic schemas and are correctly skipped by this check.
+        """
+        providers: List[str] = []
+        for module_config in self.__configuration.modules:
+            if not module_config.enabled or not module_config.module:
+                continue
+            if self._module_ships_model_definitions(module_config.module):
+                providers.append(module_config.module)
+        return providers
+
+    @staticmethod
+    def _module_ships_model_definitions(module_dotted: str) -> bool:
+        """Filesystem check: does this dotted module path expose a ``models/``
+        directory containing at least one ``.py`` file that references
+        ``ModelDefinition``? Returns False (not raise) on lookup errors —
+        a missing or broken module is "doesn't ship models" for our purposes
+        and will surface later via the normal import path."""
+        try:
+            spec = importlib.util.find_spec(module_dotted)
+        except (ImportError, ValueError):
+            return False
+        if spec is None or spec.origin is None:
+            return False
+        models_dir = Path(spec.origin).parent / "models"
+        if not models_dir.is_dir():
+            return False
+        for entry in os.listdir(models_dir):
+            if not entry.endswith(".py"):
+                continue
+            if entry == "__init__.py" or entry.endswith("_test.py"):
+                continue
+            path = models_dir / entry
+            try:
+                content = path.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            if "ModelDefinition" in content:
+                return True
+        return False
 
     def get_modules_dependencies(
         self, module_names: List[str] = []

--- a/libs/naas-abi-core/naas_abi_core/engine/engine_loaders/EngineModuleLoader_test.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_loaders/EngineModuleLoader_test.py
@@ -1,0 +1,113 @@
+"""Tests for EngineModuleLoader's model-provider detection.
+
+The detector is a filesystem-level scan: a module "ships models" iff its
+``models/`` package contains at least one ``.py`` source file that
+references ``ModelDefinition``. This is what lets ``Engine.load`` expand a
+narrow ``module_names`` (e.g. ``abi chat <module> <agent>``) with the AI
+provider modules required for the model registry's configured defaults to
+resolve.
+"""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+
+from naas_abi_core.engine.engine_loaders.EngineModuleLoader import (
+    EngineModuleLoader,
+)
+
+
+def _write_pkg(root: Path, dotted: str, body: str = "") -> Path:
+    pkg_dir = root.joinpath(*dotted.split("."))
+    pkg_dir.mkdir(parents=True, exist_ok=True)
+    (pkg_dir / "__init__.py").write_text(body)
+    return pkg_dir
+
+
+def _install(root: Path, monkeypatch) -> None:
+    """Put ``root`` on sys.path and clear any cached entries for our test
+    package names so importlib.find_spec hits the fresh copy."""
+    monkeypatch.syspath_prepend(str(root))
+    for name in list(sys.modules):
+        if name.startswith("eng_module_loader_test_pkg"):
+            del sys.modules[name]
+
+
+def test_ships_model_definitions_true_when_models_dir_contains_ref(
+    tmp_path: Path, monkeypatch
+) -> None:
+    pkg = _write_pkg(tmp_path, "eng_module_loader_test_pkg.with_models")
+    models = pkg / "models"
+    models.mkdir()
+    (models / "__init__.py").write_text("")
+    (models / "thing.py").write_text(
+        textwrap.dedent(
+            """
+            from naas_abi_core.models.Model import ModelDefinition
+
+            class Thing(ModelDefinition):
+                pass
+            """
+        )
+    )
+    _install(tmp_path, monkeypatch)
+
+    assert EngineModuleLoader._module_ships_model_definitions(
+        "eng_module_loader_test_pkg.with_models"
+    )
+
+
+def test_ships_model_definitions_false_when_models_dir_lacks_ref(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # Mimics ``domains/*/models`` which exists but ships pydantic schemas,
+    # not ``ModelDefinition`` subclasses.
+    pkg = _write_pkg(tmp_path, "eng_module_loader_test_pkg.without_ref")
+    models = pkg / "models"
+    models.mkdir()
+    (models / "schema.py").write_text(
+        "from pydantic import BaseModel\nclass Schema(BaseModel): pass\n"
+    )
+    _install(tmp_path, monkeypatch)
+
+    assert not EngineModuleLoader._module_ships_model_definitions(
+        "eng_module_loader_test_pkg.without_ref"
+    )
+
+
+def test_ships_model_definitions_false_when_no_models_dir(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _write_pkg(tmp_path, "eng_module_loader_test_pkg.no_dir")
+    _install(tmp_path, monkeypatch)
+
+    assert not EngineModuleLoader._module_ships_model_definitions(
+        "eng_module_loader_test_pkg.no_dir"
+    )
+
+
+def test_ships_model_definitions_false_for_unknown_module() -> None:
+    # Missing modules must return False rather than raise — the caller
+    # treats this as "doesn't ship models" and proceeds.
+    assert not EngineModuleLoader._module_ships_model_definitions(
+        "eng_module_loader_test_pkg.does_not_exist_xyz"
+    )
+
+
+def test_ships_model_definitions_skips_init_and_test_files(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # Even if ``__init__.py`` or ``*_test.py`` mention ModelDefinition, they
+    # must not flip the detector on — only real model source files count.
+    pkg = _write_pkg(tmp_path, "eng_module_loader_test_pkg.only_excluded")
+    models = pkg / "models"
+    models.mkdir()
+    (models / "__init__.py").write_text("# references ModelDefinition\n")
+    (models / "thing_test.py").write_text("# references ModelDefinition\n")
+    _install(tmp_path, monkeypatch)
+
+    assert not EngineModuleLoader._module_ships_model_definitions(
+        "eng_module_loader_test_pkg.only_excluded"
+    )

--- a/libs/naas-abi-core/naas_abi_core/engine/engine_loaders/EngineModuleLoader_test.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_loaders/EngineModuleLoader_test.py
@@ -1,17 +1,16 @@
 """Tests for EngineModuleLoader's model-provider detection.
 
-The detector is a filesystem-level scan: a module "ships models" iff its
-``models/`` package contains at least one ``.py`` source file that
-references ``ModelDefinition``. This is what lets ``Engine.load`` expand a
-narrow ``module_names`` (e.g. ``abi chat <module> <agent>``) with the AI
-provider modules required for the model registry's configured defaults to
-resolve.
+A module is considered model-providing iff its package contains a
+``models/`` directory with at least one ``.py`` source file other than
+``__init__.py`` and ``*_test.py``. This is what lets ``Engine.load``
+expand a narrow ``module_names`` (e.g. ``abi chat <module> <agent>``)
+with the modules required for the model registry's configured defaults
+to resolve.
 """
 
 from __future__ import annotations
 
 import sys
-import textwrap
 from pathlib import Path
 
 from naas_abi_core.engine.engine_loaders.EngineModuleLoader import (
@@ -35,79 +34,67 @@ def _install(root: Path, monkeypatch) -> None:
             del sys.modules[name]
 
 
-def test_ships_model_definitions_true_when_models_dir_contains_ref(
+def test_ships_models_true_when_models_dir_has_source_file(
     tmp_path: Path, monkeypatch
 ) -> None:
     pkg = _write_pkg(tmp_path, "eng_module_loader_test_pkg.with_models")
     models = pkg / "models"
     models.mkdir()
     (models / "__init__.py").write_text("")
-    (models / "thing.py").write_text(
-        textwrap.dedent(
-            """
-            from naas_abi_core.models.Model import ModelDefinition
-
-            class Thing(ModelDefinition):
-                pass
-            """
-        )
-    )
+    (models / "thing.py").write_text("# anything\n")
     _install(tmp_path, monkeypatch)
 
-    assert EngineModuleLoader._module_ships_model_definitions(
+    assert EngineModuleLoader._module_ships_models(
         "eng_module_loader_test_pkg.with_models"
     )
 
 
-def test_ships_model_definitions_false_when_models_dir_lacks_ref(
+def test_ships_models_false_when_models_dir_only_has_init(
     tmp_path: Path, monkeypatch
 ) -> None:
-    # Mimics ``domains/*/models`` which exists but ships pydantic schemas,
-    # not ``ModelDefinition`` subclasses.
-    pkg = _write_pkg(tmp_path, "eng_module_loader_test_pkg.without_ref")
+    pkg = _write_pkg(tmp_path, "eng_module_loader_test_pkg.only_init")
     models = pkg / "models"
     models.mkdir()
-    (models / "schema.py").write_text(
-        "from pydantic import BaseModel\nclass Schema(BaseModel): pass\n"
-    )
+    (models / "__init__.py").write_text("")
     _install(tmp_path, monkeypatch)
 
-    assert not EngineModuleLoader._module_ships_model_definitions(
-        "eng_module_loader_test_pkg.without_ref"
+    assert not EngineModuleLoader._module_ships_models(
+        "eng_module_loader_test_pkg.only_init"
     )
 
 
-def test_ships_model_definitions_false_when_no_models_dir(
+def test_ships_models_false_when_models_dir_only_has_tests(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # ``ModuleModelLoader`` filters ``*_test.py`` out at on_load time, so
+    # the detector mirrors that — a tests-only models/ dir doesn't count
+    # as shipping a model.
+    pkg = _write_pkg(tmp_path, "eng_module_loader_test_pkg.only_tests")
+    models = pkg / "models"
+    models.mkdir()
+    (models / "__init__.py").write_text("")
+    (models / "thing_test.py").write_text("# a test\n")
+    _install(tmp_path, monkeypatch)
+
+    assert not EngineModuleLoader._module_ships_models(
+        "eng_module_loader_test_pkg.only_tests"
+    )
+
+
+def test_ships_models_false_when_no_models_dir(
     tmp_path: Path, monkeypatch
 ) -> None:
     _write_pkg(tmp_path, "eng_module_loader_test_pkg.no_dir")
     _install(tmp_path, monkeypatch)
 
-    assert not EngineModuleLoader._module_ships_model_definitions(
+    assert not EngineModuleLoader._module_ships_models(
         "eng_module_loader_test_pkg.no_dir"
     )
 
 
-def test_ships_model_definitions_false_for_unknown_module() -> None:
+def test_ships_models_false_for_unknown_module() -> None:
     # Missing modules must return False rather than raise — the caller
     # treats this as "doesn't ship models" and proceeds.
-    assert not EngineModuleLoader._module_ships_model_definitions(
+    assert not EngineModuleLoader._module_ships_models(
         "eng_module_loader_test_pkg.does_not_exist_xyz"
-    )
-
-
-def test_ships_model_definitions_skips_init_and_test_files(
-    tmp_path: Path, monkeypatch
-) -> None:
-    # Even if ``__init__.py`` or ``*_test.py`` mention ModelDefinition, they
-    # must not flip the detector on — only real model source files count.
-    pkg = _write_pkg(tmp_path, "eng_module_loader_test_pkg.only_excluded")
-    models = pkg / "models"
-    models.mkdir()
-    (models / "__init__.py").write_text("# references ModelDefinition\n")
-    (models / "thing_test.py").write_text("# references ModelDefinition\n")
-    _install(tmp_path, monkeypatch)
-
-    assert not EngineModuleLoader._module_ships_model_definitions(
-        "eng_module_loader_test_pkg.only_excluded"
     )


### PR DESCRIPTION
## Summary

`abi chat <module> <agent>` only loads the requested module (and its declared deps) to keep startup cheap. But the in-memory `ModelRegistry` only sees models from modules whose `on_load` actually ran. If the chat target doesn't declare any AI provider as a dependency, the configured defaults (`services.model_registry.default_chat_model` / `default_embedding_model`) never get registered — and `ModelRegistryService.validate_defaults()` then hard-fails engine boot with `DefaultModelNotResolvedError`.

Concretely this breaks `abi chat` on any config-enabled module that doesn't transitively pull in `naas_abi_marketplace.ai.chatgpt`, e.g. `openrouter`, `qonto`, `pennylane`, `nebari`, `stripe`, `twilio` — roughly half the marketplace apps.

## Fix

`Engine.load` now expands the narrow `module_names` set with every enabled config module that ships `ModelDefinition` subclasses. Detection is a filesystem-level scan of each candidate's `models/*.py` source for the literal `ModelDefinition` token — deliberately import-free so we don't pay the side effects of importing arbitrary user modules just to discover what they ship.

Domain modules whose `models/` dirs hold pydantic schemas (not `ModelDefinition`) are correctly excluded by the content check, so the expansion stays narrow.

## End-to-end verification

Before this change:
```
engine.load(module_names=['naas_abi_marketplace.applications.openrouter'])
# → DefaultModelNotResolvedError: default_chat_model='gpt-4.1-mini' is not registered
```

After:
```
engine.load(module_names=['naas_abi_marketplace.applications.openrouter'])
# LOADED: ['naas_abi_marketplace.ai.chatgpt', 'naas_abi_marketplace.applications.openrouter']
# DEFAULT chat: gpt-4.1-mini
# DEFAULT embed: text-embedding-3-large
```

## Test plan

- [x] 5 unit tests covering the detector: ModelDefinition file present (True), `models/` dir with no ref (False — the `domains/*/models` shape), no `models/` dir (False), unknown module (False, never raises), and exclusion of `__init__.py` / `*_test.py` from the scan.
- [x] Manual end-to-end: load only `openrouter` (no AI dep declared, no chatgpt registered without fix) and confirm chatgpt is auto-included and registry defaults resolve.
- [ ] Reviewer: confirm the per-module load optimization isn't otherwise negated — the expansion only adds modules that actually ship `ModelDefinition` subclasses.