### PR TITLE
feat(naas-abi-cli): add `new app` command and modernise agent template scaffold

### DIFF
--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/__init__.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/__init__.py
@@ -1,4 +1,5 @@
 import naas_abi_cli.cli.new.agent as agent  # noqa: F401
+import naas_abi_cli.cli.new.app as app  # noqa: F401
 import naas_abi_cli.cli.new.integration as integration  # noqa: F401
 import naas_abi_cli.cli.new.module as module  # noqa: F401
 import naas_abi_cli.cli.new.orchestration as orchestration  # noqa: F401

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/app.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/app.py
@@ -1,0 +1,51 @@
+import os
+
+import click
+import naas_abi_cli
+from naas_abi_cli.cli.utils.Copier import Copier
+
+from .new import new
+from .utils import to_kebab_case, to_pascal_case, to_snake_case
+
+
+@new.command("app")
+@click.argument("app_name", required=True)
+@click.argument("app_path", required=False, default=".")
+def _new_app(app_name: str, app_path: str = "."):
+    new_app(app_name, app_path)
+
+
+def new_app(app_name: str, app_path: str = ".", extra_values: dict = {}):
+    """Scaffold an app folder (manifest.json + README.md + index.html).
+
+    The app lives under ``<module>/apps/<app_name_snake>/`` and is discovered by
+    the Nexus apps adapter from its ``manifest.json``. The HTML page is exposed
+    via the ``html:index.html`` shorthand in the manifest's ``url`` field.
+    """
+    app_name = to_kebab_case(app_name)
+
+    if app_path == ".":
+        app_path = os.getcwd()
+
+    if not os.path.exists(app_path):
+        os.makedirs(app_path, exist_ok=True)
+
+    copier = Copier(
+        templates_path=os.path.join(
+            os.path.dirname(naas_abi_cli.__file__), "cli/new/templates/apps"
+        ),
+        destination_path=app_path,
+    )
+
+    if "module_name_snake" not in extra_values:
+        extra_values["module_name_snake"] = "your_module_name"
+
+    copier.copy(
+        values={
+            "app_name": app_name,
+            "app_name_snake": to_snake_case(app_name),
+            "app_name_pascal": to_pascal_case(app_name),
+            "app_title": app_name.replace("-", " ").title(),
+        }
+        | extra_values
+    )

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/module.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/module.py
@@ -5,6 +5,7 @@ import naas_abi_cli
 from naas_abi_cli.cli.utils.Copier import Copier
 
 from .agent import new_agent
+from .app import new_app
 from .integration import new_integration
 from .new import new
 from .orchestration import new_orchestration
