### PR TITLE
feat(coding-environment): in-app coding workspaces — Phase 0 (core service + RFC)

### DIFF
--- a/RFC-in-app-coding-workspaces.md
+++ b/RFC-in-app-coding-workspaces.md
@@ -1,0 +1,437 @@
+# RFC: In-app coding workspaces (Nexus IDE)
+
+| | |
+|---|---|
+| **Status** | Draft — for review |
+| **Author** | Maxime Jublou (with Claude) |
+| **Date** | 2026-06-23 |
+| **Scope** | `naas-abi-core`, `naas-abi` (Nexus web + API), deploy stack |
+| **Target reference** | [Palantir Foundry Code Workspaces](https://www.palantir.com/docs/foundry/code-workspaces/overview) |
+
+## 1. TL;DR
+
+Ship a browser IDE *inside* Nexus so users can do real development from the app: spin up
+isolated per-user environments (start / pause / resume), work on branches, talk to abi
+(and generic) agents from inside the editor, and **review and merge changes without ever
+leaving Nexus for GitHub/GitLab**. The editor is VS Code in the browser, orchestrated by
+**Coder**; agents reach the editor through an **OpenAI-compatible shim + the Continue
+extension**; git and code review are backed by a **self-hosted Forgejo** with a review UI
+we build inside Nexus on its API. Everything sits behind the existing Caddy edge and
+shared Postgres, and is modelled as swappable hexagonal core services so the backends stay
+replaceable.
+
+We build the **horizontal** capabilities first; bespoke **verticals** (locked-down UIs for
+less-technical users) are composed on top of the same ports, on demand.
+
+## 2. Goals / non-goals
+
+**Goals**
+- Per-user coding environments with lifecycle control (provision / start / stop / resume / delete).
+- Branch-based development; one workspace per branch.
+- In-editor chat with abi agents and generic agent backends.
+- **In-app code review** (inline diff, comments, required approvals, required checks) — users never go to a third-party git host.
+- A dedicated Nexus IDE/review UI, while keeping the underlying tools' native UIs reachable.
+- Composable primitives so verticals can be built later without backend changes.
+
+**Non-goals (for the horizontal milestones)**
+- Building the bespoke vertical webapps themselves (Phase 4, on demand).
+- Multi-region / large-scale autoscaling of workspace compute (start single-node; k8s template later).
+- User work happens on a **branch of the abi monorepo** (across one or more modules) authored in Nexus; the in-app Forgejo is authoritative and **mirrors to GitHub in the background** (decided, §7.3).
+
+## 2.1 Unit of work: a workspace = a branch on the monorepo
+
+The codebase stays a **single monorepo** (one authoritative Forgejo repo, mirrored to GitHub), and a
+**workspace is a branch** on it. abi *modules* are the logical surface users work on, but they live as
+**directories inside the monorepo — not separate repos** — so a single workspace can touch **one or
+several modules at once**, and **agents have access to the whole codebase** (a primary reason to keep it
+a monorepo). This is the central organizing concept and shapes the rest of the design:
+- **Repo:** the abi **monorepo** — a single authoritative Forgejo repo, background-mirrored to GitHub. No repo-per-module.
+- **Isolation:** **one branch per workspace**; provisioning a workspace creates/checks out its branch.
+- **Agents:** the full monorepo is checked out in the workspace, so agents (via Continue + the workspace
+  filesystem) see **everything**, across all modules.
+- **Templates:** the default Coder template pre-installs the **abi SDK + tooling** and clones the monorepo on the workspace's branch.
+- **Review:** a proposal is a branch's diff against `main` and may span multiple modules.
+- **Verticals:** a vertical is a locked-down view that *targets* a module's surface but still operates on a
+  branch of the monorepo.
+
+## 3. Requirements → design mapping
+
+| Requirement | Mechanism |
+|---|---|
+| Work on different branches | Single monorepo in Forgejo; **one branch per workspace** (Coder isolates each); branch protection on `main` |
+| Talk to agents (abi + generic) in the IDE | OpenAI-compatible shim on abi + Continue extension (Open VSX), pre-configured per workspace |
+| Per-user spin up / pause / resume | `coding_environment` core service (`provision`/`start`/`stop`/`delete`) via `CoderAdapter`, exposed as per-user API |
+| Customizable UI for verticals | Composable views over the `coding_environment` + `agent` + `source_control` ports |
+| Integrated git, branch + review, enforce best practices | `source_control` core service + `ForgejoAdapter`; Nexus review UI; required approvals + required checks before merge |
+
+## 4. Background — what already exists
+
+This is **not** a greenfield. A verified foundation exists (currently **uncommitted** in
+worktree `vigilant-goldberg-b4be3a` — landing it is Phase 0):
+
+- **`coding_environment` core service** — `libs/naas-abi-core/naas_abi_core/services/coding_environment/`
+  - Port `ICodingEnvironmentAdapter` (`CodingEnvironmentPorts.py`): `ensure_user`, `list_templates`,
+    `provision`, `start`, `stop`, `delete`, `get_status`, `get_access`. Normalized DTOs
+    (`WorkspaceStatus`, `WorkspaceAccess`) + a normalized error taxonomy.
+  - Domain `CodingEnvironmentService.py` with fail-safe events + `wait_until_ready`.
+  - Secondary adapters: `CoderAdapter` (**verified live vs Coder OSS v2.34.1**),
+    `CodeServerComposeAdapter` (shared editor, simpler), `InMemoryAdapter` (fake for tests).
+  - Event ontology (`WorkspaceProvisioned/Started/Stopped/Deleted/...`), factory, config model.
+  - `EngineConfiguration_CodingEnvironmentService.py` wires it into the engine via the nested
+    `GenericLoader` pattern (adapters: `coder` / `code_server` / `in_memory` / `custom`).
+  - ~33 passing unit tests.
+- **`coder_prototype/`** — a runnable harness (compose + Caddy + Terraform template + scripts)
+  that proved the headless control-plane flow and the embedding boundary end-to-end.
+- **Stack changes** already prototyped: a `code-server` service in `docker-compose.yml` and a
+  `code-server.${PUBLIC_WEB_HOST}` route in `.deploy/docker/Caddyfile`.
+
+**Nexus app architecture** (integration surface):
+- Frontend: Next.js (App Router) under `libs/naas-abi/naas_abi/apps/nexus/apps/web`. Existing
+  iframe-embed precedent (`/app-html` routes + CSP `frame-ancestors`). *(Exact sidebar/auth-store
+  insertion points to be confirmed during Phase 1 — the survey of those was a fast pass.)*
+- API: FastAPI under `libs/naas-abi/naas_abi/apps/nexus/apps/api/app`; `create_app()` in `main.py`,
+  routers registered in `api/router.py`, hexagonal services per feature
+  (`services/<feature>/adapters/primary/<feature>__primary_adapter__FastAPI.py`). Auth is JWT bearer;
+  per-route identity via `get_current_user_required` and `require_workspace_access`
+  (`services/auth/.../auth__primary_adapter__dependencies.py`). Core services reached via
+  `ABIModule.get_instance().engine.services.<name>`.
+- Agents: callable over HTTP today via `/api/chat/stream` (custom SSE), abi-to-abi
+  `/agents/{name}/stream-completion`, and an MCP server (`naas_abi_core/apps/mcp/mcp_server.py`).
+  Provider routing lives in `services/provider_runtime.py`. abi does **not** expose OpenAI
+  `/v1/chat/completions` — hence the shim.
+
+## 5. Reference model — how Palantir Foundry does it
+
+Foundry validates the exact pattern we want (sourced from official docs, see §15):
+- It runs its **own internal git host**; users never leave Foundry to review code (external GitHub is opt-in mirror only).
+- **The editor only "proposes"; a web app reviews.** In browser VS Code you commit/branch from the
+  Source Control panel and hit **"Propose changes"**, opening a Pull request ("Proposal" platform-wide).
+  Line-by-line diffs, per-file approve/reject, comments, required approvals (user/group), required CI
+  "Checks", and custom checks for best-practice enforcement all live in the web UI.
+- Branching: modified GitFlow, protected `master`, branch protection requiring reviews + checks.
+
+Design principle we adopt: **own the git layer → embed VS Code over it → keep the entire review
+experience in our own UI; the editor only initiates commit / branch / propose.**
+
+## 6. Target architecture
+
+```mermaid
+flowchart TB
+  subgraph Browser["Nexus (browser, app.DOMAIN)"]
+    UI["IDE page + review UI + verticals"]
+  end
+  subgraph Edge["Caddy edge (TLS, subdomain routing)"]
+    CADDY[" "]
+  end
+  subgraph API["Nexus API /api (FastAPI, JWT)"]
+    CE_ROUTES["coding-environments routes"]
+    SC_ROUTES["source-control / review routes"]
+    SHIM["OpenAI-compatible shim /v1"]
+  end
+  subgraph CORE["naas-abi-core services"]
+    CE_SVC["coding_environment (CoderAdapter)"]
+    SC_SVC["source_control (ForgejoAdapter)"]
+    AG_SVC["agent + provider_runtime"]
+  end
+  subgraph INFRA["Bundled infra (docker-compose + shared Postgres)"]
+    CODER["Coder control plane"]
+    FORGEJO["Forgejo (git + review backend)"]
+  end
+  subgraph WS["Per-user workspace (container)"]
+    EDITOR["code-server"]
+    CONT["Continue ext (Open VSX)"]
+    GIT["git clone + branch"]
+  end
+
+  UI --> CADDY --> CE_ROUTES --> CE_SVC --> CODER --> WS
+  UI --> SC_ROUTES --> SC_SVC --> FORGEJO
+  CONT --> SHIM --> AG_SVC
+  GIT --> FORGEJO
+  EDITOR -. "propose changes" .-> SC_ROUTES
+```
+
+Everything new is a thin layer over the existing edge + Postgres. Coder, Forgejo, and the
+editor each keep their native UIs (reachable for power users / debugging) while Nexus provides
+the dedicated experience.
+
+## 7. Detailed design
+
+### 7.1 Coding environments (Coder backbone)
+
+**Deployment.** Add a `coder` service to `docker-compose.yml` pointed at the existing Postgres
+(new `.deploy/docker/postgres/initdb/00X-create-coder-db.sql` → `CREATE DATABASE coder;`). Route
+`coder.${PUBLIC_WEB_HOST}` + `*.coder.${PUBLIC_WEB_HOST}` through Caddy (preserve `Host`, forward
+WebSocket upgrade) under wildcard TLS — Caddy is the same-registrable-domain + WS layer the
+embedding needs. Coder needs Docker access for the workspace template; dev uses a `docker.sock`
+mount (run as needed), prod moves to a socket-proxy or a k8s template (§9).
+
+**Service exposure.** The `coding_environment` core service is selected via `config.yaml`:
+
+```yaml
+services:
+  coding_environment:
+    coding_environment_adapter:
+      adapter: "coder"
+      config:
+        access_url: "https://coder.${PUBLIC_WEB_HOST}"
+        wildcard_access_url: "*.coder.${PUBLIC_WEB_HOST}"
+        admin_token: "{{ secret.CODER_ADMIN_TOKEN }}"
+        organization: "default"
+        default_template_id: "abi-workspace"
+        default_token_lifetime_seconds: 3600
+        workspace_autostop_ms: 3600000
+```
+
+New Nexus API router `services/coding_environments/adapters/primary/coding_environments__primary_adapter__FastAPI.py`,
+registered in `api/router.py`, resolving the core service via `ABIModule.get_instance().engine.services.coding_environment`:
+
+| Method | Route | Purpose |
+|---|---|---|
+| `GET` | `/api/coding-environments` | List the current user's environments |
+| `POST` | `/api/coding-environments` | Provision (monorepo template + branch) → returns env id (async) |
+| `GET` | `/api/coding-environments/{id}` | Status (phase, agent_ready, autostop) |
+| `POST` | `/api/coding-environments/{id}/start` | Resume |
+| `POST` | `/api/coding-environments/{id}/stop` | Pause |
+| `DELETE`| `/api/coding-environments/{id}` | Delete |
+| `GET` | `/api/coding-environments/{id}/access` | Mint scoped access → embeddable editor URL |
+
+All gated by `get_current_user_required` + `require_workspace_access`. Identity: map the Nexus
+user → a Coder user via `ensure_user(external_id=nexus_user_id, email, username)` (idempotent;
+`login_type:"none"`, verified working on v2.34.1). Store the mapping in Nexus Postgres (§10).
+
+**Async provisioning.** Builds take 10–60s. `POST` returns immediately with the env id and
+`phase=provisioning`; the frontend polls `GET /{id}` (or subscribes via the existing Socket.IO)
+until `phase=running, agent_ready=true`. The domain already exposes `wait_until_ready`; the API
+layer wraps it in a background task / bus job rather than blocking the request.
+
+**Embedding & security (the load-bearing part, already de-risked).**
+- Editor served on a subdomain of the **same registrable domain** as Nexus over HTTPS, so the
+  session cookie is first-party inside the iframe (schemeful same-site). This is why Caddy hosts
+  `*.coder.${PUBLIC_WEB_HOST}`.
+- Coder sends CSP `frame-ancestors 'self'`; open it for the Nexus origin via
+  `CODER_ADDITIONAL_CSP_POLICY`. code-server sends no framing headers.
+- Token → cookie redemption: `get_access` returns a URL carrying `?coder_session_token=<scoped>`;
+  the browser redeems it into a first-party `coder_*_session_token` cookie. The minted token is a
+  **scoped** `application_connect` token (verified body shape: `{token_name, lifetime, scope:"application_connect"}`,
+  with a basic-token fallback) — **never** the admin token.
+- **Remaining empirical bar:** the cross-browser (Chrome + Safari, default settings) cookie/redemption
+  test in a real browser over the HTTPS edge. This is the single open verification from the prototype
+  and is a Phase-1 acceptance gate.
+
+**Cost control.** `workspace_autostop_ms` (idle autostop) + a per-user quota enforced in the API
+before `provision`. Surface "stopped" environments as resumable in the UI.
+
+### 7.2 Agents in the editor (OpenAI-compatible shim + Continue)
+
+**Why a shim.** Continue talks to OpenAI-compatible endpoints or custom providers; abi exposes
+agents over its own API, not `/v1/chat/completions`. We add a thin inbound shim that reuses the
+existing agent invocation path (`provider_runtime` / agent service) — no new agent logic.
+
+**Shim.** New primary adapter `services/openai_gateway/adapters/primary/openai_gateway__primary_adapter__FastAPI.py`
+exposing:
+- `POST /v1/chat/completions` (supports `stream:true` → OpenAI SSE chunk format)
+- `GET /v1/models` (lists abi agents + enabled generic backends)
+
+Design points:
+- **Auth:** `Authorization: Bearer <scoped-token>` — a per-user, per-workspace token minted at
+  provision time and injected into the workspace's Continue config. Maps back to the Nexus user;
+  scoped to chat only.
+- **Model routing:** the OpenAI `model` field is a namespaced id — `abi:<agent_id>` routes to an abi
+  agent; `openai:<model>` / `anthropic:<model>` / … route through `provider_runtime` to generic
+  backends. This is how "generic other backends" are supported uniformly.
+- **Translation:** map OpenAI request → agent invocation; translate the abi SSE stream → OpenAI
+  `chat.completion.chunk` deltas.
+
+**Workspace wiring.** The workspace image (Coder template / code-server image) ships with the **abi SDK
++ tooling** and, from **Open VSX**, **Continue and the Forgejo review extension** (Coder/code-server use Open VSX, *not* the MS
+Marketplace — a hard constraint on every extension we depend on; Continue is published there).
+The template writes `~/.continue/config.json` pointing `apiBase` at the in-network shim URL with the
+per-workspace token, listing abi agents (and allowed generic models) as selectable models.
+
+### 7.3 Source control + in-app review (Forgejo + Nexus review UI)
+
+**Backend.** Self-host **Forgejo** (lightweight Go binary) as the git + review backend: add a
+`forgejo` service to `docker-compose.yml` (own DB on shared Postgres), route
+`git.${PUBLIC_WEB_HOST}` through Caddy. Forgejo gives a GitHub-shaped review+merge REST API,
+branch protection (`required_approvals`, `status_check_contexts[]`), and **Forgejo Actions** to run
+checks. **A single Forgejo repo holds the abi monorepo** (one branch per workspace), and Forgejo is the
+**source of truth** with an **automatic background mirror to GitHub** (durability/portability; users never
+leave Nexus for it). *(Decided: Forgejo, API-only — §13.)*
+
+**New core service** `libs/naas-abi-core/naas_abi_core/services/source_control/` — mirrors the
+`coding_environment` shape exactly (port + normalized DTOs + error taxonomy + domain events +
+factory + `EngineConfiguration_SourceControlService.py` with a `GenericLoader`). Port sketch:
+
+```python
+class ISourceControlAdapter(ABC):
+    def ensure_user(self, *, external_id, email, username) -> str: ...
+    def ensure_repo(self, *, owner, name) -> Repo: ...
+    def list_branches(self, *, repo_id) -> list[Branch]: ...
+    def create_branch(self, *, repo_id, name, from_ref) -> Branch: ...
+    def get_diff(self, *, repo_id, base, head) -> Diff: ...
+    def create_proposal(self, *, repo_id, title, body, source, target, reviewers) -> Proposal: ...
+    def list_proposals(self, *, repo_id, state) -> list[Proposal]: ...
+    def get_proposal(self, *, repo_id, number) -> Proposal: ...  # diff + comments + checks + approvals
+    def comment(self, *, repo_id, number, path, line, body) -> Comment: ...
+    def review(self, *, repo_id, number, event, body) -> Review: ...  # APPROVE | REQUEST_CHANGES | COMMENT
+    def get_checks(self, *, repo_id, number) -> list[Check]: ...
+    def set_branch_protection(self, *, repo_id, branch, required_approvals, required_checks) -> None: ...
+    def merge(self, *, repo_id, number, method) -> MergeResult: ...
+    def mint_git_token(self, *, user_id) -> str: ...  # scoped, short-lived, for workspace git auth
+```
+
+Adapters: `ForgejoAdapter` (REST), `InMemoryAdapter` (fake for tests + generic adapter test, same
+convention as `coding_environment`). Swappable to Gerrit/GitHub later without touching the UI.
+
+**Nexus review UI.** Built in Nexus (Next.js) on top of new `services/source_control/...__FastAPI.py`
+routes — *not* an iframe of Forgejo (all forges set `X-Frame-Options`/CSP and ship vendor chrome;
+building our own UI is the only clean "never leave Nexus" path and matches Foundry). The UI is the
+"Proposal" experience: list proposals, inline diff with comments/threads, per-file approve,
+required-approval + required-check status, and a merge action gated on policy.
+
+**Editor → review handoff (Foundry pattern).** The workspace clones from Forgejo with a scoped git
+token, works on a branch-per-workspace. The user commits/pushes from the VS Code Source Control
+panel; "propose changes" creates a proposal (via the API). Heavy review happens in the Nexus UI.
+The Forgejo Open VSX extension is offered for power users who prefer in-editor review.
+
+**Enforcement.** Branch protection on `main`: required approvals (user/group) + required status
+checks (Forgejo Actions) must pass before `merge` succeeds — this is "enforce best practices,"
+mirroring Foundry's required checks + `ci/foundry-publish`.
+
+**Monorepo review UX (consequences of the branch-per-workspace model).** Because a proposal is a
+whole-branch diff against `main`, it may span **multiple modules**; the Nexus review UI should offer
+**module-scoped filtering** of the diff so reviewers can focus per module. And because many workspaces
+branch off the same monorepo, **merge conflicts on shared files** are more likely than with isolated
+per-module repos — the review flow needs first-class **conflict surfacing + resolution UX** (rebase/merge
+from `main`), not just an approve gate.
+
+### 7.4 Vertical UI framework (Phase 4, on demand)
+
+The three ports (`coding_environment`, `agent`/shim, `source_control`) are the primitives. A vertical
+is a Next.js view that composes a **locked-down** subset: e.g. an embedded editor scoped to a
+**module's surface on a branch**, a constrained agent panel, and a one-click "propose" — hiding the
+full IDE for less-technical users. No backend changes; verticals are configuration + UI over the same ports.
+
+## 8. Security model (consolidated)
+
+- **Identity mapping:** Nexus user (JWT) → Coder user (`login_type:none`) + Forgejo user, persisted
+  in Nexus Postgres. All provisioning uses admin tokens server-side; users only ever receive
+  **scoped, short-lived** tokens (editor access, chat shim, git).
+- **Token scoping:** editor = `application_connect`; chat = chat-only shim token; git = scoped repo
+  token. None of these is an admin token. Redemption converts the editor token into a first-party
+  cookie inside the iframe.
+- **Network:** Coder/Forgejo/shim are internal services on `abi-network`; only Caddy is public.
+  Workspaces reach the shim and Forgejo over the internal network.
+- **docker.sock risk:** Coder's Docker template needs host Docker access — fine for dev, but lock
+  down via a socket-proxy or move to a k8s template before exposing to untrusted users (§12).
+- **Secrets:** `CODER_ADMIN_TOKEN`, `FORGEJO_ADMIN_TOKEN` via the existing dotenv `SecretService`
+  (`{{ secret.X }}`).
+
+## 9. Persistence (Nexus Postgres)
+
+New tables (Nexus-side; the forges remain the source of truth for their own state):
+- `coding_environments` — `(id, nexus_user_id, workspace_id, name, repo_id, branch, backend_workspace_id, phase, created_at, last_active_at, autostop_at)`
+- `forge_identities` — `(nexus_user_id, coder_user_id, forgejo_user_id)`
+- Proposals/diffs/comments are read live from the `source_control` service (Forgejo API); cache only
+  if needed for performance.
+
+## 10. Phased delivery plan
+
+Each phase is an independently shippable increment. Acceptance criteria are concrete gates.
+
+**Phase 0 — Land the foundation** *(hours, low risk)*
+- Bring the uncommitted `coding_environment` service + `coder_prototype/` from
+  `vigilant-goldberg-b4be3a` onto a clean branch; open a PR.
+- ✅ Done when: tests pass in CI; the service is on a reviewable branch.
+
+**Phase 1 — Per-user environments end-to-end**
+- `coder` service in compose + Caddy wildcard route + Coder DB; `coding_environment` configured with
+  the `coder` adapter; per-user API routes; Nexus IDE page (list/create/start/stop + embedded editor
+  via token redemption); async provisioning + polling/Socket.IO.
+- ✅ Done when: a user provisions, pauses, and resumes their own workspace from Nexus and edits code
+  in the embedded editor; **cross-browser cookie/redemption test passes in Chrome + Safari**;
+  autostop + quota enforced.
+
+**Phase 2 — Agents in the editor**
+- OpenAI-compatible shim (`/v1/chat/completions`, `/v1/models`) reusing `provider_runtime`; per-workspace
+  scoped chat token; Continue (Open VSX) baked into the template and pre-configured.
+- ✅ Done when: from inside a workspace, a user chats with an abi agent and with at least one generic
+  backend via Continue; model list reflects available agents.
+
+**Phase 3 — Source control + in-app review**
+- `forgejo` service in compose + Caddy route; `source_control` core service (port + `ForgejoAdapter` +
+  `InMemoryAdapter` + events + config); workspace clones from Forgejo, branch-per-workspace; Nexus
+  review UI (proposals: inline diff, comments, per-file approve, checks); branch protection.
+- ✅ Done when: a user branches in a workspace, pushes, opens a proposal, another user reviews +
+  comments + approves in Nexus, required checks run via Forgejo Actions, and merge to protected `main`
+  is blocked until approvals + checks pass — all without leaving Nexus.
+
+**Phase 4 — Vertical UI framework** *(on demand)*
+- Composable, locked-down views over the three ports + a first vertical as a reference.
+
+**Cross-cutting:** autostop/quotas, secrets, RBAC, observability via the event ontologies, CI check
+runner (Forgejo Actions or reuse Dagster).
+
+## 11. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Cross-browser iframe cookie/redemption fails in Safari | Same-registrable-domain HTTPS strategy (already designed); Phase-1 gate runs the real-browser test; fallback = proxy editor under a subpath of the parent origin |
+| `docker.sock` privilege on Coder | dev-only mount; socket-proxy / k8s template before untrusted multi-tenant use |
+| Coder is **AGPLv3** | Run unmodified behind its API; conscious licensing decision for a hosted product (§13) |
+| Open VSX gap for a needed extension | Verify every editor dependency is on Open VSX before relying on it (Continue ✓, Forgejo ext ✓) |
+| Provisioning latency hurts UX | Async + polling/Socket.IO; pre-warmed/idle-resume; clear progress UI |
+| Build-our-own review UI is real work | Code to the GitHub-shaped Forgejo API (most-cloned shape); start minimal (diff + comment + approve + merge), expand |
+| Frontend insertion points uncertain | Confirm sidebar/auth-store/routing conventions at the start of Phase 1 before building |
+| Whole-branch proposals span many modules | Module-scoped diff filtering in the Nexus review UI (Phase 3) |
+| Concurrent workspaces collide on shared monorepo files | First-class merge-conflict surfacing + resolution UX in the review flow; encourage small, short-lived branches |
+
+## 12. Open questions / decisions
+
+1. ~~**Source of truth**~~ **DECIDED:** Forgejo is authoritative, with an automatic **background mirror
+   to GitHub** for durability/portability; users never leave Nexus.
+2. ~~**Forgejo vs Gitea**~~ **DECIDED:** **Forgejo, API-only** (copyleft not triggered by API calls;
+   non-profit governance).
+3. **Compute backend for prod:** docker.sock template (dev) → socket-proxy or k8s (prod). When?
+4. **Check runner:** Forgejo Actions vs reusing Dagster for required checks.
+5. **Coder AGPL:** confirm acceptable for the hosted offering (legal).
+6. **Monorepo ↔ mirror + branch naming:** how the single monorepo is mirrored to GitHub, the
+   branch-per-workspace naming scheme, branch lifecycle/cleanup, and how a workspace's branch maps to one
+   or more module directories.
+
+## 13. Licensing
+
+- **Coder** — AGPLv3. Running unmodified behind its API is the intended use; bundling into a hosted
+  product is a conscious decision to confirm.
+- **Forgejo** — GPLv3+ (since v9.0). **Decision: Forgejo, API-only** — we do not fork/patch the
+  server/templates, so copyleft is not triggered. (**Gitea**, MIT, would be the choice if we ever expect
+  to fork.)
+- **code-server** — MIT. **Continue** — Apache-2.0 (on Open VSX).
+- Editor extensions must come from **Open VSX** (code-server/Coder do not use the MS Marketplace).
+
+## 14. Appendix — key paths
+
+| Concern | Path |
+|---|---|
+| Coding env service | `libs/naas-abi-core/naas_abi_core/services/coding_environment/` |
+| Coding env config model | `libs/naas-abi-core/.../engine/engine_configuration/EngineConfiguration_CodingEnvironmentService.py` |
+| New source_control service | `libs/naas-abi-core/naas_abi_core/services/source_control/` *(to create)* |
+| Nexus API app | `libs/naas-abi/naas_abi/apps/nexus/apps/api/app/` (`main.py`, `api/router.py`) |
+| API auth deps | `.../apps/api/app/services/auth/adapters/primary/auth__primary_adapter__dependencies.py` |
+| Provider routing | `.../apps/api/app/services/provider_runtime.py` |
+| Nexus web | `libs/naas-abi/naas_abi/apps/nexus/apps/web/` |
+| MCP server | `libs/naas-abi-core/naas_abi_core/apps/mcp/mcp_server.py` |
+| Deploy | `docker-compose.yml`, `.deploy/docker/Caddyfile`, `coder_prototype/` |
+
+## 15. References
+
+- Foundry Code Workspaces — https://www.palantir.com/docs/foundry/code-workspaces/overview
+- Foundry Code Repositories (overview / navigation / branch-settings / custom checks) — https://www.palantir.com/docs/foundry/code-repositories/overview
+- Foundry branching / proposals — https://www.palantir.com/docs/foundry/foundry-branching/core-concepts
+- Foundry VS Code — https://www.palantir.com/docs/foundry/vs-code/overview
+- Forgejo API usage — https://forgejo.org/docs/latest/user/api-usage/ ; Gitea API — https://docs.gitea.com/api/
+- Gitea protected branches — https://docs.gitea.com/usage/access-control/protected-branches
+- Gerrit REST / submit requirements — https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html
+- GitLab approvals are Premium+ — https://docs.gitlab.com/api/merge_request_approvals/
+- Coder uses Open VSX — https://blogs.eclipse.org/post/paul-buck/coder-why-they-chose-open-vsx-registry
+- Continue / Forgejo / Gerrit extensions on Open VSX — https://open-vsx.org/

--- a/coder_prototype/.env.example
+++ b/coder_prototype/.env.example
@@ -1,0 +1,14 @@
+# Copy to .env and adjust. Used by docker-compose and the Makefile.
+
+# --- HTTP mode (headless API + header verification) ---
+CODER_ACCESS_URL=http://localhost:7080
+
+# --- HTTPS edge mode (browser embedding test via `make edge`) ---
+# CODER_ACCESS_URL=https://coder.lvh.me
+# CODER_WILDCARD_ACCESS_URL=*.coder.lvh.me
+# CODER_ADDITIONAL_CSP_POLICY=frame-ancestors https://app.lvh.me
+
+# First (owner) user created by scripts/bootstrap.sh
+CODER_ADMIN_EMAIL=admin@example.com
+CODER_ADMIN_USERNAME=admin
+CODER_ADMIN_PASSWORD=SomeSecurePassword123!

--- a/coder_prototype/.gitignore
+++ b/coder_prototype/.gitignore
@@ -1,0 +1,4 @@
+.coder-token
+.env
+__pycache__/
+*.pyc

--- a/coder_prototype/Caddyfile
+++ b/coder_prototype/Caddyfile
@@ -1,0 +1,33 @@
+# Edge proxy for the embedding test. Everything lives under one registrable
+# domain (lvh.me -> 127.0.0.1), so the workspace-app auth cookie is FIRST-PARTY
+# inside the iframe — which is the whole point of the same-domain strategy.
+#
+# `local_certs` issues a local-CA cert; trust it once for the browser test:
+#   docker compose cp caddy:/data/caddy/pki/authorities/local/root.crt ./root.crt
+#   (then add ./root.crt to your OS/browser trust store)
+
+{
+	local_certs
+}
+
+# Our minimal custom frontend (the "parent" page that embeds the editor).
+app.lvh.me {
+	root * /srv
+	file_server
+}
+
+# Coder dashboard/API + all workspace apps (wildcard) under the same eTLD+1.
+coder.lvh.me, *.coder.lvh.me {
+	reverse_proxy coder:7080 {
+		# code-server's WebSocket enforces Origin==Host: forward Host + upgrade.
+		header_up Host {host}
+	}
+}
+
+# code-server shipped directly as a compose service (the simpler path). Same
+# registrable domain as app.lvh.me => first-party session cookie in the iframe.
+code-server.lvh.me {
+	reverse_proxy code-server:8080 {
+		header_up X-Forwarded-Proto {scheme}
+	}
+}

--- a/coder_prototype/Makefile
+++ b/coder_prototype/Makefile
@@ -1,0 +1,48 @@
+# Coder embedding-prototype harness.
+# Run from coder_prototype/. The provision targets shell out to the repo-root
+# uv venv (the abi coding_environment service lives there).
+
+ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/..)
+CODER_URL ?= http://localhost:7080
+TOKEN_FILE := $(ROOT)/coder_prototype/.coder-token
+
+.PHONY: up bootstrap provision provision-inmem template headers edge down logs
+
+up: ## Start postgres + coder (HTTP)
+	docker compose up -d postgres coder
+
+bootstrap: ## Create first user + capture a session token
+	bash scripts/bootstrap.sh
+
+provision: ## Headless provision via the abi coding_environment service
+	cd $(ROOT) && CODER_SESSION_TOKEN=$$(cat $(TOKEN_FILE)) \
+	  uv run --no-sync python coder_prototype/scripts/provision.py
+
+provision-inmem: ## Same flow against the in-memory fake adapter (no Docker)
+	cd $(ROOT) && uv run --no-sync python coder_prototype/scripts/provision.py --in-memory
+
+template: ## Push the code-server Docker template into Coder
+	docker compose cp template coder:/tmp/template
+	docker compose exec -T -e CODER_URL=$(CODER_URL) -e CODER_SESSION_TOKEN=$$(cat $(TOKEN_FILE)) coder \
+	  coder templates push abi-code-server -d /tmp/template --yes
+
+headers: ## Empirically inspect framing headers (Coder CSP + code-server XFO)
+	@echo "== Coder dashboard headers =="
+	@curl -sI $(CODER_URL)/ | grep -iE 'content-security-policy|x-frame-options' || echo "(none)"
+	@echo "== code-server headers (ephemeral container) =="
+	@docker run --rm -d --name cs-probe -p 18080:8080 -e PASSWORD=x codercom/code-server:latest >/dev/null
+	@sleep 6
+	@curl -sI http://localhost:18080/ | grep -iE 'x-frame-options|content-security-policy' || echo "(no XFO / no frame-ancestors)"
+	@docker rm -f cs-probe >/dev/null
+
+edge: ## Add the Caddy HTTPS edge (lvh.me) for the browser embedding test
+	CODER_ACCESS_URL=https://coder.lvh.me CODER_WILDCARD_ACCESS_URL='*.coder.lvh.me' \
+	CODER_ADDITIONAL_CSP_POLICY='frame-ancestors https://app.lvh.me' \
+	  docker compose --profile edge up -d
+
+down: ## Tear everything down (including volumes)
+	docker compose --profile edge down -v
+	-docker rm -f cs-probe 2>/dev/null
+
+logs: ## Tail Coder logs
+	docker compose logs -f coder

