### PR TITLE
feat(chat): add default agent selection on new chat page

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
@@ -3730,7 +3730,7 @@ function FeedbackDislikeDialog({
         onClick={() => !submitting && onCancel()}
       />
       <div className="relative z-10 mx-4 w-full max-w-md animate-in zoom-in-95 fade-in duration-200">
-        <div className="rounded-xl border border-border bg-background p-6 shadow-2xl">
+        <div className="border border-border bg-background p-6 shadow-2xl">
           <h3 className="text-base font-semibold text-foreground">Provide negative feedback</h3>
 
           <div className="mt-4 space-y-1">
@@ -3740,7 +3740,7 @@ function FeedbackDislikeDialog({
             <select
               value={type}
               onChange={(e) => setType(e.target.value)}
-              className="w-full rounded-lg border border-border bg-muted/50 px-3 py-2 text-sm text-foreground outline-none focus-visible:ring-2 focus-visible:ring-workspace-accent focus-visible:ring-offset-2 ring-offset-background"
+              className="w-full border border-border bg-muted/50 px-3 py-2 text-sm text-foreground outline-none focus-visible:ring-2 focus-visible:ring-workspace-accent focus-visible:ring-offset-2 ring-offset-background"
             >
               <option value="">Select...</option>
               {FEEDBACK_TYPE_OPTIONS.map((opt) => (
@@ -3759,14 +3759,14 @@ function FeedbackDislikeDialog({
               value={detail}
               onChange={(e) => setDetail(e.target.value)}
               rows={4}
-              className="w-full resize-none rounded-lg border border-border bg-muted/50 px-3 py-2 text-sm text-foreground outline-none focus-visible:ring-2 focus-visible:ring-workspace-accent focus-visible:ring-offset-2 ring-offset-background"
+              className="w-full resize-none border border-border bg-muted/50 px-3 py-2 text-sm text-foreground outline-none focus-visible:ring-2 focus-visible:ring-workspace-accent focus-visible:ring-offset-2 ring-offset-background"
               placeholder="Describe the issue you encountered..."
             />
           </div>
 
           <div className="mt-4 space-y-2">
             <label className="text-sm text-foreground">
-              How unsatisfactory was this response?
+              How unsatisfactory was this response? (optional)
             </label>
             <div className="flex items-center gap-1">
               {[1, 2, 3, 4, 5].map((value) => {
@@ -3777,7 +3777,7 @@ function FeedbackDislikeDialog({
                     type="button"
                     onClick={() => setSeverity(severity === value ? null : value)}
                     className={cn(
-                      'flex h-8 w-8 items-center justify-center rounded-md border text-sm transition-colors',
+                      'flex h-8 w-8 items-center justify-center border text-sm transition-colors',
                       active
                         ? 'border-red-600/40 bg-red-50/40 text-red-600'
                         : 'border-border text-muted-foreground hover:bg-muted/40',
@@ -3803,14 +3803,14 @@ function FeedbackDislikeDialog({
             <button
               onClick={onCancel}
               disabled={submitting}
-              className="rounded-lg px-4 py-2 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-60"
+              className="px-4 py-2 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-60"
             >
               Cancel
             </button>
             <button
               onClick={handleSubmit}
               disabled={submitting}
-              className="inline-flex items-center gap-2 rounded-lg bg-workspace-accent px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-workspace-accent/90 disabled:opacity-60"
+              className="inline-flex items-center gap-2 bg-workspace-accent px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-workspace-accent/90 disabled:opacity-60"
             >
               {submitting && <Loader2 size={12} className="animate-spin" />}
               Submit

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
@@ -542,6 +542,7 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
   const {
     activeConversationId,
     selectedAgent,
+    setSelectedAgent,
     createConversation,
     setActiveConversation,
     addMessage,
@@ -587,10 +588,20 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
     setMounted(true);
   }, []);
 
-  // On first render, activate the conversation referenced in the URL (if any).
+  // Sync URL slug → active conversation. When there's no slug (/chat base route),
+  // reset to a blank new-chat state and pre-select the workspace default agent.
   useEffect(() => {
-    if (!initialConversationId) return;
-    setActiveConversation(initialConversationId);
+    if (initialConversationId) {
+      setActiveConversation(initialConversationId);
+      return;
+    }
+    setActiveConversation(null);
+    const agents = useAgentsStore.getState().agents;
+    const defaultAgent =
+      agents.find((a) => a.isDefault && a.enabled) ??
+      agents.find((a) => a.id === 'abi' && a.enabled) ??
+      agents.find((a) => a.enabled);
+    if (defaultAgent) setSelectedAgent(defaultAgent.id);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialConversationId]);
 
@@ -631,11 +642,10 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
     return () => clearTimeout(t);
   }, [activeConversationTitle, mounted, tabTitle]);
 
-  // When switching/creating a conversation (including via keyboard shortcut in the sidebar),
-  // keep the typing cursor in the chat bar.
+  // Keep the typing cursor in the chat bar whenever the active conversation changes
+  // (including null = new chat state).
   useEffect(() => {
     if (!mounted) return;
-    if (!activeConversationId) return;
     focusChatInput();
   }, [activeConversationId, mounted, focusChatInput]);
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/chat-section.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/chat-section.tsx
@@ -230,7 +230,6 @@ export function ChatSection({ collapsed, detailOnly }: { collapsed: boolean; det
   const {
     activeConversationId,
     setActiveConversation,
-    createConversation,
     projects,
     currentWorkspaceId,
     getWorkspaceConversations,
@@ -262,23 +261,25 @@ export function ChatSection({ collapsed, detailOnly }: { collapsed: boolean; det
   }, [conversations, safeProjects]);
 
   const handleNewChat = useCallback(() => {
-    createConversation();
+    const defaultAgent =
+      safeAgents.find((a) => a.isDefault && a.enabled) ??
+      safeAgents.find((a) => a.id === 'abi' && a.enabled) ??
+      safeAgents.find((a) => a.enabled);
+    if (defaultAgent) setSelectedAgent(defaultAgent.id);
+    setActiveConversation(null);
     router.push(getWorkspacePath(currentWorkspaceId, '/chat'));
-  }, [createConversation, router, currentWorkspaceId]);
+  }, [safeAgents, setSelectedAgent, setActiveConversation, router, currentWorkspaceId]);
 
-  // Clicking the "Chat" section header should drop the user into a fresh
-  // conversation seeded with the workspace's default agent (falling back to
-  // the SupervisorAgent "abi", then the first enabled agent).
+  // Clicking the "Chat" section header resets to a blank new-chat state,
+  // pre-selecting the workspace default agent (falling back to "abi" then first enabled).
   const handleChatHeaderNavigate = useCallback(() => {
     const defaultAgent =
       safeAgents.find((a) => a.isDefault && a.enabled) ??
       safeAgents.find((a) => a.id === 'abi' && a.enabled) ??
       safeAgents.find((a) => a.enabled);
-    if (defaultAgent) {
-      setSelectedAgent(defaultAgent.id);
-    }
-    createConversation();
-  }, [safeAgents, setSelectedAgent, createConversation]);
+    if (defaultAgent) setSelectedAgent(defaultAgent.id);
+    setActiveConversation(null);
+  }, [safeAgents, setSelectedAgent, setActiveConversation]);
 
   const handleSelectConversation = useCallback((id: string) => {
     setActiveConversation(id);
@@ -352,6 +353,7 @@ export function ChatSection({ collapsed, detailOnly }: { collapsed: boolean; det
                   key={agent.id}
                   onClick={() => {
                     setSelectedAgent(agent.id);
+                    setActiveConversation(null);
                     router.push(getWorkspacePath(currentWorkspaceId, '/chat'));
                   }}
                   className={cn(

--- a/uv.lock
+++ b/uv.lock
@@ -3615,7 +3615,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-cli"
-version = "1.43.2"
+version = "2.0.0"
 source = { editable = "libs/naas-abi-cli" }
 dependencies = [
     { name = "naas-abi" },
@@ -3641,7 +3641,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-core"
-version = "1.53.1"
+version = "2.0.0"
 source = { editable = "libs/naas-abi-core" }
 dependencies = [
     { name = "click" },
@@ -3769,7 +3769,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-marketplace"
-version = "1.29.0"
+version = "2.1.0"
 source = { editable = "libs/naas-abi-marketplace" }
 dependencies = [
     { name = "ijson" },


### PR DESCRIPTION
This pull request resolves #set-default-chat-page

### Summary

This PR introduces a default chat page behavior and UI improvements for the chat interface and sidebar in the Nexus web app.

### Changes

- **Default Agent Selection on New Chat:**
  - When navigating to the base `/chat` route without a conversation ID, the app now resets to a blank new chat state.
  - It pre-selects the workspace's default agent, falling back to the SupervisorAgent "abi" or the first enabled agent if no default is set.
  - This behavior is implemented in both the `ChatInterface` and `ChatSection` components.

- **Chat Interface:**
  - Added `setSelectedAgent` to the state management to allow setting the default agent.
  - On initial render, if no conversation ID is provided, the default agent is selected.
  - The typing cursor is kept focused in the chat input whenever the active conversation changes, including when switching to a new chat state.

- **Chat Sidebar:**
  - Clicking the "Chat" section header or the "New Chat" button resets to a blank new chat state and pre-selects the default agent.
  - Selecting an agent from the sidebar also resets the active conversation to null and navigates to the chat page.

- **UI/UX Improvements:**
  - Minor styling adjustments in the `FeedbackDislikeDialog` component for consistent border and padding.
  - Optional label added to the feedback severity question.

### Impact

This update improves the user experience by providing a clear default starting point when opening the chat page, ensuring users always have a pre-selected agent ready for new conversations.

### Notes

- The PR does not change existing conversations but affects the initial state when no conversation is active.
- The fallback logic ensures a robust default agent selection even if the workspace default is not set or disabled.