### PR TITLE
feat(openrouter): introduce ai.openrouter module, multi-provider model definitions, and migrate agents to ModelRegistryService

### DIFF
--- a/config.local.yaml
+++ b/config.local.yaml
@@ -146,27 +146,17 @@ modules:
   # Q: How do I add ChatGPT (OpenAI) as an AI provider?
   # A: Enable the module and give it your OpenAI API key.
   - module: naas_abi_marketplace.ai.chatgpt
-    enabled: true
+    enabled: false
     config:
       openai_api_key: "{{ secret.OPENAI_API_KEY }}"
 
   # Q: Which AI models should users be able to pick in the chat UI?
   # A: Enable OpenRouter and list the model slugs you want to expose.
   #    Find slugs at openrouter.ai/models -- format: "provider/model-name"
-  - module: naas_abi_marketplace.applications.openrouter
+  - module: naas_abi_marketplace.ai.openrouter
     enabled: true
     config:
       openrouter_api_key: "{{ secret.OPENROUTER_API_KEY }}"
-      include_models:
-        - "anthropic/claude-opus-4.7"
-        - "anthropic/claude-sonnet-4.6"
-        - "deepseek/deepseek-v3.2"
-        - "google/gemini-3.1-pro-preview"
-        - "mistralai/mistral-large-2512"
-        - "openai/gpt-5.3-codex"
-        - "openai/gpt-5.5"
-        - "perplexity/sonar-pro-search"
-        - "x-ai/grok-4.1-fast"
 
   # Q: How do I connect the WSR module to live real-world data feeds?
   # A: Provide API keys for each source. Leave blank to skip that source gracefully.
@@ -207,7 +197,7 @@ services:
   # A: Set the default chat and embedding models.
 
   model_registry:
-    default_chat_model: "gpt-4.1-mini"
+    default_chat_model: "claude-sonnet-4.6"
     default_embedding_model: "text-embedding-3-large"
 
   # Q: How does the app read secret values at startup?

--- a/config.yaml
+++ b/config.yaml
@@ -98,6 +98,19 @@ modules:
     config:
       openai_api_key: "{{ secret.OPENAI_API_KEY }}"
 
+  - module: naas_abi_marketplace.ai.openrouter
+    enabled: true
+    config:
+      openrouter_api_key: "{{ secret.OPENROUTER_API_KEY }}"
+
+  - module: naas_abi_marketplace.alpha.wsr
+    enabled: true
+    config:
+      opensky_client_id: "{{ secret.OPENSKY_CLIENT_ID }}"
+      opensky_client_secret: "{{ secret.OPENSKY_CLIENT_SECRET }}"
+      tfl_app_key: "{{ secret.TFL_APP_KEY }}"
+      openwebcamdb_api_key: "{{ secret.OPENWEBCAMDB_API_KEY }}"
+
   - module: naas_abi_marketplace.applications.git
     enabled: true
   
@@ -123,31 +136,6 @@ modules:
           max_results: 100
           max_pages: 1
   
-  - module: naas_abi_marketplace.applications.openrouter
-    enabled: true
-    config:
-      openrouter_api_key: "{{ secret.OPENROUTER_API_KEY }}"
-      include_models:
-        - "anthropic/claude-opus-4.6"
-        - "anthropic/claude-sonnet-4.6"
-        - "deepseek/deepseek-v3.2"
-        - "google/gemini-3.1-pro-preview"
-        - "mistralai/mistral-large-2512"
-        - "openai/gpt-4.1"
-        - "openai/gpt-4.1-mini"
-        - "openai/gpt-5.1"
-        - "openai/gpt-5.2"
-        - "perplexity/sonar-pro-search"
-        - "x-ai/grok-4.1-fast"
-
-  - module: naas_abi_marketplace.alpha.wsr
-    enabled: true
-    config:
-      opensky_client_id: "{{ secret.OPENSKY_CLIENT_ID }}"
-      opensky_client_secret: "{{ secret.OPENSKY_CLIENT_SECRET }}"
-      tfl_app_key: "{{ secret.TFL_APP_KEY }}"
-      openwebcamdb_api_key: "{{ secret.OPENWEBCAMDB_API_KEY }}"
-
   - module: naas_abi_marketplace.domains.document
     enabled: true
     config:
@@ -175,7 +163,7 @@ services:
   # enabled provider modules at boot — if the canonical id below isn't
   # registered after all modules load, ``Engine.load()`` hard-fails.
   model_registry:
