### PR TITLE
feat: add spend guard for XSearchRecentTweetsWorkflow to limit cost and volume per filter

### DIFF
--- a/libs/naas-abi-cli/uv.lock
+++ b/libs/naas-abi-cli/uv.lock
@@ -2384,7 +2384,7 @@ wheels = [
 
 [[package]]
 name = "naas-abi"
-version = "2.31.0"
+version = "2.33.0"
 source = { editable = "../naas-abi" }
 dependencies = [
     { name = "aiosqlite" },
@@ -2499,7 +2499,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-core"
-version = "2.3.0"
+version = "2.4.0"
 source = { editable = "../naas-abi-core" }
 dependencies = [
     { name = "click" },
@@ -2613,7 +2613,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-marketplace"
-version = "3.3.0"
+version = "3.7.0"
 source = { editable = "../naas-abi-marketplace" }
 dependencies = [
     { name = "ijson" },

--- a/libs/naas-abi-core/naas_abi_core/engine/EngineProxy_test.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/EngineProxy_test.py
@@ -4,7 +4,7 @@ import pytest
 from naas_abi_core.engine.EngineProxy import EngineProxy
 from naas_abi_core.engine.IEngine import IEngine
 from naas_abi_core.module.Module import ModuleDependencies
-from naas_abi_core.services.email.EmailPorts import IEmailAdapter
+from naas_abi_core.services.email.EmailPorts import EmailAttachment, IEmailAdapter
 from naas_abi_core.services.email.EmailService import EmailService
 from naas_abi_core.services.model_registry.ModelRegistryService import (
     ModelRegistryService,
@@ -22,6 +22,7 @@ class _DummyEmailAdapter(IEmailAdapter):
         from_email: str,
         from_name: str | None = None,
         reply_to: str | None = None,
+        attachments: list[EmailAttachment] | None = None,
     ) -> None:
         return None
 

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/__init__.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/__init__.py
@@ -73,6 +73,44 @@ class XTweetSearchWorkflowConfiguration(BaseModel):
         ),
     )
 
+    # ----- Spend guard (per filter) --------------------------------------
+    # XSearchRecentTweetsWorkflow bills `cost_per_tweet_usd` per tweet
+    # ('resource') returned by search_recent_tweets. A persistent usage ledger
+    # in object storage (keyed by this filter's `name`) tracks how many tweets
+    # this filter has retrieved today and this calendar month; once *either*
+    # the daily or the monthly cap is reached the workflow returns zero results
+    # WITHOUT calling the X API, so the sensor can keep ticking (e.g. hourly)
+    # without spending past the budget. Caps may be given as a tweet count or a
+    # USD amount (converted via `cost_per_tweet_usd`); if both are set for the
+    # same period the more restrictive one wins. Leave a cap null to disable it.
+    cost_per_tweet_usd: float = Field(
+        default=0.005,
+        gt=0,
+        description="USD billed per tweet returned by search_recent_tweets.",
+    )
+    daily_max_tweets: int | None = Field(
+        default=None,
+        ge=0,
+        description="Max tweets this filter may retrieve per UTC day (null = no limit).",
+    )
+    daily_max_usd: float | None = Field(
+        default=None,
+        ge=0,
+        description="Max USD this filter may spend per UTC day (null = no limit).",
+    )
+    monthly_max_tweets: int | None = Field(
+        default=None,
+        ge=0,
+        description=(
+            "Max tweets this filter may retrieve per calendar month (null = no limit)."
+        ),
+    )
+    monthly_max_usd: float | None = Field(
+        default=None,
+        ge=0,
+        description="Max USD this filter may spend per calendar month (null = no limit).",
+    )
+
 
 class XTweetFileIngestionConfiguration(BaseModel):
     """One configured drop-folder that the XOrchestration polls for tweet
@@ -163,14 +201,29 @@ class ABIModule(BaseModule):
             # XSearchRecentTweetsWorkflow for `query` (incrementally, from the
             # last seen tweet id), then maps each persisted envelope into the
             # graph via XSearchRecentTweetsPipeline.
+            #
+            # Spend guard (per filter): search_recent_tweets bills
+            # `cost_per_tweet_usd` per tweet ('resource') returned. A usage
+            # ledger keyed by this filter's `name` tracks tweets retrieved today
+            # and this calendar month; once EITHER the daily or monthly cap is
+            # reached the run fetches nothing (no X API call) until the next
+            # day / month — so the sensor can keep ticking (e.g. hourly) without
+            # spending past the budget. Caps may be a tweet count or a USD
+            # amount; if both are set on a period the stricter one wins. The
+            # example below caps this filter at $20/day and $250/month.
             search_recent_tweets_workflow:
               - name: ai_llms
                 query: "(openai OR anthropic OR \"llm\" OR \"large language model\") lang:en -is:retweet"
-                interval_seconds: 60
+                interval_seconds: 3600   # hourly; the spend guard stops it early
                 max_results: 100
                 max_pages: 1
                 sort_order: recency      # 'recency' or 'relevancy'
                 persist: true
+                cost_per_tweet_usd: 0.005
+                daily_max_usd: 20        # ~4000 tweets/day at $0.005
+                monthly_max_usd: 250     # ~50000 tweets/month at $0.005
+                # daily_max_tweets / monthly_max_tweets are also accepted if you
+                # prefer to cap by count instead of (or alongside) USD.
         """
 
         bearer_token: str | None = None

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/XOrchestration.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/XOrchestration.py
@@ -147,6 +147,14 @@ def _build_search_workflow_job_sensor(
             XSearchRecentTweetsWorkflowConfiguration(
                 x_integration=x_integration,
                 object_storage=module.engine.services.object_storage,
+                # Per-filter spend guard: ledger keyed by this filter's name so
+                # each filter caps its own daily / monthly X API spend.
+                budget_key=config.name,
+                cost_per_tweet_usd=config.cost_per_tweet_usd,
+                daily_max_tweets=config.daily_max_tweets,
+                daily_max_usd=config.daily_max_usd,
+                monthly_max_tweets=config.monthly_max_tweets,
+                monthly_max_usd=config.monthly_max_usd,
             )
         )
         output = workflow.run(

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/workflows/XSearchRecentTweetsWorkflow.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/workflows/XSearchRecentTweetsWorkflow.py
@@ -76,6 +76,18 @@ class XSearchRecentTweetsWorkflowConfiguration(WorkflowConfiguration):
             ABIModule.get_instance().configuration.graph_name
         )
     )
+    # ----- X API spend guard (per filter) ------------------------------------
+    # Caps are supplied per filter by the orchestration from
+    # XTweetSearchWorkflowConfiguration (or by ad-hoc callers / the CLI). A cap
+    # of None disables that limit; cost_per_tweet_usd converts USD caps into a
+    # tweet count. ``budget_key`` keys the usage ledger so each filter tracks
+    # and caps its own spend independently.
+    budget_key: str = "default"
+    cost_per_tweet_usd: float = 0.005
+    daily_max_tweets: Optional[int] = None
+    daily_max_usd: Optional[float] = None
+    monthly_max_tweets: Optional[int] = None
+    monthly_max_usd: Optional[float] = None
 
 
 class XSearchRecentTweetsWorkflowParameters(WorkflowParameters):
@@ -125,6 +137,161 @@ class XSearchRecentTweetsWorkflowParameters(WorkflowParameters):
     ] = True
 
 
