### PR TITLE
feat(chat): enhance chat analytics and default agent selection with new conversations table

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/analytics/adapters/primary/analytics__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/analytics/adapters/primary/analytics__primary_adapter__FastAPI.py
@@ -317,13 +317,17 @@ async def get_chat_analytics(
     ids = [c.id for c in conv_list]
     conversations = {c.id: c for c in conv_list}
 
-    # -- Resolve agent IDs → human-readable names (single round-trip) ---------
-    agent_ids = {c.agent for c in conv_list if c.agent}
-    agent_name_map: dict[str, str] = await chat_service.adapter.list_agent_names_by_ids(agent_ids)
-
     # -- Batch-fetch counts and messages (sequential — one session, no gather) -
     counts = await chat_service.adapter.count_messages_for_conversations(ids)
     messages_by_conv = await chat_service.adapter.list_messages_for_conversations(ids)
+
+    # -- Resolve agent IDs → human-readable names (includes message-level agents)
+    agent_ids = {c.agent for c in conv_list if c.agent}
+    for msgs in messages_by_conv.values():
+        for msg in msgs:
+            if msg.agent:
+                agent_ids.add(msg.agent)
+    agent_name_map: dict[str, str] = await chat_service.adapter.list_agent_names_by_ids(agent_ids)
 
     # Hourly or daily buckets depending on the scenario.
     hourly = scenario_id in ("today", "yesterday")
@@ -422,7 +426,12 @@ async def get_chat_analytics(
         lk = dk = 0
         last_msg_at: str | None = None
         conv_tools: set[str] = set()
+        conv_agents: set[str] = set()
+        if conv.agent:
+            conv_agents.add(agent_name_map.get(conv.agent, conv.agent))
         for msg in msgs:
+            if msg.agent:
+                conv_agents.add(agent_name_map.get(msg.agent, msg.agent))
             meta = _parse_message_metadata(msg.metadata_)
             if meta:
                 fb = meta.get("feedback")
@@ -446,7 +455,7 @@ async def get_chat_analytics(
                 message_count=counts.get(conv.id, 0),
                 likes=lk,
                 dislikes=dk,
-                agent=agent_name_map.get(conv.agent or "", conv.agent or ""),
+                agents=sorted(conv_agents),
                 tools=sorted(conv_tools),
                 last_message_at=last_msg_at,
             )

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/analytics/adapters/primary/analytics__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/analytics/adapters/primary/analytics__primary_adapter__FastAPI.py
@@ -421,6 +421,7 @@ async def get_chat_analytics(
         msgs = messages_by_conv.get(conv.id, [])
         lk = dk = 0
         last_msg_at: str | None = None
+        conv_tools: set[str] = set()
         for msg in msgs:
             meta = _parse_message_metadata(msg.metadata_)
             if meta:
@@ -429,6 +430,10 @@ async def get_chat_analytics(
                     lk += 1
                 elif fb == "dislike":
                     dk += 1
+                for step in meta.get("steps") or []:
+                    tool = step.get("tool_name") if isinstance(step, dict) else None
+                    if tool and isinstance(tool, str) and tool.lower() != "thinking":
+                        conv_tools.add(tool)
             ts = msg.created_at.isoformat() + "Z"
             if last_msg_at is None or ts > last_msg_at:
                 last_msg_at = ts
@@ -442,6 +447,7 @@ async def get_chat_analytics(
                 likes=lk,
                 dislikes=dk,
                 agent=agent_name_map.get(conv.agent or "", conv.agent or ""),
+                tools=sorted(conv_tools),
                 last_message_at=last_msg_at,
             )
         )

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/analytics/port.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/analytics/port.py
@@ -278,6 +278,7 @@ class ChatTopRow(BaseModel):
     likes: int = 0
     dislikes: int = 0
     agent: str | None = None
+    tools: list[str] = []
     last_message_at: str | None = None
 
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/analytics/port.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/analytics/port.py
@@ -277,7 +277,7 @@ class ChatTopRow(BaseModel):
     message_count: int
     likes: int = 0
     dislikes: int = 0
-    agent: str | None = None
+    agents: list[str] = []
     tools: list[str] = []
     last_message_at: str | None = None
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/components/bar-list.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/components/bar-list.tsx
@@ -14,6 +14,7 @@ interface BarListProps {
   valueLabel?: (v: number) => string;
   className?: string;
   onItemClick?: (item: BarItem) => void;
+  activeKey?: string | null;
   emptyText?: string;
 }
 
@@ -22,6 +23,7 @@ export function BarList({
   valueLabel = (v) => v.toLocaleString(),
   className,
   onItemClick,
+  activeKey,
   emptyText = 'No data',
 }: BarListProps) {
   if (items.length === 0) {
@@ -34,27 +36,36 @@ export function BarList({
       {items.map((item) => {
         const pct = Math.max(2, (item.value / max) * 100);
         const interactive = !!onItemClick;
+        const isActive = activeKey === item.key;
         return (
           <li
             key={item.key}
             className={cn(
               'group relative isolate flex items-center justify-between gap-3 px-3 py-2 text-sm',
               interactive && 'cursor-pointer transition-colors hover:bg-muted/50',
+              isActive && 'ring-1 ring-inset ring-workspace-accent rounded',
             )}
             onClick={interactive ? () => onItemClick(item) : undefined}
           >
             <div
               aria-hidden
-              className="absolute inset-y-1 left-1 -z-10 bg-workspace-accent-10 transition-all"
+              className={cn(
+                'absolute inset-y-1 left-1 -z-10 transition-all',
+                isActive ? 'bg-workspace-accent/20' : 'bg-workspace-accent-10',
+              )}
               style={{ width: `calc(${pct}% - 0.5rem)` }}
             />
             <div className="flex-1 min-w-0">
-              <p className="truncate font-medium text-foreground">{item.label}</p>
+              <p className={cn('truncate font-medium', isActive ? 'text-workspace-accent' : 'text-foreground')}>
+                {item.label}
+              </p>
               {item.sublabel && (
                 <p className="truncate text-xs text-muted-foreground">{item.sublabel}</p>
               )}
             </div>
-            <span className="text-sm tabular-nums text-muted-foreground">{valueLabel(item.value)}</span>
+            <span className={cn('text-sm tabular-nums', isActive ? 'text-workspace-accent font-semibold' : 'text-muted-foreground')}>
+              {valueLabel(item.value)}
+            </span>
           </li>
         );
       })}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/components/conversations-table.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/components/conversations-table.tsx
@@ -1,0 +1,496 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  ArrowUp,
+  ArrowDown,
+  ChevronLeft,
+  ChevronRight,
+  ListFilter,
+  X,
+  Search,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Avatar } from './filter-bar';
+import type { ChatTopRow } from '../lib/types';
+
+type SortKey = keyof ChatTopRow;
+type SortDir = 'asc' | 'desc';
+
+const PAGE_SIZES = [20, 50, 100] as const;
+type PageSize = typeof PAGE_SIZES[number];
+
+type ColKey =
+  | 'title'
+  | 'user_email'
+  | 'agent'
+  | 'message_count'
+  | 'likes'
+  | 'dislikes'
+  | 'last_message_at';
+
+const COLUMNS: { key: ColKey; label: string; align: 'left' | 'right' }[] = [
+  { key: 'title', label: 'Conversation', align: 'left' },
+  { key: 'user_email', label: 'User', align: 'left' },
+  { key: 'agent', label: 'Agent', align: 'left' },
+  { key: 'message_count', label: 'Messages', align: 'right' },
+  { key: 'likes', label: 'Likes', align: 'right' },
+  { key: 'dislikes', label: 'Dislikes', align: 'right' },
+  { key: 'last_message_at', label: 'Last message', align: 'right' },
+];
+
+interface Props {
+  rows: ChatTopRow[];
+  formatDateTime: (s: string) => string;
+  onRowClick: (id: string) => void;
+  onUserClick: (email: string) => void;
+}
+
+// Human-readable cell value used for filter matching and dropdown list
+function displayValue(r: ChatTopRow, key: ColKey, formatDateTime: (s: string) => string): string {
+  switch (key) {
+    case 'title': return r.title || r.conversation_id;
+    case 'user_email': return r.user_email ?? '(no user)';
+    case 'agent': return r.agent ?? '(no agent)';
+    case 'message_count': return String(r.message_count);
+    case 'likes': return String(r.likes);
+    case 'dislikes': return String(r.dislikes);
+    case 'last_message_at': return r.last_message_at ? formatDateTime(r.last_message_at as string) : '(no date)';
+  }
+}
+
+function sortValue(r: ChatTopRow, key: SortKey): string | number {
+  switch (key) {
+    case 'title': return r.title ?? r.conversation_id;
+    case 'user_email': return r.user_email ?? '';
+    case 'agent': return r.agent ?? '';
+    case 'message_count': return r.message_count;
+    case 'likes': return r.likes;
+    case 'dislikes': return r.dislikes;
+    case 'last_message_at': return r.last_message_at ?? '';
+    default: return '';
+  }
+}
+
+// ─── Excel-style checkbox filter dropdown ───────────────────────────────────
+
+function FilterDropdown({
+  availableValues,
+  selectedValues,
+  onChange,
+  onClose,
+  anchorRef,
+}: {
+  availableValues: string[];
+  selectedValues: string[] | undefined; // undefined = all selected (no filter)
+  onChange: (vals: string[] | undefined) => void;
+  onClose: () => void;
+  anchorRef: React.MutableRefObject<HTMLButtonElement | null>;
+}) {
+  const dropRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [search, setSearch] = useState('');
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+
+  useEffect(() => {
+    if (anchorRef.current) {
+      const rect = anchorRef.current.getBoundingClientRect();
+      // Align right edge of dropdown to right edge of anchor
+      const left = Math.max(4, rect.right + window.scrollX - 208); // 208 = w-52
+      setPos({ top: rect.bottom + window.scrollY + 2, left });
+    }
+    inputRef.current?.focus();
+  }, [anchorRef]);
+
+  useEffect(() => {
+    function handle(e: MouseEvent) {
+      if (
+        dropRef.current && !dropRef.current.contains(e.target as Node) &&
+        anchorRef.current && !anchorRef.current.contains(e.target as Node)
+      ) onClose();
+    }
+    document.addEventListener('mousedown', handle);
+    return () => document.removeEventListener('mousedown', handle);
+  }, [onClose, anchorRef]);
+
+  const displayed = search
+    ? availableValues.filter((v) => v.toLowerCase().includes(search.toLowerCase()))
+    : availableValues;
+
+  const isChecked = (val: string) =>
+    selectedValues === undefined || selectedValues.includes(val);
+
+  const allChecked =
+    selectedValues === undefined ||
+    availableValues.every((v) => selectedValues.includes(v));
+  const someChecked =
+    !allChecked && availableValues.some((v) => isChecked(v));
+
+  function toggleValue(val: string) {
+    let next: string[];
+    if (selectedValues === undefined) {
+      next = availableValues.filter((v) => v !== val);
+    } else {
+      next = isChecked(val)
+        ? selectedValues.filter((v) => v !== val)
+        : [...selectedValues, val];
+    }
+    onChange(next.length === availableValues.length ? undefined : next);
+  }
+
+  function toggleAll() {
+    onChange(allChecked ? [] : undefined);
+  }
+
+  if (!pos) return null;
+
+  return createPortal(
+    <div
+      ref={dropRef}
+      style={{ position: 'absolute', top: pos.top, left: pos.left, zIndex: 9999 }}
+      className="w-52 rounded border border-border bg-popover shadow-xl flex flex-col max-h-72"
+    >
+      {/* Search */}
+      <div className="flex items-center gap-1.5 border-b border-border px-2 py-1.5 shrink-0">
+        <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        <input
+          ref={inputRef}
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search values…"
+          className="flex-1 bg-transparent text-xs text-foreground placeholder:text-muted-foreground focus:outline-none"
+          onKeyDown={(e) => e.key === 'Escape' && onClose()}
+        />
+        {search && (
+          <button onClick={() => setSearch('')} className="text-muted-foreground hover:text-foreground">
+            <X className="h-3 w-3" />
+          </button>
+        )}
+      </div>
+
+      {/* Select All */}
+      {!search && (
+        <label className="flex cursor-pointer items-center gap-2 border-b border-border px-2 py-1.5 text-xs font-medium hover:bg-muted/40 shrink-0">
+          <input
+            type="checkbox"
+            checked={allChecked}
+            ref={(el) => { if (el) el.indeterminate = someChecked; }}
+            onChange={toggleAll}
+            className="h-3.5 w-3.5 cursor-pointer accent-workspace-accent"
+          />
+          (Select All)
+        </label>
+      )}
+
+      {/* Value list */}
+      <div className="overflow-y-auto">
+        {displayed.length === 0 ? (
+          <p className="px-2 py-3 text-center text-xs text-muted-foreground">No values</p>
+        ) : (
+          displayed.map((val) => (
+            <label
+              key={val}
+              className="flex cursor-pointer items-center gap-2 px-2 py-1 text-xs hover:bg-muted/40"
+            >
+              <input
+                type="checkbox"
+                checked={isChecked(val)}
+                onChange={() => toggleValue(val)}
+                className="h-3.5 w-3.5 cursor-pointer accent-workspace-accent"
+              />
+              <span className="truncate">{val}</span>
+            </label>
+          ))
+        )}
+      </div>
+
+      {/* Footer */}
+      <div className="flex items-center justify-between border-t border-border px-2 py-1 shrink-0">
+        <span className="text-[10px] text-muted-foreground">
+          {selectedValues === undefined
+            ? 'All selected'
+            : `${selectedValues.length} / ${availableValues.length}`}
+        </span>
+        <button
+          onClick={onClose}
+          className="rounded bg-workspace-accent px-2 py-0.5 text-[10px] font-medium text-white hover:opacity-80"
+        >
+          OK
+        </button>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+// ─── Main table ─────────────────────────────────────────────────────────────
+
+export function ConversationsTable({ rows, formatDateTime, onRowClick, onUserClick }: Props) {
+  const [sortKey, setSortKey] = useState<SortKey>('last_message_at');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
+  // filters: key present → active filter; undefined value never stored (key deleted instead)
+  const [filters, setFilters] = useState<Partial<Record<ColKey, string[]>>>({});
+  const [openFilter, setOpenFilter] = useState<ColKey | null>(null);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState<PageSize>(20);
+
+  const filterBtnRefs = useRef<Partial<Record<ColKey, React.MutableRefObject<HTMLButtonElement | null>>>>({});
+  COLUMNS.forEach(({ key }) => {
+    if (!filterBtnRefs.current[key])
+      filterBtnRefs.current[key] = { current: null } as React.MutableRefObject<HTMLButtonElement | null>;
+  });
+
+  function toggleSort(key: SortKey) {
+    if (sortKey === key) setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    else { setSortKey(key); setSortDir('asc'); }
+    setPage(1);
+  }
+
+  function applyFilter(col: ColKey, vals: string[] | undefined) {
+    setFilters((prev) => {
+      const next = { ...prev };
+      if (vals === undefined) delete next[col];
+      else next[col] = vals;
+      return next;
+    });
+    setPage(1);
+  }
+
+  // Rows that pass ALL column filters
+  const filtered = useMemo(() => {
+    const entries = Object.entries(filters) as [ColKey, string[]][];
+    if (entries.length === 0) return rows;
+    return rows.filter((r) =>
+      entries.every(([col, vals]) => vals.includes(displayValue(r, col, formatDateTime))),
+    );
+  }, [rows, filters, formatDateTime]);
+
+  const sorted = useMemo(() => {
+    return [...filtered].sort((a, b) => {
+      const av = sortValue(a, sortKey);
+      const bv = sortValue(b, sortKey);
+      const cmp = typeof av === 'number'
+        ? av - (bv as number)
+        : (av as string).localeCompare(bv as string);
+      return sortDir === 'asc' ? cmp : -cmp;
+    });
+  }, [filtered, sortKey, sortDir]);
+
+  // For the open dropdown: unique values of that column from rows filtered by ALL OTHER columns
+  const dropdownValues = useMemo((): string[] => {
+    if (!openFilter) return [];
+    const entries = Object.entries(filters) as [ColKey, string[]][];
+    const rowsExcept = rows.filter((r) =>
+      entries.every(([col, vals]) =>
+        col === openFilter || vals.includes(displayValue(r, col, formatDateTime)),
+      ),
+    );
+    const vals = rowsExcept.map((r) => displayValue(r, openFilter, formatDateTime));
+    return [...new Set(vals)].sort((a, b) => a.localeCompare(b));
+  }, [openFilter, rows, filters, formatDateTime]);
+
+  const totalPages = Math.max(1, Math.ceil(sorted.length / pageSize));
+  const safePage = Math.min(page, totalPages);
+  const pageStart = (safePage - 1) * pageSize;
+  const pageRows = sorted.slice(pageStart, pageStart + pageSize);
+
+  const hasFilters = Object.keys(filters).length > 0;
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Active filter banner */}
+      {hasFilters && (
+        <div className="flex items-center gap-2 rounded border border-amber-200 bg-amber-50/70 dark:border-amber-800 dark:bg-amber-950/20 px-3 py-1.5 text-xs text-muted-foreground">
+          <ListFilter className="h-3 w-3 shrink-0" />
+          <span>{sorted.length} of {rows.length.toLocaleString()} row(s) shown</span>
+          <button onClick={() => setFilters({})} className="ml-auto underline hover:text-foreground">
+            Clear all filters
+          </button>
+        </div>
+      )}
+
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse text-xs">
+          <thead>
+            <tr className="bg-muted/60 text-muted-foreground">
+              {COLUMNS.map(({ key, label, align }) => {
+                const isActiveSort = sortKey === key;
+                const isActiveFilter = key in filters;
+                return (
+                  <th
+                    key={key}
+                    className="border border-border px-0 py-0 text-left"
+                  >
+                    {/* Always: [sort label flex-1] [filter icon on the right] */}
+                    <div className="flex items-stretch">
+                      <button
+                        onClick={() => toggleSort(key as SortKey)}
+                        className={cn(
+                          'flex flex-1 items-center gap-1 px-2 py-2 font-semibold uppercase tracking-wide select-none transition-colors hover:bg-muted/80',
+                          align === 'right' ? 'justify-end' : 'justify-start',
+                          isActiveSort && 'text-foreground',
+                        )}
+                      >
+                        {label}
+                        {isActiveSort && (
+                          sortDir === 'asc'
+                            ? <ArrowUp className="h-3 w-3 shrink-0" />
+                            : <ArrowDown className="h-3 w-3 shrink-0" />
+                        )}
+                      </button>
+
+                      {/* Filter icon — always pinned to the right */}
+                      <button
+                        ref={(el) => {
+                          const ref = filterBtnRefs.current[key];
+                          if (ref) ref.current = el;
+                        }}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setOpenFilter((prev) => (prev === key ? null : key));
+                        }}
+                        className={cn(
+                          'flex shrink-0 items-center border-l border-border px-1.5 py-2 transition-colors hover:bg-muted/80',
+                          isActiveFilter
+                            ? 'text-workspace-accent bg-workspace-accent/5'
+                            : 'text-muted-foreground hover:text-foreground',
+                        )}
+                        title={isActiveFilter
+                          ? `Filter active (${(filters[key] ?? []).length} value(s))`
+                          : 'Filter'}
+                      >
+                        <ListFilter className={cn('h-3 w-3', isActiveFilter && 'fill-workspace-accent/20')} />
+                      </button>
+
+                      {openFilter === key && (
+                        <FilterDropdown
+                          availableValues={dropdownValues}
+                          selectedValues={filters[key]}
+                          onChange={(vals) => applyFilter(key, vals)}
+                          onClose={() => setOpenFilter(null)}
+                          anchorRef={filterBtnRefs.current[key] as React.MutableRefObject<HTMLButtonElement | null>}
+                        />
+                      )}
+                    </div>
+                  </th>
+                );
+              })}
+            </tr>
+          </thead>
+          <tbody>
+            {pageRows.map((c, i) => (
+              <tr
+                key={c.conversation_id}
+                className={cn(
+                  'cursor-pointer transition-colors',
+                  i % 2 === 0
+                    ? 'bg-background hover:bg-muted/30'
+                    : 'bg-muted/20 hover:bg-muted/40',
+                )}
+                onClick={() => onRowClick(c.conversation_id)}
+              >
+                <td className="border border-border px-2 py-1.5">
+                  <div className="flex flex-col min-w-0">
+                    <span className="font-medium truncate max-w-[220px] text-foreground">
+                      {c.title || c.conversation_id}
+                    </span>
+                    <span className="font-mono text-[10px] text-muted-foreground truncate max-w-[220px]">
+                      {c.conversation_id}
+                    </span>
+                  </div>
+                </td>
+                <td className="border border-border px-2 py-1.5">
+                  {c.user_email ? (
+                    <button
+                      onClick={(e) => { e.stopPropagation(); onUserClick(c.user_email as string); }}
+                      className="flex items-center gap-1.5 hover:underline"
+                    >
+                      <Avatar email={c.user_email} size={18} />
+                      <span className="truncate max-w-[160px]">{c.user_email}</span>
+                    </button>
+                  ) : (
+                    <span className="text-muted-foreground">—</span>
+                  )}
+                </td>
+                <td className="border border-border px-2 py-1.5 text-muted-foreground">
+                  {c.agent ?? '—'}
+                </td>
+                <td className="border border-border px-2 py-1.5 text-right tabular-nums font-medium">
+                  {c.message_count}
+                </td>
+                <td className="border border-border px-2 py-1.5 text-right tabular-nums text-emerald-600">
+                  {c.likes > 0 ? c.likes : <span className="text-muted-foreground">—</span>}
+                </td>
+                <td className="border border-border px-2 py-1.5 text-right tabular-nums text-red-600">
+                  {c.dislikes > 0 ? c.dislikes : <span className="text-muted-foreground">—</span>}
+                </td>
+                <td className="border border-border px-2 py-1.5 text-right text-muted-foreground">
+                  {c.last_message_at ? formatDateTime(c.last_message_at) : '—'}
+                </td>
+              </tr>
+            ))}
+
+            {pageRows.length === 0 && (
+              <tr>
+                <td
+                  colSpan={COLUMNS.length}
+                  className="border border-border px-5 py-10 text-center text-sm text-muted-foreground"
+                >
+                  No conversations match the current filters.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination footer */}
+      <div className="flex items-center justify-between gap-4 pt-1 text-xs text-muted-foreground">
+        <span>
+          {sorted.length === 0
+            ? 'No results'
+            : `${pageStart + 1}–${Math.min(pageStart + pageSize, sorted.length)} of ${sorted.length.toLocaleString()} conversation(s)`}
+        </span>
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-1.5">
+            <span>Rows:</span>
+            <div className="flex items-center gap-0.5">
+              {PAGE_SIZES.map((size) => (
+                <button
+                  key={size}
+                  onClick={() => { setPageSize(size); setPage(1); }}
+                  className={cn(
+                    'rounded px-2 py-0.5 text-xs transition-colors',
+                    pageSize === size
+                      ? 'bg-workspace-accent text-white font-semibold'
+                      : 'hover:bg-muted',
+                  )}
+                >
+                  {size}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <button
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={safePage === 1}
+              className="rounded p-0.5 hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed"
+            >
+              <ChevronLeft className="h-3.5 w-3.5" />
+            </button>
+            <span className="tabular-nums">{safePage} / {totalPages}</span>
+            <button
+              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              disabled={safePage === totalPages}
+              className="rounded p-0.5 hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed"
+            >
+              <ChevronRight className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/components/conversations-table.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/components/conversations-table.tsx
@@ -337,7 +337,7 @@ export function ConversationsTable({ rows, formatDateTime, onRowClick, onUserCli
       <div className="overflow-x-auto">
         <table className="w-full border-collapse text-xs">
           <thead>
-            <tr className="bg-muted/60 text-muted-foreground">
+            <tr className="bg-workspace-accent-10 text-muted-foreground">
               {COLUMNS.map(({ key, label, align }) => {
                 const isActiveSort = sortKey === key;
                 const isActiveFilter = key in filters;
@@ -351,7 +351,7 @@ export function ConversationsTable({ rows, formatDateTime, onRowClick, onUserCli
                       <button
                         onClick={() => toggleSort(key as SortKey)}
                         className={cn(
-                          'flex flex-1 items-center gap-1 px-2 py-2 font-semibold uppercase tracking-wide select-none transition-colors hover:bg-muted/80',
+                          'flex flex-1 items-center gap-1 px-2 py-2 font-semibold uppercase tracking-wide select-none transition-colors hover:bg-workspace-accent-10',
                           align === 'right' ? 'justify-end' : 'justify-start',
                           isActiveSort && 'text-foreground',
                         )}
@@ -375,7 +375,7 @@ export function ConversationsTable({ rows, formatDateTime, onRowClick, onUserCli
                           setOpenFilter((prev) => (prev === key ? null : key));
                         }}
                         className={cn(
-                          'flex shrink-0 items-center border-l border-border px-1.5 py-2 transition-colors hover:bg-muted/80',
+                          'flex shrink-0 items-center border-l border-border px-1.5 py-2 transition-colors hover:bg-workspace-accent-10',
                           isActiveFilter
                             ? 'text-workspace-accent bg-workspace-accent/5'
                             : 'text-muted-foreground hover:text-foreground',
@@ -403,15 +403,10 @@ export function ConversationsTable({ rows, formatDateTime, onRowClick, onUserCli
             </tr>
           </thead>
           <tbody>
-            {pageRows.map((c, i) => (
+            {pageRows.map((c) => (
               <tr
                 key={c.conversation_id}
-                className={cn(
-                  'cursor-pointer transition-colors',
-                  i % 2 === 0
-                    ? 'bg-background hover:bg-muted/30'
-                    : 'bg-muted/20 hover:bg-muted/40',
-                )}
+                className="cursor-pointer transition-colors bg-white hover:bg-muted/20 dark:bg-background dark:hover:bg-muted/20"
                 onClick={() => onRowClick(c.conversation_id)}
               >
                 <td className="border border-border px-2 py-1.5">

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/components/conversations-table.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/components/conversations-table.tsx
@@ -25,6 +25,7 @@ type ColKey =
   | 'title'
   | 'user_email'
   | 'agent'
+  | 'tools'
   | 'message_count'
   | 'likes'
   | 'dislikes'
@@ -34,6 +35,7 @@ const COLUMNS: { key: ColKey; label: string; align: 'left' | 'right' }[] = [
   { key: 'title', label: 'Conversation', align: 'left' },
   { key: 'user_email', label: 'User', align: 'left' },
   { key: 'agent', label: 'Agent', align: 'left' },
+  { key: 'tools', label: 'Tools', align: 'left' },
   { key: 'message_count', label: 'Messages', align: 'right' },
   { key: 'likes', label: 'Likes', align: 'right' },
   { key: 'dislikes', label: 'Dislikes', align: 'right' },
@@ -47,12 +49,13 @@ interface Props {
   onUserClick: (email: string) => void;
 }
 
-// Human-readable cell value used for filter matching and dropdown list
+// Human-readable cell value — for scalar columns only (tools handled separately)
 function displayValue(r: ChatTopRow, key: ColKey, formatDateTime: (s: string) => string): string {
   switch (key) {
     case 'title': return r.title || r.conversation_id;
     case 'user_email': return r.user_email ?? '(no user)';
     case 'agent': return r.agent ?? '(no agent)';
+    case 'tools': return (r.tools ?? []).join(', ') || '(no tools)';
     case 'message_count': return String(r.message_count);
     case 'likes': return String(r.likes);
     case 'dislikes': return String(r.dislikes);
@@ -65,12 +68,32 @@ function sortValue(r: ChatTopRow, key: SortKey): string | number {
     case 'title': return r.title ?? r.conversation_id;
     case 'user_email': return r.user_email ?? '';
     case 'agent': return r.agent ?? '';
+    case 'tools': return (r.tools ?? []).length;
     case 'message_count': return r.message_count;
     case 'likes': return r.likes;
     case 'dislikes': return r.dislikes;
     case 'last_message_at': return r.last_message_at ?? '';
     default: return '';
   }
+}
+
+// For the tools column, filtering is "row uses at least one of the selected tools"
+function rowMatchesFilter(r: ChatTopRow, col: ColKey, vals: string[], formatDateTime: (s: string) => string): boolean {
+  if (col === 'tools') {
+    const rowTools = r.tools ?? [];
+    return vals.some((v) => rowTools.includes(v));
+  }
+  return vals.includes(displayValue(r, col, formatDateTime));
+}
+
+// Available filter values for a column (tools → individual names, others → unique display values)
+function availableValuesForCol(rows: ChatTopRow[], col: ColKey, formatDateTime: (s: string) => string): string[] {
+  if (col === 'tools') {
+    const all = rows.flatMap((r) => r.tools ?? []);
+    return [...new Set(all)].sort((a, b) => a.localeCompare(b));
+  }
+  const all = rows.map((r) => displayValue(r, col, formatDateTime));
+  return [...new Set(all)].sort((a, b) => a.localeCompare(b));
 }
 
 // ─── Excel-style checkbox filter dropdown ───────────────────────────────────
@@ -262,7 +285,7 @@ export function ConversationsTable({ rows, formatDateTime, onRowClick, onUserCli
     const entries = Object.entries(filters) as [ColKey, string[]][];
     if (entries.length === 0) return rows;
     return rows.filter((r) =>
-      entries.every(([col, vals]) => vals.includes(displayValue(r, col, formatDateTime))),
+      entries.every(([col, vals]) => rowMatchesFilter(r, col, vals, formatDateTime)),
     );
   }, [rows, filters, formatDateTime]);
 
@@ -283,11 +306,10 @@ export function ConversationsTable({ rows, formatDateTime, onRowClick, onUserCli
     const entries = Object.entries(filters) as [ColKey, string[]][];
     const rowsExcept = rows.filter((r) =>
       entries.every(([col, vals]) =>
-        col === openFilter || vals.includes(displayValue(r, col, formatDateTime)),
+        col === openFilter || rowMatchesFilter(r, col, vals, formatDateTime),
       ),
     );
-    const vals = rowsExcept.map((r) => displayValue(r, openFilter, formatDateTime));
-    return [...new Set(vals)].sort((a, b) => a.localeCompare(b));
+    return availableValuesForCol(rowsExcept, openFilter, formatDateTime);
   }, [openFilter, rows, filters, formatDateTime]);
 
   const totalPages = Math.max(1, Math.ceil(sorted.length / pageSize));
@@ -415,6 +437,22 @@ export function ConversationsTable({ rows, formatDateTime, onRowClick, onUserCli
                 </td>
                 <td className="border border-border px-2 py-1.5 text-muted-foreground">
                   {c.agent ?? '—'}
+                </td>
+                <td className="border border-border px-2 py-1.5">
+                  {(c.tools ?? []).length > 0 ? (
+                    <div className="flex flex-wrap gap-0.5">
+                      {(c.tools ?? []).map((t) => (
+                        <span
+                          key={t}
+                          className="inline-block rounded bg-muted px-1 py-0.5 text-[10px] text-muted-foreground leading-tight"
+                        >
+                          {t}
+                        </span>
+                      ))}
+                    </div>
+                  ) : (
+                    <span className="text-muted-foreground">—</span>
+                  )}
                 </td>
                 <td className="border border-border px-2 py-1.5 text-right tabular-nums font-medium">
                   {c.message_count}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/components/conversations-table.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/components/conversations-table.tsx
@@ -24,7 +24,7 @@ type PageSize = typeof PAGE_SIZES[number];
 type ColKey =
   | 'title'
   | 'user_email'
-  | 'agent'
+  | 'agents'
   | 'tools'
   | 'message_count'
   | 'likes'
@@ -34,7 +34,7 @@ type ColKey =
 const COLUMNS: { key: ColKey; label: string; align: 'left' | 'right' }[] = [
   { key: 'title', label: 'Conversation', align: 'left' },
   { key: 'user_email', label: 'User', align: 'left' },
-  { key: 'agent', label: 'Agent', align: 'left' },
+  { key: 'agents', label: 'Agents', align: 'left' },
   { key: 'tools', label: 'Tools', align: 'left' },
   { key: 'message_count', label: 'Messages', align: 'right' },
   { key: 'likes', label: 'Likes', align: 'right' },
@@ -54,7 +54,7 @@ function displayValue(r: ChatTopRow, key: ColKey, formatDateTime: (s: string) =>
   switch (key) {
     case 'title': return r.title || r.conversation_id;
     case 'user_email': return r.user_email ?? '(no user)';
-    case 'agent': return r.agent ?? '(no agent)';
+    case 'agents': return (r.agents ?? []).join(', ') || '(no agent)';
     case 'tools': return (r.tools ?? []).join(', ') || '(no tools)';
     case 'message_count': return String(r.message_count);
     case 'likes': return String(r.likes);
@@ -67,7 +67,7 @@ function sortValue(r: ChatTopRow, key: SortKey): string | number {
   switch (key) {
     case 'title': return r.title ?? r.conversation_id;
     case 'user_email': return r.user_email ?? '';
-    case 'agent': return r.agent ?? '';
+    case 'agents': return (r.agents ?? []).length;
     case 'tools': return (r.tools ?? []).length;
     case 'message_count': return r.message_count;
     case 'likes': return r.likes;
@@ -79,15 +79,17 @@ function sortValue(r: ChatTopRow, key: SortKey): string | number {
 
 // For the tools column, filtering is "row uses at least one of the selected tools"
 function rowMatchesFilter(r: ChatTopRow, col: ColKey, vals: string[], formatDateTime: (s: string) => string): boolean {
-  if (col === 'tools') {
-    const rowTools = r.tools ?? [];
-    return vals.some((v) => rowTools.includes(v));
-  }
+  if (col === 'agents') return vals.some((v) => (r.agents ?? []).includes(v));
+  if (col === 'tools') return vals.some((v) => (r.tools ?? []).includes(v));
   return vals.includes(displayValue(r, col, formatDateTime));
 }
 
 // Available filter values for a column (tools → individual names, others → unique display values)
 function availableValuesForCol(rows: ChatTopRow[], col: ColKey, formatDateTime: (s: string) => string): string[] {
+  if (col === 'agents') {
+    const all = rows.flatMap((r) => r.agents ?? []);
+    return [...new Set(all)].sort((a, b) => a.localeCompare(b));
+  }
   if (col === 'tools') {
     const all = rows.flatMap((r) => r.tools ?? []);
     return [...new Set(all)].sort((a, b) => a.localeCompare(b));
@@ -435,8 +437,21 @@ export function ConversationsTable({ rows, formatDateTime, onRowClick, onUserCli
                     <span className="text-muted-foreground">—</span>
                   )}
                 </td>
-                <td className="border border-border px-2 py-1.5 text-muted-foreground">
-                  {c.agent ?? '—'}
+                <td className="border border-border px-2 py-1.5">
+                  {(c.agents ?? []).length > 0 ? (
+                    <div className="flex flex-wrap gap-0.5">
+                      {(c.agents ?? []).map((a) => (
+                        <span
+                          key={a}
+                          className="inline-block rounded bg-muted px-1 py-0.5 text-[10px] text-muted-foreground leading-tight"
+                        >
+                          {a}
+                        </span>
+                      ))}
+                    </div>
+                  ) : (
+                    <span className="text-muted-foreground">—</span>
+                  )}
                 </td>
                 <td className="border border-border px-2 py-1.5">
                   {(c.tools ?? []).length > 0 ? (

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/components/conversations-table.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/components/conversations-table.tsx
@@ -47,6 +47,8 @@ interface Props {
   formatDateTime: (s: string) => string;
   onRowClick: (id: string) => void;
   onUserClick: (email: string) => void;
+  externalFilter?: { col: ColKey; values: string[] } | null;
+  onExternalFilterClear?: () => void;
 }
 
 // Human-readable cell value — for scalar columns only (tools handled separately)
@@ -251,7 +253,7 @@ function FilterDropdown({
 
 // ─── Main table ─────────────────────────────────────────────────────────────
 
-export function ConversationsTable({ rows, formatDateTime, onRowClick, onUserClick }: Props) {
+export function ConversationsTable({ rows, formatDateTime, onRowClick, onUserClick, externalFilter, onExternalFilterClear }: Props) {
   const [sortKey, setSortKey] = useState<SortKey>('last_message_at');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
   // filters: key present → active filter; undefined value never stored (key deleted instead)
@@ -259,6 +261,26 @@ export function ConversationsTable({ rows, formatDateTime, onRowClick, onUserCli
   const [openFilter, setOpenFilter] = useState<ColKey | null>(null);
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState<PageSize>(20);
+
+  // Track which col was last set by an external filter so we can clean it up when cleared
+  const lastExternalCol = useRef<ColKey | null>(null);
+
+  useEffect(() => {
+    if (externalFilter) {
+      lastExternalCol.current = externalFilter.col;
+      setFilters((prev) => ({ ...prev, [externalFilter.col]: externalFilter.values }));
+      setPage(1);
+    } else if (lastExternalCol.current) {
+      const col = lastExternalCol.current;
+      lastExternalCol.current = null;
+      setFilters((prev) => {
+        const next = { ...prev };
+        delete next[col];
+        return next;
+      });
+      setPage(1);
+    }
+  }, [externalFilter]);
 
   const filterBtnRefs = useRef<Partial<Record<ColKey, React.MutableRefObject<HTMLButtonElement | null>>>>({});
   COLUMNS.forEach(({ key }) => {
@@ -279,6 +301,20 @@ export function ConversationsTable({ rows, formatDateTime, onRowClick, onUserCli
       else next[col] = vals;
       return next;
     });
+    // If the user manually clears a filter that was set by the bar, deselect the bar too
+    if (vals === undefined && col === lastExternalCol.current) {
+      lastExternalCol.current = null;
+      onExternalFilterClear?.();
+    }
+    setPage(1);
+  }
+
+  function clearAllFilters() {
+    setFilters({});
+    if (lastExternalCol.current) {
+      lastExternalCol.current = null;
+      onExternalFilterClear?.();
+    }
     setPage(1);
   }
 
@@ -328,7 +364,7 @@ export function ConversationsTable({ rows, formatDateTime, onRowClick, onUserCli
         <div className="flex items-center gap-2 rounded border border-amber-200 bg-amber-50/70 dark:border-amber-800 dark:bg-amber-950/20 px-3 py-1.5 text-xs text-muted-foreground">
           <ListFilter className="h-3 w-3 shrink-0" />
           <span>{sorted.length} of {rows.length.toLocaleString()} row(s) shown</span>
-          <button onClick={() => setFilters({})} className="ml-auto underline hover:text-foreground">
+          <button onClick={clearAllFilters} className="ml-auto underline hover:text-foreground">
             Clear all filters
           </button>
         </div>

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/lib/types.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/lib/types.ts
@@ -185,6 +185,7 @@ export interface ChatTopRow {
   likes: number;
   dislikes: number;
   agent?: string | null;
+  tools?: string[] | null;
   last_message_at?: string | null;
 }
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/lib/types.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/lib/types.ts
@@ -184,7 +184,7 @@ export interface ChatTopRow {
   message_count: number;
   likes: number;
   dislikes: number;
-  agent?: string | null;
+  agents?: string[] | null;
   tools?: string[] | null;
   last_message_at?: string | null;
 }

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/page.tsx
@@ -1013,27 +1013,31 @@ function ChatsSection({
           {/* Ranked bar lists */}
           <div className="grid gap-6 lg:grid-cols-2">
             <Card title="Agent usage" subtitle="Messages per agent">
-              <BarList
-                items={(data.top_agents as ChatAgentRow[]).map<BarItem>((a) => ({
-                  key: a.agent,
-                  label: a.agent,
-                  sublabel: `${a.chats} chat${a.chats === 1 ? '' : 's'}`,
-                  value: a.messages,
-                }))}
-                valueLabel={(v) => `${formatNumber(v)} msgs`}
-                emptyText="No agent data."
-              />
+              <div className="max-h-[200px] overflow-y-auto">
+                <BarList
+                  items={(data.top_agents as ChatAgentRow[]).map<BarItem>((a) => ({
+                    key: a.agent,
+                    label: a.agent,
+                    sublabel: `${a.chats} chat${a.chats === 1 ? '' : 's'}`,
+                    value: a.messages,
+                  }))}
+                  valueLabel={(v) => `${formatNumber(v)} msgs`}
+                  emptyText="No agent data."
+                />
+              </div>
             </Card>
             <Card title="Tool usage" subtitle="Most invoked tools">
-              <BarList
-                items={(data.top_tools as ChatToolRow[]).map<BarItem>((t) => ({
-                  key: t.tool_name,
-                  label: t.tool_name,
-                  value: t.uses,
-                }))}
-                valueLabel={(v) => `${formatNumber(v)} uses`}
-                emptyText="No tool data."
-              />
+              <div className="max-h-[200px] overflow-y-auto">
+                <BarList
+                  items={(data.top_tools as ChatToolRow[]).map<BarItem>((t) => ({
+                    key: t.tool_name,
+                    label: t.tool_name,
+                    value: t.uses,
+                  }))}
+                  valueLabel={(v) => `${formatNumber(v)} uses`}
+                  emptyText="No tool data."
+                />
+              </div>
             </Card>
           </div>
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/page.tsx
@@ -961,6 +961,13 @@ function ChatsSection({
     filters,
   );
   const [openId, setOpenId] = useState<string | null>(null);
+  const [barFilter, setBarFilter] = useState<{ col: 'agents' | 'tools'; value: string } | null>(null);
+
+  function handleBarClick(col: 'agents' | 'tools', value: string) {
+    setBarFilter((prev) =>
+      prev?.col === col && prev.value === value ? null : { col, value },
+    );
+  }
 
   if (openId) {
     return <ChatDetailFullPage conversationId={openId} onClose={() => setOpenId(null)} />;
@@ -1013,7 +1020,7 @@ function ChatsSection({
 
           {/* Ranked bar lists */}
           <div className="grid gap-6 lg:grid-cols-2">
-            <Card title="Agent usage" subtitle="Messages per agent">
+            <Card title="Agent usage" subtitle="Messages per agent — click to filter conversations">
               <div className="max-h-[200px] overflow-y-auto">
                 <BarList
                   items={(data.top_agents as ChatAgentRow[]).map<BarItem>((a) => ({
@@ -1024,10 +1031,12 @@ function ChatsSection({
                   }))}
                   valueLabel={(v) => `${formatNumber(v)} msgs`}
                   emptyText="No agent data."
+                  activeKey={barFilter?.col === 'agents' ? barFilter.value : null}
+                  onItemClick={(item) => handleBarClick('agents', item.key)}
                 />
               </div>
             </Card>
-            <Card title="Tool usage" subtitle="Most invoked tools">
+            <Card title="Tool usage" subtitle="Most invoked tools — click to filter conversations">
               <div className="max-h-[200px] overflow-y-auto">
                 <BarList
                   items={(data.top_tools as ChatToolRow[]).map<BarItem>((t) => ({
@@ -1037,6 +1046,8 @@ function ChatsSection({
                   }))}
                   valueLabel={(v) => `${formatNumber(v)} uses`}
                   emptyText="No tool data."
+                  activeKey={barFilter?.col === 'tools' ? barFilter.value : null}
+                  onItemClick={(item) => handleBarClick('tools', item.key)}
                 />
               </div>
             </Card>
@@ -1052,6 +1063,8 @@ function ChatsSection({
               formatDateTime={formatDateTime}
               onRowClick={(id) => setOpenId(id)}
               onUserClick={(email) => onUserPick(email)}
+              externalFilter={barFilter ? { col: barFilter.col, values: [barFilter.value] } : null}
+              onExternalFilterClear={() => setBarFilter(null)}
             />
           </Card>
         </>

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/analytics/page.tsx
@@ -28,6 +28,7 @@ import { Avatar, FilterBar, type FilterValue } from './components/filter-bar';
 import { KpiCard } from './components/kpi-card';
 import { LineChart } from './components/line-chart';
 import { BarList, type BarItem } from './components/bar-list';
+import { ConversationsTable } from './components/conversations-table';
 import { Card } from './components/card';
 import { EventIcon, formatEventName } from './components/event-icon';
 import { UpdateStatus } from './components/update-status';
@@ -1046,75 +1047,12 @@ function ChatsSection({
             title="Conversations"
             subtitle={`${data.top_chats.length.toLocaleString()} conversation(s) in this range`}
           >
-            <div className="-mx-5 -my-5">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b border-border/60 text-left text-xs uppercase tracking-wide text-muted-foreground">
-                    <th className="px-5 py-3 font-medium">Conversation</th>
-                    <th className="px-5 py-3 font-medium">User</th>
-                    <th className="px-5 py-3 font-medium">Agent</th>
-                    <th className="px-5 py-3 font-medium text-right">Messages</th>
-                    <th className="px-5 py-3 font-medium text-right">Likes</th>
-                    <th className="px-5 py-3 font-medium text-right">Dislikes</th>
-                    <th className="px-5 py-3 font-medium text-right">Last message</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-border/50">
-                  {(data.top_chats as ChatTopRow[]).slice(0, 200).map((c) => (
-                    <tr
-                      key={c.conversation_id}
-                      className="cursor-pointer transition-colors hover:bg-muted/40"
-                      onClick={() => setOpenId(c.conversation_id)}
-                    >
-                      <td className="px-5 py-3">
-                        <div className="flex flex-col min-w-0">
-                          <span className="font-medium truncate max-w-[200px]">
-                            {c.title || c.conversation_id}
-                          </span>
-                          <span className="font-mono text-xs text-muted-foreground truncate max-w-[200px]">
-                            {c.conversation_id}
-                          </span>
-                        </div>
-                      </td>
-                      <td className="px-5 py-3">
-                        {c.user_email ? (
-                          <button
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              onUserPick(c.user_email as string);
-                            }}
-                            className="flex items-center gap-2 hover:underline"
-                          >
-                            <Avatar email={c.user_email} size={22} />
-                            <span className="truncate max-w-[140px]">{c.user_email}</span>
-                          </button>
-                        ) : (
-                          <span className="text-muted-foreground">—</span>
-                        )}
-                      </td>
-                      <td className="px-5 py-3 text-muted-foreground">{c.agent ?? '—'}</td>
-                      <td className="px-5 py-3 text-right tabular-nums font-medium">
-                        {c.message_count}
-                      </td>
-                      <td className="px-5 py-3 text-right tabular-nums text-emerald-600">
-                        {c.likes > 0 ? c.likes : <span className="text-muted-foreground">—</span>}
-                      </td>
-                      <td className="px-5 py-3 text-right tabular-nums text-red-600">
-                        {c.dislikes > 0 ? c.dislikes : <span className="text-muted-foreground">—</span>}
-                      </td>
-                      <td className="px-5 py-3 text-right text-muted-foreground">
-                        {c.last_message_at ? formatDateTime(c.last_message_at) : '—'}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-              {data.top_chats.length > 200 && (
-                <div className="border-t border-border/50 px-5 py-3 text-xs text-muted-foreground">
-                  Showing first 200 of {data.top_chats.length.toLocaleString()} conversations.
-                </div>
-              )}
-            </div>
+            <ConversationsTable
+              rows={data.top_chats as ChatTopRow[]}
+              formatDateTime={formatDateTime}
+              onRowClick={(id) => setOpenId(id)}
+              onUserClick={(email) => onUserPick(email)}
+            />
           </Card>
         </>
       )}


### PR DESCRIPTION
This pull request resolves #set-default-chat-page

### Summary

This PR introduces several improvements and new features related to chat analytics and the chat interface:

1. **Chat Analytics Enhancements:**
   - The analytics now resolve agent IDs not only at the conversation level but also at the message level, allowing for more comprehensive agent tracking.
   - Added tracking of tools used in conversations by parsing message metadata steps.
   - Updated the `ChatTopRow` data model to include lists of agents and tools instead of a single agent string.

2. **New Conversations Table Component:**
   - Added a new React component `ConversationsTable` for displaying chat conversations with sortable and filterable columns including conversation title, user email, agents, tools, message count, likes, dislikes, and last message date.
   - The table supports pagination, sorting, and filtering with a user-friendly UI.
   - Replaced the previous static table in the analytics page with this new component.

3. **Chat Interface Default Agent Selection:**
   - When navigating to the chat page without a specific conversation ID, the interface now resets to a blank new chat state and pre-selects the workspace's default agent (falling back to a supervisor agent or first enabled agent).
   - This behavior is also applied when clicking the chat section header or starting a new chat from the sidebar.

4. **UI and Styling Fixes:**
   - Minor styling adjustments in the feedback dislike dialog.

### Impact
- Users can now see detailed agent and tool usage per conversation in analytics.
- The chat interface provides a better default experience by pre-selecting agents when starting new chats.
- The new conversations table improves usability for browsing and filtering chat data.

### Files Changed
- `analytics__primary_adapter__FastAPI.py`: Enhanced agent and tool resolution in chat analytics.
- `port.py`: Updated data model for chat analytics rows.
- `conversations-table.tsx`: New component for displaying conversations with sorting and filtering.
- `page.tsx`: Integrated the new conversations table component.
- `chat-interface.tsx`: Added logic to pre-select default agent on new chat.
- `chat-section.tsx`: Updated new chat and chat header behavior to reset conversation and select default agent.

This PR improves both backend analytics data handling and frontend user experience for chat management.