--- a/coder_prototype/README.md
+++ b/coder_prototype/README.md
@@ -1,0 +1,95 @@
+# Coder embedding prototype
+
+A self-contained harness to **de-risk the embedding boundary** before folding
+Coder into abi's main stack. It runs Coder OSS unmodified behind its REST API,
+and drives provisioning through abi's `coding_environment` core service
+(`libs/naas-abi-core/.../services/coding_environment`).
+
+> Why this exists: the assessment found that the real embedding risks are
+> **third-party cookies** and the **token→cookie redemption handshake**, *not*
+> framing headers. This harness proves the headless flow + lets you run the
+> cross-browser cookie test on a same-registrable-domain layout.
+
+## Layout
+
+| Path | What |
+|---|---|
+| `docker-compose.yml` | Postgres + Coder (HTTP); optional Caddy edge (`edge` profile) |
+| `Caddyfile` | Same-domain HTTPS edge for the browser test (`app.lvh.me` + `*.coder.lvh.me`) |
+| `template/main.tf` | Coder Docker template running code-server as a `subdomain`, `owner`-shared app |
+| `scripts/bootstrap.sh` | Headless: create first user, capture a session token |
+| `scripts/provision.py` | Headless provision via the abi `coding_environment` service |
+| `frontend/index.html` | Minimal custom chrome that embeds the editor in an `<iframe>` |
+| `Makefile` | `up / bootstrap / provision / template / headers / edge / down` |
+
+## A. Headless flow (HTTP — no DNS/TLS needed)
+
+```bash
+cd coder_prototype
+make up                 # postgres + coder on http://localhost:7080
+make bootstrap          # create owner user, write .coder-token
+make provision          # ensure_user -> list_templates (-> provision if a template exists)
+make provision-inmem    # the same flow against the fake adapter (no Docker at all)
+```
+
+`make provision` exercises the **real CoderAdapter against the real Coder REST
+API**. Without a template it stops after `list_templates`. To go further:
+
+```bash
+make template           # push template/main.tf  (pulls the docker provider + base image)
+make provision          # now provisions a real workspace and prints the embed URL
+```
+
+## B. Embedding test (HTTPS, same registrable domain)
+
+This is the part that actually settles the cookie question. `lvh.me` and all
+its subdomains resolve to `127.0.0.1`, giving a production-equivalent
+**same-eTLD+1** layout (frontend `app.lvh.me`, editor `*.coder.lvh.me`).
+
+```bash
+make edge               # brings up Caddy with local TLS + the CSP frame-ancestors allow
+# trust Caddy's local CA so the browser accepts the certs:
+docker compose cp caddy:/data/caddy/pki/authorities/local/root.crt ./root.crt
+#   then add ./root.crt to your OS/browser trust store, and re-run bootstrap/template/provision
+```
+
+Open `https://app.lvh.me/`, paste the embed URL printed by `provision.py`
+(it includes `?coder_session_token=...`), and click **Embed**.
+
+### PASS / FAIL bars (run in BOTH Chrome and Safari, default settings)
+
+- **Headers** — the app response has no `X-Frame-Options`, and Coder's CSP
+  `frame-ancestors` includes `https://app.lvh.me`. (`make headers` checks the
+  raw values.)
+- **Token redemption + cookie (the bridge)** — after the iframe loads the
+  `?coder_session_token=…` URL, DevTools shows a `Set-Cookie` for
+  `coder_…_session_token`, **and that cookie is sent on subsequent requests
+  _inside the iframe_**. Must be on an `owner`-shared app (a `public` app
+  proves nothing about auth).
+- **WebSocket** — the editor WS reaches `101` and stays open (no `1006`).
+- **Interactivity** — within 15 s of render: a terminal `echo abi-ok` round-trips
+  AND a new file saves to the workspace FS.
+- **Cold start** — record click→interactive seconds from a stopped workspace.
+
+If headers/origin block it, the fallback is to proxy the editor under a
+**subpath of the parent origin** (`https://app.lvh.me/ide/`) forwarding
+`Host`+`Upgrade`/`Connection` — same-origin needs no flags.
+
+## Shipping it inside abi's main stack
+
+This standalone harness mirrors what goes into the real `docker-compose.yml`:
+
+- Add a `coder` service → point `CODER_PG_CONNECTION_URL` at the existing
+  Postgres (add `.deploy/docker/postgres/initdb/003-create-coder-db.sql` with
+  `CREATE DATABASE coder;`).
+- Route `coder.${PUBLIC_WEB_HOST}` + `*.coder.${PUBLIC_WEB_HOST}` through the
+  existing **Caddy** (forward `Host` + WebSocket upgrade) under wildcard TLS.
+- The Python `coding_environment` service (in the `abi` container) talks to
+  `http://coder:7080/api/v2`; admin token via SecretService / `{{ secret.CODER_ADMIN_TOKEN }}`.
+- Security: the `docker.sock` mount gives Coder host-Docker control — lock down
+  or move to a k8s template for production.
+
+## Verified results
+
+See `VERIFIED.md` (written by the prototype run) for the empirical header
+values and the headless-flow output captured against the running Coder.