+@dataclass
+class _BudgetLimits:
+    """Resolved spend caps for the X recent-search workflow.
+
+    A cap can be given as a tweet count, a USD amount, or both. USD caps are
+    converted to a tweet count via ``cost_per_tweet_usd``; when both are set for
+    the same period the more restrictive (smaller) tweet count wins. ``None``
+    on both inputs means that period is uncapped.
+    """
+
+    cost_per_tweet_usd: float
+    daily_max_tweets: Optional[int]
+    daily_max_usd: Optional[float]
+    monthly_max_tweets: Optional[int]
+    monthly_max_usd: Optional[float]
+
+    def _tweet_cap(
+        self, max_tweets: Optional[int], max_usd: Optional[float]
+    ) -> Optional[int]:
+        caps: list[int] = []
+        if max_tweets is not None:
+            caps.append(int(max_tweets))
+        if max_usd is not None and self.cost_per_tweet_usd > 0:
+            # Floor (tweets can't be fractional), with a tiny epsilon so float
+            # artefacts don't turn an exact $0.50 / $0.005 = 100 into 99.
+            caps.append(int(max_usd / self.cost_per_tweet_usd + 1e-9))
+        return min(caps) if caps else None
+
+    @property
+    def daily_tweet_cap(self) -> Optional[int]:
+        return self._tweet_cap(self.daily_max_tweets, self.daily_max_usd)
+
+    @property
+    def monthly_tweet_cap(self) -> Optional[int]:
+        return self._tweet_cap(self.monthly_max_tweets, self.monthly_max_usd)
+
+
+class _XApiBudget:
+    """Persistent global ledger of tweets retrieved per day and per month.
+
+    Each filter keeps its own ledger, a single JSON object in object storage at
+    ``<budget_path>/<budget_key>.json``::
+
+        {"daily": {"2026-06-22": 1234}, "monthly": {"2026-06": 56789}}
+
+    Counts are tweets (the billed X 'resource'); USD is derived on read via
+    ``cost_per_tweet_usd``. The guard is all-or-nothing: if *either* the daily
+    or monthly cap has already been reached, :meth:`exhausted_reason` returns a
+    message and the caller fetches nothing; otherwise it runs and afterwards
+    calls :meth:`record` with the number of tweets actually retrieved.
+
+    Read-modify-write is not atomic across processes, but the XOrchestration
+    runs each filter's job in-process and skips ticks while a run is in flight,
+    so concurrent writers are not expected. A small overshoot (one tick's worth)
+    is acceptable for a soft spend guard.
+    """
+
+    # Keep the ledger from growing without bound: retain at most this many of
+    # the most recent day / month buckets on each write.
+    _MAX_DAILY_BUCKETS = 90
+    _MAX_MONTHLY_BUCKETS = 24
+
+    def __init__(
+        self,
+        storage_utils: StorageUtils,
+        budget_path: str,
+        budget_key: str,
+        limits: _BudgetLimits,
+    ):
+        self._storage = storage_utils
+        self._path = budget_path
+        # One ledger file per filter so each tracks/caps its own spend.
+        self._ledger_filename = f"{slugify_query(budget_key) or 'default'}.json"
+        self._limits = limits
+
+    @staticmethod
+    def _period_keys() -> tuple[str, str]:
+        now = datetime.now(timezone.utc)
+        return now.strftime("%Y-%m-%d"), now.strftime("%Y-%m")
+
+    def _load(self) -> dict:
+        # StorageUtils.get_json returns {} when the ledger does not exist yet.
+        data = self._storage.get_json(self._path, self._ledger_filename) or {}
+        if not isinstance(data.get("daily"), dict):
+            data["daily"] = {}
+        if not isinstance(data.get("monthly"), dict):
+            data["monthly"] = {}
+        return data
+
+    def usage(self) -> tuple[int, int]:
+        """Return ``(tweets_today, tweets_this_month)`` from the ledger."""
+        data = self._load()
+        day_key, month_key = self._period_keys()
+        return (
+            int(data["daily"].get(day_key, 0)),
+            int(data["monthly"].get(month_key, 0)),
+        )
+
+    def exhausted_reason(self) -> Optional[str]:
+        """Return a human-readable reason if a cap is reached, else None."""
+        used_day, used_month = self.usage()
+        cost = self._limits.cost_per_tweet_usd
+        day_cap = self._limits.daily_tweet_cap
+        month_cap = self._limits.monthly_tweet_cap
+        if day_cap is not None and used_day >= day_cap:
+            return (
+                f"daily X budget reached: {used_day}/{day_cap} tweets "
+                f"(~${used_day * cost:.2f}) already retrieved today"
+            )
+        if month_cap is not None and used_month >= month_cap:
+            return (
+                f"monthly X budget reached: {used_month}/{month_cap} tweets "
+                f"(~${used_month * cost:.2f}) already retrieved this month"
+            )
+        return None
+
+    def record(self, tweets_retrieved: int) -> None:
+        """Add ``tweets_retrieved`` to today's and this month's counters."""
+        if tweets_retrieved <= 0:
+            return
+        data = self._load()
+        day_key, month_key = self._period_keys()
+        data["daily"][day_key] = int(data["daily"].get(day_key, 0)) + tweets_retrieved
+        data["monthly"][month_key] = (
+            int(data["monthly"].get(month_key, 0)) + tweets_retrieved
+        )
+        data["daily"] = self._prune(data["daily"], self._MAX_DAILY_BUCKETS)
+        data["monthly"] = self._prune(data["monthly"], self._MAX_MONTHLY_BUCKETS)
+        self._storage.save_json(
+            data, self._path, self._ledger_filename, copy=False
+        )
+
+    @staticmethod
+    def _prune(buckets: dict, keep: int) -> dict:
+        if len(buckets) <= keep:
+            return buckets
+        # Keys are sortable ISO date / month strings; keep the most recent.
+        newest = sorted(buckets)[-keep:]
+        return {k: buckets[k] for k in newest}
+
+    def snapshot(self) -> dict:
+        """Current usage + caps, suitable for returning to callers / logs."""
+        used_day, used_month = self.usage()
+        cost = self._limits.cost_per_tweet_usd
+        return {
+            "tweets_today": used_day,
+            "tweets_this_month": used_month,
+            "usd_today": round(used_day * cost, 4),
+            "usd_this_month": round(used_month * cost, 4),
+            "daily_tweet_cap": self._limits.daily_tweet_cap,
+            "monthly_tweet_cap": self._limits.monthly_tweet_cap,
+            "cost_per_tweet_usd": cost,
+        }
+
+
 class XSearchRecentTweetsWorkflow(Workflow[XSearchRecentTweetsWorkflowParameters]):
     """Run several X recent-search queries incrementally.
 
@@ -142,11 +309,27 @@ class XSearchRecentTweetsWorkflow(Workflow[XSearchRecentTweetsWorkflowParameters
 
     __configuration: XSearchRecentTweetsWorkflowConfiguration
     __storage_utils: StorageUtils
+    __budget: _XApiBudget
 
     def __init__(self, configuration: XSearchRecentTweetsWorkflowConfiguration):
         super().__init__(configuration)
         self.__configuration = configuration
         self.__storage_utils = StorageUtils(self.__configuration.object_storage)
+        # Global spend ledger lives under <datastore_path>/_budget so it sits
+        # next to (but never collides with) the per-query search_recent_tweets
+        # envelopes the integration writes.
+        self.__budget = _XApiBudget(
+            self.__storage_utils,
+            os.path.join(self.__configuration.datastore_path, "_budget"),
+            self.__configuration.budget_key,
+            _BudgetLimits(
+                cost_per_tweet_usd=self.__configuration.cost_per_tweet_usd,
+                daily_max_tweets=self.__configuration.daily_max_tweets,
+                daily_max_usd=self.__configuration.daily_max_usd,
+                monthly_max_tweets=self.__configuration.monthly_max_tweets,
+                monthly_max_usd=self.__configuration.monthly_max_usd,
+            ),
+        )
 
     def get_since_id(self, query: str) -> Optional[str]:
         """Return the highest tweet id already fetched for ``query``, or None.
