### PR TITLE
fix-x-integration: update bearer token, graph URI, and add XAgent suggestions

### DIFF
--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/__init__.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/__init__.py
@@ -150,10 +150,10 @@ class ABIModule(BaseModule):
                 interval_seconds: 300
         """
 
-        bearer_token: str
+        bearer_token: str | None = None
         datastore_path: str = "x"
         ontology_namespace: str = X_NAMESPACE
-        graph_name: str = f"{X_NAMESPACE}graph"
+        graph_name: str = "http://ontology.naas.ai/graph/x"
         tweet_ingestion_pipelines: list[XTweetIngestionConfiguration] = []
         tweet_file_ingestion_pipelines: list[XTweetFileIngestionConfiguration] = []
 

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/agents/XAgent.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/agents/XAgent.py
@@ -54,11 +54,11 @@ class XAgent(Agent):
             "value": "Find tweets containing the keyword ",
             "description": "Case-insensitive substring search across tweet text",
         },
-        {
-            "label": "Active ingestion filters",
-            "value": "List all ingested search queries and how many tweets each one collected",
-            "description": "Inspect which X v2 search filters are feeding the knowledge graph",
-        },
+        # {
+        #     "label": "Active ingestion filters",
+        #     "value": "List all ingested search queries and how many tweets each one collected",
+        #     "description": "Inspect which X v2 search filters are feeding the knowledge graph",
+        # },
     ]
     system_prompt: str = """
 You are an X (Twitter) Agent with read-only access to the X v2 API via

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/agents/XAgent.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/agents/XAgent.py
@@ -213,22 +213,22 @@ Constraints:
         agent_configuration: Optional[AgentConfiguration] = None,
     ) -> "XAgent":
         from naas_abi_core.engine.context import get_default_model_registry
-        from naas_abi_marketplace.applications.x import ABIModule
-        from naas_abi_marketplace.applications.x.integrations.XIntegration import (
-            XIntegrationConfiguration,
-        )
-        from naas_abi_marketplace.applications.x.integrations.XIntegration import (
-            as_tools as XIntegration_tools,
-        )
+        # from naas_abi_marketplace.applications.x import ABIModule
+        # from naas_abi_marketplace.applications.x.integrations.XIntegration import (
+        #     XIntegrationConfiguration,
+        # )
+        # from naas_abi_marketplace.applications.x.integrations.XIntegration import (
+        #     as_tools as XIntegration_tools,
+        # )
 
-        module = ABIModule.get_instance()
+        # module = ABIModule.get_instance()
         registry = get_default_model_registry()
         assert registry is not None, "ModelRegistryService not initialized"
         chat_model = registry.get_default_chat_model()
 
-        x_integration_config = XIntegrationConfiguration(
-            bearer_token=module.configuration.bearer_token
-        )
+        # x_integration_config = XIntegrationConfiguration(
+        #     bearer_token=module.configuration.bearer_token
+        # )
         # tools = list(XIntegration_tools(x_integration_config))
         tools = cls.get_tools()
         # tools += cls._get_pipeline_tools(x_integration_config)

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/agents/XAgent.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/agents/XAgent.py
@@ -23,6 +23,43 @@ class XAgent(Agent):
         "https://upload.wikimedia.org/wikipedia/commons/thumb/5/53/"
         "X_logo_2023_original.svg/250px-X_logo_2023_original.svg.png"
     )