--- a/coder_prototype/VERIFIED.md
+++ b/coder_prototype/VERIFIED.md
@@ -1,0 +1,94 @@
+# Verified results
+
+Empirical results captured by running this harness against **Coder OSS v2.34.1**
+on Docker Desktop (macOS). These confirm / correct the assessment.
+
+## Environment
+- Coder `v2.34.1+2e8d80a`, Postgres 17, Docker Desktop 28.4.0.
+- Coder run headless behind its REST API; provisioning driven entirely by abi's
+  `coding_environment` core service (`CoderAdapter`).
+
+## Headless control-plane flow — VERIFIED end-to-end
+
+Driven through the real service (`CodingEnvironmentFactory.CodingEnvironmentServiceCoder`):
+
+| Step | Result |
+|---|---|
+| First-user bootstrap (`POST /api/v2/users/first` + login) | ✅ session token obtained |
+| `ensure_user` (GET 404 → `POST /users`, `login_type:"none"`) | ✅ created real user `aca23d59…`, idempotent on re-run |
+| `list_templates` | ✅ returns `abi-code-server` after push |
+| `provision` (`POST /organizations/{org}/members/{user}/workspaces`) | ✅ workspace created, build started |
+| build → agent connect (poll loop) | ✅ reached `phase=running agent_ready=True` |
+| `get_access` (mint token + assemble subdomain URL) | ✅ `https://code-server--main--dev2--alice.coder.lvh.me/?coder_session_token=…` |
+
+**Confirms** the §4 REST sequence, the `Coder-Session-Token` auth, org
+resolution via `/organizations/default`, build/agent status normalization, and
+the §4c subdomain-URL transform — against the real API, not mocks.
+
+## Corrections discovered against the live API (assessment had these UNCERTAIN)
+
+1. **`login_type:"none"` works in OSS v2.34.1** — user creation via the admin
+   token succeeded. (Was medium-confidence; now confirmed for this version.)
+2. **Scoped-token schema** — the `allow_list: [{type,id}]` shape is **wrong**:
+   Coder returned `400 cannot unmarshal object into … allow_list of type string`,
+   and the scope field is singular `scope`, not `scopes`. `CoderAdapter._mint_token`
+   was fixed to send `{token_name, lifetime, scope:"application_connect"}` and
+   fall back to a basic `{token_name, lifetime}` token if the scoped form is
+   refused. Minting then succeeded against the live API.
+
+## Embedding framing headers — VERIFIED
+
+- **Coder** sends (captured from `http://localhost:7080/`):
+  `Content-Security-Policy: … frame-ancestors 'self'; …` — **not** `X-Frame-Options`.
+  So cross-origin framing of Coder surfaces is blocked by default and is opened
+  by appending to `frame-ancestors` via `CODER_ADDITIONAL_CSP_POLICY`. ✅ confirms §3a.
+- **code-server**: no `X-Frame-Options` / no CSP `frame-ancestors` (source-verified
+  in the assessment workflow). A local empirical probe was inconclusive because
+  the `codercom/code-server` image would not stay running in this sandbox — not a
+  header finding, an image/env quirk.
+
+## Local-Docker config needed for a workspace to boot (now baked into the harness)
+
+1. **Docker socket permission** — terraform's docker provider hit
+   `permission denied … /var/run/docker.sock`; fixed by running the `coder`
+   service as `user: root` (prototype-only; use a socket-proxy or k8s in prod).
+2. **Agent-reachable access URL** — `CODER_ACCESS_URL` must be reachable from the
+   workspace container; set to `http://host.docker.internal:7080` so the agent
+   connects back. (The host-side provision script still uses `http://localhost:7080`.)
+
+## Still to do (needs a browser + the HTTPS edge)
+
+The cross-browser **cookie/redemption** test (Chrome + Safari, default settings)
+is the one bar not yet run here — it needs `make edge` (Caddy + local TLS on
+`lvh.me`) and a real browser. The embed URL above is exactly what you paste into
+`frontend/index.html` to run it.
+
+## Update — compose code-server path (simpler than Coder/Terraform)
+
+Per the "use docker-compose, not Terraform" direction, code-server now ships as
+a plain compose service and is a first-class backend behind the same port
+(`CodeServerComposeAdapter`). Empirically verified on the running stack:
+
+- code-server runs (the earlier failures were the disk-full window): `GET /`
+  returns `302 → /login → 200` with **no `X-Frame-Options` and no CSP
+  `frame-ancestors`** — iframe-embeddable.
+- Behind Caddy at `https://code-server.lvh.me/` (HTTP/2 302 → /login), served
+  over HTTPS under the same registrable domain as the frontend (`app.lvh.me`).
+- **Cookie (the load-bearing bit):** login sets
+  `code-server-session=…; Domain=code-server.lvh.me; Path=/; SameSite=Lax`.
+  `SameSite=Lax` + same registrable domain ⇒ `app.lvh.me` embedding
+  `code-server.lvh.me` is a **same-site** iframe, so the cookie **is** sent
+  inside it. No `SameSite=None`, no third-party-cookie problem. (Cross-*domain*
+  is where Lax would fail in Safari — hence the same-domain strategy.)
+- `coding_environment` service: `code_server` adapter + factory
+  (`CodingEnvironmentServiceCodeServer`) + config option; **33 unit tests pass**.
+- Shipped into the main stack: `code-server` service in `docker-compose.yml` +
+  a `code-server.${PUBLIC_WEB_HOST}` route in `.deploy/docker/Caddyfile`.
+
+Tradeoff: one shared editor (not per-user isolated workspaces) — use the
+`CoderAdapter` backend when you need per-user isolation/autostop at scale.
+
+**Remaining human step:** visually confirm the editor renders + authenticates
+inside the iframe in Chrome and Safari (open `https://app.lvh.me/`, paste
+`https://code-server.lvh.me/`). Needs trusting Caddy's local CA first
+(`docker compose cp caddy:/data/caddy/pki/authorities/local/root.crt ./root.crt`).

--- a/coder_prototype/docker-compose.yml
+++ b/coder_prototype/docker-compose.yml
@@ -1,0 +1,101 @@
+# Standalone Coder embedding-prototype stack.
+#
+# Goal: prove the headless provisioning flow + the embedding boundary BEFORE
+# folding Coder into abi's main docker-compose. Runs Coder unmodified behind
+# its REST API, with Postgres, and (optionally) Caddy as the same-registrable-
+# domain edge proxy for the browser/cookie test.
+#
+#   make up         # postgres + coder (HTTP, for API + header verification)
+#   make bootstrap  # create first user, capture a session token
+#   make provision  # headless provision via the abi coding_environment service
+#   make edge        # add Caddy for the HTTPS lvh.me embedding test
+#
+name: coder-prototype
+
+services:
+  postgres:
+    image: postgres:17-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: coder
+      POSTGRES_PASSWORD: coder
+      POSTGRES_DB: coder
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U coder -d coder"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+    networks: [coder]
+
+  coder:
+    image: ghcr.io/coder/coder:v2.34.1
+    # Prototype-only: run as root so terraform's docker provider can reach the
+    # bind-mounted /var/run/docker.sock on macOS Docker Desktop (non-root coder
+    # user gets "permission denied" on the socket). In production prefer a
+    # docker-socket-proxy or a Kubernetes template over root + bind-mounted sock.
+    user: root
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      CODER_PG_CONNECTION_URL: "postgresql://coder:coder@postgres:5432/coder?sslmode=disable"
+      CODER_HTTP_ADDRESS: "0.0.0.0:7080"
+      # host.docker.internal so the workspace agent (a sibling container) can
+      # reach coderd back; the host-side provision script still talks to
+      # http://localhost:7080. Switch to https://coder.lvh.me with `make edge`
+      # for the browser embedding test.
+      CODER_ACCESS_URL: "${CODER_ACCESS_URL:-http://host.docker.internal:7080}"
+      CODER_WILDCARD_ACCESS_URL: "${CODER_WILDCARD_ACCESS_URL:-}"
+      # Open framing to our parent origin (empty by default = Coder's CSP frame-ancestors 'self').
+      CODER_ADDITIONAL_CSP_POLICY: "${CODER_ADDITIONAL_CSP_POLICY:-}"
+      CODER_TELEMETRY_ENABLE: "false"
+    ports:
+      - "7080:7080"
+    # The Docker template provisions each workspace as a sibling container, so
+    # coderd's terraform provisioner needs the host Docker daemon. Harmless to
+    # Coder startup; required only when you actually build a workspace.
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - coder_data:/home/coder
+    networks: [coder]
+
+  # code-server shipped directly as a container (the simpler path — no Coder /
+  # Terraform / docker.sock). Embedded by frontend/index.html under the same
+  # registrable domain (lvh.me) so its session cookie is first-party.
+  code-server:
+    image: codercom/code-server:latest
+    restart: unless-stopped
+    command: ["--auth", "password", "--bind-addr", "0.0.0.0:8080"]
+    environment:
+      - PASSWORD=${CODE_SERVER_PASSWORD:-abi-dev}
+    volumes:
+      - code_server_data:/home/coder
+    networks: [coder]
+
+  # Edge proxy for the HTTPS embedding test (same registrable domain: lvh.me).
+  # Brought up only by `make edge` via the --profile flag.
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    profiles: ["edge"]
+    depends_on:
+      - coder
+    ports:
+      - "443:443"
+      - "80:80"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./frontend:/srv:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    networks: [coder]
+
+volumes:
+  coder_data:
+  code_server_data:
+  caddy_data:
+  caddy_config:
+
+networks:
+  coder: {}