@@ -235,6 +418,23 @@ class XSearchRecentTweetsWorkflow(Workflow[XSearchRecentTweetsWorkflowParameters
         if not queries:
             return {"total_new_tweets": 0, "results": []}
 
+        # All-or-nothing spend guard: if the daily or monthly cap is already
+        # reached, fetch nothing this tick (no X API call, so no spend) and let
+        # the orchestration try again on its next interval. The counter resets
+        # naturally — a new day / month is simply a new ledger bucket.
+        blocked_reason = self.__budget.exhausted_reason()
+        if blocked_reason is not None:
+            logger.warning(
+                f"XSearchRecentTweetsWorkflow: skipping fetch — {blocked_reason}"
+            )
+            return {
+                "total_new_tweets": 0,
+                "results": [],
+                "budget_blocked": True,
+                "budget_reason": blocked_reason,
+                "budget": self.__budget.snapshot(),
+            }
+
         # One worker thread per query, as requested — each thread fetches its
         # query independently. ``ThreadPoolExecutor.map`` preserves input order,
         # so ``results`` lines up with ``queries``.
@@ -247,9 +447,14 @@ class XSearchRecentTweetsWorkflow(Workflow[XSearchRecentTweetsWorkflowParameters
             )
 
         total_new = sum(item["new_count"] for item in results)
+        # Charge the budget for every tweet ('resource') actually retrieved so
+        # the next tick sees the updated spend.
+        self.__budget.record(total_new)
         return {
             "total_new_tweets": total_new,
             "results": results,
+            "budget_blocked": False,
+            "budget": self.__budget.snapshot(),
         }
 
     def as_tools(self) -> list[BaseTool]:

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/workflows/XSearchRecentTweetsWorkflow.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/workflows/XSearchRecentTweetsWorkflow.py
@@ -3,7 +3,7 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from enum import Enum
-from typing import Annotated, Optional
+from typing import Annotated, Optional, Protocol
 
 from langchain_core.tools import BaseTool, StructuredTool
 from naas_abi_core import logger
@@ -174,6 +174,14 @@ class _BudgetLimits:
         return self._tweet_cap(self.monthly_max_tweets, self.monthly_max_usd)
 
 
+class _BudgetLedgerStorage(Protocol):
+    def get_json(self, dir_path: str, file_name: str) -> dict: ...
+
+    def save_json(
+        self, data: dict | list, dir_path: str, file_name: str, copy: bool = True
+    ) -> tuple[str, str]: ...
+
+
 class _XApiBudget:
     """Persistent global ledger of tweets retrieved per day and per month.
 
@@ -201,7 +209,7 @@ class _XApiBudget:
 
     def __init__(
         self,
-        storage_utils: StorageUtils,
+        storage_utils: _BudgetLedgerStorage,
         budget_path: str,
         budget_key: str,
         limits: _BudgetLimits,

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/workflows/XSearchRecentTweetsWorkflow_test.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/workflows/XSearchRecentTweetsWorkflow_test.py
@@ -13,14 +13,15 @@ class _FakeStorage:
     """
 
     def __init__(self) -> None:
-        self.store: dict[tuple[str, str], dict] = {}
+        self.store: dict[tuple[str, str], dict | list] = {}
 
     def get_json(self, dir_path: str, file_name: str) -> dict:
         # Matches StorageUtils.get_json: missing file -> {}.
-        return self.store.get((dir_path, file_name), {})
+        stored = self.store.get((dir_path, file_name), {})
+        return stored if isinstance(stored, dict) else {}
 
     def save_json(
-        self, data: dict, dir_path: str, file_name: str, copy: bool = True
+        self, data: dict | list, dir_path: str, file_name: str, copy: bool = True
     ) -> tuple[str, str]:
         self.store[(dir_path, file_name)] = data
         return dir_path, file_name

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/workflows/XSearchRecentTweetsWorkflow_test.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/workflows/XSearchRecentTweetsWorkflow_test.py
@@ -1,0 +1,131 @@
+from naas_abi_marketplace.applications.x.workflows.XSearchRecentTweetsWorkflow import (
+    _BudgetLimits,
+    _XApiBudget,
+)
+
+
+class _FakeStorage:
+    """In-memory stand-in for the object-storage-backed StorageUtils.
+
+    Only the two methods _XApiBudget calls are implemented; keyed by
+    ``(dir_path, file_name)`` so the budget ledger round-trips like the real
+    JSON object would.
+    """
+
+    def __init__(self) -> None:
+        self.store: dict[tuple[str, str], dict] = {}
+
+    def get_json(self, dir_path: str, file_name: str) -> dict:
+        # Matches StorageUtils.get_json: missing file -> {}.
+        return self.store.get((dir_path, file_name), {})
+
+    def save_json(
+        self, data: dict, dir_path: str, file_name: str, copy: bool = True
+    ) -> tuple[str, str]:
+        self.store[(dir_path, file_name)] = data
+        return dir_path, file_name
+
+
+def _budget(limits: _BudgetLimits) -> _XApiBudget:
+    return _XApiBudget(_FakeStorage(), "x/_budget", "test_filter", limits)
+
+
+# --------------------------------------------------------------- cap resolution
+
+
+def test_usd_cap_converts_to_tweet_count():
+    limits = _BudgetLimits(
+        cost_per_tweet_usd=0.005,
+        daily_max_tweets=None,
+        daily_max_usd=0.5,
+        monthly_max_tweets=None,
+        monthly_max_usd=5.0,
+    )
+    # $0.50 / $0.005 == 100 and $5.00 / $0.005 == 1000, with no float off-by-one.
+    assert limits.daily_tweet_cap == 100
+    assert limits.monthly_tweet_cap == 1000
+
+
+def test_more_restrictive_cap_wins_when_both_set():
+    limits = _BudgetLimits(
+        cost_per_tweet_usd=0.005,
+        daily_max_tweets=50,  # 50 tweets
+        daily_max_usd=0.5,  # == 100 tweets
+        monthly_max_tweets=None,
+        monthly_max_usd=None,
+    )
+    assert limits.daily_tweet_cap == 50
+
+
+def test_no_cap_when_both_inputs_none():
+    limits = _BudgetLimits(0.005, None, None, None, None)
+    assert limits.daily_tweet_cap is None
+    assert limits.monthly_tweet_cap is None
+
+
+# ------------------------------------------------------------- ledger behaviour
+
+
+def test_record_accumulates_and_blocks_when_daily_cap_reached():
+    limits = _BudgetLimits(
+        cost_per_tweet_usd=0.005,
+        daily_max_tweets=100,
+        daily_max_usd=None,
+        monthly_max_tweets=None,
+        monthly_max_usd=None,
+    )
+    budget = _budget(limits)
+
+    assert budget.exhausted_reason() is None
+    budget.record(80)
+    assert budget.usage()[0] == 80
+    assert budget.exhausted_reason() is None  # still under the cap
+
+    budget.record(30)  # 110 >= 100
+    assert budget.usage()[0] == 110
+    reason = budget.exhausted_reason()
+    assert reason is not None and "daily" in reason
+
+
+def test_monthly_cap_blocks_independently_of_daily():
+    limits = _BudgetLimits(
+        cost_per_tweet_usd=0.005,
+        daily_max_tweets=None,  # no daily cap
+        daily_max_usd=None,
+        monthly_max_tweets=10,
+        monthly_max_usd=None,
+    )
+    budget = _budget(limits)
+    budget.record(10)
+    reason = budget.exhausted_reason()
+    assert reason is not None and "monthly" in reason
+
+
+def test_record_zero_or_negative_is_noop():
+    budget = _budget(_BudgetLimits(0.005, 100, None, None, None))
+    budget.record(0)
+    budget.record(-5)
+    assert budget.usage() == (0, 0)
+
+
+def test_filters_track_separate_ledgers():
+    # Same backing storage, different budget keys -> independent counters.
+    storage = _FakeStorage()
+    limits = _BudgetLimits(0.005, 10, None, None, None)
+    a = _XApiBudget(storage, "x/_budget", "filter_a", limits)
+    b = _XApiBudget(storage, "x/_budget", "filter_b", limits)
+
+    a.record(10)
+    assert a.exhausted_reason() is not None  # filter_a is capped …
+    assert b.exhausted_reason() is None  # … but filter_b is untouched
+    assert b.usage() == (0, 0)
+
+
+def test_snapshot_reports_usage_and_usd():
+    budget = _budget(_BudgetLimits(0.005, 100, None, 1000, None))
+    budget.record(40)
+    snap = budget.snapshot()
+    assert snap["tweets_today"] == 40
+    assert snap["usd_today"] == 0.2  # 40 * 0.005
+    assert snap["daily_tweet_cap"] == 100
+    assert snap["monthly_tweet_cap"] == 1000


### PR DESCRIPTION
This pull request resolves #filter-x-recent-tweets

### Summary

This PR introduces a spend guard feature for the `XSearchRecentTweetsWorkflow` to control and limit the cost and volume of tweets retrieved from the X API (formerly Twitter) on a per-filter basis.

### Key Changes

- **Configuration Enhancements:**
  - Added new fields to `XTweetSearchWorkflowConfiguration` to specify cost per tweet and daily/monthly caps both in tweet counts and USD amounts.
  - These caps can be set independently or together, with the stricter limit taking precedence.

- **Orchestration Updates:**
  - The orchestration now passes these budget parameters to the workflow configuration.

- **Workflow Logic:**
  - Introduced `_BudgetLimits` dataclass to resolve and manage the effective caps.
  - Added `_XApiBudget` class to maintain a persistent ledger of tweets retrieved per day and month, stored in object storage.
  - The ledger tracks usage per filter and enforces all-or-nothing spend guard: if either daily or monthly cap is reached, the workflow skips fetching tweets to avoid overspending.
  - The workflow records the number of tweets retrieved after each run to update the ledger.
  - The workflow returns budget usage and blocking status in its results.

- **Testing:**
  - Added comprehensive tests for budget cap resolution, ledger behavior, and blocking logic using a fake in-memory storage.

### Benefits

- Prevents unexpected overspending on X API usage by enforcing strict daily and monthly limits.
- Allows flexible budgeting either by tweet count or USD cost.
- Enables continuous sensor operation without exceeding budget by skipping fetches when caps are reached.

### Example Usage

A filter can be configured with:
```yaml
search_recent_tweets_workflow:
  - name: ai_llms
    query: "(openai OR anthropic OR \"llm\" OR \"large language model\") lang:en -is:retweet"
    interval_seconds: 3600
    max_results: 100
    max_pages: 1
    sort_order: recency
    persist: true
    cost_per_tweet_usd: 0.005
    daily_max_usd: 20
    monthly_max_usd: 250
```

This caps the filter at approximately $20/day and $250/month, preventing overspend.

---

This enhancement improves cost control and operational safety for workflows fetching recent tweets from X.