@@ -76,6 +77,12 @@ def new_module(module_name: str, module_path: str = ".", quiet: bool = False):
     new_orchestration(
         module_name,
         os.path.join(module_path, "orchestrations"),
+        extra_values={"module_name_snake": to_snake_case(module_name)},
+    )
+
+    new_app(
+        module_name,
+        os.path.join(module_path, "apps"),
         extra_values={"module_name_snake": to_snake_case(module_name)},
     )
 

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/agent/{{agent_name_pascal}}Agent.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/agent/{{agent_name_pascal}}Agent.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 from naas_abi_core.services.agent.Agent import (
@@ -6,39 +8,81 @@ from naas_abi_core.services.agent.Agent import (
     AgentSharedState,
 )
 
-NAME = "{{agent_name_pascal}}Agent"
-DESCRIPTION = "An helpful agent that can help you with your tasks."
-SYSTEM_PROMPT = """
-You are {{agent_name_pascal}}Agent.
-"""
 
 class {{agent_name_pascal}}Agent(Agent):
+    name: str = "{{agent_name_pascal}}"
+    description: str = "An helpful agent that can help you with your tasks."
+    avatar_url: str = (
+        "https://naasai-public.s3.eu-west-3.amazonaws.com/abi-demo/ontology_ABI.png"
+    )
+    system_prompt: str = """<role>
+You are {{agent_name_pascal}}Agent, a helpful assistant.
+</role>
+
+<objective>
+Help the user accomplish their tasks using the tools available to you.
+</objective>
+
+<tools>
+[TOOLS]
+</tools>
+
+<operating_guidelines>
+- Maintain a clear, concise, and professional tone.
+- Format responses as clean, well-structured Markdown.
+- Confirm actions and provide next steps when appropriate.
+</operating_guidelines>
+
+<constraints>
+- Preserve the language of the user's message in your response.
+- Only use the provided tools — do not fabricate data or capabilities.
+</constraints>
+"""
+
+    suggestions: list[dict] = [
+        {
+            "label": "What can you do?",
+            "value": "What can you do?",
+            "description": "Get an overview of this agent's capabilities",
+        },
+    ]
 
     @classmethod
-    def New(cls, agent_shared_state: Optional[AgentSharedState] = None, agent_configuration: Optional[AgentConfiguration] = None) -> "{{agent_name_pascal}}Agent":
-        #from {{module_name_snake}} import ABIModule
-        
-        # Set model
-        from naas_abi_marketplace.ai.chatgpt.models.gpt_5 import model as chatgpt_model
+    def New(
+        cls,
+        agent_shared_state: Optional[AgentSharedState] = None,
+        agent_configuration: Optional[AgentConfiguration] = None,
+    ) -> "{{agent_name_pascal}}Agent":
+        # from {{module_name_snake}} import ABIModule
+        from naas_abi_core.engine.context import get_default_model_registry
 
-        model = chatgpt_model.model
-
-        # Use provided configuration or create default one
-        if agent_configuration is None:
-            agent_configuration = AgentConfiguration(system_prompt=SYSTEM_PROMPT)
-
-        # Use provided shared state or create new one
-        if agent_shared_state is None:
-            agent_shared_state = AgentSharedState()
+        # Use the workspace's default chat model from the model registry.
+        registry = get_default_model_registry()
+        assert registry is not None, "ModelRegistryService not initialized"
+        chat_model = registry.get_default_chat_model()
 
         tools: list = []
 
         agents: list = []
 
+        # Use provided configuration or build one from the class system prompt.
+        if agent_configuration is None:
+            tools_section = (
+                "\n".join([f"- {tool.name}: {tool.description}" for tool in tools])
+                or ""
+            )
+            agent_configuration = AgentConfiguration(
+                system_prompt=cls.system_prompt.replace("[TOOLS]", tools_section)
+            )
+
+        # Use provided shared state or create new one
+        if agent_shared_state is None:
+            agent_shared_state = AgentSharedState(thread_id="0")
+
         return cls(
-            name=NAME,
-            description=DESCRIPTION,
-            chat_model=model,
+            name=cls.name,
+            description=cls.description,
+            chat_model=chat_model,
             tools=tools,
             agents=agents,
             memory=None,

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/apps/AGENTS.md
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/apps/AGENTS.md
@@ -1,0 +1,75 @@
+# `apps/` — AGENTS.md
+
+> Scope: app definitions for the `{{ module_name_snake }}` module. See the module's [AGENTS.md](../AGENTS.md) for module-wide context.
+
+## What goes here
+
+**Apps** are self-contained UI surfaces this module ships to the Nexus catalog. Each app is a folder holding a `manifest.json` (its catalog entry) and, optionally, the assets it serves — typically a single `index.html`. Apps are *discovered*, not imported: nothing in Python code references them. The Nexus API walks every loaded module's `apps/` directory at startup.
+
+## Folder shape
+
+One folder per app, `snake_case`, never starting with `_` (underscore-prefixed folders are skipped by discovery):
+
+```
+apps/
+└── <app_name>/
+    ├── manifest.json   # catalog entry (required)
+    ├── index.html      # the page served to the iframe (optional)
+    └── README.md       # per-app notes
+```
+
+The app id exposed by the API is `<module.dotted.path>:<app_name>`, so the folder name *is* the app name — keep it stable.
+
+## `manifest.json`
+
+The only required file. Read verbatim into the catalog by the apps adapter. Recognised fields:
+
+| Field | Required | Notes |
+|---|---|---|
+| `name` | yes | Human-readable title in the catalog. |
+| `description` | yes | One-line summary. |
+| `category` | yes | Catalog bucket (e.g. `marketplace`, `alpha`). Falls back to `unknown`. |
+| `url` | no | Where the app lives — `html:<filename>` for a bundled file, or a full `https://…` URL for an external app. |
+| `icon_emoji` / `avatar_url` | no | Catalog icon. |
+| `version`, `author`, `license`, `maintainer`, `tier` | no | Metadata. |
+| `keywords` | no | List of search terms. |
+| `pricing` | no | `{ "type": "free", "price": 0 }`. |
+| `demo_login` / `demo_password` | no | Pre-filled demo credentials. |
+
+## How an app gets served
+
+Set `url` to **`html:<filename>`** (e.g. `html:index.html`). The Nexus apps adapter (`apps__primary_adapter__FastAPI.py`) resolves the shorthand:
+
+1. Discovery reads `apps/<app>/manifest.json` for every loaded module.
+2. `url: "html:index.html"` is rewritten to `/app-html/<module/path/url>/<app>/index.html`
+   (the module's dotted path becomes slash-separated).
+3. `GET /api/apps/?workspace_id=…` turns that into a fully-qualified URL the frontend iframe loads.
+
+Point `url` at any file in the app folder (`html:dashboard.html`, `html:build/index.html`, …) — it only has to exist. To embed an externally hosted app instead, set `url` to a full `https://…` URL and skip the bundled HTML.
+
+> **The catalog is process-cached.** Restart the Nexus API to pick up a new or changed manifest.
+
+## Scaffold a new app
+
+```bash
+abi new app <name> apps/
+```
+
+This drops `apps/<name>/` with a templated `manifest.json` (wired to `html:index.html`), a Hello-world `index.html`, and a `README.md`.
+
+## Enabling
+
+No registration needed. As long as this module is enabled in `config.yaml`, its apps appear in the catalog automatically:
+
+```yaml
+modules:
+  - path: src/custom/{{ module_name_snake }}
+    enabled: true
+```
+
+Drop the folder in, restart the API, and it shows up.
+
+## See also
+
+- Apps adapter (discovery + `html:` resolution + serving routes): `.abi/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/apps/adapters/primary/apps__primary_adapter__FastAPI.py`
+- Reference apps: `.abi/libs/naas-abi-marketplace/.../alpha/wsr/apps/dashboard/manifest.json` (external URL), `.abi/libs/naas-abi-marketplace/.../domains/document/apps/sandbox/manifest.json` (`html:` bundled page)

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/apps/{{app_name_snake}}/README.md
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/apps/{{app_name_snake}}/README.md
@@ -1,0 +1,62 @@
+# `{{ app_name_snake }}` — app
+
+> An **app** is a self-contained UI surface that the `{{ module_name_snake }}` module ships to the Nexus catalog. It is discovered from this folder's `manifest.json` and (optionally) served as a static HTML page.
+
+## Layout
+
+```
+apps/
+└── {{ app_name_snake }}/
+    ├── manifest.json   # catalog entry (required)
+    ├── index.html      # the page served to the iframe (optional)
+    └── README.md       # this file
+```
+
+The app id exposed by the API is `<module.dotted.path>:{{ app_name_snake }}`. The folder name is the app name — keep it `snake_case` and avoid a leading `_` (folders starting with `_` are skipped by discovery).
+
+## `manifest.json`
+
+The manifest is the only required file. It is read verbatim into the catalog. Recognised fields:
+
+| Field | Required | Notes |
+|---|---|---|
+| `name` | yes | Human-readable title shown in the catalog. |
+| `description` | yes | One-line summary. |
+| `category` | yes | Catalog bucket (e.g. `marketplace`, `alpha`). Falls back to `unknown`. |
+| `url` | no | Where the app lives. Use `html:<filename>` to serve a bundled file (see below), or a full `https://…` URL for an external app. |
+| `icon_emoji` / `avatar_url` | no | Catalog icon. |
+| `version`, `author`, `license`, `maintainer` | no | Metadata. |
+| `keywords` | no | List of search terms. |
+| `tier` | no | `community` / `marketplace` / … |
+| `pricing` | no | `{ "type": "free", "price": 0 }`. |
+| `demo_login` / `demo_password` | no | Pre-filled demo credentials. |
+
+## Serving the HTML page
+
+Set `url` to **`html:index.html`** (or any filename in this folder). The Nexus API resolves that shorthand and serves the file:
+
+1. Discovery walks every loaded module's `apps/<app>/manifest.json`.
+2. A `url` of `html:index.html` is rewritten to `/app-html/<module/path/url>/{{ app_name_snake }}/index.html`.
+3. The `list_apps` endpoint turns that into a fully-qualified URL the frontend iframe loads.
+
+You can point at any file (`html:dashboard.html`, `html:build/index.html`, …) — it just has to exist in this folder. To embed an externally hosted app instead, set `url` to a full `https://…` URL and drop `index.html`.
+
+> The catalog is process-cached. **Restart the Nexus API** to pick up a new or changed manifest.
+
+## Enabling
+
+Apps are discovered automatically as long as the parent module is enabled in your `config.yaml`:
+
+```yaml
+modules:
+  - path: src/custom/{{ module_name_snake }}
+    enabled: true
+```
+
+No extra registration is needed — drop the folder in, restart the API, and the app shows up in the catalog (`GET /api/apps/?workspace_id=…`).
+
+## Scaffold another app
+
+```bash
+abi new app <name> apps/
+```

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/apps/{{app_name_snake}}/index.html
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/apps/{{app_name_snake}}/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{ app_title }}</title>
+    <style>
+      body {
+        margin: 0;
+        height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-family: system-ui, -apple-system, sans-serif;
+        background: #0b0b0f;
+        color: #f5f5f7;
+      }
+      .card {
+        text-align: center;
+      }
+      .card h1 {
+        font-size: 2rem;
+        margin: 0 0 0.5rem;
+      }
+      .card p {
+        opacity: 0.6;
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <h1>Hello world 👋</h1>
+      <p>{{ app_title }} — served by the {{ module_name_snake }} module.</p>
+    </div>
+  </body>
+</html>

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/apps/{{app_name_snake}}/manifest.json
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/apps/{{app_name_snake}}/manifest.json
@@ -1,0 +1,17 @@
+{
+    "name": "{{ app_title }}",
+    "description": "{{ app_title }} app shipped by the {{ module_name_snake }} module.",
+    "category": "marketplace",
+    "url": "html:index.html",
+    "icon_emoji": "✨",
+    "version": "1.0.0",
+    "author": "naas.ai",
+    "license": "MIT",
+    "keywords": ["{{ app_name }}"],
+    "tier": "community",
+    "maintainer": "naas.ai",
+    "pricing": {
+        "type": "free",
+        "price": 0
+    }
+}


### PR DESCRIPTION
# Summary

This PR enhances the `naas-abi-cli` scaffolding tool by introducing a new `abi new app` command and updating the `abi new module` command to automatically scaffold an app alongside a new module. It also modernises the agent template to align with the latest `naas-abi-core` API.

---

## Changes

### ✨ New: `abi new app` command (`cli/new/app.py`)

A new CLI command `abi new app <app_name> [app_path]` has been added. It scaffolds a self-contained Nexus app folder under `<module>/apps/<app_name_snake>/` containing:

- `manifest.json` — catalog entry wired to `html:index.html`
- `index.html` — a Hello-world HTML page served by the Nexus API
- `README.md` — per-app documentation

The command is registered in `cli/new/__init__.py` and exposed via the `new` Click group.

### 🔗 `abi new module` now scaffolds an app automatically (`cli/new/module.py`)

When creating a new module, `new_module` now calls `new_app` to generate an `apps/` subfolder with a default app named after the module. This ensures every new module ships with a ready-to-use Nexus catalog entry out of the box.

### 📄 New app templates (`cli/new/templates/apps/`)

| File | Description |
|---|---|
| `AGENTS.md` | Developer guide for the `apps/` directory: discovery rules, `manifest.json` fields, `html:` URL resolution, and scaffolding instructions. |
| `{{app_name_snake}}/manifest.json` | Templated catalog entry with sensible defaults (`category`, `url`, `icon_emoji`, `pricing`, …). |
| `{{app_name_snake}}/index.html` | Minimal Hello-world HTML page (dark-themed, centered card). |
| `{{app_name_snake}}/README.md` | Per-app documentation covering layout, manifest fields, serving mechanics, and enabling via `config.yaml`. |

### 🔄 Updated agent template (`templates/agent/{{agent_name_pascal}}Agent.py`)

The generated agent class has been modernised:

- **Class-level attributes** (`name`, `description`, `avatar_url`, `system_prompt`, `suggestions`) replace the old module-level constants.
- **Model resolution** now uses `get_default_model_registry()` from `naas_abi_core.engine.context` instead of a hard-coded GPT-5 import.
- **System prompt** follows the structured `<role>` / `<objective>` / `<tools>` / `<operating_guidelines>` / `<constraints>` format with a `[TOOLS]` placeholder that is filled at instantiation time.
- **`AgentSharedState`** is initialised with `thread_id="0"`.
- **`from __future__ import annotations`** added for forward-reference compatibility.

---

## How it works — app discovery

1. The Nexus API walks every enabled module's `apps/` directory at startup.
2. Each subfolder containing a `manifest.json` is registered as a catalog entry.
3. A `url` of `html:index.html` is rewritten to `/app-html/<module/path>/<app>/index.html` and served as a static file.
4. The catalog is process-cached — **restart the Nexus API** to pick up new or changed manifests.

---

## Test plan

```bash
# Scaffold a standalone app
abi new app my-dashboard apps/

# Scaffold a full module (now includes an app automatically)
abi new module my-module
```

- Verify `apps/<app_name_snake>/manifest.json`, `index.html`, and `README.md` are created correctly.
- Verify the Nexus API picks up the new app after a restart.
- Verify the modernised agent template generates a valid agent class with class-level attributes and correct model resolution.