### PR TITLE
feat(email-service): support multiple recipients in email sending

### DIFF
--- a/libs/naas-abi-core/naas_abi_core/engine/EngineProxy_test.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/EngineProxy_test.py
@@ -15,7 +15,7 @@ class _DummyEmailAdapter(IEmailAdapter):
     def send(
         self,
         *,
-        to_email: str,
+        to_email: str | None = None,
         subject: str,
         text_body: str,
         html_body: str | None = None,
@@ -23,6 +23,7 @@ class _DummyEmailAdapter(IEmailAdapter):
         from_name: str | None = None,
         reply_to: str | None = None,
         attachments: list[EmailAttachment] | None = None,
+        to_emails: list[str] | str | None = None,
     ) -> None:
         return None
 

--- a/libs/naas-abi-core/naas_abi_core/services/email/EmailMessageBuilder.py
+++ b/libs/naas-abi-core/naas_abi_core/services/email/EmailMessageBuilder.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from email.message import EmailMessage
 from email.utils import formataddr
 
-from naas_abi_core.services.email.EmailPorts import EmailAttachment
+from naas_abi_core.services.email.EmailPorts import EmailAttachment, resolve_recipients
 
 
 def build_email_message(
     *,
-    to_email: str,
+    to_email: str | None = None,
     subject: str,
     text_body: str,
     html_body: str | None = None,
@@ -16,9 +16,10 @@ def build_email_message(
     from_name: str | None = None,
     reply_to: str | None = None,
     attachments: list[EmailAttachment] | None = None,
+    to_emails: list[str] | str | None = None,
 ) -> EmailMessage:
     msg = EmailMessage()
-    msg["To"] = to_email
+    msg["To"] = ", ".join(resolve_recipients(to_email, to_emails))
     msg["Subject"] = subject
     msg["From"] = (
         formataddr((from_name or "", from_email)) if from_name else from_email

--- a/libs/naas-abi-core/naas_abi_core/services/email/EmailPorts.py
+++ b/libs/naas-abi-core/naas_abi_core/services/email/EmailPorts.py
@@ -11,12 +11,41 @@ class EmailAttachment:
     mime_type: str
 
 
+def resolve_recipients(
+    to_email: str | list[str] | None = None,
+    to_emails: list[str] | str | None = None,
+) -> list[str]:
+    """Normalize ``to_email`` and/or ``to_emails`` into an ordered recipient list.
+
+    Either argument may be a single address, a comma-separated string, or a list
+    of those. Both are accepted together; addresses are trimmed and de-duplicated
+    while preserving first-seen order. Raises ``ValueError`` when no address is
+    found so callers never silently send to nobody.
+    """
+
+    seen: set[str] = set()
+    recipients: list[str] = []
+    for value in (to_email, to_emails):
+        if value is None:
+            continue
+        parts = [value] if isinstance(value, str) else value
+        for part in parts:
+            for address in part.split(","):
+                cleaned = address.strip()
+                if cleaned and cleaned not in seen:
+                    seen.add(cleaned)
+                    recipients.append(cleaned)
+    if not recipients:
+        raise ValueError("At least one recipient is required (to_email/to_emails).")
+    return recipients
+
+
 class IEmailAdapter(ABC):
     @abstractmethod
     def send(
         self,
         *,
-        to_email: str,
+        to_email: str | None = None,
         subject: str,
         text_body: str,
         html_body: str | None = None,
@@ -24,5 +53,6 @@ class IEmailAdapter(ABC):
         from_name: str | None = None,
         reply_to: str | None = None,
         attachments: list[EmailAttachment] | None = None,
+        to_emails: list[str] | str | None = None,
     ) -> None:
         raise NotImplementedError()

--- a/libs/naas-abi-core/naas_abi_core/services/email/EmailService.py
+++ b/libs/naas-abi-core/naas_abi_core/services/email/EmailService.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from naas_abi_core import logger
 from naas_abi_core.services.ServiceBase import ServiceBase
-from naas_abi_core.services.email.EmailPorts import EmailAttachment, IEmailAdapter
+from naas_abi_core.services.email.EmailPorts import (
+    EmailAttachment,
+    IEmailAdapter,
+    resolve_recipients,
+)
 from naas_abi_core.services.email.ontologies.modules.EmailEventOntology import (
     EmailError,
     EmailSent,
@@ -28,7 +32,7 @@ class EmailService(ServiceBase):
     def send(
         self,
         *,
-        to_email: str,
+        to_email: str | None = None,
         subject: str,
         text_body: str,
         html_body: str | None = None,
@@ -36,7 +40,9 @@ class EmailService(ServiceBase):
         from_name: str | None = None,
         reply_to: str | None = None,
         attachments: list[EmailAttachment] | None = None,
+        to_emails: list[str] | str | None = None,
     ) -> None:
+        recipients = ", ".join(resolve_recipients(to_email, to_emails))
         try:
             self._adapter.send(
                 to_email=to_email,
@@ -47,12 +53,13 @@ class EmailService(ServiceBase):
                 from_name=from_name,
                 reply_to=reply_to,
                 attachments=attachments,
+                to_emails=to_emails,
             )
         except Exception as exc:
             self.__publish_event(
-                EmailError(to=to_email, subject=subject, message=str(exc))
+                EmailError(to=recipients, subject=subject, message=str(exc))
             )
             raise
         self.__publish_event(
-            EmailSent(to=to_email, subject=subject, sender=from_email)
+            EmailSent(to=recipients, subject=subject, sender=from_email)
         )

--- a/libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/FilesystemAdapter.py
+++ b/libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/FilesystemAdapter.py
@@ -15,7 +15,7 @@ class FilesystemAdapter(IEmailAdapter):
     def send(
         self,
         *,
-        to_email: str,
+        to_email: str | None = None,
         subject: str,
         text_body: str,
         html_body: str | None = None,
@@ -23,6 +23,7 @@ class FilesystemAdapter(IEmailAdapter):
         from_name: str | None = None,
         reply_to: str | None = None,
         attachments: list[EmailAttachment] | None = None,
+        to_emails: list[str] | str | None = None,
     ) -> None:
         msg = build_email_message(
             to_email=to_email,
@@ -33,6 +34,7 @@ class FilesystemAdapter(IEmailAdapter):
             from_name=from_name,
             reply_to=reply_to,
             attachments=attachments,
+            to_emails=to_emails,
         )
 
         self._directory.mkdir(parents=True, exist_ok=True)

--- a/libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/SESAdapter.py
+++ b/libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/SESAdapter.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from typing import Any
 
 from naas_abi_core.services.email.EmailMessageBuilder import build_email_message
-from naas_abi_core.services.email.EmailPorts import EmailAttachment, IEmailAdapter
+from naas_abi_core.services.email.EmailPorts import (
+    EmailAttachment,
+    IEmailAdapter,
+    resolve_recipients,
+)
 
 
 class SESAdapter(IEmailAdapter):
@@ -44,7 +48,7 @@ class SESAdapter(IEmailAdapter):
     def send(
         self,
         *,
-        to_email: str,
+        to_email: str | None = None,
         subject: str,
         text_body: str,
         html_body: str | None = None,
@@ -52,7 +56,9 @@ class SESAdapter(IEmailAdapter):
         from_name: str | None = None,
         reply_to: str | None = None,
         attachments: list[EmailAttachment] | None = None,
+        to_emails: list[str] | str | None = None,
     ) -> None:
+        destinations = resolve_recipients(to_email, to_emails)
         msg = build_email_message(
             to_email=to_email,
             subject=subject,
@@ -62,10 +68,11 @@ class SESAdapter(IEmailAdapter):
             from_name=from_name,
             reply_to=reply_to,
             attachments=attachments,
+            to_emails=to_emails,
         )
 
         self._get_client().send_raw_email(
             Source=from_email,
-            Destinations=[to_email],
+            Destinations=destinations,
             RawMessage={"Data": bytes(msg)},
         )

--- a/libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/SESAdapter_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/SESAdapter_test.py
@@ -72,6 +72,47 @@ class TestSESAdapter(GenericEmailSecondaryAdapterTest):
             if part.get_content_type() == "text/plain"
         )
 
+    def test_comma_separated_recipients_become_individual_destinations(
+        self, monkeypatch
+    ) -> None:
+        factory = _BotoClientFactory()
+        monkeypatch.setattr(boto3, "client", factory)
+
+        adapter = SESAdapter(region_name="us-east-1")
+        adapter.send(
+            to_email="alice@example.com, bob@example.com , carol@example.com",
+            subject="Hello",
+            text_body="Hello world",
+            from_email="noreply@example.com",
+        )
+
+        call = factory.client.send_raw_email_calls[0]
+        assert call["Destinations"] == [
+            "alice@example.com",
+            "bob@example.com",
+            "carol@example.com",
+        ]
+        # The To header carries every recipient so they appear on one email.
+        msg = _parse_raw_message(call)
+        assert msg["To"] == "alice@example.com, bob@example.com, carol@example.com"
+
+    def test_to_emails_list_becomes_individual_destinations(self, monkeypatch) -> None:
+        factory = _BotoClientFactory()
+        monkeypatch.setattr(boto3, "client", factory)
+
+        adapter = SESAdapter(region_name="us-east-1")
+        adapter.send(
+            to_emails=["alice@example.com", "bob@example.com"],
+            subject="Hello",
+            text_body="Hello world",
+            from_email="noreply@example.com",
+        )
+
+        call = factory.client.send_raw_email_calls[0]
+        assert call["Destinations"] == ["alice@example.com", "bob@example.com"]
+        msg = _parse_raw_message(call)
+        assert msg["To"] == "alice@example.com, bob@example.com"
+
     def test_send_html_email_with_from_name_and_reply_to(self, monkeypatch) -> None:
         factory = _BotoClientFactory()
         monkeypatch.setattr(boto3, "client", factory)

--- a/libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/SMTPAdapter.py
+++ b/libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/SMTPAdapter.py
@@ -31,7 +31,7 @@ class SMTPAdapter(IEmailAdapter):
     def send(
         self,
         *,
-        to_email: str,
+        to_email: str | None = None,
         subject: str,
         text_body: str,
         html_body: str | None = None,
@@ -39,6 +39,7 @@ class SMTPAdapter(IEmailAdapter):
         from_name: str | None = None,
         reply_to: str | None = None,
         attachments: list[EmailAttachment] | None = None,
+        to_emails: list[str] | str | None = None,
     ) -> None:
         msg = build_email_message(
             to_email=to_email,
@@ -49,6 +50,7 @@ class SMTPAdapter(IEmailAdapter):
             from_name=from_name,
             reply_to=reply_to,
             attachments=attachments,
+            to_emails=to_emails,
         )
 
         smtp_cls = smtplib.SMTP_SSL if self._use_ssl else smtplib.SMTP

--- a/libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/SendGridAdapter.py
+++ b/libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/SendGridAdapter.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import base64
 from typing import Any
 
-from naas_abi_core.services.email.EmailPorts import EmailAttachment, IEmailAdapter
+from naas_abi_core.services.email.EmailPorts import (
+    EmailAttachment,
+    IEmailAdapter,
+    resolve_recipients,
+)
 
 
 class SendGridAdapter(IEmailAdapter):
@@ -59,7 +63,7 @@ class SendGridAdapter(IEmailAdapter):
     def send(
         self,
         *,
-        to_email: str,
+        to_email: str | None = None,
         subject: str,
         text_body: str,
         html_body: str | None = None,
@@ -67,6 +71,7 @@ class SendGridAdapter(IEmailAdapter):
         from_name: str | None = None,
         reply_to: str | None = None,
         attachments: list[EmailAttachment] | None = None,
+        to_emails: list[str] | str | None = None,
     ) -> None:
         content: list[dict[str, str]] = []
         if text_body:
@@ -81,7 +86,9 @@ class SendGridAdapter(IEmailAdapter):
             from_payload["name"] = from_name
 
         payload: dict[str, Any] = {
-            "personalizations": [{"to": [{"email": to_email}]}],
+            "personalizations": [
+                {"to": [{"email": addr} for addr in resolve_recipients(to_email, to_emails)]}
+            ],
             "from": from_payload,
             "subject": subject,
             "content": content,


### PR DESCRIPTION
This pull request resolves #email-service-multiples-receivers

### Summary

This PR introduces support for sending emails to multiple recipients in the email service. It enhances the existing email sending functionality by allowing both single and multiple recipients to be specified via `to_email` and `to_emails` parameters.

### Changes

- Added a new utility function `resolve_recipients` in `EmailPorts.py` to normalize and deduplicate email addresses from `to_email` and `to_emails` inputs.
- Updated `build_email_message` to accept `to_emails` and set the `To` header with all resolved recipients.
- Modified the `IEmailAdapter` interface and all its implementations (`SESAdapter`, `SMTPAdapter`, `SendGridAdapter`, `FilesystemAdapter`) to support the new `to_emails` parameter.
- Updated `EmailService` to use `resolve_recipients` and pass multiple recipients to the adapter.
- Enhanced SESAdapter to send emails to multiple destinations.
- Added tests in `SESAdapter_test.py` to verify handling of multiple recipients both as comma-separated strings and lists.

### Benefits

- Allows sending emails to multiple recipients in a single call.
- Ensures recipients are deduplicated and properly formatted.
- Improves flexibility and usability of the email service.

### Notes

- The `to_email` parameter remains supported for backward compatibility.
- The `to_emails` parameter can be a string, list of strings, or None.
- Raises `ValueError` if no recipients are provided.

This enhancement is backward compatible and does not break existing single recipient usage.