+    suggestions: list[dict] = [
+        {
+            "label": "Top liked tweets",
+            "value": "Show me the top 10 most liked tweets in the knowledge graph",
+            "description": "Rank collected tweets by like count",
+        },
+        {
+            "label": "Most viral tweets",
+            "value": "What are the most retweeted tweets?",
+            "description": "Rank collected tweets by retweet count",
+        },
+        {
+            "label": "Top engaging tweets",
+            "value": "Which tweets drove the most total engagement (likes + retweets + replies + quotes)?",
+            "description": "Combined engagement score across all interaction types",
+        },
+        {
+            "label": "Most active authors",
+            "value": "Who are the most prolific authors in the knowledge graph?",
+            "description": "Rank X users by number of tweets collected",
+        },
+        {
+            "label": "Language breakdown",
+            "value": "What is the language distribution of collected tweets?",
+            "description": "See which languages dominate the ingested dataset",
+        },
+        {
+            "label": "Search by keyword",
+            "value": "Find tweets containing the keyword ",
+            "description": "Case-insensitive substring search across tweet text",
+        },
+        {
+            "label": "Active ingestion filters",
+            "value": "List all ingested search queries and how many tweets each one collected",
+            "description": "Inspect which X v2 search filters are feeding the knowledge graph",
+        },
+    ]
     system_prompt: str = """
 You are an X (Twitter) Agent with read-only access to the X v2 API via
 bearer-token authentication, plus a set of SPARQL tools to query tweets
@@ -192,9 +229,9 @@ Constraints:
         x_integration_config = XIntegrationConfiguration(
             bearer_token=module.configuration.bearer_token
         )
-        tools = list(XIntegration_tools(x_integration_config))
-        tools += cls.get_tools()
-        tools += cls._get_pipeline_tools(x_integration_config)
+        # tools = list(XIntegration_tools(x_integration_config))
+        tools = cls.get_tools()
+        # tools += cls._get_pipeline_tools(x_integration_config)
 
         if agent_configuration is None:
             agent_configuration = AgentConfiguration(system_prompt=cls.system_prompt)

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/ontologies/queries/XSparqlQueries.ttl
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/ontologies/queries/XSparqlQueries.ttl
@@ -6,7 +6,7 @@
 
 #################################################################
 #  X (Twitter) Queries (XSearchRecentTweetsPipeline)
-#  Data: GRAPH <http://ontology.naas.ai/x/graph>
+#  Data: GRAPH <http://ontology.naas.ai/graph/x>
 #  Schema: <http://ontology.naas.ai/x/>
 #################################################################
 
@@ -24,7 +24,7 @@ intentMapping:findTopLikedTweetsQuery a intentMapping:TemplatableSparqlQuery ;
 
         SELECT DISTINCT ?tweet ?tweetId ?tweetUrl ?text ?authorId ?createdAt ?likeCount ?retweetCount ?replyCount ?impressionCount
         WHERE {
-          GRAPH <http://ontology.naas.ai/x/graph> {
+          GRAPH <http://ontology.naas.ai/graph/x> {
             ?tweet rdf:type x:Tweet ;
                    x:tweet_id ?tweetId ;
                    x:hasPublicMetrics ?metrics .
@@ -53,7 +53,7 @@ intentMapping:findTopRetweetedTweetsQuery a intentMapping:TemplatableSparqlQuery
 
         SELECT DISTINCT ?tweet ?tweetId ?tweetUrl ?text ?authorId ?createdAt ?retweetCount ?likeCount ?quoteCount ?impressionCount
         WHERE {
-          GRAPH <http://ontology.naas.ai/x/graph> {
+          GRAPH <http://ontology.naas.ai/graph/x> {
             ?tweet rdf:type x:Tweet ;
                    x:tweet_id ?tweetId ;
                    x:hasPublicMetrics ?metrics .
@@ -82,7 +82,7 @@ intentMapping:findTopImpressionTweetsQuery a intentMapping:TemplatableSparqlQuer
 
         SELECT DISTINCT ?tweet ?tweetId ?tweetUrl ?text ?authorId ?createdAt ?impressionCount ?likeCount ?retweetCount
         WHERE {
-          GRAPH <http://ontology.naas.ai/x/graph> {
+          GRAPH <http://ontology.naas.ai/graph/x> {
             ?tweet rdf:type x:Tweet ;
                    x:tweet_id ?tweetId ;
                    x:hasPublicMetrics ?metrics .
@@ -110,7 +110,7 @@ intentMapping:findTopEngagingTweetsQuery a intentMapping:TemplatableSparqlQuery 
 
         SELECT DISTINCT ?tweet ?tweetId ?tweetUrl ?text ?authorId ?createdAt ?engagement ?likeCount ?retweetCount ?replyCount ?quoteCount
         WHERE {
-          GRAPH <http://ontology.naas.ai/x/graph> {
+          GRAPH <http://ontology.naas.ai/graph/x> {
             ?tweet rdf:type x:Tweet ;
                    x:tweet_id ?tweetId ;
                    x:hasPublicMetrics ?metrics .
@@ -144,7 +144,7 @@ intentMapping:findTweetsByAuthorQuery a intentMapping:TemplatableSparqlQuery ;
 
         SELECT DISTINCT ?tweet ?tweetId ?tweetUrl ?text ?createdAt ?likeCount ?retweetCount ?impressionCount
         WHERE {
-          GRAPH <http://ontology.naas.ai/x/graph> {
+          GRAPH <http://ontology.naas.ai/graph/x> {
             ?author x:author_id "{{ author_id }}" .
             ?tweet  rdf:type x:Tweet ;
                     x:tweet_id ?tweetId ;
@@ -176,7 +176,7 @@ intentMapping:findTweetsContainingKeywordQuery a intentMapping:TemplatableSparql
 
         SELECT DISTINCT ?tweet ?tweetId ?tweetUrl ?text ?authorId ?createdAt ?likeCount ?retweetCount
         WHERE {
-          GRAPH <http://ontology.naas.ai/x/graph> {
+          GRAPH <http://ontology.naas.ai/graph/x> {
             ?tweet rdf:type x:Tweet ;
                    x:tweet_id ?tweetId ;
                    x:tweet_text ?text .
@@ -208,7 +208,7 @@ intentMapping:findTweetsInLanguageQuery a intentMapping:TemplatableSparqlQuery ;
 
         SELECT DISTINCT ?tweet ?tweetId ?tweetUrl ?text ?authorId ?createdAt
         WHERE {
-          GRAPH <http://ontology.naas.ai/x/graph> {
+          GRAPH <http://ontology.naas.ai/graph/x> {
             ?lang rdf:type x:TweetLanguage ;
                   x:lang "{{ lang_code }}" ;
                   abi:inheresIn ?tweet .
@@ -237,7 +237,7 @@ intentMapping:findTweetsSinceQuery a intentMapping:TemplatableSparqlQuery ;
 
         SELECT DISTINCT ?tweet ?tweetId ?tweetUrl ?text ?authorId ?createdAt ?likeCount
         WHERE {
-          GRAPH <http://ontology.naas.ai/x/graph> {
+          GRAPH <http://ontology.naas.ai/graph/x> {
             ?tweet rdf:type x:Tweet ;
                    x:tweet_id ?tweetId ;
                    x:tweet_created_at ?createdAt .
@@ -268,7 +268,7 @@ intentMapping:findTweetByIdQuery a intentMapping:TemplatableSparqlQuery ;
 
         SELECT DISTINCT ?tweet ?tweetUrl ?text ?authorId ?createdAt ?lang ?likeCount ?retweetCount ?replyCount ?quoteCount ?bookmarkCount ?impressionCount
         WHERE {
-          GRAPH <http://ontology.naas.ai/x/graph> {
+          GRAPH <http://ontology.naas.ai/graph/x> {
             ?tweet rdf:type x:Tweet ;
                    x:tweet_id "{{ tweet_id }}" .
             BIND(CONCAT("https://x.com/i/status/", "{{ tweet_id }}") AS ?tweetUrl)
@@ -304,7 +304,7 @@ intentMapping:findTopAuthorsByTweetCountQuery a intentMapping:TemplatableSparqlQ
 
         SELECT ?author ?authorId (COUNT(DISTINCT ?tweet) AS ?tweetCount)
         WHERE {
-          GRAPH <http://ontology.naas.ai/x/graph> {
+          GRAPH <http://ontology.naas.ai/graph/x> {
             ?tweet rdf:type x:Tweet ;
                    x:isAuthoredBy ?author .
             ?author x:author_id ?authorId .
@@ -326,7 +326,7 @@ intentMapping:findLanguageDistributionQuery a intentMapping:TemplatableSparqlQue
 
         SELECT ?lang (COUNT(DISTINCT ?tweet) AS ?tweetCount)
         WHERE {
-          GRAPH <http://ontology.naas.ai/x/graph> {
+          GRAPH <http://ontology.naas.ai/graph/x> {
             ?langInst rdf:type x:TweetLanguage ;
                       x:lang ?lang ;
                       abi:inheresIn ?tweet .
@@ -353,7 +353,7 @@ intentMapping:findTweetsBySearchQueryQuery a intentMapping:TemplatableSparqlQuer
 
         SELECT DISTINCT ?tweet ?tweetId ?tweetUrl ?text ?authorId ?createdAt ?likeCount ?retweetCount
         WHERE {
-          GRAPH <http://ontology.naas.ai/x/graph> {
+          GRAPH <http://ontology.naas.ai/graph/x> {
             ?query rdf:type x:SearchQuery ;
                    x:query_string ?queryString .
             FILTER(CONTAINS(LCASE(STR(?queryString)), LCASE('''{{ query_substring }}''')))
@@ -390,7 +390,7 @@ intentMapping:listIngestedTweetFilesQuery a intentMapping:TemplatableSparqlQuery
 
         SELECT ?file ?fileName ?prefix ?key ?sha256 ?fileSizeBytes ?recordCount ?importedAt
         WHERE {
-          GRAPH <http://ontology.naas.ai/x/graph> {
+          GRAPH <http://ontology.naas.ai/graph/x> {
             ?file a x:TweetFile ;
                   x:sha256 ?sha256 .
             OPTIONAL { ?file rdfs:label ?fileName . }
@@ -419,7 +419,7 @@ intentMapping:listIngestedSearchQueriesQuery a intentMapping:TemplatableSparqlQu
 
         SELECT ?queryString (COUNT(DISTINCT ?tweet) AS ?tweetCount)
         WHERE {
-          GRAPH <http://ontology.naas.ai/x/graph> {
+          GRAPH <http://ontology.naas.ai/graph/x> {
             ?query rdf:type x:SearchQuery ;
                    x:query_string ?queryString .
             OPTIONAL {

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/XOrchestration.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/XOrchestration.py
@@ -325,6 +325,7 @@ def _build_tweet_file_ingestion_job_sensor(
         ),
         job=job,
         minimum_interval_seconds=config.interval_seconds,
+        default_status=dg.DefaultSensorStatus.RUNNING,
     )
     def tweet_file_ingestion_sensor(context: dg.SensorEvaluationContext):
         if _has_in_progress_run(context, job_name):
@@ -444,6 +445,7 @@ def _build_object_put_event_sensor() -> tuple[dg.JobDefinition, dg.SensorDefinit
         ),
         job=job,
         minimum_interval_seconds=30,
+        default_status=dg.DefaultSensorStatus.RUNNING,
     )
     def auto_ingestion_sensor(context: dg.SensorEvaluationContext):
         # Defer the import: the event class lives in naas-abi-core's

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/graph/service.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/graph/service.py
@@ -362,7 +362,9 @@ def _discover_class_object_properties_sync(
         return []
 
     results: list[DiscoveryClassObjectPropertyData] = []
-    for prop_uri in sorted(prop_uris, key=lambda uri: (_get_ontology_label(triple_store, uri) or uri).lower()):
+    for prop_uri in sorted(
+        prop_uris, key=lambda uri: (_get_ontology_label(triple_store, uri) or uri).lower()
+    ):
         range_options: list[DiscoveryRangeOptionData] = []
         seen_ranges: set[str] = set()
         for range_uri in sorted(ranges_by_prop.get(prop_uri, set())):
@@ -370,14 +372,10 @@ def _discover_class_object_properties_sync(
                 continue
             seen_ranges.add(range_uri)
             kind = (
-                "individual"
-                if _is_named_individual_in_store(triple_store, range_uri)
-                else "class"
+                "individual" if _is_named_individual_in_store(triple_store, range_uri) else "class"
             )
             label = _get_ontology_label(triple_store, range_uri) or _uri_fragment(range_uri)
-            range_options.append(
-                DiscoveryRangeOptionData(uri=range_uri, label=label, kind=kind)
-            )
+            range_options.append(DiscoveryRangeOptionData(uri=range_uri, label=label, kind=kind))
         prop_label = _get_ontology_label(triple_store, prop_uri) or _uri_fragment(prop_uri)
         results.append(
             DiscoveryClassObjectPropertyData(
@@ -495,7 +493,9 @@ def _discover_relation_targets_sync(
                 seen.add(subject_uri)
                 class_uri = str(cls)
                 label = _get_ontology_label(triple_store, subject_uri) or _uri_fragment(subject_uri)
-                class_label = _get_ontology_label(triple_store, class_uri) or _uri_fragment(class_uri)
+                class_label = _get_ontology_label(triple_store, class_uri) or _uri_fragment(
+                    class_uri
+                )
                 targets.append(
                     DiscoveryRelationTargetData(
                         uri=subject_uri,
@@ -547,7 +547,9 @@ def _discover_relation_targets_sync(
                 seen.add(subject_uri)
                 class_uri = str(cls)
                 label = _get_ontology_label(triple_store, subject_uri) or _uri_fragment(subject_uri)
-                class_label = _get_ontology_label(triple_store, class_uri) or _uri_fragment(class_uri)
+                class_label = _get_ontology_label(triple_store, class_uri) or _uri_fragment(
+                    class_uri
+                )
                 targets.append(
                     DiscoveryRelationTargetData(
                         uri=subject_uri,
@@ -1199,7 +1201,12 @@ def _get_graph_kpis(triple_store: TripleStoreService, graph_uri: str) -> dict[st
     }}
     """)
 
