### PR TITLE
feat(email): add Microsoft Outlook email adapter using Graph API

### DIFF
--- a/libs/naas-abi-cli/uv.lock
+++ b/libs/naas-abi-cli/uv.lock
@@ -2384,7 +2384,7 @@ wheels = [
 
 [[package]]
 name = "naas-abi"
-version = "2.34.0"
+version = "2.35.0"
 source = { editable = "../naas-abi" }
 dependencies = [
     { name = "aiosqlite" },
@@ -2499,7 +2499,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-core"
-version = "2.6.0"
+version = "2.7.0"
 source = { editable = "../naas-abi-core" }
 dependencies = [
     { name = "click" },
@@ -2567,8 +2567,10 @@ requires-dist = [
     { name = "langgraph", specifier = ">=0.6.6" },
     { name = "langgraph-checkpoint-postgres", specifier = ">=2.0.21" },
     { name = "loguru", specifier = ">=0.7.2,<0.8" },
+    { name = "msal", marker = "extra == 'microsoft'", specifier = ">=1.37.0" },
     { name = "naas-abi-core", extras = ["aws"], marker = "extra == 'all'" },
     { name = "naas-abi-core", extras = ["dagster"], marker = "extra == 'all'" },
+    { name = "naas-abi-core", extras = ["microsoft"], marker = "extra == 'all'" },
     { name = "naas-abi-core", extras = ["openrouter"], marker = "extra == 'all'" },
     { name = "naas-abi-core", extras = ["qdrant"], marker = "extra == 'all'" },
     { name = "naas-abi-core", extras = ["rabbitmq"], marker = "extra == 'all'" },
@@ -2601,7 +2603,7 @@ requires-dist = [
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
     { name = "types-tqdm", specifier = ">=4.67.0.20250809" },
 ]
-provides-extras = ["ssh", "aws", "qdrant", "sqlite-vec", "all", "openrouter", "dagster", "redis", "rabbitmq"]
+provides-extras = ["ssh", "aws", "qdrant", "sqlite-vec", "all", "openrouter", "dagster", "redis", "rabbitmq", "microsoft"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_EmailService.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_EmailService.py
@@ -45,8 +45,17 @@ class EmailAdapterSendGridConfiguration(BaseModel):
     base_url: str = "https://api.sendgrid.com/v3"
 
 
+class EmailAdapterMicrosoftOutlookConfiguration(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    tenant_id: str
+    client_id: str
+    client_secret: str
+    user: str
+
+
 class EmailAdapterConfiguration(GenericLoader):
-    adapter: Literal["smtp", "filesystem", "ses", "sendgrid", "custom"]
+    adapter: Literal["smtp", "filesystem", "ses", "sendgrid", "microsoft_outlook", "custom"]
     config: dict | None = None
 
     @model_validator(mode="after")
@@ -79,6 +88,12 @@ class EmailAdapterConfiguration(GenericLoader):
                 EmailAdapterSendGridConfiguration,
                 self.config,
                 "Invalid configuration for services.email.email_adapter 'sendgrid' adapter",
+            )
+        elif self.adapter == "microsoft_outlook":
+            pydantic_model_validator(
+                EmailAdapterMicrosoftOutlookConfiguration,
+                self.config,
+                "Invalid configuration for services.email.email_adapter 'microsoft_outlook' adapter",
             )
 
         return self
@@ -114,6 +129,13 @@ class EmailAdapterConfiguration(GenericLoader):
             )
 
             return SendGridAdapter(**self.config)
+        elif self.adapter == "microsoft_outlook":
+            assert self.config is not None, "config is required for microsoft_outlook adapter"
+            from naas_abi_core.services.email.adapters.secondary.MicrosoftOutlookAdapter import (
+                MicrosoftOutlookAdapter,
+            )
+
+            return MicrosoftOutlookAdapter(**self.config)
         elif self.adapter == "custom":
             return super().load()
         else:

--- a/libs/naas-abi-core/naas_abi_core/engine/engine_loaders/EngineModuleLoader.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_loaders/EngineModuleLoader.py
@@ -247,12 +247,17 @@ class EngineModuleLoader:
         models_dir = Path(spec.origin).parent / "models"
         if not models_dir.is_dir():
             return False
-        for entry in os.listdir(models_dir):
-            if not entry.endswith(".py"):
-                continue
-            if entry == "__init__.py" or entry.endswith("_test.py"):
-                continue
-            return True
+        # Walk recursively: models may live in provider subdirectories
+        # (e.g. ``models/openai/gpt_4_1_mini.py``) with no source files at the
+        # top level. This mirrors ``ModuleModelLoader.load_models``, which uses
+        # ``os.walk`` to discover those nested models at on_load time.
+        for _dirpath, _dirnames, filenames in os.walk(models_dir):
+            for entry in filenames:
+                if not entry.endswith(".py"):
+                    continue
+                if entry == "__init__.py" or entry.endswith("_test.py"):
+                    continue
+                return True
         return False
 
     def get_modules_dependencies(

--- a/libs/naas-abi-core/naas_abi_core/services/email/EmailFactory.py
+++ b/libs/naas-abi-core/naas_abi_core/services/email/EmailFactory.py
@@ -4,6 +4,9 @@ from naas_abi_core.services.email.EmailService import EmailService
 from naas_abi_core.services.email.adapters.secondary.FilesystemAdapter import (
     FilesystemAdapter,
 )
+from naas_abi_core.services.email.adapters.secondary.MicrosoftOutlookAdapter import (
+    MicrosoftOutlookAdapter,
+)
 from naas_abi_core.services.email.adapters.secondary.SESAdapter import SESAdapter
 from naas_abi_core.services.email.adapters.secondary.SendGridAdapter import (
     SendGridAdapter,
@@ -66,5 +69,22 @@ class EmailFactory:
             SendGridAdapter(
                 api_key=api_key,
                 base_url=base_url,
+            )
+        )
+
+    @staticmethod
+    def EmailServiceMicrosoftOutlook(
+        *,
+        tenant_id: str,
+        client_id: str,
+        client_secret: str,
+        user: str,
+    ) -> EmailService:
+        return EmailService(
+            MicrosoftOutlookAdapter(
+                tenant_id=tenant_id,
+                client_id=client_id,
+                client_secret=client_secret,
+                user=user,
             )
         )

--- a/libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/MicrosoftOutlookAdapter.py
+++ b/libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/MicrosoftOutlookAdapter.py
@@ -60,7 +60,7 @@ class MicrosoftOutlookAdapter(IEmailAdapter):
         if self._token:
             return self._token
 
-        import msal  # lazy — not required at import time
+        import msal  # lazy — optional extra
 
         app = msal.ConfidentialClientApplication(
             client_id=self._client_id,

--- a/libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/MicrosoftOutlookAdapter.py
+++ b/libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/MicrosoftOutlookAdapter.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import base64
+from typing import Any
+from urllib.parse import quote
+
+from naas_abi_core.services.email.EmailPorts import (
+    EmailAttachment,
+    IEmailAdapter,
+    resolve_recipients,
+)
+
+_GRAPH_BASE = "https://graph.microsoft.com/v1.0"
+_SCOPE = ["https://graph.microsoft.com/.default"]
+
+
+class MicrosoftOutlookAdapter(IEmailAdapter):
+    """Email adapter that sends via Microsoft Graph API (app-only / client-credentials).
+
+    The sender mailbox is determined by ``from_email`` passed to ``send()``, which
+    must be a UPN the registered app has ``Mail.Send`` permission on.
+
+    Limitations:
+    - ``from_name`` is accepted for interface compatibility but silently ignored:
+      the Graph API always uses the Azure AD display name of the sender mailbox.
+    - Attachments must be < 3 MB (Graph API ``fileAttachment`` limit).
+    - When both ``html_body`` and ``text_body`` are provided, the HTML body is used.
+      The Graph API structured payload does not support multipart/alternative natively.
+
+    Args:
+        tenant_id: Azure AD tenant ID.
+        client_id: App registration client ID.
+        client_secret: App registration client secret.
+        user: Default sender mailbox UPN (used when ``from_email`` is absent).
+        client: Optional injectable fake for unit tests. Must expose
+            ``post(url, payload)`` and ``get_token() -> str``.
+    """
+
+    def __init__(
+        self,
+        *,
+        tenant_id: str,
+        client_id: str,
+        client_secret: str,
+        user: str,
+        client: Any | None = None,
+    ) -> None:
+        self._tenant_id = tenant_id
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._user = user
+        self._client = client
+        self._token: str | None = None
+
+    # ── Auth ──────────────────────────────────────────────────────────────────
+
+    def _get_token(self) -> str:
+        if self._client is not None:
+            return self._client.get_token()
+        if self._token:
+            return self._token
+
+        import msal  # lazy — not required at import time
+
+        app = msal.ConfidentialClientApplication(
+            client_id=self._client_id,
+            authority=f"https://login.microsoftonline.com/{self._tenant_id}",
+            client_credential=self._client_secret,
+        )
+        result = app.acquire_token_for_client(scopes=_SCOPE)
+        if "access_token" not in result:
+            raise RuntimeError(
+                f"Microsoft Graph token error: {result.get('error')} — "
+                f"{result.get('error_description')}"
+            )
+        self._token = result["access_token"]
+        return self._token
+
+    # ── HTTP transport ────────────────────────────────────────────────────────
+
+    def _post(self, url: str, payload: dict[str, Any]) -> None:
+        if self._client is not None:
+            self._client.post(url, payload)
+            return
+
+        import requests  # lazy
+
+        response = requests.post(
+            url,
+            headers={
+                "Authorization": f"Bearer {self._get_token()}",
+                "Content-Type": "application/json",
+            },
+            json=payload,
+            timeout=30,
+        )
+        if response.status_code >= 400:
+            detail = response.text.strip() or response.reason
+            raise RuntimeError(
+                f"Microsoft Graph API request failed ({response.status_code}): {detail}"
+            )
+
+    # ── IEmailAdapter ─────────────────────────────────────────────────────────
+
+    def send(
+        self,
+        *,
+        to_email: str | None = None,
+        subject: str,
+        text_body: str,
+        html_body: str | None = None,
+        from_email: str,
+        from_name: str | None = None,
+        reply_to: str | None = None,
+        attachments: list[EmailAttachment] | None = None,
+        to_emails: list[str] | str | None = None,
+    ) -> None:
+        mailbox = quote(from_email or self._user)
+        url = f"{_GRAPH_BASE}/users/{mailbox}/sendMail"
+
+        body_payload = (
+            {"contentType": "HTML", "content": html_body}
+            if html_body
+            else {"contentType": "Text", "content": text_body}
+        )
+
+        message: dict[str, Any] = {
+            "subject": subject,
+            "body": body_payload,
+            "toRecipients": [
+                {"emailAddress": {"address": addr}}
+                for addr in resolve_recipients(to_email, to_emails)
+            ],
+        }
+
+        if reply_to:
+            message["replyTo"] = [{"emailAddress": {"address": reply_to}}]
+
+        if attachments:
+            message["attachments"] = [
+                {
+                    "@odata.type": "#microsoft.graph.fileAttachment",
+                    "name": att.filename,
+                    "contentType": att.mime_type,
+                    "contentBytes": base64.b64encode(att.content).decode("ascii"),
+                }
+                for att in attachments
+            ]
+
+        self._post(url, {"message": message, "saveToSentItems": True})

--- a/libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/MicrosoftOutlookAdapter_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/MicrosoftOutlookAdapter_test.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from naas_abi_core.services.email.adapters.secondary.MicrosoftOutlookAdapter import (
+    MicrosoftOutlookAdapter,
+)
+from naas_abi_core.services.email.EmailPorts import EmailAttachment
+from naas_abi_core.services.email.tests.email__secondary_adapter__generic_test import (
+    GenericEmailSecondaryAdapterTest,
+)
+
+
+class _FakeGraphClient:
+    """Captures Graph API calls without hitting the network."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def get_token(self) -> str:
+        return "fake-token"
+
+    def post(self, url: str, payload: dict[str, Any]) -> None:
+        self.calls.append((url, payload))
+
+
+def _make_adapter(client: _FakeGraphClient) -> MicrosoftOutlookAdapter:
+    return MicrosoftOutlookAdapter(
+        tenant_id="test-tenant",
+        client_id="test-client",
+        client_secret="test-secret",
+        user="sender@example.com",
+        client=client,
+    )
+
+
+class TestMicrosoftOutlookAdapter(GenericEmailSecondaryAdapterTest):
+    @pytest.fixture
+    def adapter_class(self):
+        return MicrosoftOutlookAdapter
+
+
+class TestMicrosoftOutlookAdapterSend:
+    def test_send_plain_text_email(self) -> None:
+        client = _FakeGraphClient()
+        adapter = _make_adapter(client)
+
+        adapter.send(
+            to_email="bob@example.com",
+            subject="Hello",
+            text_body="Hello world",
+            from_email="sender@example.com",
+        )
+
+        assert len(client.calls) == 1
+        url, payload = client.calls[0]
+        assert "sender%40example.com/sendMail" in url
+        msg = payload["message"]
+        assert msg["subject"] == "Hello"
+        assert msg["body"] == {"contentType": "Text", "content": "Hello world"}
+        assert msg["toRecipients"] == [{"emailAddress": {"address": "bob@example.com"}}]
+        assert payload["saveToSentItems"] is True
+
+    def test_send_html_email_prefers_html_body(self) -> None:
+        client = _FakeGraphClient()
+        adapter = _make_adapter(client)
+
+        adapter.send(
+            to_email="bob@example.com",
+            subject="Report",
+            text_body="plain fallback",
+            html_body="<p>html content</p>",
+            from_email="sender@example.com",
+        )
+
+        _, payload = client.calls[0]
+        assert payload["message"]["body"] == {
+            "contentType": "HTML",
+            "content": "<p>html content</p>",
+        }
+
+    def test_send_with_reply_to(self) -> None:
+        client = _FakeGraphClient()
+        adapter = _make_adapter(client)
+
+        adapter.send(
+            to_email="bob@example.com",
+            subject="Hello",
+            text_body="Hello",
+            from_email="sender@example.com",
+            reply_to="support@example.com",
+        )
+
+        _, payload = client.calls[0]
+        assert payload["message"]["replyTo"] == [
+            {"emailAddress": {"address": "support@example.com"}}
+        ]
+
+    def test_send_with_attachment(self) -> None:
+        client = _FakeGraphClient()
+        adapter = _make_adapter(client)
+
+        adapter.send(
+            to_email="bob@example.com",
+            subject="Report",
+            text_body="See attached",
+            from_email="sender@example.com",
+            attachments=[
+                EmailAttachment(
+                    filename="report.pdf",
+                    content=b"%PDF",
+                    mime_type="application/pdf",
+                )
+            ],
+        )
+
+        _, payload = client.calls[0]
+        att = payload["message"]["attachments"][0]
+        assert att["@odata.type"] == "#microsoft.graph.fileAttachment"
+        assert att["name"] == "report.pdf"
+        assert att["contentType"] == "application/pdf"
+        import base64
+        assert base64.b64decode(att["contentBytes"]) == b"%PDF"
+
+    def test_send_multiple_recipients(self) -> None:
+        client = _FakeGraphClient()
+        adapter = _make_adapter(client)
+
+        adapter.send(
+            to_emails=["alice@example.com", "bob@example.com"],
+            subject="Broadcast",
+            text_body="Hello all",
+            from_email="sender@example.com",
+        )
+
+        _, payload = client.calls[0]
+        recipients = [r["emailAddress"]["address"] for r in payload["message"]["toRecipients"]]
+        assert recipients == ["alice@example.com", "bob@example.com"]
+
+    def test_from_name_is_accepted_without_error(self) -> None:
+        """from_name is silently ignored (Graph API uses Azure AD display name)."""
+        client = _FakeGraphClient()
+        adapter = _make_adapter(client)
+
+        adapter.send(
+            to_email="bob@example.com",
+            subject="Hello",
+            text_body="Hello",
+            from_email="sender@example.com",
+            from_name="Ignored Name",
+        )
+
+        assert len(client.calls) == 1
+        _, payload = client.calls[0]
+        assert "from" not in payload["message"]

--- a/libs/naas-abi-core/pyproject.toml
+++ b/libs/naas-abi-core/pyproject.toml
@@ -71,6 +71,7 @@ all = [
     "naas-abi-core[dagster]",
     "naas-abi-core[redis]",
     "naas-abi-core[rabbitmq]",
+    "naas-abi-core[microsoft]",
 ]
 openrouter = [
     "langchain-openai>=0.3.35",
@@ -85,6 +86,9 @@ redis = [
 ]
 rabbitmq = [
     "pika",
+]
+microsoft = [
+    "msal>=1.37.0",
 ]
 [project.scripts]
 onto2py = "naas_abi_core.utils.onto2py.__main__:main"

--- a/libs/naas-abi-core/uv.lock
+++ b/libs/naas-abi-core/uv.lock
@@ -1955,6 +1955,20 @@ wheels = [
 ]
 
 [[package]]
+name = "msal"
+version = "1.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/99/d840198ecf6e8057bbc937f129ae940404485d736cda73253bbff9537f01/msal-1.37.0.tar.gz", hash = "sha256:1b1672a33ee467c1d70b341bb16cafd51bb3c817147a95b93263794b03971bec", size = 182444, upload-time = "2026-05-29T19:49:05.561Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/b0/d807279f4b55d16d1f120d5ac4344c6e39b56732e2a224d40bded7fd67ad/msal-1.37.0-py3-none-any.whl", hash = "sha256:dd17e95a7c71bce75e8108113438ba7c4a086b3bcad4f57a8c09b7af3d753c2d", size = 123725, upload-time = "2026-05-29T19:49:04.335Z" },
+]
+
+[[package]]
 name = "multidict"
 version = "6.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2233,6 +2247,7 @@ all = [
     { name = "dagster-postgres" },
     { name = "dagster-webserver" },
     { name = "langchain-openai" },
+    { name = "msal" },
     { name = "paramiko" },
     { name = "pika" },
     { name = "qdrant-client" },
@@ -2248,6 +2263,9 @@ dagster = [
     { name = "dagster" },
     { name = "dagster-postgres" },
     { name = "dagster-webserver" },
+]
+microsoft = [
+    { name = "msal" },
 ]
 openrouter = [
     { name = "langchain-openai" },
@@ -2298,8 +2316,10 @@ requires-dist = [
     { name = "langgraph", specifier = ">=0.6.6" },
     { name = "langgraph-checkpoint-postgres", specifier = ">=2.0.21" },
     { name = "loguru", specifier = ">=0.7.2,<0.8" },
+    { name = "msal", marker = "extra == 'microsoft'", specifier = ">=1.37.0" },
     { name = "naas-abi-core", extras = ["aws"], marker = "extra == 'all'" },
     { name = "naas-abi-core", extras = ["dagster"], marker = "extra == 'all'" },
+    { name = "naas-abi-core", extras = ["microsoft"], marker = "extra == 'all'" },
     { name = "naas-abi-core", extras = ["openrouter"], marker = "extra == 'all'" },
     { name = "naas-abi-core", extras = ["qdrant"], marker = "extra == 'all'" },
     { name = "naas-abi-core", extras = ["rabbitmq"], marker = "extra == 'all'" },
@@ -2332,7 +2352,7 @@ requires-dist = [
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
     { name = "types-tqdm", specifier = ">=4.67.0.20250809" },
 ]
-provides-extras = ["ssh", "aws", "qdrant", "sqlite-vec", "all", "openrouter", "dagster", "redis", "rabbitmq"]
+provides-extras = ["ssh", "aws", "qdrant", "sqlite-vec", "all", "openrouter", "dagster", "redis", "rabbitmq", "microsoft"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/libs/naas-abi-marketplace/uv.lock
+++ b/libs/naas-abi-marketplace/uv.lock
@@ -3312,7 +3312,7 @@ wheels = [
 
 [[package]]
 name = "naas-abi-core"
-version = "2.6.0"
+version = "2.7.0"
 source = { editable = "../naas-abi-core" }
 dependencies = [
     { name = "click" },
@@ -3370,8 +3370,10 @@ requires-dist = [
     { name = "langgraph", specifier = ">=0.6.6" },
     { name = "langgraph-checkpoint-postgres", specifier = ">=2.0.21" },
     { name = "loguru", specifier = ">=0.7.2,<0.8" },
+    { name = "msal", marker = "extra == 'microsoft'", specifier = ">=1.37.0" },
     { name = "naas-abi-core", extras = ["aws"], marker = "extra == 'all'" },
     { name = "naas-abi-core", extras = ["dagster"], marker = "extra == 'all'" },
+    { name = "naas-abi-core", extras = ["microsoft"], marker = "extra == 'all'" },
     { name = "naas-abi-core", extras = ["openrouter"], marker = "extra == 'all'" },
     { name = "naas-abi-core", extras = ["qdrant"], marker = "extra == 'all'" },
     { name = "naas-abi-core", extras = ["rabbitmq"], marker = "extra == 'all'" },
@@ -3404,7 +3406,7 @@ requires-dist = [
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
     { name = "types-tqdm", specifier = ">=4.67.0.20250809" },
 ]
-provides-extras = ["ssh", "aws", "qdrant", "sqlite-vec", "all", "openrouter", "dagster", "redis", "rabbitmq"]
+provides-extras = ["ssh", "aws", "qdrant", "sqlite-vec", "all", "openrouter", "dagster", "redis", "rabbitmq", "microsoft"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -3305,6 +3305,20 @@ wheels = [
 ]
 
 [[package]]
+name = "msal"
+version = "1.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/99/d840198ecf6e8057bbc937f129ae940404485d736cda73253bbff9537f01/msal-1.37.0.tar.gz", hash = "sha256:1b1672a33ee467c1d70b341bb16cafd51bb3c817147a95b93263794b03971bec", size = 182444, upload-time = "2026-05-29T19:49:05.561Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/b0/d807279f4b55d16d1f120d5ac4344c6e39b56732e2a224d40bded7fd67ad/msal-1.37.0-py3-none-any.whl", hash = "sha256:dd17e95a7c71bce75e8108113438ba7c4a086b3bcad4f57a8c09b7af3d753c2d", size = 123725, upload-time = "2026-05-29T19:49:04.335Z" },
+]
+
+[[package]]
 name = "multidict"
 version = "6.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3533,7 +3547,7 @@ wheels = [
 
 [[package]]
 name = "naas-abi"
-version = "2.34.0"
+version = "2.35.0"
 source = { editable = "libs/naas-abi" }
 dependencies = [
     { name = "aiosqlite" },
@@ -3686,6 +3700,7 @@ all = [
     { name = "dagster-postgres" },
     { name = "dagster-webserver" },
     { name = "langchain-openai" },
+    { name = "msal" },
     { name = "paramiko" },
     { name = "pika" },
     { name = "qdrant-client" },
@@ -3723,8 +3738,10 @@ requires-dist = [
     { name = "langgraph", specifier = ">=0.6.6" },
     { name = "langgraph-checkpoint-postgres", specifier = ">=2.0.21" },
     { name = "loguru", specifier = ">=0.7.2,<0.8" },
+    { name = "msal", marker = "extra == 'microsoft'", specifier = ">=1.37.0" },
     { name = "naas-abi-core", extras = ["aws"], marker = "extra == 'all'" },
     { name = "naas-abi-core", extras = ["dagster"], marker = "extra == 'all'" },
+    { name = "naas-abi-core", extras = ["microsoft"], marker = "extra == 'all'" },
     { name = "naas-abi-core", extras = ["openrouter"], marker = "extra == 'all'" },
     { name = "naas-abi-core", extras = ["qdrant"], marker = "extra == 'all'" },
     { name = "naas-abi-core", extras = ["rabbitmq"], marker = "extra == 'all'" },
@@ -3757,7 +3774,7 @@ requires-dist = [
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
     { name = "types-tqdm", specifier = ">=4.67.0.20250809" },
 ]
-provides-extras = ["ssh", "aws", "qdrant", "sqlite-vec", "all", "openrouter", "dagster", "redis", "rabbitmq"]
+provides-extras = ["ssh", "aws", "qdrant", "sqlite-vec", "all", "openrouter", "dagster", "redis", "rabbitmq", "microsoft"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
This pull request resolves #email-outlook-adapter

### Summary

This PR introduces a new email adapter for Microsoft Outlook using the Microsoft Graph API with app-only authentication (client credentials flow). It adds support for sending emails through Outlook mailboxes in the Azure AD tenant.

### Changes

- Added `MicrosoftOutlookAdapter` implementing the `IEmailAdapter` interface to send emails via Microsoft Graph API.
- Added configuration model `EmailAdapterMicrosoftOutlookConfiguration` for the new adapter.
- Extended `EmailAdapterConfiguration` to support the `microsoft_outlook` adapter type with validation and loading logic.
- Updated `EmailFactory` to provide a factory method for creating an `EmailService` with the Microsoft Outlook adapter.
- Modified `EngineModuleLoader` to recursively detect Python model files in subdirectories.
- Added comprehensive unit tests for the `MicrosoftOutlookAdapter` covering sending plain text, HTML emails, attachments, multiple recipients, and reply-to headers.

### Details

- The adapter uses MSAL to acquire tokens for the Microsoft Graph API.
- Supports sending emails with attachments (up to 3MB), HTML or plain text bodies.
- The sender mailbox is specified by the `from_email` parameter or defaults to the configured user.
- The adapter handles multiple recipients and reply-to addresses.
- The `from_name` parameter is accepted but ignored due to Graph API limitations.

### Testing

- Unit tests use a fake Graph client to capture and verify API calls without network requests.
- Tests cover all major sending scenarios and payload construction.

This addition enables sending emails through Microsoft Outlook accounts in a secure and scalable manner using modern Microsoft Graph API standards.