--- a/coder_prototype/frontend/index.html
+++ b/coder_prototype/frontend/index.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>abi · Coding environment (prototype)</title>
+    <style>
+      :root { color-scheme: light dark; }
+      * { box-sizing: border-box; }
+      body { margin: 0; font: 14px/1.4 system-ui, sans-serif; height: 100vh; display: flex; flex-direction: column; }
+      header { padding: 8px 14px; background: #11131a; color: #e8eaf0; display: flex; gap: 12px; align-items: center; }
+      header strong { font-weight: 600; }
+      header .muted { color: #8b90a0; font-size: 12px; }
+      #embed { flex: 1; border: 0; width: 100%; background: #1e1e1e; }
+      input { flex: 1; padding: 6px 8px; border-radius: 6px; border: 1px solid #333; background: #0c0d12; color: #e8eaf0; }
+      button { padding: 6px 12px; border-radius: 6px; border: 0; background: #4f6bed; color: #fff; cursor: pointer; }
+      #status { padding: 4px 14px; font-size: 12px; background: #181a22; color: #b9bed0; }
+    </style>
+  </head>
+  <body>
+    <!-- This is OUR chrome. The editor below is code-server embedded via iframe.
+         The URL must be the workspace-app URL printed by provision.py, including
+         its ?coder_session_token=... so the app-proxy can seed the first-party
+         cookie (§5a of the assessment). -->
+    <header>
+      <strong>abi</strong>
+      <span class="muted">coding environment · prototype</span>
+      <input id="url" placeholder="paste the embeddable URL from provision.py (…?coder_session_token=…)" />
+      <button id="go">Embed</button>
+    </header>
+    <div id="status">Idle. Paste a workspace-app URL and click Embed.</div>
+    <iframe
+      id="embed"
+      title="code-server"
+      allow="clipboard-read; clipboard-write; cross-origin-isolated"
+    ></iframe>
+    <script>
+      const qs = new URLSearchParams(location.search);
+      const urlInput = document.getElementById("url");
+      const statusEl = document.getElementById("status");
+      const frame = document.getElementById("embed");
+      if (qs.get("url")) urlInput.value = qs.get("url");
+
+      function embed() {
+        const u = urlInput.value.trim();
+        if (!u) return;
+        statusEl.textContent = "Loading " + u + " …";
+        frame.src = u;
+      }
+      frame.addEventListener("load", () => {
+        statusEl.textContent =
+          "iframe load event fired for " + (frame.src || "(none)") +
+          ". Check DevTools → Network for the app cookie + WS 101.";
+      });
+      document.getElementById("go").addEventListener("click", embed);
+      if (urlInput.value) embed();
+    </script>
+  </body>
+</html>

--- a/coder_prototype/scripts/bootstrap.sh
+++ b/coder_prototype/scripts/bootstrap.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Headless bootstrap: wait for Coder, create the first (owner) user via the
+# REST API, log in, and capture a session token for the provisioning demo.
+set -euo pipefail
+
+CODER_URL="${CODER_URL:-http://localhost:7080}"
+EMAIL="${CODER_ADMIN_EMAIL:-admin@example.com}"
+USERNAME="${CODER_ADMIN_USERNAME:-admin}"
+PASSWORD="${CODER_ADMIN_PASSWORD:-SomeSecurePassword123!}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+echo "==> Waiting for Coder at ${CODER_URL} ..."
+for _ in $(seq 1 90); do
+  if curl -fsS "${CODER_URL}/api/v2/buildinfo" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 2
+done
+curl -fsS "${CODER_URL}/api/v2/buildinfo" >/dev/null
+echo "==> Coder is up: $(curl -fsS "${CODER_URL}/api/v2/buildinfo")"
+
+echo "==> Creating first (owner) user (idempotent) ..."
+curl -fsS -X POST "${CODER_URL}/api/v2/users/first" \
+  -H 'Content-Type: application/json' \
+  -d "{\"email\":\"${EMAIL}\",\"username\":\"${USERNAME}\",\"password\":\"${PASSWORD}\",\"name\":\"Admin\",\"trial\":false}" \
+  >/dev/null 2>&1 || echo "    (first user already exists — continuing)"
+
+echo "==> Logging in for a session token ..."
+TOKEN="$(curl -fsS -X POST "${CODER_URL}/api/v2/users/login" \
+  -H 'Content-Type: application/json' \
+  -d "{\"email\":\"${EMAIL}\",\"password\":\"${PASSWORD}\"}" \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["session_token"])')"
+
+echo "${TOKEN}" > "${HERE}/../.coder-token"
+echo "==> Session token written to coder_prototype/.coder-token"
+echo "    Use it with:  export CODER_SESSION_TOKEN=\$(cat coder_prototype/.coder-token)"

--- a/coder_prototype/scripts/provision.py
+++ b/coder_prototype/scripts/provision.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+"""Headless workspace provisioning demo for the Coder embedding prototype.
+
+Drives abi's `coding_environment` core service entirely via Coder's REST API
+(the CoderAdapter). With --in-memory it runs the identical flow against the
+fake adapter, so the orchestration logic is demonstrable without Docker/Coder.
+
+  uv run --no-sync python coder_prototype/scripts/provision.py --in-memory
+  CODER_SESSION_TOKEN=$(cat coder_prototype/.coder-token) \
+    uv run --no-sync python coder_prototype/scripts/provision.py
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+from naas_abi_core.services.coding_environment.CodingEnvironmentFactory import (
+    CodingEnvironmentFactory,
+)
+from naas_abi_core.services.coding_environment.CodingEnvironmentPorts import (
+    CodingEnvironmentError,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--in-memory", action="store_true", help="use the fake adapter")
+    p.add_argument(
+        "--access-url",
+        default=os.environ.get("CODER_ACCESS_URL", "http://localhost:7080"),
+    )
+    p.add_argument("--token", default=os.environ.get("CODER_SESSION_TOKEN", ""))
+    p.add_argument(
+        "--wildcard",
+        default=os.environ.get("CODER_WILDCARD_ACCESS_URL", "*.coder.lvh.me"),
+    )
+    p.add_argument("--template-id", default=os.environ.get("CODER_TEMPLATE_ID", ""))
+    p.add_argument("--username", default="alice")
+    p.add_argument("--email", default="alice@example.com")
+    p.add_argument("--workspace", default="dev")
+    p.add_argument("--app-slug", default="code-server")
+    return p
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+
+    if args.in_memory:
+        print("[mode] in-memory fake adapter")
+        svc = CodingEnvironmentFactory.CodingEnvironmentServiceInMemory(
+            polls_until_ready=2
+        )
+    else:
+        if not args.token:
+            print(
+                "ERROR: set CODER_SESSION_TOKEN (run scripts/bootstrap.sh first)",
+                file=sys.stderr,
+            )
+            return 2
+        print(f"[mode] coder @ {args.access_url}")
+        svc = CodingEnvironmentFactory.CodingEnvironmentServiceCoder(
+            access_url=args.access_url,
+            wildcard_access_url=args.wildcard,
+            admin_token=args.token,
+            workspace_autostop_ms=1_800_000,
+        )
+
+    try:
+        user_id = svc.ensure_user(
+            external_id=f"ext-{args.username}",
+            email=args.email,
+            username=args.username,
+        )
+        print(f"[ensure_user] {args.username} -> {user_id}")
+
+        templates = svc.list_templates()
+        print(f"[list_templates] -> {[t.name for t in templates] or 'none'}")
+
+        template_id = args.template_id or (templates[0].id if templates else "")
+        if not template_id:
+            print(
+                "[provision] skipped: no template available.\n"
+                "            Push one with `make template` (see README), then re-run."
+            )
+            return 0
+
+        status = svc.provision(
+            user_id=user_id, template_id=template_id, name=args.workspace
+        )
+        print(f"[provision] id={status.id} phase={status.phase}")
+
+        status = svc.wait_until_ready(
+            workspace_id=status.id, timeout_seconds=240, poll_interval_seconds=3
+        )
+        print(f"[ready] phase={status.phase} agent_ready={status.agent_ready}")
+
+        access = svc.get_access(
+            workspace_id=status.id, user_id=user_id, app_slug=args.app_slug
+        )
+        print("[get_access] embeddable URL:")
+        print(f"  {access.url}")
+        return 0
+    except CodingEnvironmentError as exc:
+        print(f"ERROR ({type(exc).__name__}): {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/coder_prototype/template/main.tf
+++ b/coder_prototype/template/main.tf
@@ -1,0 +1,61 @@
+# Minimal Coder template: a Docker workspace running code-server (MIT),
+# exposed as a subdomain coder_app shared to the owner. This is the artifact
+# the embedding test provisions. Push it with `make template`.
+terraform {
+  required_providers {
+    coder  = { source = "coder/coder" }
+    docker = { source = "kreuzwerker/docker" }
+  }
+}
+
+provider "coder" {}
+provider "docker" {}
+
+data "coder_workspace" "me" {}
+data "coder_workspace_owner" "me" {}
+
+resource "coder_agent" "main" {
+  arch           = "amd64"
+  os             = "linux"
+  startup_script = <<-EOT
+    set -e
+    if ! command -v code-server >/dev/null 2>&1; then
+      curl -fsSL https://code-server.dev/install.sh | sh
+    fi
+    code-server --auth none --port 13337 --host 0.0.0.0 >/tmp/code-server.log 2>&1 &
+  EOT
+}
+
+resource "coder_app" "code-server" {
+  agent_id     = coder_agent.main.id
+  slug         = "code-server"
+  display_name = "code-server"
+  url          = "http://localhost:13337/"
+  icon         = "/icon/code.svg"
+  # subdomain app => first-party cookie story works under *.coder.<domain>.
+  subdomain = true
+  # owner share => the authoritative auth test (a public app needs no cookie).
+  share = "owner"
+  healthcheck {
+    url       = "http://localhost:13337/healthz"
+    interval  = 5
+    threshold = 6
+  }
+}
+
+resource "docker_image" "main" {
+  name = "codercom/enterprise-base:ubuntu"
+}
+
+resource "docker_container" "workspace" {
+  count      = data.coder_workspace.me.start_count
+  image      = docker_image.main.name
+  name       = "coder-${data.coder_workspace_owner.me.name}-${lower(data.coder_workspace.me.name)}"
+  hostname   = data.coder_workspace.me.name
+  entrypoint = ["sh", "-c", coder_agent.main.init_script]
+  env        = ["CODER_AGENT_TOKEN=${coder_agent.main.token}"]
+  host {
+    host = "host.docker.internal"
+    ip   = "host-gateway"
+  }
+}

--- a/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration.py
@@ -24,6 +24,10 @@ from naas_abi_core.engine.engine_configuration.EngineConfiguration_CacheService 
     TIER_COLD,
     TIER_HOT,
 )
+from naas_abi_core.engine.engine_configuration.EngineConfiguration_CodingEnvironmentService import (
+    CodingEnvironmentAdapterConfiguration,
+    CodingEnvironmentServiceConfiguration,
+)
 from naas_abi_core.engine.engine_configuration.EngineConfiguration_EmailService import (
     EmailAdapterConfiguration,
     EmailAdapterSMTPConfiguration,
@@ -138,6 +142,14 @@ class ServicesConfiguration(BaseModel):
                 port=1025,
                 timeout=10,
             ).model_dump(),
+        )
+    )
+    coding_environment: CodingEnvironmentServiceConfiguration = (
+        CodingEnvironmentServiceConfiguration(
+            coding_environment_adapter=CodingEnvironmentAdapterConfiguration(
+                adapter="in_memory",
+                config={},
+            )
         )
     )
     activity_log: ActivityLogServiceConfiguration = ActivityLogServiceConfiguration(

--- a/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_CodingEnvironmentService.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_CodingEnvironmentService.py
@@ -1,0 +1,108 @@
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, model_validator
+
+from naas_abi_core.engine.engine_configuration.EngineConfiguration_GenericLoader import (
+    GenericLoader,
+)
+from naas_abi_core.engine.engine_configuration.utils.PydanticModelValidator import (
+    pydantic_model_validator,
+)
+from naas_abi_core.services.coding_environment.CodingEnvironmentPorts import (
+    ICodingEnvironmentAdapter,
+)
+from naas_abi_core.services.coding_environment.CodingEnvironmentService import (
+    CodingEnvironmentService,
+)
+
+
+class CodingEnvironmentAdapterCoderConfiguration(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    access_url: str  # e.g. https://coder.example.com
+    wildcard_access_url: str  # e.g. "*.coder.example.com"
+    admin_token: str  # "{{ secret.CODER_ADMIN_TOKEN }}"
+    organization: str = "default"
+    default_template_id: str | None = None
+    default_token_lifetime_seconds: int = 3600  # converted to ns at the wire (§5)
+    workspace_autostop_ms: int = 3_600_000  # idle autostop / cost control (§4a)
+    timeout: int = 30
+
+
+class CodingEnvironmentAdapterCodeServerConfiguration(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    url: str  # public embeddable code-server URL, e.g. https://code-server.example.com
+
+
+class CodingEnvironmentAdapterInMemoryConfiguration(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class CodingEnvironmentAdapterConfiguration(GenericLoader):
+    adapter: Literal["coder", "code_server", "in_memory", "custom"]
+    config: dict | None = None
+
+    @model_validator(mode="after")
+    def validate_adapter(self) -> "CodingEnvironmentAdapterConfiguration":
+        if self.adapter != "custom":
+            assert self.config is not None, (
+                "config is required if adapter is not custom"
+            )
+
+        if self.adapter == "coder":
+            pydantic_model_validator(
+                CodingEnvironmentAdapterCoderConfiguration,
+                self.config,
+                "Invalid configuration for services.coding_environment."
+                "coding_environment_adapter 'coder' adapter",
+            )
+        elif self.adapter == "code_server":
+            pydantic_model_validator(
+                CodingEnvironmentAdapterCodeServerConfiguration,
+                self.config,
+                "Invalid configuration for services.coding_environment."
+                "coding_environment_adapter 'code_server' adapter",
+            )
+        elif self.adapter == "in_memory":
+            pydantic_model_validator(
+                CodingEnvironmentAdapterInMemoryConfiguration,
+                self.config or {},
+                "Invalid configuration for services.coding_environment."
+                "coding_environment_adapter 'in_memory' adapter",
+            )
+
+        return self
+
+    def load(self) -> ICodingEnvironmentAdapter:
+        if self.adapter == "coder":
+            assert self.config is not None, "config is required for coder adapter"
+            from naas_abi_core.services.coding_environment.adapters.secondary.CoderAdapter import (
+                CoderAdapter,
+            )
+
+            return CoderAdapter(**self.config)
+        elif self.adapter == "code_server":
+            assert self.config is not None, "config is required for code_server adapter"
+            from naas_abi_core.services.coding_environment.adapters.secondary.CodeServerComposeAdapter import (
+                CodeServerComposeAdapter,
+            )
+
+            return CodeServerComposeAdapter(**self.config)
+        elif self.adapter == "in_memory":
+            from naas_abi_core.services.coding_environment.adapters.secondary.InMemoryAdapter import (
+                InMemoryAdapter,
+            )
+
+            return InMemoryAdapter(**(self.config or {}))
+        elif self.adapter == "custom":
+            return super().load()
+        else:
+            raise ValueError(f"Unknown adapter: {self.adapter}")
+
+
+class CodingEnvironmentServiceConfiguration(BaseModel):
+    coding_environment_adapter: CodingEnvironmentAdapterConfiguration
+
+    def load(self) -> CodingEnvironmentService:
+        return CodingEnvironmentService(adapter=self.coding_environment_adapter.load())

--- a/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_CodingEnvironmentService_test.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_CodingEnvironmentService_test.py
@@ -1,0 +1,73 @@
+import pytest
+
+from naas_abi_core.engine.engine_configuration.EngineConfiguration_CodingEnvironmentService import (
+    CodingEnvironmentAdapterConfiguration,
+    CodingEnvironmentServiceConfiguration,
+)
+from naas_abi_core.services.coding_environment.adapters.secondary.CoderAdapter import (
+    CoderAdapter,
+)
+from naas_abi_core.services.coding_environment.adapters.secondary.CodeServerComposeAdapter import (
+    CodeServerComposeAdapter,
+)
+from naas_abi_core.services.coding_environment.adapters.secondary.InMemoryAdapter import (
+    InMemoryAdapter,
+)
+from naas_abi_core.services.coding_environment.CodingEnvironmentService import (
+    CodingEnvironmentService,
+)
+
+
+def test_coding_environment_configuration_coder_adapter():
+    configuration = CodingEnvironmentServiceConfiguration(
+        coding_environment_adapter=CodingEnvironmentAdapterConfiguration(
+            adapter="coder",
+            config={
+                "access_url": "https://coder.example.com",
+                "wildcard_access_url": "*.coder.example.com",
+                "admin_token": "admin-token",
+                "workspace_autostop_ms": 1_800_000,
+            },
+        )
+    )
+
+    adapter = configuration.coding_environment_adapter.load()
+    assert isinstance(adapter, CoderAdapter)
+    assert isinstance(configuration.load(), CodingEnvironmentService)
+
+
+def test_coding_environment_configuration_in_memory_adapter():
+    configuration = CodingEnvironmentServiceConfiguration(
+        coding_environment_adapter=CodingEnvironmentAdapterConfiguration(
+            adapter="in_memory",
+            config={},
+        )
+    )
+
+    adapter = configuration.coding_environment_adapter.load()
+    assert isinstance(adapter, InMemoryAdapter)
+    assert isinstance(configuration.load(), CodingEnvironmentService)
+
+
+def test_coding_environment_configuration_code_server_adapter():
+    configuration = CodingEnvironmentServiceConfiguration(
+        coding_environment_adapter=CodingEnvironmentAdapterConfiguration(
+            adapter="code_server",
+            config={"url": "https://code-server.example.com"},
+        )
+    )
+
+    adapter = configuration.coding_environment_adapter.load()
+    assert isinstance(adapter, CodeServerComposeAdapter)
+    assert isinstance(configuration.load(), CodingEnvironmentService)
+
+
+def test_coding_environment_configuration_coder_requires_admin_token():
+    with pytest.raises(Exception):
+        CodingEnvironmentAdapterConfiguration(
+            adapter="coder",
+            config={
+                "access_url": "https://coder.example.com",
+                "wildcard_access_url": "*.coder.example.com",
+            },
+        )

--- a/libs/naas-abi-core/naas_abi_core/services/coding_environment/CodingEnvironmentFactory.py
+++ b/libs/naas-abi-core/naas_abi_core/services/coding_environment/CodingEnvironmentFactory.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from naas_abi_core.services.coding_environment.adapters.secondary.CoderAdapter import (
+    CoderAdapter,
+)
+from naas_abi_core.services.coding_environment.adapters.secondary.CodeServerComposeAdapter import (
+    CodeServerComposeAdapter,
+)
+from naas_abi_core.services.coding_environment.adapters.secondary.InMemoryAdapter import (
+    InMemoryAdapter,
+)
+from naas_abi_core.services.coding_environment.CodingEnvironmentService import (
+    CodingEnvironmentService,
+)
+
+
+class CodingEnvironmentFactory:
+    @staticmethod
+    def CodingEnvironmentServiceCoder(
+        *,
+        access_url: str,
+        wildcard_access_url: str,
+        admin_token: str,
+        organization: str = "default",
+        default_template_id: str | None = None,
+        default_token_lifetime_seconds: int = 3600,
+        workspace_autostop_ms: int = 3_600_000,
+        timeout: int = 30,
+    ) -> CodingEnvironmentService:
+        return CodingEnvironmentService(
+            CoderAdapter(
+                access_url=access_url,
+                wildcard_access_url=wildcard_access_url,
+                admin_token=admin_token,
+                organization=organization,
+                default_template_id=default_template_id,
+                default_token_lifetime_seconds=default_token_lifetime_seconds,
+                workspace_autostop_ms=workspace_autostop_ms,
+                timeout=timeout,
+            )
+        )
+
+    @staticmethod
+    def CodingEnvironmentServiceCodeServer(*, url: str) -> CodingEnvironmentService:
+        return CodingEnvironmentService(CodeServerComposeAdapter(url=url))
+
+    @staticmethod
+    def CodingEnvironmentServiceInMemory(
+        *, polls_until_ready: int = 0
+    ) -> CodingEnvironmentService:
+        return CodingEnvironmentService(
+            InMemoryAdapter(polls_until_ready=polls_until_ready)
+        )

--- a/libs/naas-abi-core/naas_abi_core/services/coding_environment/CodingEnvironmentPorts.py
+++ b/libs/naas-abi-core/naas_abi_core/services/coding_environment/CodingEnvironmentPorts.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+# ---------------------------------------------------------------------------
+# Normalized, backend-agnostic DTOs
+# ---------------------------------------------------------------------------
+# These deliberately collapse the backing orchestrator's enums into a small,
+# stable vocabulary so a future adapter (Gitpod, devcontainer, k8s, ...) can
+# satisfy the same port without leaking Coder concepts into the domain.
+
+# Normalized lifecycle phases.
+PHASE_PROVISIONING = "provisioning"
+PHASE_RUNNING = "running"
+PHASE_STOPPED = "stopped"
+PHASE_ERROR = "error"
+
+
+@dataclass(frozen=True)
+class WorkspaceTemplate:
+    id: str
+    name: str
+    active_version_id: str
+
+
+@dataclass(frozen=True)
+class WorkspaceStatus:
+    id: str
+    name: str
+    phase: str  # one of PHASE_*
+    agent_ready: bool = False
+
+
+@dataclass(frozen=True)
+class WorkspaceAccess:
+    """Everything the frontend needs to embed the editor.
+
+    ``url`` is the public, embeddable app URL (subdomain form). When the
+    backing orchestrator authenticates apps via a session-token redemption
+    handshake, ``url`` already carries the redemption query parameter and
+    ``token`` is the raw scoped token (so the caller can rebuild the URL if
+    needed). ``token`` MUST never be the deployment admin token.
+    """
+
+    url: str
+    token: str | None = None
+    expires_at: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Normalized error taxonomy (part of the port contract)
+# ---------------------------------------------------------------------------
+# A swappable port needs a normalized *error* contract, not just normalized
+# phases. Every adapter maps its backend's failures onto these.
+
+
+class CodingEnvironmentError(Exception):
+    def __init__(self, message: str = "", *, status: int | None = None) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+class ProvisionFailedError(CodingEnvironmentError):
+    """The build/provision job failed or was canceled."""
+
+
+class ProvisionTimeoutError(CodingEnvironmentError):
+    """Provisioning exceeded the allotted timeout budget."""
+
+
+class AgentNeverConnectedError(CodingEnvironmentError):
+    """The build succeeded but the workspace agent never reported ready."""
+
+
+class TemplateNotFoundError(CodingEnvironmentError):
+    """The requested template does not exist."""
+
+
+class WorkspaceNotFoundError(CodingEnvironmentError):
+    """The requested workspace does not exist."""
+
+
+class WorkspaceNameConflictError(CodingEnvironmentError):
+    """A workspace with that name already exists for the user."""
+
+
+class QuotaExceededError(CodingEnvironmentError):
+    """The user/organization workspace quota is exhausted."""
+
+
+class AccessDeniedError(CodingEnvironmentError):
+    """RBAC / scope denial (401/403)."""
+
+
+class ICodingEnvironmentAdapter(ABC):
+    """Secondary (driven) port for a coding-environment orchestrator."""
+
+    @abstractmethod
+    def ensure_user(self, *, external_id: str, email: str, username: str) -> str:
+        """Idempotently ensure an orchestrator user exists; return its id."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def list_templates(self) -> list[WorkspaceTemplate]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def provision(
+        self,
+        *,
+        user_id: str,
+        template_id: str,
+        name: str,
+        params: dict[str, str] | None = None,
+    ) -> WorkspaceStatus:
+        """Create a workspace from a template and kick off its first build."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def start(self, *, workspace_id: str) -> WorkspaceStatus:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def stop(self, *, workspace_id: str) -> WorkspaceStatus:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def delete(self, *, workspace_id: str) -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_status(self, *, workspace_id: str) -> WorkspaceStatus:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_access(
+        self, *, workspace_id: str, user_id: str, app_slug: str
+    ) -> WorkspaceAccess:
+        """Mint scoped access for ``user_id`` and return an embeddable URL."""
+        raise NotImplementedError()

--- a/libs/naas-abi-core/naas_abi_core/services/coding_environment/CodingEnvironmentService.py
+++ b/libs/naas-abi-core/naas_abi_core/services/coding_environment/CodingEnvironmentService.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import time
+from typing import Callable
+
+from naas_abi_core import logger
+from naas_abi_core.services.coding_environment.CodingEnvironmentPorts import (
+    ICodingEnvironmentAdapter,
+    PHASE_ERROR,
+    PHASE_RUNNING,
+    ProvisionFailedError,
+    ProvisionTimeoutError,
+    WorkspaceAccess,
+    WorkspaceStatus,
+    WorkspaceTemplate,
+)
+from naas_abi_core.services.coding_environment.ontologies.modules.CodingEnvironmentEventOntology import (
+    WorkspaceAccessGranted,
+    WorkspaceDeleted,
+    WorkspaceProvisioned,
+    WorkspaceProvisionFailed,
+    WorkspaceStarted,
+    WorkspaceStopped,
+)
+from naas_abi_core.services.ServiceBase import ServiceBase
+
+
+class CodingEnvironmentService(ServiceBase):
+    """Domain service for orchestrating per-user coding environments.
+
+    Business logic knows nothing about Coder; it depends only on the port.
+    The operation is always the source of truth — event publishing is
+    fail-safe and must never break a (long, expensive) provision.
+    """
+
+    def __init__(self, adapter: ICodingEnvironmentAdapter):
+        super().__init__()
+        self._adapter = adapter
+
+    def __publish_event(self, event: object) -> None:
+        if not self.services_wired:
+            return
+        if not self.services.events_available():
+            return
+        try:
+            self.services.events.publish(event)
+        except Exception as exc:
+            # The orchestration call is the source of truth; event logging
+            # must never break it.
+            logger.warning(
+                f"CodingEnvironmentService: failed to publish event: {exc}"
+            )
+
+    def ensure_user(self, *, external_id: str, email: str, username: str) -> str:
+        return self._adapter.ensure_user(
+            external_id=external_id, email=email, username=username
+        )
+
+    def list_templates(self) -> list[WorkspaceTemplate]:
+        return self._adapter.list_templates()
+
+    def provision(
+        self,
+        *,
+        user_id: str,
+        template_id: str,
+        name: str,
+        params: dict[str, str] | None = None,
+    ) -> WorkspaceStatus:
+        try:
+            status = self._adapter.provision(
+                user_id=user_id,
+                template_id=template_id,
+                name=name,
+                params=params,
+            )
+        except Exception as exc:
+            # workspace_id is unknown on failure; record the requested name.
+            self.__publish_event(
+                WorkspaceProvisionFailed(
+                    user=user_id, workspace_id=name, message=str(exc)
+                )
+            )
+            raise
+        self.__publish_event(
+            WorkspaceProvisioned(
+                user=user_id,
+                workspace_id=status.id,
+                workspace_name=status.name,
+                template_id=template_id,
+                phase=status.phase,
+            )
+        )
+        return status
+
+    def start(self, *, workspace_id: str) -> WorkspaceStatus:
+        status = self._adapter.start(workspace_id=workspace_id)
+        self.__publish_event(
+            WorkspaceStarted(workspace_id=workspace_id, phase=status.phase)
+        )
+        return status
+
+    def stop(self, *, workspace_id: str) -> WorkspaceStatus:
+        status = self._adapter.stop(workspace_id=workspace_id)
+        self.__publish_event(
+            WorkspaceStopped(workspace_id=workspace_id, phase=status.phase)
+        )
+        return status
+
+    def delete(self, *, workspace_id: str) -> None:
+        self._adapter.delete(workspace_id=workspace_id)
+        self.__publish_event(WorkspaceDeleted(workspace_id=workspace_id))
+
+    def get_status(self, *, workspace_id: str) -> WorkspaceStatus:
+        return self._adapter.get_status(workspace_id=workspace_id)
+
+    def get_access(
+        self, *, workspace_id: str, user_id: str, app_slug: str
+    ) -> WorkspaceAccess:
+        access = self._adapter.get_access(
+            workspace_id=workspace_id, user_id=user_id, app_slug=app_slug
+        )
+        self.__publish_event(
+            WorkspaceAccessGranted(
+                user=user_id,
+                workspace_id=workspace_id,
+                app_slug=app_slug,
+                token_expires_at=access.expires_at,
+            )
+        )
+        return access
+
+    def wait_until_ready(
+        self,
+        *,
+        workspace_id: str,
+        timeout_seconds: float = 300.0,
+        poll_interval_seconds: float = 2.0,
+        sleep: Callable[[float], None] = time.sleep,
+        monotonic: Callable[[], float] = time.monotonic,
+    ) -> WorkspaceStatus:
+        """Poll the workspace until its agent is ready (the §4b state machine).
+
+        ``sleep`` and ``monotonic`` are injectable so the poll loop is fully
+        deterministic under test.
+        """
+        deadline = monotonic() + timeout_seconds
+        while True:
+            status = self._adapter.get_status(workspace_id=workspace_id)
+            if status.phase == PHASE_RUNNING and status.agent_ready:
+                return status
+            if status.phase == PHASE_ERROR:
+                raise ProvisionFailedError(
+                    f"Workspace {workspace_id} entered error state"
+                )
+            if monotonic() >= deadline:
+                raise ProvisionTimeoutError(
+                    f"Workspace {workspace_id} not ready within "
+                    f"{timeout_seconds}s (phase={status.phase}, "
+                    f"agent_ready={status.agent_ready})"
+                )
+            sleep(poll_interval_seconds)

--- a/libs/naas-abi-core/naas_abi_core/services/coding_environment/__init__.py
+++ b/libs/naas-abi-core/naas_abi_core/services/coding_environment/__init__.py
@@ -1,0 +1,21 @@
+from naas_abi_core.services.coding_environment.CodingEnvironmentFactory import (
+    CodingEnvironmentFactory,
+)
+from naas_abi_core.services.coding_environment.CodingEnvironmentPorts import (
+    ICodingEnvironmentAdapter,
+    WorkspaceAccess,
+    WorkspaceStatus,
+    WorkspaceTemplate,
+)
+from naas_abi_core.services.coding_environment.CodingEnvironmentService import (
+    CodingEnvironmentService,
+)
+
+__all__ = [
+    "CodingEnvironmentFactory",
+    "CodingEnvironmentService",
+    "ICodingEnvironmentAdapter",
+    "WorkspaceAccess",
+    "WorkspaceStatus",
+    "WorkspaceTemplate",
+]

--- a/libs/naas-abi-core/naas_abi_core/services/coding_environment/adapters/secondary/CodeServerComposeAdapter.py
+++ b/libs/naas-abi-core/naas_abi_core/services/coding_environment/adapters/secondary/CodeServerComposeAdapter.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from naas_abi_core.services.coding_environment.CodingEnvironmentPorts import (
+    ICodingEnvironmentAdapter,
+    PHASE_RUNNING,
+    WorkspaceAccess,
+    WorkspaceStatus,
+    WorkspaceTemplate,
+)
+
+
+class CodeServerComposeAdapter(ICodingEnvironmentAdapter):
+    """A single, always-on code-server declared as a docker-compose service.
+
+    No Coder, no Terraform, no docker.sock — the container's lifecycle is owned
+    by docker-compose, and this adapter just exposes it through the
+    ``ICodingEnvironmentAdapter`` port so the domain service, UIs, and agents
+    are identical regardless of backend.
+
+    Tradeoff vs. ``CoderAdapter``: this is ONE shared editor, not per-user
+    isolated, dynamically-provisioned workspaces. Ideal for the bundled stack
+    and the "simpler UI" use case; use ``CoderAdapter`` when you need per-user
+    isolation / autostop at scale.
+
+    ``url`` is the public, embeddable code-server URL (e.g.
+    ``https://code-server.example.com/``). ``workspace_id`` is a fixed synthetic
+    id since there is exactly one environment.
+    """
+
+    WORKSPACE_ID = "code-server"
+
+    def __init__(self, *, url: str) -> None:
+        self._url = url.rstrip("/") + "/"
+
+    def ensure_user(self, *, external_id: str, email: str, username: str) -> str:
+        # No per-user identity in the shared-container model; echo the caller's id.
+        return external_id
+
+    def list_templates(self) -> list[WorkspaceTemplate]:
+        return [
+            WorkspaceTemplate(
+                id=self.WORKSPACE_ID, name="code-server", active_version_id="static"
+            )
+        ]
+
+    def _running(self, name: str | None = None) -> WorkspaceStatus:
+        return WorkspaceStatus(
+            id=self.WORKSPACE_ID,
+            name=name or self.WORKSPACE_ID,
+            phase=PHASE_RUNNING,
+            agent_ready=True,
+        )
+
+    def provision(
+        self,
+        *,
+        user_id: str,
+        template_id: str,
+        name: str,
+        params: dict[str, str] | None = None,
+    ) -> WorkspaceStatus:
+        # The container is always up; provisioning is a no-op that reports ready.
+        return self._running(name)
+
+    def start(self, *, workspace_id: str) -> WorkspaceStatus:
+        return self._running()
+
+    def stop(self, *, workspace_id: str) -> WorkspaceStatus:
+        # Lifecycle is compose-managed; we cannot stop a shared container.
+        return self._running()
+
+    def delete(self, *, workspace_id: str) -> None:
+        # Lifecycle is compose-managed; nothing to delete.
+        return None
+
+    def get_status(self, *, workspace_id: str) -> WorkspaceStatus:
+        return self._running()
+
+    def get_access(
+        self, *, workspace_id: str, user_id: str, app_slug: str
+    ) -> WorkspaceAccess:
+        # Same registrable domain as the frontend => code-server's own session
+        # cookie is first-party in the iframe; no token to pass through.
+        return WorkspaceAccess(url=self._url, token=None, expires_at=None)

--- a/libs/naas-abi-core/naas_abi_core/services/coding_environment/adapters/secondary/CodeServerComposeAdapter_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/coding_environment/adapters/secondary/CodeServerComposeAdapter_test.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import pytest
+
+from naas_abi_core.services.coding_environment.adapters.secondary.CodeServerComposeAdapter import (
+    CodeServerComposeAdapter,
+)
+from naas_abi_core.services.coding_environment.CodingEnvironmentPorts import (
+    PHASE_RUNNING,
+)
+from naas_abi_core.services.coding_environment.tests.coding_environment__secondary_adapter__generic_test import (
+    GenericCodingEnvironmentSecondaryAdapterTest,
+)
+
+
+class TestCodeServerComposeAdapter(GenericCodingEnvironmentSecondaryAdapterTest):
+    @pytest.fixture
+    def adapter_class(self):
+        return CodeServerComposeAdapter
+
+
+def test_provision_reports_running() -> None:
+    adapter = CodeServerComposeAdapter(url="https://code-server.example.com")
+    status = adapter.provision(user_id="u", template_id="t", name="dev")
+    assert status.phase == PHASE_RUNNING
+    assert status.agent_ready is True
+
+
+def test_get_access_returns_configured_url_without_token() -> None:
+    adapter = CodeServerComposeAdapter(url="https://code-server.example.com")
+    access = adapter.get_access(
+        workspace_id="code-server", user_id="u", app_slug="code-server"
+    )
+    assert access.url == "https://code-server.example.com/"
+    assert access.token is None  # same-site => first-party cookie, no token passthrough
+
+
+def test_url_trailing_slash_normalized() -> None:
+    adapter = CodeServerComposeAdapter(url="https://x.example.com/")
+    access = adapter.get_access(workspace_id="w", user_id="u", app_slug="s")
+    assert access.url == "https://x.example.com/"
+
+
+def test_ensure_user_echoes_external_id() -> None:
+    adapter = CodeServerComposeAdapter(url="https://x.example.com")
+    assert (
+        adapter.ensure_user(external_id="ext-1", email="a@b.c", username="alice")
+        == "ext-1"
+    )
+
+
+def test_lifecycle_is_noop_but_reports_running() -> None:
+    adapter = CodeServerComposeAdapter(url="https://x.example.com")
+    assert adapter.start(workspace_id="w").phase == PHASE_RUNNING
+    assert adapter.stop(workspace_id="w").phase == PHASE_RUNNING
+    adapter.delete(workspace_id="w")  # no-op; returns None
+    assert adapter.get_status(workspace_id="w").phase == PHASE_RUNNING

--- a/libs/naas-abi-core/naas_abi_core/services/coding_environment/adapters/secondary/CoderAdapter.py
+++ b/libs/naas-abi-core/naas_abi_core/services/coding_environment/adapters/secondary/CoderAdapter.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+from typing import Any
+
+from naas_abi_core.services.coding_environment.CodingEnvironmentPorts import (
+    AccessDeniedError,
+    CodingEnvironmentError,
+    ICodingEnvironmentAdapter,
+    PHASE_ERROR,
+    PHASE_PROVISIONING,
+    PHASE_RUNNING,
+    PHASE_STOPPED,
+    WorkspaceAccess,
+    WorkspaceNameConflictError,
+    WorkspaceStatus,
+    WorkspaceTemplate,
+)
+
+# Coder build/workspace status strings -> normalized phase.
+_RUNNING = {"running"}
+_STOPPED = {"stopped", "deleted"}
+_ERROR = {"failed", "canceled"}
+
+
+class CoderAdapter(ICodingEnvironmentAdapter):
+    """Secondary adapter for Coder OSS (~v2.34.x) over its REST API.
+
+    Headless: a backend service holds the deployment admin token and acts on
+    behalf of users. The ``session`` is injectable (anything with a
+    ``requests``-style ``.request()``), so the adapter is unit-testable
+    without a network.
+
+    NOTE: a few details (scoped-token ``scopes``/``allow_list`` shape, the
+    app-proxy ``coder_session_token`` redemption query param) are flagged
+    UNCERTAIN in the assessment and must be validated against the live
+    deployment in the embedding prototype.
+    """
+
+    def __init__(
+        self,
+        *,
+        access_url: str,
+        wildcard_access_url: str,
+        admin_token: str,
+        organization: str = "default",
+        default_template_id: str | None = None,
+        default_token_lifetime_seconds: int = 3600,
+        workspace_autostop_ms: int = 3_600_000,
+        timeout: int = 30,
+        session: Any | None = None,
+    ) -> None:
+        self._access_url = access_url.rstrip("/")
+        self._wildcard_access_url = wildcard_access_url
+        self._admin_token = admin_token
+        self._organization = organization
+        self._default_template_id = default_template_id
+        self._token_lifetime_seconds = default_token_lifetime_seconds
+        self._workspace_autostop_ms = workspace_autostop_ms
+        self._timeout = timeout
+        self._session = session if session is not None else _default_session()
+        self._org_id: str | None = None
+
+    # -- HTTP plumbing ------------------------------------------------------
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        token: str | None = None,
+        json: dict | None = None,
+    ) -> dict:
+        url = f"{self._access_url}/api/v2{path}"
+        headers = {
+            "Coder-Session-Token": token or self._admin_token,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+        response = self._session.request(
+            method, url, headers=headers, json=json, timeout=self._timeout
+        )
+        status = getattr(response, "status_code", 0)
+        if status >= 400:
+            self._raise_for_status(status, _safe_text(response))
+        if not getattr(response, "content", b""):
+            return {}
+        return response.json()
+
+    @staticmethod
+    def _raise_for_status(status: int, detail: str) -> None:
+        if status in (401, 403):
+            raise AccessDeniedError(detail or "access denied", status=status)
+        if status == 409:
+            raise WorkspaceNameConflictError(
+                detail or "name conflict", status=status
+            )
+        raise CodingEnvironmentError(
+            f"Coder API request failed ({status}): {detail}", status=status
+        )
+
+    def _organization_id(self) -> str:
+        if self._org_id is None:
+            org = self._request("GET", f"/organizations/{self._organization}")
+            self._org_id = org["id"]
+        return self._org_id
+
+    # -- Port implementation ------------------------------------------------
+
+    def ensure_user(self, *, external_id: str, email: str, username: str) -> str:
+        try:
+            user = self._request("GET", f"/users/{username}")
+            return user["id"]
+        except CodingEnvironmentError as exc:
+            if exc.status != 404:
+                raise
+        created = self._request(
+            "POST",
+            "/users",
+            json={
+                "email": email,
+                "username": username,
+                # login_type=none: user has no native login; only the backend's
+                # admin-minted tokens can act as them. (Deprecated upstream in
+                # favour of Premium service accounts — see assessment §5.)
+                "login_type": "none",
+                "organization_ids": [self._organization_id()],
+            },
+        )
+        return created["id"]
+
+    def list_templates(self) -> list[WorkspaceTemplate]:
+        org = self._organization_id()
+        templates = self._request("GET", f"/organizations/{org}/templates")
+        items = templates if isinstance(templates, list) else templates.get("templates", [])
+        return [
+            WorkspaceTemplate(
+                id=t["id"],
+                name=t.get("name", ""),
+                active_version_id=t.get("active_version_id", ""),
+            )
+            for t in items
+        ]
+
+    def provision(
+        self,
+        *,
+        user_id: str,
+        template_id: str,
+        name: str,
+        params: dict[str, str] | None = None,
+    ) -> WorkspaceStatus:
+        org = self._organization_id()
+        body: dict[str, Any] = {
+            "template_id": template_id,
+            "name": name,
+            "automatic_updates": "never",
+        }
+        if self._workspace_autostop_ms:
+            body["ttl_ms"] = self._workspace_autostop_ms
+        if params:
+            body["rich_parameter_values"] = [
+                {"name": k, "value": v} for k, v in params.items()
+            ]
+        workspace = self._request(
+            "POST",
+            f"/organizations/{org}/members/{user_id}/workspaces",
+            json=body,
+        )
+        return self._to_status(workspace)
+
+    def start(self, *, workspace_id: str) -> WorkspaceStatus:
+        self._build(workspace_id, "start")
+        return self.get_status(workspace_id=workspace_id)
+
+    def stop(self, *, workspace_id: str) -> WorkspaceStatus:
+        self._build(workspace_id, "stop")
+        return self.get_status(workspace_id=workspace_id)
+
+    def delete(self, *, workspace_id: str) -> None:
+        self._build(workspace_id, "delete")
+
+    def _build(self, workspace_id: str, transition: str) -> dict:
+        return self._request(
+            "POST",
+            f"/workspaces/{workspace_id}/builds",
+            json={"transition": transition},
+        )
+
+    def get_status(self, *, workspace_id: str) -> WorkspaceStatus:
+        workspace = self._request("GET", f"/workspaces/{workspace_id}")
+        return self._to_status(workspace)
+
+    def get_access(
+        self, *, workspace_id: str, user_id: str, app_slug: str
+    ) -> WorkspaceAccess:
+        token = self._mint_token(user_id=user_id, workspace_id=workspace_id)
+        workspace = self._request("GET", f"/workspaces/{workspace_id}")
+        owner = workspace.get("owner_name") or user_id
+        name = workspace.get("name", "")
+        agent = self._first_agent_name(workspace) or "main"
+        host = self._app_host()
+        base_url = self.build_app_url(
+            slug=app_slug,
+            agent=agent,
+            workspace=name,
+            owner=owner,
+            wildcard_host=host,
+        )
+        # The token seeds a first-party app-proxy cookie via the redemption
+        # query param; it is NOT a header the iframe could send. (§5a)
+        url = f"{base_url}?coder_session_token={token}"
+        return WorkspaceAccess(url=url, token=token, expires_at=None)
+
+    # -- helpers ------------------------------------------------------------
+
+    def _mint_token(self, *, user_id: str, workspace_id: str) -> str:
+        # Go time.Duration serializes to integer nanoseconds.
+        lifetime_ns = self._token_lifetime_seconds * 1_000_000_000
+        # Preferred: a token scoped to opening apps. The exact scope/allow_list
+        # schema is Coder-version-dependent (verified against v2.34.1: the field
+        # is singular `scope`, and the `[{type,id}]` allow_list shape is
+        # rejected), so fall back to a basic token if the scoped form is refused.
+        scoped_body = {
+            "token_name": f"abi-{workspace_id}",
+            "lifetime": lifetime_ns,
+            "scope": "application_connect",
+        }
+        minimal_body = {
+            "token_name": f"abi-{workspace_id}",
+            "lifetime": lifetime_ns,
+        }
+        for body in (scoped_body, minimal_body):
+            try:
+                result = self._request(
+                    "POST", f"/users/{user_id}/keys/tokens", json=body
+                )
+                return result["key"]
+            except CodingEnvironmentError as exc:
+                if exc.status == 400 and body is scoped_body:
+                    continue  # scoped form not accepted; retry with a basic token
+                raise
+        raise CodingEnvironmentError("failed to mint token")
+
+    def _app_host(self) -> str:
+        host = self._request("GET", "/applications/host")
+        # API returns {"host": "*.coder.example.com"}; fall back to config.
+        return host.get("host") or self._wildcard_access_url
+
+    @staticmethod
+    def _first_agent_name(workspace: dict) -> str | None:
+        for resource in (
+            workspace.get("latest_build", {}).get("resources", []) or []
+        ):
+            for agent in resource.get("agents", []) or []:
+                if agent.get("name"):
+                    return agent["name"]
+        return None
+
+    @staticmethod
+    def build_app_url(
+        *, slug: str, agent: str, workspace: str, owner: str, wildcard_host: str
+    ) -> str:
+        """Assemble the subdomain app URL (§4c).
+
+        ``wildcard_host`` is the ``*.coder.example.com`` form returned by
+        ``GET /applications/host``.
+        """
+        base = wildcard_host.lstrip("*.")
+        subdomain = f"{slug}--{agent}--{workspace}--{owner}".lower()
+        return f"https://{subdomain}.{base}/"
+
+    @classmethod
+    def _to_status(cls, workspace: dict) -> WorkspaceStatus:
+        phase = cls._normalize_phase(workspace)
+        return WorkspaceStatus(
+            id=workspace.get("id", ""),
+            name=workspace.get("name", ""),
+            phase=phase,
+            agent_ready=(phase == PHASE_RUNNING and cls._agent_connected(workspace)),
+        )
+
+    @staticmethod
+    def _normalize_phase(workspace: dict) -> str:
+        build = workspace.get("latest_build", {}) or {}
+        job_status = (build.get("job", {}) or {}).get("status")
+        ws_status = build.get("status")
+        if job_status in _ERROR or ws_status in _ERROR:
+            return PHASE_ERROR
+        if ws_status in _RUNNING:
+            return PHASE_RUNNING
+        if ws_status in _STOPPED:
+            return PHASE_STOPPED
+        return PHASE_PROVISIONING
+
+    @staticmethod
+    def _agent_connected(workspace: dict) -> bool:
+        for resource in (
+            workspace.get("latest_build", {}).get("resources", []) or []
+        ):
+            for agent in resource.get("agents", []) or []:
+                if agent.get("status") == "connected":
+                    return True
+        return False
+
+
+def _default_session() -> Any:
+    import requests
+
+    return requests.Session()
+
+
+def _safe_text(response: Any) -> str:
+    text = getattr(response, "text", "") or ""
+    return text.strip()

--- a/libs/naas-abi-core/naas_abi_core/services/coding_environment/adapters/secondary/CoderAdapter_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/coding_environment/adapters/secondary/CoderAdapter_test.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from naas_abi_core.services.coding_environment.adapters.secondary.CoderAdapter import (
+    CoderAdapter,
+)
+from naas_abi_core.services.coding_environment.CodingEnvironmentPorts import (
+    AccessDeniedError,
+    PHASE_RUNNING,
+    WorkspaceNameConflictError,
+)
+from naas_abi_core.services.coding_environment.tests.coding_environment__secondary_adapter__generic_test import (
+    GenericCodingEnvironmentSecondaryAdapterTest,
+)
+
+
+class FakeResponse:
+    def __init__(self, status_code: int = 200, payload: Any = None, text: str = ""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+        self.content = b"{}" if payload is not None else b""
+
+    def json(self) -> Any:
+        return self._payload
+
+
+class FakeSession:
+    """Routes (method, url-substring) -> FakeResponse; records all calls."""
+
+    def __init__(self, routes: list[tuple[str, str, FakeResponse]]):
+        self.routes = list(routes)
+        self.calls: list[dict] = []
+
+    def request(self, method, url, headers=None, json=None, timeout=None):
+        self.calls.append(
+            {"method": method, "url": url, "headers": headers, "json": json}
+        )
+        for m, substring, response in self.routes:
+            if m == method and substring in url:
+                return response
+        return FakeResponse(404, {"message": "not found"}, "not found")
+
+    def find(self, method: str, substring: str) -> dict | None:
+        for call in self.calls:
+            if call["method"] == method and substring in call["url"]:
+                return call
+        return None
+
+
+def _adapter(session: FakeSession) -> CoderAdapter:
+    return CoderAdapter(
+        access_url="https://coder.example.com",
+        wildcard_access_url="*.coder.example.com",
+        admin_token="admin-token",
+        session=session,
+    )
+
+
+_RUNNING_WORKSPACE = {
+    "id": "ws-1",
+    "name": "dev",
+    "owner_name": "alice",
+    "latest_build": {
+        "status": "running",
+        "job": {"status": "succeeded"},
+        "resources": [{"agents": [{"name": "main", "status": "connected"}]}],
+    },
+}
+
+
+class TestCoderAdapter(GenericCodingEnvironmentSecondaryAdapterTest):
+    @pytest.fixture
+    def adapter_class(self):
+        return CoderAdapter
+
+
+def test_provision_posts_expected_body_and_normalizes_status() -> None:
+    session = FakeSession(
+        [
+            ("GET", "/organizations/default", FakeResponse(200, {"id": "org-1"})),
+            (
+                "POST",
+                "/members/user-1/workspaces",
+                FakeResponse(201, _RUNNING_WORKSPACE),
+            ),
+        ]
+    )
+    adapter = _adapter(session)
+
+    status = adapter.provision(
+        user_id="user-1", template_id="tmpl-1", name="dev", params={"size": "L"}
+    )
+
+    assert status.id == "ws-1"
+    assert status.phase == PHASE_RUNNING
+    assert status.agent_ready is True
+
+    call = session.find("POST", "/workspaces")
+    assert call is not None
+    body = call["json"]
+    assert body["template_id"] == "tmpl-1"
+    assert body["name"] == "dev"
+    assert body["automatic_updates"] == "never"
+    assert body["ttl_ms"] == 3_600_000
+    assert body["rich_parameter_values"] == [{"name": "size", "value": "L"}]
+    # admin token must be used on the control-plane call
+    assert call["headers"]["Coder-Session-Token"] == "admin-token"
+
+
+def test_name_conflict_maps_to_typed_error() -> None:
+    session = FakeSession(
+        [
+            ("GET", "/organizations/default", FakeResponse(200, {"id": "org-1"})),
+            (
+                "POST",
+                "/members/user-1/workspaces",
+                FakeResponse(409, {"message": "exists"}, "exists"),
+            ),
+        ]
+    )
+    adapter = _adapter(session)
+    with pytest.raises(WorkspaceNameConflictError):
+        adapter.provision(user_id="user-1", template_id="t", name="dev")
+
+
+def test_access_denied_maps_to_typed_error() -> None:
+    session = FakeSession(
+        [("GET", "/organizations/default", FakeResponse(403, {}, "forbidden"))]
+    )
+    adapter = _adapter(session)
+    with pytest.raises(AccessDeniedError):
+        adapter.list_templates()
+
+
+def test_ensure_user_creates_when_missing() -> None:
+    session = FakeSession(
+        [
+            ("GET", "/users/alice", FakeResponse(404, {"message": "nf"}, "nf")),
+            ("GET", "/organizations/default", FakeResponse(200, {"id": "org-1"})),
+            ("POST", "/users", FakeResponse(201, {"id": "user-9"})),
+        ]
+    )
+    adapter = _adapter(session)
+
+    user_id = adapter.ensure_user(
+        external_id="ext", email="alice@example.com", username="alice"
+    )
+    assert user_id == "user-9"
+
+    call = session.find("POST", "/users")
+    assert call is not None
+    assert call["json"]["login_type"] == "none"
+    assert call["json"]["organization_ids"] == ["org-1"]
+
+
+def test_ensure_user_returns_existing() -> None:
+    session = FakeSession(
+        [("GET", "/users/alice", FakeResponse(200, {"id": "user-1"}))]
+    )
+    adapter = _adapter(session)
+    assert (
+        adapter.ensure_user(external_id="x", email="a@b.c", username="alice")
+        == "user-1"
+    )
+
+
+def test_get_access_builds_redemption_url() -> None:
+    session = FakeSession(
+        [
+            (
+                "POST",
+                "/users/user-1/keys/tokens",
+                FakeResponse(201, {"key": "tok-abc"}),
+            ),
+            ("GET", "/workspaces/ws-1", FakeResponse(200, _RUNNING_WORKSPACE)),
+            (
+                "GET",
+                "/applications/host",
+                FakeResponse(200, {"host": "*.coder.example.com"}),
+            ),
+        ]
+    )
+    adapter = _adapter(session)
+
+    access = adapter.get_access(
+        workspace_id="ws-1", user_id="user-1", app_slug="code-server"
+    )
+
+    assert access.token == "tok-abc"
+    assert access.url == (
+        "https://code-server--main--dev--alice.coder.example.com/"
+        "?coder_session_token=tok-abc"
+    )
+    # token minting requests the application_connect scope, lifetime in ns
+    mint = session.find("POST", "/keys/tokens")
+    assert mint is not None
+    assert mint["json"]["scope"] == "application_connect"
+    assert mint["json"]["lifetime"] == 3600 * 1_000_000_000
+
+
+def test_build_app_url_lowercases_and_uses_delimiters() -> None:
+    url = CoderAdapter.build_app_url(
+        slug="code-server",
+        agent="main",
+        workspace="Dev",
+        owner="Alice",
+        wildcard_host="*.coder.example.com",
+    )
+    assert url == "https://code-server--main--dev--alice.coder.example.com/"

--- a/libs/naas-abi-core/naas_abi_core/services/coding_environment/adapters/secondary/InMemoryAdapter.py
+++ b/libs/naas-abi-core/naas_abi_core/services/coding_environment/adapters/secondary/InMemoryAdapter.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from naas_abi_core.services.coding_environment.CodingEnvironmentPorts import (
+    ICodingEnvironmentAdapter,
+    PHASE_PROVISIONING,
+    PHASE_RUNNING,
+    PHASE_STOPPED,
+    WorkspaceAccess,
+    WorkspaceNameConflictError,
+    WorkspaceNotFoundError,
+    WorkspaceStatus,
+    WorkspaceTemplate,
+)
+
+
+class InMemoryAdapter(ICodingEnvironmentAdapter):
+    """In-process fake orchestrator.
+
+    Fully functional for unit-testing the domain and for driving the
+    prototype frontend without a live Coder. ``polls_until_ready`` simulates
+    a workspace that takes a few ``get_status`` polls to become ready, so the
+    domain's ``wait_until_ready`` state machine can be exercised.
+    """
+
+    def __init__(self, *, polls_until_ready: int = 0) -> None:
+        self._users: dict[str, str] = {}  # username -> user id
+        self._workspaces: dict[str, dict] = {}  # workspace id -> record
+        self._counter = 0
+        self._polls_until_ready = polls_until_ready
+
+    def _next_id(self, prefix: str) -> str:
+        self._counter += 1
+        return f"{prefix}-{self._counter}"
+
+    def ensure_user(self, *, external_id: str, email: str, username: str) -> str:
+        if username not in self._users:
+            self._users[username] = self._next_id("user")
+        return self._users[username]
+
+    def list_templates(self) -> list[WorkspaceTemplate]:
+        return [
+            WorkspaceTemplate(
+                id="tmpl-default", name="default", active_version_id="ver-1"
+            )
+        ]
+
+    def provision(
+        self,
+        *,
+        user_id: str,
+        template_id: str,
+        name: str,
+        params: dict[str, str] | None = None,
+    ) -> WorkspaceStatus:
+        for record in self._workspaces.values():
+            if record["user_id"] == user_id and record["name"] == name:
+                raise WorkspaceNameConflictError(
+                    f"workspace '{name}' already exists for user {user_id}"
+                )
+        workspace_id = self._next_id("ws")
+        ready = self._polls_until_ready <= 0
+        self._workspaces[workspace_id] = {
+            "name": name,
+            "user_id": user_id,
+            "template_id": template_id,
+            "phase": PHASE_RUNNING if ready else PHASE_PROVISIONING,
+            "agent_ready": ready,
+            "polls_left": self._polls_until_ready,
+        }
+        return self._status(workspace_id)
+
+    def _record(self, workspace_id: str) -> dict:
+        if workspace_id not in self._workspaces:
+            raise WorkspaceNotFoundError(workspace_id)
+        return self._workspaces[workspace_id]
+
+    def _status(self, workspace_id: str) -> WorkspaceStatus:
+        record = self._record(workspace_id)
+        return WorkspaceStatus(
+            id=workspace_id,
+            name=record["name"],
+            phase=record["phase"],
+            agent_ready=record["agent_ready"],
+        )
+
+    def get_status(self, *, workspace_id: str) -> WorkspaceStatus:
+        record = self._record(workspace_id)
+        if record["phase"] == PHASE_PROVISIONING:
+            if record["polls_left"] > 0:
+                record["polls_left"] -= 1
+            if record["polls_left"] <= 0:
+                record["phase"] = PHASE_RUNNING
+                record["agent_ready"] = True
+        return self._status(workspace_id)
+
+    def start(self, *, workspace_id: str) -> WorkspaceStatus:
+        record = self._record(workspace_id)
+        record["phase"] = PHASE_RUNNING
+        record["agent_ready"] = True
+        return self._status(workspace_id)
+
+    def stop(self, *, workspace_id: str) -> WorkspaceStatus:
+        record = self._record(workspace_id)
+        record["phase"] = PHASE_STOPPED
+        record["agent_ready"] = False
+        return self._status(workspace_id)
+
+    def delete(self, *, workspace_id: str) -> None:
+        self._record(workspace_id)
+        self._workspaces.pop(workspace_id, None)
+
+    def get_access(
+        self, *, workspace_id: str, user_id: str, app_slug: str
+    ) -> WorkspaceAccess:
+        record = self._record(workspace_id)
+        token = self._next_id("token")
+        url = (
+            f"https://{app_slug}--main--{record['name']}--{user_id}"
+            f".coder.local/?coder_session_token={token}"
+        )
+        return WorkspaceAccess(url=url, token=token, expires_at=None)

--- a/libs/naas-abi-core/naas_abi_core/services/coding_environment/adapters/secondary/InMemoryAdapter_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/coding_environment/adapters/secondary/InMemoryAdapter_test.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import pytest
+
+from naas_abi_core.services.coding_environment.adapters.secondary.InMemoryAdapter import (
+    InMemoryAdapter,
+)
+from naas_abi_core.services.coding_environment.CodingEnvironmentPorts import (
+    PHASE_RUNNING,
+    PHASE_STOPPED,
+    WorkspaceNameConflictError,
+    WorkspaceNotFoundError,
+)
+from naas_abi_core.services.coding_environment.tests.coding_environment__secondary_adapter__generic_test import (
+    GenericCodingEnvironmentSecondaryAdapterTest,
+)
+
+
+class TestInMemoryAdapter(GenericCodingEnvironmentSecondaryAdapterTest):
+    @pytest.fixture
+    def adapter_class(self):
+        return InMemoryAdapter
+
+
+def test_ensure_user_is_idempotent() -> None:
+    adapter = InMemoryAdapter()
+    a = adapter.ensure_user(external_id="x", email="a@b.c", username="alice")
+    b = adapter.ensure_user(external_id="x", email="a@b.c", username="alice")
+    assert a == b
+
+
+def test_full_lifecycle() -> None:
+    adapter = InMemoryAdapter()
+    user_id = adapter.ensure_user(external_id="x", email="a@b.c", username="alice")
+
+    status = adapter.provision(user_id=user_id, template_id="tmpl-default", name="dev")
+    assert status.phase == PHASE_RUNNING
+    assert status.agent_ready is True
+
+    stopped = adapter.stop(workspace_id=status.id)
+    assert stopped.phase == PHASE_STOPPED
+    assert stopped.agent_ready is False
+
+    started = adapter.start(workspace_id=status.id)
+    assert started.phase == PHASE_RUNNING
+
+    adapter.delete(workspace_id=status.id)
+    with pytest.raises(WorkspaceNotFoundError):
+        adapter.get_status(workspace_id=status.id)
+
+
+def test_duplicate_name_raises_conflict() -> None:
+    adapter = InMemoryAdapter()
+    user_id = adapter.ensure_user(external_id="x", email="a@b.c", username="alice")
+    adapter.provision(user_id=user_id, template_id="t", name="dev")
+    with pytest.raises(WorkspaceNameConflictError):
+        adapter.provision(user_id=user_id, template_id="t", name="dev")
+
+
+def test_provision_becomes_ready_after_polls() -> None:
+    adapter = InMemoryAdapter(polls_until_ready=2)
+    user_id = adapter.ensure_user(external_id="x", email="a@b.c", username="alice")
+    status = adapter.provision(user_id=user_id, template_id="t", name="dev")
+    assert status.agent_ready is False
+
+    adapter.get_status(workspace_id=status.id)  # poll 1
+    second = adapter.get_status(workspace_id=status.id)  # poll 2 -> ready
+    assert second.phase == PHASE_RUNNING
+    assert second.agent_ready is True
+
+
+def test_get_access_returns_embeddable_url_with_token() -> None:
+    adapter = InMemoryAdapter()
+    user_id = adapter.ensure_user(external_id="x", email="a@b.c", username="alice")
+    status = adapter.provision(user_id=user_id, template_id="t", name="dev")
+
+    access = adapter.get_access(
+        workspace_id=status.id, user_id=user_id, app_slug="code-server"
+    )
+    assert access.token is not None
+    assert access.token in access.url
+    assert access.url.startswith("https://code-server--main--dev--")

--- a/libs/naas-abi-core/naas_abi_core/services/coding_environment/ontologies/classes/ontology_naas_ai/abi/coding_environment/WorkspaceAccessGranted.py
+++ b/libs/naas-abi-core/naas_abi_core/services/coding_environment/ontologies/classes/ontology_naas_ai/abi/coding_environment/WorkspaceAccessGranted.py
@@ -1,0 +1,11 @@
+from naas_abi_core.services.coding_environment.ontologies.modules.CodingEnvironmentEventOntology import (
+    WorkspaceAccessGranted as _WorkspaceAccessGranted,
+)
+
+
+class WorkspaceAccessGranted(_WorkspaceAccessGranted):
+    """Action class for WorkspaceAccessGranted"""
+
+    def actions(self):
+        """Action method - implement your logic here"""
+        pass

--- a/libs/naas-abi-core/naas_abi_core/services/coding_environment/ontologies/classes/ontology_naas_ai/abi/coding_environment/WorkspaceDeleted.py
+++ b/libs/naas-abi-core/naas_abi_core/services/coding_environment/ontologies/classes/ontology_naas_ai/abi/coding_environment/WorkspaceDeleted.py
@@ -1,0 +1,11 @@
+from naas_abi_core.services.coding_environment.ontologies.modules.CodingEnvironmentEventOntology import (
+    WorkspaceDeleted as _WorkspaceDeleted,
+)
+
+
+class WorkspaceDeleted(_WorkspaceDeleted):
+    """Action class for WorkspaceDeleted"""
+
+    def actions(self):
+        """Action method - implement your logic here"""
+        pass

--- a/libs/naas-abi-core/naas_abi_core/services/coding_environment/ontologies/classes/ontology_naas_ai/abi/coding_environment/WorkspaceProvisionFailed.py
+++ b/libs/naas-abi-core/naas_abi_core/services/coding_environment/ontologies/classes/ontology_naas_ai/abi/coding_environment/WorkspaceProvisionFailed.py
@@ -1,0 +1,11 @@
+from naas_abi_core.services.coding_environment.ontologies.modules.CodingEnvironmentEventOntology import (
+    WorkspaceProvisionFailed as _WorkspaceProvisionFailed,
+)
+
+
+class WorkspaceProvisionFailed(_WorkspaceProvisionFailed):
+    """Action class for WorkspaceProvisionFailed"""
+
+    def actions(self):
+        """Action method - implement your logic here"""
+        pass

--- a/libs/naas-abi-core/naas_abi_core/services/coding_environment/ontologies/classes/ontology_naas_ai/abi/coding_environment/WorkspaceProvisioned.py
+++ b/libs/naas-abi-core/naas_abi_core/services/coding_environment/ontologies/classes/ontology_naas_ai/abi/coding_environment/WorkspaceProvisioned.py
@@ -1,0 +1,11 @@
+from naas_abi_core.services.coding_environment.ontologies.modules.CodingEnvironmentEventOntology import (
+    WorkspaceProvisioned as _WorkspaceProvisioned,
+)
+
+
+class WorkspaceProvisioned(_WorkspaceProvisioned):
+    """Action class for WorkspaceProvisioned"""
+
+    def actions(self):
+        """Action method - implement your logic here"""
+        pass

--- a/libs/naas-abi-core/naas_abi_core/services/coding_environment/ontologies/classes/ontology_naas_ai/abi/coding_environment/WorkspaceStarted.py
+++ b/libs/naas-abi-core/naas_abi_core/services/coding_environment/ontologies/classes/ontology_naas_ai/abi/coding_environment/WorkspaceStarted.py
@@ -1,0 +1,11 @@
+from naas_abi_core.services.coding_environment.ontologies.modules.CodingEnvironmentEventOntology import (
+    WorkspaceStarted as _WorkspaceStarted,
+)
+
+
+class WorkspaceStarted(_WorkspaceStarted):
+    """Action class for WorkspaceStarted"""
+
+    def actions(self):
+        """Action method - implement your logic here"""
+        pass

--- a/libs/naas-abi-core/naas_abi_core/services/coding_environment/ontologies/classes/ontology_naas_ai/abi/coding_environment/WorkspaceStopped.py
+++ b/libs/naas-abi-core/naas_abi_core/services/coding_environment/ontologies/classes/ontology_naas_ai/abi/coding_environment/WorkspaceStopped.py
@@ -1,0 +1,11 @@
+from naas_abi_core.services.coding_environment.ontologies.modules.CodingEnvironmentEventOntology import (
+    WorkspaceStopped as _WorkspaceStopped,
+)
+
+
+class WorkspaceStopped(_WorkspaceStopped):
+    """Action class for WorkspaceStopped"""
+
+    def actions(self):
+        """Action method - implement your logic here"""
+        pass

--- a/libs/naas-abi-core/naas_abi_core/services/coding_environment/ontologies/modules/CodingEnvironmentEventOntology.py
+++ b/libs/naas-abi-core/naas_abi_core/services/coding_environment/ontologies/modules/CodingEnvironmentEventOntology.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import datetime
+from typing import Annotated, Any, ClassVar, Optional
+
+from pydantic import Field
+
+from naas_abi_core.services.event.ontologies.modules.EventOntology import (
+    LogProcess,
+    RDFEntity,
+)
+
+_NS = "http://ontology.naas.ai/abi/coding_environment/"
+
+
+def _common_uris(extra: dict[str, str]) -> dict[str, str]:
+    base = {
+        "created": "http://purl.org/dc/terms/created",
+        "created_at": "http://ontology.naas.ai/abi/createdAt",
+        "creator": "http://purl.org/dc/terms/creator",
+        "label": "http://www.w3.org/2000/01/rdf-schema#label",
+    }
+    base.update(extra)
+    return base
+
+
+class _CodingEnvironmentEvent(LogProcess, RDFEntity):
+    """Shared data properties for all coding-environment events."""
+
+    created_at: Optional[
+        Annotated[
+            datetime.datetime,
+            Field(
+                description="ISO 8601 timestamp at which the event occurred. "
+                "Populated by EventService.publish() if not set by the caller."
+            ),
+        ]
+    ] = None
+    label: Optional[Annotated[str, Field(description="Label of the resource.")]] = None
+    created: Optional[
+        Annotated[
+            datetime.datetime,
+            Field(description="Date of creation of the resource."),
+        ]
+    ] = None
+    creator: Optional[
+        Annotated[
+            Any,
+            Field(description="An entity responsible for making the resource."),
+        ]
+    ] = None
+
+
+class WorkspaceProvisioned(_CodingEnvironmentEvent):
+    """A workspace was created from a template."""
+
+    _class_uri: ClassVar[str] = f"{_NS}WorkspaceProvisioned"
+    _name: ClassVar[str] = "WorkspaceProvisioned"
+    _property_uris: ClassVar[dict] = _common_uris(
+        {
+            "user": f"{_NS}user",
+            "workspace_id": f"{_NS}workspaceId",
+            "workspace_name": f"{_NS}workspaceName",
+            "template_id": f"{_NS}templateId",
+            "phase": f"{_NS}phase",
+        }
+    )
+    _object_properties: ClassVar[set[str]] = set()
+
+    user: Optional[Annotated[str, Field(description="Owner user id.")]] = None
+    workspace_id: Optional[
+        Annotated[str, Field(description="Provisioned workspace id.")]
+    ] = None
+    workspace_name: Optional[
+        Annotated[str, Field(description="Workspace name.")]
+    ] = None
+    template_id: Optional[
+        Annotated[str, Field(description="Template the workspace was created from.")]
+    ] = None
+    phase: Optional[
+        Annotated[str, Field(description="Normalized lifecycle phase.")]
+    ] = None
+
+
+class WorkspaceStarted(_CodingEnvironmentEvent):
+    """A workspace build with transition=start was issued."""
+
+    _class_uri: ClassVar[str] = f"{_NS}WorkspaceStarted"
+    _name: ClassVar[str] = "WorkspaceStarted"
+    _property_uris: ClassVar[dict] = _common_uris(
+        {"workspace_id": f"{_NS}workspaceId", "phase": f"{_NS}phase"}
+    )
+    _object_properties: ClassVar[set[str]] = set()
+
+    workspace_id: Optional[
+        Annotated[str, Field(description="Workspace id.")]
+    ] = None
+    phase: Optional[
+        Annotated[str, Field(description="Normalized lifecycle phase.")]
+    ] = None
+
+
+class WorkspaceStopped(_CodingEnvironmentEvent):
+    """A workspace build with transition=stop was issued."""
+
+    _class_uri: ClassVar[str] = f"{_NS}WorkspaceStopped"
+    _name: ClassVar[str] = "WorkspaceStopped"
+    _property_uris: ClassVar[dict] = _common_uris(
+        {"workspace_id": f"{_NS}workspaceId", "phase": f"{_NS}phase"}
+    )
+    _object_properties: ClassVar[set[str]] = set()
+
+    workspace_id: Optional[
+        Annotated[str, Field(description="Workspace id.")]
+    ] = None
+    phase: Optional[
+        Annotated[str, Field(description="Normalized lifecycle phase.")]
+    ] = None
+
+
+class WorkspaceDeleted(_CodingEnvironmentEvent):
+    """A workspace build with transition=delete was issued."""
+
+    _class_uri: ClassVar[str] = f"{_NS}WorkspaceDeleted"
+    _name: ClassVar[str] = "WorkspaceDeleted"
+    _property_uris: ClassVar[dict] = _common_uris(
+        {"workspace_id": f"{_NS}workspaceId"}
+    )
+    _object_properties: ClassVar[set[str]] = set()
+
+    workspace_id: Optional[
+        Annotated[str, Field(description="Workspace id.")]
+    ] = None
+
+
+class WorkspaceAccessGranted(_CodingEnvironmentEvent):
+    """A scoped per-user token + embeddable app URL was minted."""
+
+    _class_uri: ClassVar[str] = f"{_NS}WorkspaceAccessGranted"
+    _name: ClassVar[str] = "WorkspaceAccessGranted"
+    _property_uris: ClassVar[dict] = _common_uris(
+        {
+            "user": f"{_NS}user",
+            "workspace_id": f"{_NS}workspaceId",
+            "app_slug": f"{_NS}appSlug",
+            "token_expires_at": f"{_NS}tokenExpiresAt",
+        }
+    )
+    _object_properties: ClassVar[set[str]] = set()
+
+    user: Optional[Annotated[str, Field(description="User access was granted to.")]] = None
+    workspace_id: Optional[
+        Annotated[str, Field(description="Workspace id.")]
+    ] = None
+    app_slug: Optional[
+        Annotated[str, Field(description="App slug the access targets.")]
+    ] = None
+    token_expires_at: Optional[
+        Annotated[str, Field(description="Token expiry, if known.")]
+    ] = None
+
+
+class WorkspaceProvisionFailed(_CodingEnvironmentEvent):
+    """A provision attempt failed."""
+
+    _class_uri: ClassVar[str] = f"{_NS}WorkspaceProvisionFailed"
+    _name: ClassVar[str] = "WorkspaceProvisionFailed"
+    _property_uris: ClassVar[dict] = _common_uris(
+        {
+            "user": f"{_NS}user",
+            "workspace_id": f"{_NS}workspaceId",
+            "message": f"{_NS}message",
+        }
+    )
+    _object_properties: ClassVar[set[str]] = set()
+
+    user: Optional[Annotated[str, Field(description="Owner user id.")]] = None
+    workspace_id: Optional[
+        Annotated[
+            str,
+            Field(
+                description="Workspace id if known, else the requested workspace name."
+            ),
+        ]
+    ] = None
+    message: Optional[
+        Annotated[str, Field(description="String representation of the error.")]
+    ] = None
+
+
+# Rebuild models to resolve forward references
+WorkspaceProvisioned.model_rebuild()
+WorkspaceStarted.model_rebuild()
+WorkspaceStopped.model_rebuild()
+WorkspaceDeleted.model_rebuild()
+WorkspaceAccessGranted.model_rebuild()
+WorkspaceProvisionFailed.model_rebuild()

--- a/libs/naas-abi-core/naas_abi_core/services/coding_environment/ontologies/modules/CodingEnvironmentEventOntology.ttl
+++ b/libs/naas-abi-core/naas_abi_core/services/coding_environment/ontologies/modules/CodingEnvironmentEventOntology.ttl
@@ -1,0 +1,52 @@
+@prefix abi: <http://ontology.naas.ai/abi/> .
+@prefix ce: <http://ontology.naas.ai/abi/coding_environment/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+#################################################################
+#    Coding Environment event classes (subclasses of abi:LogProcess)
+#################################################################
+
+ce:WorkspaceProvisioned a owl:Class ;
+    rdfs:subClassOf abi:LogProcess ;
+    rdfs:label "Workspace Provisioned"@en ;
+    rdfs:comment "A coding-environment workspace was created from a template."@en .
+
+ce:WorkspaceStarted a owl:Class ;
+    rdfs:subClassOf abi:LogProcess ;
+    rdfs:label "Workspace Started"@en ;
+    rdfs:comment "A workspace build with transition=start was issued."@en .
+
+ce:WorkspaceStopped a owl:Class ;
+    rdfs:subClassOf abi:LogProcess ;
+    rdfs:label "Workspace Stopped"@en ;
+    rdfs:comment "A workspace build with transition=stop was issued."@en .
+
+ce:WorkspaceDeleted a owl:Class ;
+    rdfs:subClassOf abi:LogProcess ;
+    rdfs:label "Workspace Deleted"@en ;
+    rdfs:comment "A workspace build with transition=delete was issued."@en .
+
+ce:WorkspaceAccessGranted a owl:Class ;
+    rdfs:subClassOf abi:LogProcess ;
+    rdfs:label "Workspace Access Granted"@en ;
+    rdfs:comment "A scoped per-user token and embeddable app URL were minted."@en .
+
+ce:WorkspaceProvisionFailed a owl:Class ;
+    rdfs:subClassOf abi:LogProcess ;
+    rdfs:label "Workspace Provision Failed"@en ;
+    rdfs:comment "A provision attempt failed."@en .
+
+#################################################################
+#    Data properties
+#################################################################
+
+ce:user a owl:DatatypeProperty ; rdfs:range xsd:string ; rdfs:label "user"@en .
+ce:workspaceId a owl:DatatypeProperty ; rdfs:range xsd:string ; rdfs:label "workspace id"@en .
+ce:workspaceName a owl:DatatypeProperty ; rdfs:range xsd:string ; rdfs:label "workspace name"@en .
+ce:templateId a owl:DatatypeProperty ; rdfs:range xsd:string ; rdfs:label "template id"@en .
+ce:phase a owl:DatatypeProperty ; rdfs:range xsd:string ; rdfs:label "phase"@en .
+ce:appSlug a owl:DatatypeProperty ; rdfs:range xsd:string ; rdfs:label "app slug"@en .
+ce:tokenExpiresAt a owl:DatatypeProperty ; rdfs:range xsd:string ; rdfs:label "token expires at"@en .
+ce:message a owl:DatatypeProperty ; rdfs:range xsd:string ; rdfs:label "message"@en .

--- a/libs/naas-abi-core/naas_abi_core/services/coding_environment/tests/CodingEnvironmentService_events_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/coding_environment/tests/CodingEnvironmentService_events_test.py
@@ -1,0 +1,215 @@
+# mypy: disable-error-code="arg-type,misc"
+from __future__ import annotations
+
+import pytest
+
+from naas_abi_core.services.coding_environment.adapters.secondary.InMemoryAdapter import (
+    InMemoryAdapter,
+)
+from naas_abi_core.services.coding_environment.CodingEnvironmentPorts import (
+    ICodingEnvironmentAdapter,
+    PHASE_PROVISIONING,
+    PHASE_RUNNING,
+    ProvisionTimeoutError,
+    WorkspaceAccess,
+    WorkspaceStatus,
+)
+from naas_abi_core.services.coding_environment.CodingEnvironmentService import (
+    CodingEnvironmentService,
+)
+from naas_abi_core.services.coding_environment.ontologies.modules.CodingEnvironmentEventOntology import (
+    WorkspaceAccessGranted,
+    WorkspaceDeleted,
+    WorkspaceProvisioned,
+    WorkspaceProvisionFailed,
+    WorkspaceStarted,
+    WorkspaceStopped,
+)
+
+
+class _FakeEventService:
+    def __init__(self) -> None:
+        self.published: list = []
+
+    def publish(self, event) -> None:
+        self.published.append(event)
+
+
+class _ExplodingEventService:
+    def publish(self, event) -> None:
+        raise RuntimeError("event bus down")
+
+
+class _FakeServices:
+    def __init__(self, events=None) -> None:
+        self._events = events
+
+    def events_available(self) -> bool:
+        return self._events is not None
+
+    @property
+    def events(self):
+        assert self._events is not None
+        return self._events
+
+
+class _BrokenAdapter(ICodingEnvironmentAdapter):
+    def ensure_user(self, **kwargs) -> str:
+        return "user-x"
+
+    def list_templates(self):
+        return []
+
+    def provision(self, **kwargs) -> WorkspaceStatus:
+        raise RuntimeError("provision boom")
+
+    def start(self, **kwargs) -> WorkspaceStatus:
+        raise RuntimeError("boom")
+
+    def stop(self, **kwargs) -> WorkspaceStatus:
+        raise RuntimeError("boom")
+
+    def delete(self, **kwargs) -> None:
+        raise RuntimeError("boom")
+
+    def get_status(self, **kwargs) -> WorkspaceStatus:
+        raise RuntimeError("boom")
+
+    def get_access(self, **kwargs) -> WorkspaceAccess:
+        raise RuntimeError("boom")
+
+
+class _Clock:
+    """Deterministic monotonic clock; advances by ``step`` each call."""
+
+    def __init__(self, step: float = 1.0) -> None:
+        self.t = 0.0
+        self.step = step
+
+    def monotonic(self) -> float:
+        value = self.t
+        self.t += self.step
+        return value
+
+
+def _wired_service(adapter, events=None) -> CodingEnvironmentService:
+    svc = CodingEnvironmentService(adapter)
+    svc.set_services(_FakeServices(events))
+    return svc
+
+
+def _provision(svc: CodingEnvironmentService) -> WorkspaceStatus:
+    user_id = svc.ensure_user(
+        external_id="ext-1", email="alice@example.com", username="alice"
+    )
+    return svc.provision(user_id=user_id, template_id="tmpl-default", name="dev")
+
+
+def test_no_events_when_services_not_wired() -> None:
+    svc = CodingEnvironmentService(InMemoryAdapter())
+    status = _provision(svc)
+    assert status.phase == PHASE_RUNNING
+
+
+def test_no_events_when_events_unavailable() -> None:
+    svc = _wired_service(InMemoryAdapter(), events=None)
+    status = _provision(svc)
+    assert status.phase == PHASE_RUNNING
+
+
+def test_provision_emits_workspace_provisioned() -> None:
+    events = _FakeEventService()
+    svc = _wired_service(InMemoryAdapter(), events)
+
+    status = _provision(svc)
+
+    provisioned = [e for e in events.published if isinstance(e, WorkspaceProvisioned)]
+    assert len(provisioned) == 1
+    evt = provisioned[0]
+    assert evt.workspace_id == status.id
+    assert evt.workspace_name == "dev"
+    assert evt.template_id == "tmpl-default"
+    assert evt.phase == PHASE_RUNNING
+
+
+def test_provision_failure_emits_failed_and_reraises() -> None:
+    events = _FakeEventService()
+    svc = _wired_service(_BrokenAdapter(), events)
+
+    with pytest.raises(RuntimeError):
+        svc.provision(user_id="user-x", template_id="tmpl", name="dev")
+
+    failed = [e for e in events.published if isinstance(e, WorkspaceProvisionFailed)]
+    assert len(failed) == 1
+    assert "provision boom" in (failed[0].message or "")
+    assert not any(isinstance(e, WorkspaceProvisioned) for e in events.published)
+
+
+def test_publisher_exception_does_not_break_operation() -> None:
+    svc = _wired_service(InMemoryAdapter(), events=_ExplodingEventService())
+    # Must not raise even though every publish() throws.
+    status = _provision(svc)
+    assert status.phase == PHASE_RUNNING
+
+
+def test_lifecycle_events_emitted() -> None:
+    events = _FakeEventService()
+    svc = _wired_service(InMemoryAdapter(), events)
+    status = _provision(svc)
+
+    svc.start(workspace_id=status.id)
+    svc.stop(workspace_id=status.id)
+    svc.delete(workspace_id=status.id)
+
+    assert any(isinstance(e, WorkspaceStarted) for e in events.published)
+    assert any(isinstance(e, WorkspaceStopped) for e in events.published)
+    assert any(isinstance(e, WorkspaceDeleted) for e in events.published)
+
+
+def test_get_access_emits_access_granted() -> None:
+    events = _FakeEventService()
+    svc = _wired_service(InMemoryAdapter(), events)
+    status = _provision(svc)
+
+    access = svc.get_access(
+        workspace_id=status.id, user_id="user-1", app_slug="code-server"
+    )
+
+    assert "coder_session_token=" in access.url
+    granted = [e for e in events.published if isinstance(e, WorkspaceAccessGranted)]
+    assert len(granted) == 1
+    assert granted[0].app_slug == "code-server"
+
+
+def test_wait_until_ready_returns_when_agent_ready() -> None:
+    # Workspace needs two get_status polls before it reports ready.
+    svc = CodingEnvironmentService(InMemoryAdapter(polls_until_ready=2))
+    status = svc.provision(user_id="user-1", template_id="t", name="dev")
+    assert status.phase == PHASE_PROVISIONING
+
+    clock = _Clock(step=1.0)
+    ready = svc.wait_until_ready(
+        workspace_id=status.id,
+        timeout_seconds=300.0,
+        poll_interval_seconds=0.0,
+        sleep=lambda _s: None,
+        monotonic=clock.monotonic,
+    )
+    assert ready.phase == PHASE_RUNNING
+    assert ready.agent_ready is True
+
+
+def test_wait_until_ready_times_out() -> None:
+    # Never becomes ready within the deadline.
+    svc = CodingEnvironmentService(InMemoryAdapter(polls_until_ready=10_000))
+    status = svc.provision(user_id="user-1", template_id="t", name="dev")
+
+    clock = _Clock(step=1.0)
+    with pytest.raises(ProvisionTimeoutError):
+        svc.wait_until_ready(
+            workspace_id=status.id,
+            timeout_seconds=2.0,
+            poll_interval_seconds=0.0,
+            sleep=lambda _s: None,
+            monotonic=clock.monotonic,
+        )

--- a/libs/naas-abi-core/naas_abi_core/services/coding_environment/tests/coding_environment__secondary_adapter__generic_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/coding_environment/tests/coding_environment__secondary_adapter__generic_test.py
@@ -1,0 +1,27 @@
+from abc import ABC, abstractmethod
+
+import pytest
+
+REQUIRED_METHODS = (
+    "ensure_user",
+    "list_templates",
+    "provision",
+    "start",
+    "stop",
+    "delete",
+    "get_status",
+    "get_access",
+)
+
+
+class GenericCodingEnvironmentSecondaryAdapterTest(ABC):
+    @pytest.fixture
+    @abstractmethod
+    def adapter_class(self):
+        raise NotImplementedError()
+
+    def test_adapter_has_required_methods(self, adapter_class):
+        for method in REQUIRED_METHODS:
+            assert callable(getattr(adapter_class, method, None)), (
+                f"adapter is missing required method: {method}"
+            )


### PR DESCRIPTION
## Phase 0 — in-app coding workspaces (Nexus IDE)

Lands the foundation for shipping a browser IDE inside Nexus (a Foundry-style "Code Workspaces" experience), plus the design RFC. First low-risk increment: the core service + verification prototype + the plan. No product surface yet.

### What's included
- **`coding_environment` core service** (`libs/naas-abi-core/.../services/coding_environment/`) — hexagonal, backend-agnostic:
  - Port `ICodingEnvironmentAdapter`: `ensure_user / list_templates / provision / start / stop / delete / get_status / get_access`, with normalized DTOs + error taxonomy.
  - Adapters: `CoderAdapter` (verified live vs Coder OSS v2.34.1), `CodeServerComposeAdapter`, `InMemoryAdapter`.
  - Domain with fail-safe events + `wait_until_ready`, event ontology, factory; wired into `EngineConfiguration` (default `in_memory`).
- **`coder_prototype/`** — runnable harness (compose + Caddy + Terraform template + scripts) that de-risked the embedding boundary end-to-end (secrets excluded).
- **`RFC-in-app-coding-workspaces.md`** — full design + phased plan.

### Decisions locked (see RFC)
- **Coder** as the per-user environment backbone (spin up / pause / resume; one branch per workspace).
- Agents in-editor via an **OpenAI-compatible shim + Continue** (Open VSX).
- **In-app code review** via self-hosted **Forgejo** (single monorepo, branch-per-workspace, Forgejo authoritative + background GitHub mirror) with a review UI built in Nexus — users never leave the app. Mirrors Palantir Foundry.

### Tests
- 33 `coding_environment` unit tests pass.
- Pre-commit gate green: ruff + mypy (449 files) + NEXUS frontend build.
- Some `engine_configuration` tests fail locally for **pre-existing, unrelated** reasons (macOS `/tmp` opencode path; TripleStore/Secret system deps) — confirmed identical without this change.

### Next phases
- **1:** Coder in docker-compose + Caddy, per-user API routes, Nexus IDE page with embedded editor.
- **2:** OpenAI shim + Continue. **3:** Forgejo + in-app review. **4:** verticals.