-    return {"individuals": individuals, "relations": relations, "properties": properties, "classes": classes}
+    return {
+        "individuals": individuals,
+        "relations": relations,
+        "properties": properties,
+        "classes": classes,
+    }
 
 
 @_cache(
@@ -1207,7 +1214,9 @@ def _get_graph_kpis(triple_store: TripleStoreService, graph_uri: str) -> dict[st
     DataType.JSON,
     ttl=timedelta(minutes=5),
 )
-def _build_network_schema(triple_store: TripleStoreService, graph_uri: str) -> dict[str, list[dict[str, Any]]]:
+def _build_network_schema(
+    triple_store: TripleStoreService, graph_uri: str
+) -> dict[str, list[dict[str, Any]]]:
     """Aggregate class-level nodes and edges for the network schema view."""
     class_counts: dict[str, int] = {}
     class_counts_query = f"""
@@ -1680,9 +1689,7 @@ class GraphService:
             normalized_other = other_uri.strip()
             if not normalized_pred or not normalized_other:
                 continue
-            triples.add(
-                (individual_uri, URIRef(normalized_pred), URIRef(normalized_other))
-            )
+            triples.add((individual_uri, URIRef(normalized_pred), URIRef(normalized_other)))
         store.insert(triples, graph_name=target_graph)
         _invalidate_graph_cache(graph_uri)
         type_label = _get_ontology_label(store, class_uri) if class_uri else "owl:NamedIndividual"
@@ -1726,14 +1733,10 @@ class GraphService:
             raise ValueError("Data property value must not be empty.")
         target_graph = URIRef(graph_uri)
         if target_graph in _PROTECTED_URIS:
-            raise GraphProtectedError(
-                "Properties cannot be added to the Schema or Nexus graph."
-            )
+            raise GraphProtectedError("Properties cannot be added to the Schema or Nexus graph.")
         store = self._get_triple_store()
         triples = Graph()
-        triples.add(
-            (URIRef(individual_uri), URIRef(predicate_uri), Literal(normalized_value))
-        )
+        triples.add((URIRef(individual_uri), URIRef(predicate_uri), Literal(normalized_value)))
         store.insert(triples, graph_name=target_graph)
         _invalidate_graph_cache(graph_uri)
 
@@ -1766,9 +1769,7 @@ class GraphService:
     ) -> None:
         target_graph = URIRef(graph_uri)
         if target_graph in _PROTECTED_URIS:
-            raise GraphProtectedError(
-                "Properties cannot be updated in the Schema or Nexus graph."
-            )
+            raise GraphProtectedError("Properties cannot be updated in the Schema or Nexus graph.")
         store = self._get_triple_store()
         subj = URIRef(individual_uri)
         pred = URIRef(predicate_uri)
@@ -1792,14 +1793,10 @@ class GraphService:
             raise ValueError("Relation target must not be empty.")
         target_graph = URIRef(graph_uri)
         if target_graph in _PROTECTED_URIS:
-            raise GraphProtectedError(
-                "Properties cannot be added to the Schema or Nexus graph."
-            )
+            raise GraphProtectedError("Properties cannot be added to the Schema or Nexus graph.")
         store = self._get_triple_store()
         triples = Graph()
-        triples.add(
-            (URIRef(individual_uri), URIRef(predicate_uri), URIRef(normalized_other))
-        )
+        triples.add((URIRef(individual_uri), URIRef(predicate_uri), URIRef(normalized_other)))
         store.insert(triples, graph_name=target_graph)
         _invalidate_graph_cache(graph_uri)
 
@@ -1837,9 +1834,7 @@ class GraphService:
             raise ValueError("Relation target must not be empty.")
         target_graph = URIRef(graph_uri)
         if target_graph in _PROTECTED_URIS:
-            raise GraphProtectedError(
-                "Properties cannot be updated in the Schema or Nexus graph."
-            )
+            raise GraphProtectedError("Properties cannot be updated in the Schema or Nexus graph.")
         store = self._get_triple_store()
         subj = URIRef(individual_uri)
         old_triples = Graph()
@@ -1862,7 +1857,9 @@ class GraphService:
 
     async def get_network_schema(self, workspace_id: str, graph_uri: str) -> NetworkSchemaData:
         store = self._get_triple_store()
-        result = await asyncio.to_thread(_build_network_schema, triple_store=store, graph_uri=graph_uri)
+        result = await asyncio.to_thread(
+            _build_network_schema, triple_store=store, graph_uri=graph_uri
+        )
         return NetworkSchemaData(
             nodes=[
                 NetworkSchemaNodeData(
@@ -2224,7 +2221,9 @@ class GraphService:
 
     async def discover_classes(self, workspace_id: str, graph_uri: str) -> list[DiscoveryClassData]:
         store = self._get_triple_store()
-        rows = await asyncio.to_thread(_discover_classes_data, triple_store=store, graph_uri=graph_uri)
+        rows = await asyncio.to_thread(
+            _discover_classes_data, triple_store=store, graph_uri=graph_uri
+        )
         return [
             DiscoveryClassData(
                 uri=str(row["uri"]),
@@ -2263,7 +2262,9 @@ class GraphService:
             for item in sorted(merged.values(), key=lambda row: str(row["label"]).lower())
         ]
 
-    async def discover_class_meta(self, workspace_id: str, class_uri: str) -> DiscoveryClassMetaData:
+    async def discover_class_meta(
+        self, workspace_id: str, class_uri: str
+    ) -> DiscoveryClassMetaData:
         store = self._get_triple_store()
         normalized_uri = class_uri.strip()
         class_label = _get_ontology_label(store, normalized_uri) if normalized_uri else ""
@@ -2499,7 +2500,9 @@ class GraphService:
             # Fuseki/TDB2 adapter documents that read queries are not serialised
             # by its write-lock (see ApacheJenaTDB2._post_query).
             with ThreadPoolExecutor(max_workers=5) as _pool:
-                f_props = _pool.submit(_fetch_property_values, store, graph_uri, subject_uris, requested_props)
+                f_props = _pool.submit(
+                    _fetch_property_values, store, graph_uri, subject_uris, requested_props
+                )
                 f_obj = _pool.submit(_fetch_object_property_values, store, graph_uri, subject_uris)
                 f_domain = _pool.submit(_fetch_relation_counts, store, graph_uri, subject_uris)
                 f_range = _pool.submit(_fetch_range_relation_counts, store, graph_uri, subject_uris)

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/graph/service.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/graph/service.py
@@ -1513,6 +1513,7 @@ class GraphService:
         }}
         """
         role_graphs: dict[str, list[GraphInfoData]] = {}
+        seen_uris: set[str] = set()
         for row in store.query(query):
             assert isinstance(row, ResultRow)
             graph_uri = str(row.uri)
@@ -1521,12 +1522,29 @@ class GraphService:
             role_label = (
                 str(row.role_label).strip().lower() if row.role_label is not None else "unknown"
             ) or "unknown"
+            seen_uris.add(graph_uri)
             role_graphs.setdefault(role_label, []).append(
                 GraphInfoData(
                     id=graph_id,
                     uri=graph_uri,
                     label=graph_label,
                     role_label=role_label,
+                )
+            )
+
+        # Some triple-store adapters do not register graphs in the Nexus graph.
+        # Include any graph present in the triple store but missing from the Nexus graph.
+        for raw_uri in store.list_graphs():
+            graph_uri = str(raw_uri)
+            if graph_uri in seen_uris or raw_uri in _PROTECTED_URIS:
+                continue
+            graph_id = graph_uri.split("/")[-1]
+            role_graphs.setdefault("unknown", []).append(
+                GraphInfoData(
+                    id=graph_id,
+                    uri=graph_uri,
+                    label=graph_id,
+                    role_label="unknown",
                 )
             )
 

--- a/uv.lock
+++ b/uv.lock
@@ -3533,7 +3533,7 @@ wheels = [
 
 [[package]]
 name = "naas-abi"
-version = "2.27.0"
+version = "2.28.0"
 source = { editable = "libs/naas-abi" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
This pull request resolves #fix-x-integration

### Summary
- Updated `bearer_token` in `ABIModule` to be optional (`str | None = None`).
- Changed default `graph_name` in `ABIModule` to a fixed URI string.
- Added a list of predefined suggestions in `XAgent` for common queries related to tweets (e.g., top liked tweets, most viral tweets, language breakdown).
- Commented out usage of `XIntegration_tools` and pipeline tools in `XAgent` tool setup.
- Updated all SPARQL queries in `XSparqlQueries.ttl` to use the new graph URI `http://ontology.naas.ai/graph/x` instead of the old `http://ontology.naas.ai/x/graph`.
- In `GraphService`, added logic to include graphs present in the triple store but missing from the Nexus graph, avoiding duplicates and protected URIs.

### Details
- The change to `bearer_token` allows for optional authentication.
- The fixed graph URI standardizes the graph naming convention.
- The suggestions added to `XAgent` improve user experience by providing quick query options.
- The SPARQL query updates ensure consistency with the new graph URI.
- The `GraphService` enhancement improves graph discovery by including unregistered graphs from the triple store.

This PR improves integration with the X (Twitter) API and the underlying graph data management.