-    default_chat_model: "gpt-4.1-mini"
+    default_chat_model: "claude-sonnet-4.6"
     default_embedding_model: "text-embedding-3-large"
   secret:
     secret_adapters:

--- a/libs/naas-abi-core/naas_abi_core/models/Model.py
+++ b/libs/naas-abi-core/naas_abi_core/models/Model.py
@@ -37,9 +37,11 @@ class CanonicalModelId(StrEnum):
     """
 
     # Chat — Anthropic family
+    CLAUDE_SONNET_4_6 = "claude-sonnet-4.6"
     CLAUDE_SONNET_4_5 = "claude-sonnet-4.5"
     CLAUDE_SONNET_4 = "claude-sonnet-4"
     CLAUDE_SONNET_3_7 = "claude-sonnet-3.7"
+    CLAUDE_OPUS_4_7 = "claude-opus-4.7"
     CLAUDE_OPUS_4_1 = "claude-opus-4.1"
     CLAUDE_OPUS_4 = "claude-opus-4"
     CLAUDE_HAIKU_4_5 = "claude-haiku-4.5"
@@ -64,6 +66,8 @@ class CanonicalModelId(StrEnum):
     GPT_5_NANO = "gpt-5-nano"
     GPT_5_1 = "gpt-5.1"
     GPT_5_1_MINI = "gpt-5.1-mini"
+    GPT_5_5 = "gpt-5.5"
+    GPT_5_3_CODEX = "gpt-5.3-codex"
     GPT_5_2 = "gpt-5.2"
     GPT_4_1 = "gpt-4.1"
     GPT_4_1_MINI = "gpt-4.1-mini"
@@ -73,12 +77,23 @@ class CanonicalModelId(StrEnum):
     O4_MINI_DEEP_RESEARCH = "o4-mini-deep-research"
 
     # Chat — Google family
+    GEMINI_3_1_PRO_PREVIEW = "gemini-3.1-pro-preview"
     GEMINI_2_5_FLASH = "gemini-2.5-flash"
     GEMINI_2_5_PRO = "gemini-2.5-pro"
     GEMMA_3_27B_IT = "gemma-3-27b-it"
 
     # Chat — xAI family
+    GROK_4_1_FAST = "grok-4.1-fast"
     GROK_4 = "grok-4"
+
+    # Chat — DeepSeek family
+    DEEPSEEK_V3_2 = "deepseek-v3.2"
+
+    # Chat — Mistral family
+    MISTRAL_LARGE_2512 = "mistral-large-2512"
+
+    # Chat — Perplexity family
+    SONAR_PRO_SEARCH = "sonar-pro-search"
 
     # Chat — OpenAI open-weights
     GPT_OSS_120B = "gpt-oss-120b"

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/__init__.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/__init__.py
@@ -1,0 +1,30 @@
+from naas_abi_core.module.Module import (
+    BaseModule,
+    ModuleConfiguration,
+    ModuleDependencies,
+)
+from naas_abi_core.services.model_registry.ModelRegistryService import (
+    ModelRegistryService,
+)
+
+
+class ABIModule(BaseModule):
+    dependencies: ModuleDependencies = ModuleDependencies(
+        modules=[],
+        services=[ModelRegistryService],
+    )
+
+    class Configuration(ModuleConfiguration):
+        """
+        Configuration example:
+
+        module: naas_abi_marketplace.ai.openrouter
+        enabled: true
+        config:
+            openrouter_api_key: "{{ secret.OPENROUTER_API_KEY }}"
+        """
+
+        openrouter_api_key: str
+
+    def on_load(self):
+        super().on_load()

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/models/claude_opus_4_7.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/models/claude_opus_4_7.py
@@ -1,0 +1,33 @@
+from langchain_openai import ChatOpenAI
+from naas_abi_core.models.Model import (
+    CanonicalModelId,
+    ChatModel,
+    ModelDefinition,
+    ModelProvider,
+)
+from naas_abi_marketplace.ai.openrouter import ABIModule
+from pydantic import SecretStr
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+class ClaudeOpus47Model(ModelDefinition):
+    CANONICAL_ID = CanonicalModelId.CLAUDE_OPUS_4_7
+    MODEL_ID = "anthropic/claude-opus-4.7"
+    PROVIDER = ModelProvider.OPENROUTER
+
+    model: ChatModel = ChatModel(
+        model_id=MODEL_ID,
+        provider=PROVIDER,
+        model=ChatOpenAI(
+            model=MODEL_ID,
+            temperature=0,
+            timeout=120,
+            max_retries=3,
+            api_key=SecretStr(ABIModule.get_instance().configuration.openrouter_api_key),
+            base_url=OPENROUTER_BASE_URL,
+        ),
+    )
+
+
+model: ChatModel = ClaudeOpus47Model.model

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/models/claude_sonnet_4_6.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/models/claude_sonnet_4_6.py
@@ -1,0 +1,33 @@
+from langchain_openai import ChatOpenAI
+from naas_abi_core.models.Model import (
+    CanonicalModelId,
+    ChatModel,
+    ModelDefinition,
+    ModelProvider,
+)
+from naas_abi_marketplace.ai.openrouter import ABIModule
+from pydantic import SecretStr
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+class ClaudeSonnet46Model(ModelDefinition):
+    CANONICAL_ID = CanonicalModelId.CLAUDE_SONNET_4_6
+    MODEL_ID = "anthropic/claude-sonnet-4.6"
+    PROVIDER = ModelProvider.OPENROUTER
+
+    model: ChatModel = ChatModel(
+        model_id=MODEL_ID,
+        provider=PROVIDER,
+        model=ChatOpenAI(
+            model=MODEL_ID,
+            temperature=0,
+            timeout=120,
+            max_retries=3,
+            api_key=SecretStr(ABIModule.get_instance().configuration.openrouter_api_key),
+            base_url=OPENROUTER_BASE_URL,
+        ),
+    )
+
+
+model: ChatModel = ClaudeSonnet46Model.model

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/models/deepseek_v3_2.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/models/deepseek_v3_2.py
@@ -1,0 +1,33 @@
+from langchain_openai import ChatOpenAI
+from naas_abi_core.models.Model import (
+    CanonicalModelId,
+    ChatModel,
+    ModelDefinition,
+    ModelProvider,
+)
+from naas_abi_marketplace.ai.openrouter import ABIModule
+from pydantic import SecretStr
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+class DeepseekV32Model(ModelDefinition):
+    CANONICAL_ID = CanonicalModelId.DEEPSEEK_V3_2
+    MODEL_ID = "deepseek/deepseek-v3.2"
+    PROVIDER = ModelProvider.OPENROUTER
+
+    model: ChatModel = ChatModel(
+        model_id=MODEL_ID,
+        provider=PROVIDER,
+        model=ChatOpenAI(
+            model=MODEL_ID,
+            temperature=0,
+            timeout=120,
+            max_retries=3,
+            api_key=SecretStr(ABIModule.get_instance().configuration.openrouter_api_key),
+            base_url=OPENROUTER_BASE_URL,
+        ),
+    )
+
+
+model: ChatModel = DeepseekV32Model.model

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/models/gemini_3_1_pro_preview.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/models/gemini_3_1_pro_preview.py
@@ -1,0 +1,33 @@
+from langchain_openai import ChatOpenAI
+from naas_abi_core.models.Model import (
+    CanonicalModelId,
+    ChatModel,
+    ModelDefinition,
+    ModelProvider,
+)
+from naas_abi_marketplace.ai.openrouter import ABIModule
+from pydantic import SecretStr
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+class Gemini31ProPreviewModel(ModelDefinition):
+    CANONICAL_ID = CanonicalModelId.GEMINI_3_1_PRO_PREVIEW
+    MODEL_ID = "google/gemini-3.1-pro-preview"
+    PROVIDER = ModelProvider.OPENROUTER
+
+    model: ChatModel = ChatModel(
+        model_id=MODEL_ID,
+        provider=PROVIDER,
+        model=ChatOpenAI(
+            model=MODEL_ID,
+            temperature=0,
+            timeout=120,
+            max_retries=3,
+            api_key=SecretStr(ABIModule.get_instance().configuration.openrouter_api_key),
+            base_url=OPENROUTER_BASE_URL,
+        ),
+    )
+
+
+model: ChatModel = Gemini31ProPreviewModel.model

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/models/gpt_4_1_mini.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/models/gpt_4_1_mini.py
@@ -1,0 +1,33 @@
+from langchain_openai import ChatOpenAI
+from naas_abi_core.models.Model import (
+    CanonicalModelId,
+    ChatModel,
+    ModelDefinition,
+    ModelProvider,
+)
+from naas_abi_marketplace.ai.openrouter import ABIModule
+from pydantic import SecretStr
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+class Gpt41MiniModel(ModelDefinition):
+    CANONICAL_ID = CanonicalModelId.GPT_4_1_MINI
+    MODEL_ID = "openai/gpt-4.1-mini"
+    PROVIDER = ModelProvider.OPENROUTER
+
+    model: ChatModel = ChatModel(
+        model_id=MODEL_ID,
+        provider=PROVIDER,
+        model=ChatOpenAI(
+            model=MODEL_ID,
+            temperature=0,
+            timeout=120,
+            max_retries=3,
+            api_key=SecretStr(ABIModule.get_instance().configuration.openrouter_api_key),
+            base_url=OPENROUTER_BASE_URL,
+        ),
+    )
+
+
+model: ChatModel = Gpt41MiniModel.model

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/models/gpt_5_1.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/models/gpt_5_1.py
@@ -1,0 +1,33 @@
+from langchain_openai import ChatOpenAI
+from naas_abi_core.models.Model import (
+    CanonicalModelId,
+    ChatModel,
+    ModelDefinition,
+    ModelProvider,
+)
+from naas_abi_marketplace.ai.openrouter import ABIModule
+from pydantic import SecretStr
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+class Gpt51Model(ModelDefinition):
+    CANONICAL_ID = CanonicalModelId.GPT_5_1
+    MODEL_ID = "openai/gpt-5.1"
+    PROVIDER = ModelProvider.OPENROUTER
+
+    model: ChatModel = ChatModel(
+        model_id=MODEL_ID,
+        provider=PROVIDER,
+        model=ChatOpenAI(
+            model=MODEL_ID,
+            temperature=0,
+            timeout=120,
+            max_retries=3,
+            api_key=SecretStr(ABIModule.get_instance().configuration.openrouter_api_key),
+            base_url=OPENROUTER_BASE_URL,
+        ),
+    )
+
+
+model: ChatModel = Gpt51Model.model

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/models/gpt_5_3_codex.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/models/gpt_5_3_codex.py
@@ -1,0 +1,33 @@
+from langchain_openai import ChatOpenAI
+from naas_abi_core.models.Model import (
+    CanonicalModelId,
+    ChatModel,
+    ModelDefinition,
+    ModelProvider,
+)
+from naas_abi_marketplace.ai.openrouter import ABIModule
+from pydantic import SecretStr
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+class Gpt53CodexModel(ModelDefinition):
+    CANONICAL_ID = CanonicalModelId.GPT_5_3_CODEX
+    MODEL_ID = "openai/gpt-5.3-codex"
+    PROVIDER = ModelProvider.OPENROUTER
+
+    model: ChatModel = ChatModel(
+        model_id=MODEL_ID,
+        provider=PROVIDER,
+        model=ChatOpenAI(
+            model=MODEL_ID,
+            temperature=0,
+            timeout=120,
+            max_retries=3,
+            api_key=SecretStr(ABIModule.get_instance().configuration.openrouter_api_key),
+            base_url=OPENROUTER_BASE_URL,
+        ),
+    )
+
+
+model: ChatModel = Gpt53CodexModel.model

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/models/gpt_5_5.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/models/gpt_5_5.py
@@ -1,0 +1,33 @@
+from langchain_openai import ChatOpenAI
+from naas_abi_core.models.Model import (
+    CanonicalModelId,
+    ChatModel,
+    ModelDefinition,
+    ModelProvider,
+)
+from naas_abi_marketplace.ai.openrouter import ABIModule
+from pydantic import SecretStr
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+class Gpt55Model(ModelDefinition):
+    CANONICAL_ID = CanonicalModelId.GPT_5_5
+    MODEL_ID = "openai/gpt-5.5"
+    PROVIDER = ModelProvider.OPENROUTER
+
+    model: ChatModel = ChatModel(
+        model_id=MODEL_ID,
+        provider=PROVIDER,
+        model=ChatOpenAI(
+            model=MODEL_ID,
+            temperature=0,
+            timeout=120,
+            max_retries=3,
+            api_key=SecretStr(ABIModule.get_instance().configuration.openrouter_api_key),
+            base_url=OPENROUTER_BASE_URL,
+        ),
+    )
+
+
+model: ChatModel = Gpt55Model.model

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/models/grok_4_1_fast.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/models/grok_4_1_fast.py
@@ -1,0 +1,33 @@
+from langchain_openai import ChatOpenAI
+from naas_abi_core.models.Model import (
+    CanonicalModelId,
+    ChatModel,
+    ModelDefinition,
+    ModelProvider,
+)
+from naas_abi_marketplace.ai.openrouter import ABIModule
+from pydantic import SecretStr
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+class Grok41FastModel(ModelDefinition):
+    CANONICAL_ID = CanonicalModelId.GROK_4_1_FAST
+    MODEL_ID = "x-ai/grok-4.1-fast"
+    PROVIDER = ModelProvider.OPENROUTER
+
+    model: ChatModel = ChatModel(
+        model_id=MODEL_ID,
+        provider=PROVIDER,
+        model=ChatOpenAI(
+            model=MODEL_ID,
+            temperature=0,
+            timeout=120,
+            max_retries=3,
+            api_key=SecretStr(ABIModule.get_instance().configuration.openrouter_api_key),
+            base_url=OPENROUTER_BASE_URL,
+        ),
+    )
+
+
+model: ChatModel = Grok41FastModel.model

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/models/mistral_large_2512.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/models/mistral_large_2512.py
@@ -1,0 +1,33 @@
+from langchain_openai import ChatOpenAI
+from naas_abi_core.models.Model import (
+    CanonicalModelId,
+    ChatModel,
+    ModelDefinition,
+    ModelProvider,
+)
+from naas_abi_marketplace.ai.openrouter import ABIModule
+from pydantic import SecretStr
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+class MistralLarge2512Model(ModelDefinition):
+    CANONICAL_ID = CanonicalModelId.MISTRAL_LARGE_2512
+    MODEL_ID = "mistralai/mistral-large-2512"
+    PROVIDER = ModelProvider.OPENROUTER
+
+    model: ChatModel = ChatModel(
+        model_id=MODEL_ID,
+        provider=PROVIDER,
+        model=ChatOpenAI(
+            model=MODEL_ID,
+            temperature=0,
+            timeout=120,
+            max_retries=3,
+            api_key=SecretStr(ABIModule.get_instance().configuration.openrouter_api_key),
+            base_url=OPENROUTER_BASE_URL,
+        ),
+    )
+
+
+model: ChatModel = MistralLarge2512Model.model

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/models/sonar_pro_search.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/models/sonar_pro_search.py
@@ -1,0 +1,33 @@
+from langchain_openai import ChatOpenAI
+from naas_abi_core.models.Model import (
+    CanonicalModelId,
+    ChatModel,
+    ModelDefinition,
+    ModelProvider,
+)
+from naas_abi_marketplace.ai.openrouter import ABIModule
+from pydantic import SecretStr
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+class SonarProSearchModel(ModelDefinition):
+    CANONICAL_ID = CanonicalModelId.SONAR_PRO_SEARCH
+    MODEL_ID = "perplexity/sonar-pro-search"
+    PROVIDER = ModelProvider.OPENROUTER
+
+    model: ChatModel = ChatModel(
+        model_id=MODEL_ID,
+        provider=PROVIDER,
+        model=ChatOpenAI(
+            model=MODEL_ID,
+            temperature=0,
+            timeout=120,
+            max_retries=3,
+            api_key=SecretStr(ABIModule.get_instance().configuration.openrouter_api_key),
+            base_url=OPENROUTER_BASE_URL,
+        ),
+    )
+
+
+model: ChatModel = SonarProSearchModel.model

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/models/text_embedding_3_large.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/models/text_embedding_3_large.py
@@ -1,0 +1,30 @@
+from langchain_openai import OpenAIEmbeddings
+from naas_abi_core.models.Model import (
+    CanonicalModelId,
+    EmbeddingModel,
+    ModelDefinition,
+    ModelProvider,
+)
+from naas_abi_marketplace.ai.openrouter import ABIModule
+from pydantic import SecretStr
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+class TextEmbedding3LargeModel(ModelDefinition):
+    CANONICAL_ID = CanonicalModelId.TEXT_EMBEDDING_3_LARGE
+    MODEL_ID = "openai/text-embedding-3-large"
+    PROVIDER = ModelProvider.OPENROUTER
+
+    model: EmbeddingModel = EmbeddingModel(
+        model_id=MODEL_ID,
+        provider=PROVIDER,
+        model=OpenAIEmbeddings(
+            model=MODEL_ID,
+            api_key=SecretStr(ABIModule.get_instance().configuration.openrouter_api_key),
+            base_url=OPENROUTER_BASE_URL,
+        ),
+    )
+
+
+model: EmbeddingModel = TextEmbedding3LargeModel.model

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/alpha/wsr/agents/WSRAgent.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/alpha/wsr/agents/WSRAgent.py
@@ -105,31 +105,23 @@ The WSR platform fuses the following live data layers:
         agent_shared_state: Optional[AgentSharedState] = None,
         agent_configuration: Optional[AgentConfiguration] = None,
     ) -> "WSRAgent":
-        from langchain_openai import ChatOpenAI
-        from naas_abi_core.models.Model import ChatModel
-        from naas_abi_marketplace.ai.chatgpt import ABIModule as ChatGPTModule
+        from naas_abi_core.engine.context import get_default_model_registry
+
+        registry = get_default_model_registry()
+        assert registry is not None, "ModelRegistryService not initialized"
+        chat_model = registry.get_default_chat_model()
+        embedding_model = registry.get_default_embedding_model().model
 
         if agent_configuration is None:
             agent_configuration = AgentConfiguration(system_prompt=cls.system_prompt)
         if agent_shared_state is None:
             agent_shared_state = AgentSharedState(thread_id="0")
 
-        model = ChatModel(
-            model_id="gpt-4.1-mini",
-            provider="openai",
-            model=ChatOpenAI(
-                model="gpt-4.1-mini",
-                temperature=0,
-                timeout=120,
-                max_retries=3,
-                api_key=ChatGPTModule.get_instance().configuration.openai_api_key,
-            ),
-        )
-
-        return WSRAgent(
+        return cls(
             name=cls.name,
             description=cls.description,
-            chat_model=model,
+            chat_model=chat_model,
+            embedding_model=embedding_model,
             tools=[],
             intents=cls.intents,
             state=agent_shared_state,

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/domains/document/agents/DocumentAgent.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/domains/document/agents/DocumentAgent.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional
 
 import numpy as np
+from langchain_core.embeddings import Embeddings
 from langchain_core.tools import BaseTool, StructuredTool
-from langchain_openai import OpenAIEmbeddings
 from naas_abi_core.services.agent.IntentAgent import (
     AgentConfiguration,
     AgentSharedState,
@@ -78,7 +78,7 @@ class DocumentSearchInput(BaseModel):
 
 
 def _build_search_tool(
-    embeddings_model: OpenAIEmbeddings,
+    embeddings_model: Embeddings,
     vector_store_service: Any,
 ) -> StructuredTool:
     """Create a LangChain StructuredTool that performs vector similarity search."""
@@ -133,18 +133,15 @@ def create_agent(
     agent_shared_state: Optional[AgentSharedState] = None,
     agent_configuration: Optional[AgentConfiguration] = None,
 ) -> "DocumentAgent":
-    from naas_abi_marketplace.ai.chatgpt.models.gpt_4_1_mini import model
+    from naas_abi_core.engine.context import get_default_model_registry
     from naas_abi_marketplace.domains.document import ABIModule
 
+    registry = get_default_model_registry()
+    assert registry is not None, "ModelRegistryService not initialized"
+    chat_model = registry.get_default_chat_model()
+    embeddings_model = registry.get_default_embedding_model().model
+
     module = ABIModule.get_instance()
-
-    agent_config = module.configuration.document_agent
-
-    embeddings_model = OpenAIEmbeddings(
-        model=agent_config.model_id,
-        dimensions=agent_config.dimension,
-        api_key=agent_config.api_key,
-    )
     vector_store_service = module.engine.services.vector_store
 
     search_tool = _build_search_tool(embeddings_model, vector_store_service)
@@ -163,7 +160,8 @@ def create_agent(
     return DocumentAgent(
         name=NAME,
         description=DESCRIPTION,
-        chat_model=model,
+        chat_model=chat_model,
+        embedding_model=embeddings_model,
         tools=tools,
         agents=[],
         intents=[],

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/domains/support/agents/SupportAgent.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/domains/support/agents/SupportAgent.py
@@ -105,7 +105,6 @@ Project management:
             "value": "Report a bug on: {{Bug Description}}",
         },
     ]
-    model = "gpt-4.1-mini"
 
     @staticmethod
     def get_intents(file_path: Path | str) -> list[Intent]:
@@ -225,7 +224,13 @@ Project management:
         agent_shared_state: Optional[AgentSharedState] = None,
         agent_configuration: Optional[AgentConfiguration] = None,
     ) -> "SupportAgent":
+        from naas_abi_core.engine.context import get_default_model_registry
         from naas_abi_marketplace.domains.support import ABIModule
+
+        registry = get_default_model_registry()
+        assert registry is not None, "ModelRegistryService not initialized"
+        chat_model = registry.get_default_chat_model()
+        embedding_model = registry.get_default_embedding_model().model
 
         module = ABIModule.get_instance()
         secret = module.engine.services.secret
@@ -233,12 +238,6 @@ Project management:
         default_repository = module.configuration.default_repository
         github_access_token = secret.get("GITHUB_ACCESS_TOKEN")
 
-        from langchain_openai import ChatOpenAI
-        from pydantic import SecretStr
-
-        model = ChatOpenAI(
-            model=cls.model, api_key=SecretStr(secret.get("OPENAI_API_KEY"))
-        )
         tools = cls.get_tools(github_access_token)
         system_prompt = cls.build_system_prompt(
             default_repository, github_project_id, tools
@@ -253,7 +252,8 @@ Project management:
         return cls(
             name=cls.name,
             description=cls.description,
-            chat_model=model,
+            chat_model=chat_model,
+            embedding_model=embedding_model,
             tools=tools,
             agents=[],
             intents=cls.intents,

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/domains/support/agents/SupportAgent_test.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/domains/support/agents/SupportAgent_test.py
@@ -185,7 +185,6 @@ def test_get_tools_filters_allowlisted_github_tools_and_appends_workflows(
 def test_support_agent_static_identity() -> None:
     assert SupportAgent.name == "Support"
     assert "GitHub" in SupportAgent.description
-    assert SupportAgent.model == "gpt-4.1-mini"
     assert len(SupportAgent.suggestions) == 2
     labels = {s["label"] for s in SupportAgent.suggestions}
     assert "Feature Request" in labels

--- a/libs/naas-abi/naas_abi/__init__.py
+++ b/libs/naas-abi/naas_abi/__init__.py
@@ -516,7 +516,7 @@ class ABIModule(BaseModule):
         # Canonical model id used by AbiAgent. Must resolve against the
         # ModelRegistry once all modules have loaded; the engine's
         # validate_defaults pass will surface any mismatch.
-        abi_agent_model: str = "gpt-4.1-mini"
+        abi_agent_model: str = "claude-sonnet-4.6"
 
         # Optional provider pin. When multiple modules register the same
         # canonical id (e.g. ``claude-sonnet-4`` ships via both the anthropic
@@ -526,7 +526,7 @@ class ABIModule(BaseModule):
 
         # Canonical model id used by OntologyEngineerAgent. Same registry
         # semantics as ``abi_agent_model``.
-        ontology_engineer_model: str = "gpt-5.1"
+        ontology_engineer_model: str = "claude-sonnet-4.6"
         ontology_engineer_provider: str | None = None
 
         # Canonical nexus runtime settings (passed to app.core.config.Settings).

--- a/uv.lock
+++ b/uv.lock
@@ -3533,7 +3533,7 @@ wheels = [
 
 [[package]]
 name = "naas-abi"
-version = "2.18.0"
+version = "2.19.0"
 source = { editable = "libs/naas-abi" }
 dependencies = [
     { name = "aiosqlite" },
@@ -3615,7 +3615,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-cli"
-version = "2.0.0"
+version = "2.1.0"
 source = { editable = "libs/naas-abi-cli" }
 dependencies = [
     { name = "naas-abi" },
@@ -3641,7 +3641,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-core"
-version = "2.0.0"
+version = "2.1.0"
 source = { editable = "libs/naas-abi-core" }
 dependencies = [
     { name = "click" },
@@ -3769,7 +3769,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-marketplace"
-version = "2.1.0"
+version = "3.0.0"
 source = { editable = "libs/naas-abi-marketplace" }
 dependencies = [
     { name = "ijson" },


### PR DESCRIPTION
## Summary

This PR migrates the OpenRouter integration from `naas_abi_marketplace.applications.openrouter` to a proper `naas_abi_marketplace.ai.openrouter` module, introduces a full suite of individually-defined model files for all supported OpenRouter models, and decouples agents from hardcoded model/provider references by routing them through the `ModelRegistryService`.

---

## Changes

### 🆕 New: `naas_abi_marketplace.ai.openrouter` Module

- Created `libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/__init__.py` as a proper `ABIModule` with `ModelRegistryService` as a dependency and `openrouter_api_key` as its sole configuration field.
- Removed the old `naas_abi_marketplace.applications.openrouter` module references from both `config.yaml` and `config.local.yaml`.
- Removed the static `include_models` list from config — models are now registered individually as first-class module files.

### 🤖 New Model Definitions (via OpenRouter)

Each model is defined in its own file under `naas_abi_marketplace/ai/openrouter/models/`:

| File | Canonical ID | OpenRouter Slug |
|---|---|---|
| `claude_sonnet_4_6.py` | `claude-sonnet-4.6` | `anthropic/claude-sonnet-4.6` |
| `claude_opus_4_7.py` | `claude-opus-4.7` | `anthropic/claude-opus-4.7` |
| `deepseek_v3_2.py` | `deepseek-v3.2` | `deepseek/deepseek-v3.2` |
| `gemini_3_1_pro_preview.py` | `gemini-3.1-pro-preview` | `google/gemini-3.1-pro-preview` |
| `gpt_4_1_mini.py` | `gpt-4.1-mini` | `openai/gpt-4.1-mini` |
| `gpt_5_1.py` | `gpt-5.1` | `openai/gpt-5.1` |
| `gpt_5_5.py` | `gpt-5.5` | `openai/gpt-5.5` |
| `gpt_5_3_codex.py` | `gpt-5.3-codex` | `openai/gpt-5.3-codex` |
| `grok_4_1_fast.py` | `grok-4.1-fast` | `x-ai/grok-4.1-fast` |
| `mistral_large_2512.py` | `mistral-large-2512` | `mistralai/mistral-large-2512` |
| `sonar_pro_search.py` | `sonar-pro-search` | `perplexity/sonar-pro-search` |
| `text_embedding_3_large.py` | `text-embedding-3-large` | `openai/text-embedding-3-large` |

### 🧩 New Canonical Model IDs (`CanonicalModelId`)

Added the following entries to `naas_abi_core/models/Model.py`:

- `CLAUDE_SONNET_4_6`
- `CLAUDE_OPUS_4_7`
- `GPT_5_5`
- `GPT_5_3_CODEX`
- `GEMINI_3_1_PRO_PREVIEW`
- `GROK_4_1_FAST`
- `DEEPSEEK_V3_2`
- `MISTRAL_LARGE_2512`
- `SONAR_PRO_SEARCH`

### 🔄 Agent Refactoring: Model Registry Decoupling

Agents no longer hardcode model instantiation. They now resolve models via `get_default_model_registry()`:

- **`WSRAgent`**: Replaced hardcoded `ChatOpenAI(gpt-4.1-mini)` with `registry.get_default_chat_model()` and `registry.get_default_embedding_model()`.
- **`DocumentAgent`**: Replaced hardcoded `OpenAIEmbeddings` and `gpt-4.1-mini` with registry-resolved chat and embedding models. Widened `embeddings_model` type from `OpenAIEmbeddings` to `langchain_core.embeddings.Embeddings`.
- **`SupportAgent`**: Replaced hardcoded `ChatOpenAI(gpt-4.1-mini)` with registry-resolved chat and embedding models. Removed the static `model = "gpt-4.1-mini"` class attribute.

### ⚙️ Configuration Updates

- **`config.yaml` & `config.local.yaml`**:
  - Replaced `naas_abi_marketplace.applications.openrouter` with `naas_abi_marketplace.ai.openrouter`.
  - Moved `naas_abi_marketplace.alpha.wsr` to appear before the `applications.git` module (ordering fix).
  - Changed `default_chat_model` from `gpt-4.1-mini` → `claude-sonnet-4.6` in both configs.
  - Disabled `naas_abi_marketplace.ai.chatgpt` in `config.local.yaml`.

- **`naas_abi/__init__.py`**:
  - Changed `abi_agent_model` default from `gpt-4.1-mini` → `claude-sonnet-4.6`.
  - Changed `ontology_engineer_model` default from `gpt-5.1` → `claude-sonnet-4.6`.

### 🧪 Test Updates

- Removed the assertion `SupportAgent.model == "gpt-4.1-mini"` from `SupportAgent_test.py` since the static `model` attribute was removed.

---

## Impact

- **No breaking changes** to external APIs or module interfaces.
- All agents now resolve models dynamically from the registry, making them provider-agnostic.
- Adding or swapping models only requires registering a new model file — no agent code changes needed.

---

## Test plan

- [x] Verify `naas_abi_marketplace.ai.openrouter` module loads correctly with a valid `openrouter_api_key`.
- [x] Confirm all new model files register successfully in `ModelRegistryService`.
- [x] Run `SupportAgent_test.py` to confirm the removed `model` attribute assertion no longer causes failures.
- [x] Smoke-test `WSRAgent`, `DocumentAgent`, and `SupportAgent` to confirm they resolve models from the registry correctly.
- [x] Validate that `default_chat_model` resolves to `claude-sonnet-4.6` in both `config.yaml` and `config.local.yaml`.