### PR TITLE
refactor: enhance ontology import/export and sidebar UI

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/ontology/export/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/ontology/export/page.tsx
@@ -1,0 +1,313 @@
+'use client';
+
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useParams } from 'next/navigation';
+import { Header } from '@/components/shell/header';
+import {
+  AlertCircle,
+  Box,
+  Download,
+  GitBranch,
+  Link2,
+  Loader2,
+  RefreshCw,
+  Tag,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { getApiUrl } from '@/lib/config';
+import { authFetch } from '@/stores/auth';
+import { useOntologyStore } from '@/stores/ontology';
+import { KpiCard } from '@/app/analytics/components/kpi-card';
+
+interface OntologyFileApiItem {
+  name?: string;
+  path?: string;
+  module_name?: string;
+  submodule_name?: string | null;
+}
+
+interface OntologyFile {
+  name: string;
+  path: string;
+  moduleName: string;
+}
+
+interface OntologyStats {
+  name: string;
+  path: string;
+  total_items: number;
+  classes: number;
+  object_properties: number;
+  data_properties: number;
+  named_individuals: number;
+  imports: number;
+}
+
+interface ModuleGroup {
+  moduleName: string;
+  files: OntologyFile[];
+}
+
+export default function OntologyExportPage() {
+  const params = useParams();
+  const workspaceId = params.workspaceId as string;
+  const { selectedOntologyPath } = useOntologyStore();
+
+  const [files, setFiles] = useState<OntologyFile[]>([]);
+  const [filesLoading, setFilesLoading] = useState(true);
+  const [filesError, setFilesError] = useState<string | null>(null);
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const [stats, setStats] = useState<OntologyStats | null>(null);
+  const [statsLoading, setStatsLoading] = useState(false);
+  const [exporting, setExporting] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
+
+  const loadFiles = useCallback(async () => {
+    setFilesLoading(true);
+    setFilesError(null);
+    try {
+      const res = await authFetch(`${getApiUrl()}/api/ontology/ontologies`);
+      if (!res.ok) throw new Error(`Failed to load ontologies (${res.status})`);
+      const data = (await res.json()) as { items?: OntologyFileApiItem[] };
+      const items = Array.isArray(data.items) ? data.items : [];
+      const normalized: OntologyFile[] = items
+        .filter((f): f is OntologyFileApiItem & { name: string; path: string } =>
+          typeof f.name === 'string' && typeof f.path === 'string')
+        .map((f) => ({
+          name: f.name,
+          path: f.path,
+          moduleName: f.module_name || 'Unknown module',
+        }))
+        .sort((a, b) =>
+          a.moduleName.localeCompare(b.moduleName, undefined, { sensitivity: 'base' })
+          || a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
+      setFiles(normalized);
+    } catch (err) {
+      setFilesError(err instanceof Error ? err.message : 'Failed to load ontologies');
+      setFiles([]);
+    } finally {
+      setFilesLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadFiles();
+  }, [loadFiles]);
+
+  const moduleGroups = useMemo<ModuleGroup[]>(() => {
+    const byModule = new Map<string, OntologyFile[]>();
+    for (const f of files) {
+      const bucket = byModule.get(f.moduleName);
+      if (bucket) bucket.push(f);
+      else byModule.set(f.moduleName, [f]);
+    }
+    return [...byModule.entries()].map(([moduleName, fs]) => ({ moduleName, files: fs }));
+  }, [files]);
+
+  // Resolve the active ontology: explicit selection wins, else the workspace-wide
+  // selected ontology, else the first available.
+  const activePath = useMemo<string | null>(() => {
+    if (selectedPath && files.some((f) => f.path === selectedPath)) return selectedPath;
+    if (selectedOntologyPath && files.some((f) => f.path === selectedOntologyPath)) {
+      return selectedOntologyPath;
+    }
+    return files[0]?.path ?? null;
+  }, [selectedPath, selectedOntologyPath, files]);
+
+  const activeFile = useMemo(
+    () => files.find((f) => f.path === activePath) ?? null,
+    [files, activePath],
+  );
+
+  useEffect(() => {
+    if (!activePath) {
+      setStats(null);
+      return;
+    }
+    let cancelled = false;
+    setStatsLoading(true);
+    void (async () => {
+      try {
+        const res = await authFetch(
+          `${getApiUrl()}/api/ontology/overview/stats?ontology_path=${encodeURIComponent(activePath)}`,
+        );
+        if (!res.ok) throw new Error(`Failed to load ontology stats (${res.status})`);
+        const data = (await res.json()) as OntologyStats;
+        if (!cancelled) setStats(data);
+      } catch {
+        if (!cancelled) setStats(null);
+      } finally {
+        if (!cancelled) setStatsLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [activePath]);
+
+  const handleExport = useCallback(async () => {
+    if (!activePath || exporting) return;
+    setExporting(true);
+    setExportError(null);
+    try {
+      const res = await authFetch(
+        `${getApiUrl()}/api/ontology/export?ontology_path=${encodeURIComponent(activePath)}`,
+      );
+      if (!res.ok) throw new Error(`Failed to export ontology (${res.status})`);
+
+      const contentDisposition = res.headers.get('content-disposition') || '';
+      const filenameMatch = contentDisposition.match(/filename="?([^"]+)"?/i);
+      const filename = filenameMatch?.[1] || activePath.split('/').pop() || 'ontology.ttl';
+
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      setExportError(err instanceof Error ? err.message : 'Export failed');
+    } finally {
+      setExporting(false);
+    }
+  }, [activePath, exporting]);
+
+  return (
+    <div className="flex h-full flex-col">
+      <Header />
+      <div className="flex flex-1 overflow-hidden">
+        <div className="flex flex-1 flex-col overflow-hidden">
+          <div className="flex-1 overflow-y-auto px-6 py-6">
+            {filesLoading ? (
+              <div className="flex h-full items-center justify-center">
+                <Loader2 size={20} className="animate-spin text-muted-foreground" />
+              </div>
+            ) : filesError ? (
+              <div className="flex h-full items-center justify-center">
+                <div className="max-w-md text-center">
+                  <AlertCircle size={32} className="mx-auto mb-3 text-red-500" />
+                  <p className="mb-2 text-sm">{filesError}</p>
+                  <button
+                    onClick={() => void loadFiles()}
+                    className="mx-auto flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
+                  >
+                    <RefreshCw size={14} />
+                    Retry
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <div className="mx-auto max-w-5xl space-y-10">
+                <div className="space-y-8">
+                  <div>
+                    <h2 className="text-base font-semibold">Export Ontology</h2>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      Pick an ontology and download it as a Turtle (.ttl) file.
+                    </p>
+                  </div>
+
+                  <div className="space-y-2">
+                    <label htmlFor="export-ontology" className="text-xs font-medium text-muted-foreground">
+                      Ontology
+                    </label>
+                    {files.length > 0 ? (
+                      <select
+                        id="export-ontology"
+                        value={activePath ?? ''}
+                        onChange={(e) => setSelectedPath(e.target.value)}
+                        className="block w-full max-w-sm rounded-md border border-border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                      >
+                        {moduleGroups.map((group) => (
+                          <optgroup key={group.moduleName} label={group.moduleName}>
+                            {group.files.map((f) => (
+                              <option key={f.path} value={f.path}>
+                                {f.name}
+                              </option>
+                            ))}
+                          </optgroup>
+                        ))}
+                      </select>
+                    ) : (
+                      <p className="text-sm text-muted-foreground">No ontology selected</p>
+                    )}
+                  </div>
+
+                  {activeFile && (
+                    <div className="grid grid-cols-3 gap-4">
+                      {statsLoading ? (
+                        Array.from({ length: 3 }).map((_, i) => (
+                          <div key={i} className="h-[110px] animate-pulse rounded border bg-muted/30" />
+                        ))
+                      ) : stats ? (
+                        <>
+                          <KpiCard
+                            label="Classes"
+                            value={stats.classes.toLocaleString()}
+                            hint="OWL classes defined in this ontology"
+                            icon={Box}
+                          />
+                          <KpiCard
+                            label="Object Properties"
+                            value={stats.object_properties.toLocaleString()}
+                            hint="Relationships between classes"
+                            icon={Link2}
+                          />
+                          <KpiCard
+                            label="Data Properties"
+                            value={stats.data_properties.toLocaleString()}
+                            hint="Literal data attributes on classes"
+                            icon={Tag}
+                          />
+                        </>
+                      ) : null}
+                    </div>
+                  )}
+
+                  <div className="space-y-2 pt-1">
+                    <button
+                      type="button"
+                      onClick={() => void handleExport()}
+                      disabled={!activePath || exporting}
+                      className={cn(
+                        'flex items-center gap-2 rounded-md bg-foreground px-4 py-2 text-sm font-medium text-background transition-opacity hover:opacity-90',
+                        (!activePath || exporting) && 'cursor-not-allowed opacity-50',
+                      )}
+                    >
+                      {exporting ? (
+                        <>
+                          <Loader2 size={14} className="animate-spin" />
+                          Exporting…
+                        </>
+                      ) : (
+                        <>
+                          <Download size={14} />
+                          Export as .ttl
+                        </>
+                      )}
+                    </button>
+
+                    <p className="text-xs text-muted-foreground">
+                      Exports the ontology definition file as-is. The download starts immediately.
+                    </p>
+                  </div>
+
+                  {exportError && (
+                    <div className="rounded-md border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-200">
+                      <span className="flex items-center gap-2">
+                        <GitBranch size={14} />
+                        {exportError}
+                      </span>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/ontology/import/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/ontology/import/page.tsx
@@ -1,0 +1,391 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { Header } from '@/components/shell/header';
+import {
+  AlertCircle,
+  Box,
+  CheckCircle2,
+  Clock,
+  FileText,
+  Link2,
+  Loader2,
+  Upload,
+  X,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useOntologyStore } from '@/stores/ontology';
+import { useWorkspaceStore } from '@/stores/workspace';
+import { getWorkspacePath } from '@/components/shell/sidebar/utils';
+import { KpiCard } from '@/app/analytics/components/kpi-card';
+import { ToastStack, type ToastItem } from '@/components/graph/toast-notification';
+
+const ACCEPTED_EXTENSIONS = ['.ttl', '.owl', '.rdf', '.n3', '.nt'];
+
+function isAcceptedFile(name: string): boolean {
+  const ext = `.${name.split('.').pop()?.toLowerCase() ?? ''}`;
+  return ACCEPTED_EXTENSIONS.includes(ext);
+}
+
+type ImportStatus = 'processing' | 'done' | 'error';
+
+interface ImportRecord {
+  id: string;
+  filename: string;
+  ontologyName: string;
+  classes: number;
+  properties: number;
+  status: ImportStatus;
+  createdAt: string;
+  error?: string;
+}
+
+function storageKey(workspaceId: string) {
+  return `ontology-imports-${workspaceId}`;
+}
+
+function loadRecords(workspaceId: string): ImportRecord[] {
+  try {
+    const raw = localStorage.getItem(storageKey(workspaceId));
+    return raw ? (JSON.parse(raw) as ImportRecord[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveRecords(workspaceId: string, records: ImportRecord[]) {
+  try {
+    localStorage.setItem(storageKey(workspaceId), JSON.stringify(records));
+  } catch {}
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function StatusBadge({ status, error }: { status: ImportStatus; error?: string }) {
+  if (status === 'processing') {
+    return (
+      <span className="flex items-center gap-1.5 text-sm text-muted-foreground">
+        <Loader2 size={13} className="animate-spin" />
+        Processing
+      </span>
+    );
+  }
+  if (status === 'error') {
+    return (
+      <span className="flex items-center gap-1.5 text-sm text-red-500" title={error}>
+        <AlertCircle size={13} />
+        Error
+      </span>
+    );
+  }
+  return (
+    <span className="flex items-center gap-1.5 text-sm text-green-600">
+      <CheckCircle2 size={13} />
+      Done
+    </span>
+  );
+}
+
+export default function OntologyImportPage() {
+  const params = useParams();
+  const router = useRouter();
+  const workspaceId = params.workspaceId as string;
+  const { currentWorkspaceId } = useWorkspaceStore();
+  const importReferenceFromContent = useOntologyStore((state) => state.importReferenceFromContent);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [dragOver, setDragOver] = useState(false);
+  const [file, setFile] = useState<File | null>(null);
+  const [fileError, setFileError] = useState<string | null>(null);
+  const [importing, setImporting] = useState(false);
+  const [records, setRecords] = useState<ImportRecord[]>([]);
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+
+  const dismissToast = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const pushToast = useCallback((toast: Omit<ToastItem, 'id'>) => {
+    const item: ToastItem = {
+      ...toast,
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+    };
+    setToasts((prev) => [...prev, item]);
+  }, []);
+
+  useEffect(() => {
+    setRecords(loadRecords(workspaceId));
+  }, [workspaceId]);
+
+  const handleFiles = useCallback((files: FileList | null) => {
+    if (!files || files.length === 0) return;
+    const f = files[0];
+    if (!isAcceptedFile(f.name)) {
+      setFileError(`Unsupported format. Accepted: ${ACCEPTED_EXTENSIONS.join(', ')}`);
+      return;
+    }
+    setFileError(null);
+    setFile(f);
+  }, []);
+
+  const handleDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setDragOver(false);
+    handleFiles(e.dataTransfer.files);
+  }, [handleFiles]);
+
+  const clearFile = useCallback(() => {
+    setFile(null);
+    setFileError(null);
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  }, []);
+
+  const handleImport = useCallback(async () => {
+    if (!file || importing) return;
+
+    const recordId = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+    setImporting(true);
+
+    const newRecord: ImportRecord = {
+      id: recordId,
+      filename: file.name,
+      ontologyName: '',
+      classes: 0,
+      properties: 0,
+      status: 'processing',
+      createdAt: new Date().toISOString(),
+    };
+    setRecords((prev) => {
+      const next = [newRecord, ...prev];
+      saveRecords(workspaceId, next);
+      return next;
+    });
+
+    try {
+      const content = await file.text();
+      const ontology = await importReferenceFromContent(content, file.name);
+      if (!ontology) throw new Error('Failed to import ontology');
+
+      const classes = ontology.classes?.length ?? 0;
+      const properties = ontology.properties?.length ?? 0;
+      setRecords((prev) => {
+        const next = prev.map((r) =>
+          r.id === recordId
+            ? { ...r, status: 'done' as const, ontologyName: ontology.name, classes, properties }
+            : r,
+        );
+        saveRecords(workspaceId, next);
+        return next;
+      });
+
+      pushToast({
+        type: 'success',
+        title: 'Import complete',
+        message: `"${ontology.name}" imported — ${classes} class${classes !== 1 ? 'es' : ''}, ${properties} propert${properties !== 1 ? 'ies' : 'y'}`,
+      });
+      clearFile();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Import failed';
+      setRecords((prev) => {
+        const next = prev.map((r) =>
+          r.id === recordId ? { ...r, status: 'error' as const, error: msg } : r,
+        );
+        saveRecords(workspaceId, next);
+        return next;
+      });
+      pushToast({ type: 'error', title: 'Import failed', message: msg });
+    } finally {
+      setImporting(false);
+    }
+  }, [file, importing, workspaceId, importReferenceFromContent, pushToast, clearFile]);
+
+  const lastDone = records.find((r) => r.status === 'done');
+
+  return (
+    <div className="flex h-full flex-col">
+      <Header />
+      <ToastStack toasts={toasts} onDismiss={dismissToast} />
+      <div className="flex flex-1 overflow-hidden">
+        <div className="flex flex-1 flex-col overflow-hidden">
+          <div className="flex-1 overflow-y-auto px-6 py-6">
+            <div className="mx-auto max-w-3xl space-y-8">
+
+              {/* Drop zone */}
+              <div className="space-y-4">
+                <div>
+                  <h2 className="text-base font-semibold">Import Ontology</h2>
+                  <p className="mt-0.5 text-sm text-muted-foreground">
+                    Upload a Turtle, OWL or RDF file to register it as a reference ontology.
+                  </p>
+                </div>
+
+                {!file ? (
+                  <div
+                    onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
+                    onDragLeave={() => setDragOver(false)}
+                    onDrop={handleDrop}
+                    onClick={() => fileInputRef.current?.click()}
+                    className={cn(
+                      'flex cursor-pointer flex-col items-center justify-center gap-3 rounded-lg border-2 border-dashed px-6 py-12 transition-colors',
+                      dragOver
+                        ? 'border-foreground bg-muted/30'
+                        : 'border-border hover:border-muted-foreground hover:bg-muted/10',
+                    )}
+                  >
+                    <Upload size={28} className="text-muted-foreground" />
+                    <div className="text-center">
+                      <p className="text-sm font-medium">Drop your ontology file here</p>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        or click to browse — {ACCEPTED_EXTENSIONS.join(', ')}
+                      </p>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-3 rounded-lg border bg-muted/20 px-4 py-3">
+                    <FileText size={16} className="shrink-0 text-muted-foreground" />
+                    <span className="min-w-0 flex-1 truncate text-sm font-medium">{file.name}</span>
+                    <span className="shrink-0 text-xs text-muted-foreground">
+                      {(file.size / 1024).toFixed(1)} KB
+                    </span>
+                    <button
+                      type="button"
+                      onClick={clearFile}
+                      className="shrink-0 rounded p-0.5 text-muted-foreground hover:text-foreground"
+                      title="Remove file"
+                    >
+                      <X size={14} />
+                    </button>
+                  </div>
+                )}
+
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept={ACCEPTED_EXTENSIONS.join(',')}
+                  className="hidden"
+                  onChange={(e) => handleFiles(e.target.files)}
+                />
+
+                {fileError && (
+                  <p className="flex items-center gap-2 text-sm text-red-500">
+                    <AlertCircle size={14} />
+                    {fileError}
+                  </p>
+                )}
+              </div>
+
+              {/* Result preview */}
+              {lastDone && (
+                <div className="grid grid-cols-2 gap-3">
+                  <KpiCard label="Classes" value={lastDone.classes} icon={Box} />
+                  <KpiCard label="Object Properties" value={lastDone.properties} icon={Link2} />
+                </div>
+              )}
+
+              {/* Action */}
+              {file && (
+                <div className="flex items-center gap-3">
+                  <button
+                    type="button"
+                    onClick={() => void handleImport()}
+                    disabled={importing}
+                    className={cn(
+                      'flex items-center gap-2 rounded-md bg-foreground px-4 py-2 text-sm font-medium text-background transition-opacity hover:opacity-90',
+                      importing && 'cursor-not-allowed opacity-50',
+                    )}
+                  >
+                    {importing ? (
+                      <>
+                        <Loader2 size={14} className="animate-spin" />
+                        Importing…
+                      </>
+                    ) : (
+                      <>
+                        <Upload size={14} />
+                        Import
+                      </>
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => router.push(getWorkspacePath(currentWorkspaceId, '/ontology?view=network'))}
+                    className="rounded-md border px-4 py-2 text-sm font-medium transition-colors hover:bg-muted"
+                  >
+                    Done
+                  </button>
+                </div>
+              )}
+
+              {/* Import history */}
+              {records.length > 0 && (
+                <div className="space-y-3">
+                  <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                    Import History
+                  </h3>
+                  <div className="overflow-hidden rounded-lg border">
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="border-b bg-muted/30">
+                          <th className="px-4 py-2.5 text-left font-medium text-muted-foreground">Date</th>
+                          <th className="px-4 py-2.5 text-left font-medium text-muted-foreground">File</th>
+                          <th className="px-4 py-2.5 text-left font-medium text-muted-foreground">Ontology</th>
+                          <th className="px-4 py-2.5 text-right font-medium text-muted-foreground">Classes</th>
+                          <th className="px-4 py-2.5 text-right font-medium text-muted-foreground">Properties</th>
+                          <th className="px-4 py-2.5 text-left font-medium text-muted-foreground">Status</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y">
+                        {records.map((rec) => (
+                          <tr key={rec.id} className="hover:bg-muted/20">
+                            <td className="px-4 py-3 text-muted-foreground">
+                              <span className="flex items-center gap-1.5">
+                                <Clock size={12} />
+                                {formatDate(rec.createdAt)}
+                              </span>
+                            </td>
+                            <td className="max-w-[160px] truncate px-4 py-3 font-mono text-xs">
+                              {rec.filename}
+                            </td>
+                            <td className="px-4 py-3">
+                              {rec.ontologyName || <span className="text-muted-foreground">—</span>}
+                            </td>
+                            <td className="px-4 py-3 text-right">
+                              {rec.status === 'done' ? (
+                                <span className="font-medium">{rec.classes}</span>
+                              ) : (
+                                <span className="text-muted-foreground">—</span>
+                              )}
+                            </td>
+                            <td className="px-4 py-3 text-right">
+                              {rec.status === 'done' ? (
+                                <span className="font-medium">{rec.properties}</span>
+                              ) : (
+                                <span className="text-muted-foreground">—</span>
+                              )}
+                            </td>
+                            <td className="px-4 py-3">
+                              <StatusBadge status={rec.status} error={rec.error} />
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/ontology/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/ontology/page.tsx
@@ -10,9 +10,6 @@ import {
   Network,
   Plus,
   Eye,
-  Download,
-  Upload,
-  FolderOpen,
   X,
   Box,
   Link2,
@@ -42,7 +39,7 @@ import { cn } from '@/lib/utils';
 import { useOntologyStore, type ReferenceClass, type ReferenceProperty, type OntologyItem, type EntityProperty, type EntityStatus, type EntityVisibility } from '@/stores/ontology';
 import { buildHoverTitle } from '@/components/graph/vis-network';
 
-type ViewMode = 'overview' | 'network' | 'classes' | 'relations' | 'editor' | 'import' | 'export' | 'create-entity' | 'create-relationship';
+type ViewMode = 'overview' | 'network' | 'classes' | 'relations' | 'editor' | 'create-entity' | 'create-relationship';
 
 type OntologyOverviewGraphNode = {
   id: string;
@@ -79,11 +76,6 @@ export default function OntologyPage() {
   const [lastCatalogView, setLastCatalogView] = useState<'classes' | 'relations'>(
     initialView === 'relations' ? 'relations' : 'classes'
   );
-  const [importPath, setImportPath] = useState('');
-  const [importing, setImporting] = useState(false);
-  const [importError, setImportError] = useState<string | null>(null);
-  const [exporting, setExporting] = useState(false);
-  
   // Creation form state
   const [formName, setFormName] = useState('');
   const [formDescription, setFormDescription] = useState('');
@@ -105,7 +97,7 @@ export default function OntologyPage() {
   // Update view mode and pre-fill form when URL changes
   useEffect(() => {
     const view = searchParams?.get('view') as ViewMode;
-    if (view && ['overview', 'network', 'classes', 'relations', 'editor', 'import', 'export', 'create-entity', 'create-relationship'].includes(view)) {
+    if (view && ['overview', 'network', 'classes', 'relations', 'editor', 'create-entity', 'create-relationship'].includes(view)) {
       const normalizedView = view === 'editor' ? 'classes' : view;
       setViewMode(normalizedView);
       if (normalizedView === 'classes' || normalizedView === 'relations') {
@@ -131,7 +123,6 @@ export default function OntologyPage() {
     items,
     selectedItemId,
     referenceOntologies,
-    importReferenceOntology,
     createEntity,
     createRelationship,
     setSelectedItem,
@@ -188,13 +179,6 @@ export default function OntologyPage() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [viewMode, selectedOntologyPath, graphRefreshTrigger]);
 
-  // When on Export view but no ontology is selected, return to overview (Export not available)
-  useEffect(() => {
-    if (viewMode === 'export' && !selectedOntologyPath) {
-      setViewMode('network');
-    }
-  }, [viewMode, selectedOntologyPath]);
-
   useEffect(() => {
     if (viewMode === 'classes') {
       fetchItemsForView('classes', selectedOntologyPath);
@@ -213,27 +197,6 @@ export default function OntologyPage() {
     });
     return classes;
   }, [referenceOntologies]);
-
-  const handleImport = async () => {
-    if (!importPath.trim()) return;
-
-    setImporting(true);
-    setImportError(null);
-
-    try {
-      const result = await importReferenceOntology(importPath.trim());
-      if (result) {
-        setImportPath('');
-        setViewMode('network');
-      } else {
-        setImportError('Failed to import ontology. Check the file path.');
-      }
-    } catch (err) {
-      setImportError('Error importing ontology');
-    } finally {
-      setImporting(false);
-    }
-  };
 
   const resetForm = () => {
     setFormName('');
@@ -363,39 +326,6 @@ export default function OntologyPage() {
     }
   };
 
-  const handleExportCurrentOntology = async () => {
-    if (!selectedOntologyPath || exporting) return;
-
-    setExporting(true);
-    try {
-      const baseUrl = getApiUrl();
-      const response = await authFetch(
-        `${baseUrl}/api/ontology/export?ontology_path=${encodeURIComponent(selectedOntologyPath)}`
-      );
-      if (!response.ok) {
-        throw new Error(`Failed to export ontology: ${response.status}`);
-      }
-
-      const contentDisposition = response.headers.get('content-disposition') || '';
-      const filenameMatch = contentDisposition.match(/filename="?([^"]+)"?/i);
-      const filename = filenameMatch?.[1] || selectedOntologyPath.split('/').pop() || 'ontology.ttl';
-
-      const blob = await response.blob();
-      const downloadUrl = URL.createObjectURL(blob);
-      const link = document.createElement('a');
-      link.href = downloadUrl;
-      link.download = filename;
-      document.body.appendChild(link);
-      link.click();
-      link.remove();
-      URL.revokeObjectURL(downloadUrl);
-    } catch (error) {
-      console.error('Failed to export ontology:', error);
-    } finally {
-      setExporting(false);
-    }
-  };
-
   return (
     <div className="flex h-full flex-col">
       <Header />
@@ -451,143 +381,10 @@ export default function OntologyPage() {
               Object Properties
             </button>
           </div>
-          <div className="flex items-center gap-3">
-            <button
-              onClick={() => setViewMode('import')}
-              className={cn(
-                'flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground',
-                viewMode === 'import' && 'text-foreground'
-              )}
-            >
-              <Upload size={14} />
-              Import
-            </button>
-            <button
-              onClick={() => setViewMode('export')}
-              disabled={!selectedOntologyPath}
-              className={cn(
-                'flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground',
-                viewMode === 'export' && 'text-foreground',
-                !selectedOntologyPath && 'cursor-not-allowed'
-              )}
-              title={!selectedOntologyPath ? 'Select an ontology in Metrics to export' : 'Export selected ontology'}
-            >
-              <Download size={14} />
-              Export
-            </button>
-          </div>
         </div>
 
         {/* Content - scrollable */}
         <div className="flex flex-1 min-h-0 overflow-y-auto">
-          {viewMode === 'import' && (
-            <div className="flex min-h-full w-full flex-col items-center justify-center bg-card p-8">
-              <div className="w-full max-w-xl">
-                <div className="mb-6 text-center">
-                  <div className="mb-4 flex justify-center">
-                    <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-muted">
-                      <Upload size={32} className="text-muted-foreground" />
-                    </div>
-                  </div>
-                  <h2 className="mb-2 text-lg font-semibold">Import Reference Ontology</h2>
-                  <p className="text-muted-foreground">
-                    Import TTL, OWL, or RDF files to use as reference when creating entities.
-                  </p>
-                </div>
-
-                <div className="space-y-4">
-                  {/* File path input */}
-                  <div>
-                    <label className="mb-2 block text-sm font-medium">
-                      File Path
-                    </label>
-                    <div className="flex gap-2">
-                      <div className="relative flex-1">
-                        <FolderOpen size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
-                        <input
-                          type="text"
-                          value={importPath}
-                          onChange={(e) => setImportPath(e.target.value)}
-                          placeholder="/path/to/ontology.ttl"
-                          className="w-full rounded-lg border bg-background py-2 pl-10 pr-4 text-sm outline-none focus:ring-2 focus:ring-primary"
-                        />
-                      </div>
-                      <button
-                        onClick={handleImport}
-                        disabled={!importPath.trim() || importing}
-                        className={cn(
-                          'flex items-center gap-2 rounded-lg bg-workspace-accent px-4 py-2 text-sm font-medium text-white',
-                          'hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed'
-                        )}
-                      >
-                        {importing ? (
-                          <Loader2 size={16} className="animate-spin" />
-                        ) : (
-                          <Upload size={16} />
-                        )}
-                        Import
-                      </button>
-                    </div>
-                    {importError && (
-                      <p className="mt-2 text-sm text-red-500">{importError}</p>
-                    )}
-                  </div>
-
-                  {/* Supported formats */}
-                  <div className="text-center text-xs text-muted-foreground">
-                    Supported: .ttl (Turtle), .owl (OWL), .rdf (RDF/XML)
-                  </div>
-                </div>
-              </div>
-            </div>
-          )}
-
-          {viewMode === 'export' && selectedOntologyPath && (
-            <div className="flex min-h-full w-full flex-col items-center justify-center bg-card p-8">
-              <div className="w-full max-w-xl">
-                <div className="mb-6 text-center">
-                  <div className="mb-4 flex justify-center">
-                    <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-muted">
-                      <Download size={32} className="text-muted-foreground" />
-                    </div>
-                  </div>
-                  <h2 className="mb-2 text-lg font-semibold">Export Ontology</h2>
-                  <p className="text-muted-foreground">
-                    Download the selected ontology as a TTL file.
-                  </p>
-                </div>
-
-                <div className="space-y-4">
-                  <div className="rounded-lg border bg-muted/30 p-4">
-                    <p className="mb-1 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                      Selected ontology
-                    </p>
-                    <p className="truncate font-mono text-sm" title={selectedOntologyPath}>
-                      {selectedOntologyPath}
-                    </p>
-                  </div>
-
-                  <div className="flex justify-center">
-                    <button
-                      onClick={handleExportCurrentOntology}
-                      disabled={exporting}
-                      className={cn(
-                        'flex items-center gap-2 rounded-lg bg-workspace-accent px-6 py-2.5 text-sm font-medium text-white',
-                        'hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50'
-                      )}
-                    >
-                      {exporting ? (
-                        <Loader2 size={16} className="animate-spin" />
-                      ) : (
-                        <Download size={16} />
-                      )}
-                      {exporting ? 'Exporting...' : 'Export ontology'}
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          )}
 
           {viewMode === 'overview' && (
             <div className="min-h-full w-full">

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/files-section.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/files-section.tsx
@@ -7,6 +7,7 @@ import { cn } from '@/lib/utils';
 import { useFilesStore } from '@/stores/files';
 import { useWorkspaceStore } from '@/stores/workspace';
 import { CollapsibleSection } from './collapsible-section';
+import { SidebarToolbarButton } from './sidebar-toolbar';
 import { getWorkspacePath } from './utils';
 
 export function FilesSection({ collapsed, detailOnly }: { collapsed: boolean; detailOnly?: boolean }) {
@@ -58,21 +59,18 @@ export function FilesSection({ collapsed, detailOnly }: { collapsed: boolean; de
 
   const sectionActions = (
     <>
-      <button
+      <SidebarToolbarButton
+        icon={<Settings size={14} />}
+        label="Drive settings"
         onClick={handleOpenDriveSettings}
-        title="Drive settings"
-        className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:bg-workspace-accent-10 hover:text-workspace-accent"
-      >
-        <Settings size={14} />
-      </button>
-      <button
+      />
+      <SidebarToolbarButton
+        icon={<RefreshCw size={14} />}
+        label="Refresh"
         onClick={handleRefresh}
         disabled={loading}
-        title="Refresh"
-        className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:bg-workspace-accent-10 hover:text-workspace-accent disabled:opacity-50"
-      >
-        <RefreshCw size={14} className={cn(loading && 'animate-spin')} />
-      </button>
+        spinning={loading}
+      />
     </>
   );
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/knowledge-graph-section.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/knowledge-graph-section.tsx
@@ -15,6 +15,7 @@ import { getApiUrl } from '@/lib/config';
 import { listViews, deleteView, type SavedView } from '@/lib/graph-query/client';
 import { useConfirm } from '@/components/ui/dialogs';
 import { CollapsibleSection } from './collapsible-section';
+import { SidebarToolbar, SidebarToolbarButton } from './sidebar-toolbar';
 import { getWorkspacePath } from './utils';
 
 interface GraphItem {
@@ -688,35 +689,28 @@ export function KnowledgeGraphSection({ collapsed, detailOnly }: { collapsed: bo
       onNavigate={selectKnowledgeGraphRoot}
     >
       {/* Quick actions — create / import / export */}
-      <div className="flex items-center gap-1 px-1 pb-1">
+      <SidebarToolbar>
         {[
           { icon: <Network size={14} />, label: 'Create graph', onClick: () => router.push(graphCreateGraphPath) },
           { icon: <Users size={14} />, label: 'Create individual', onClick: () => router.push(graphCreateIndividualPath) },
           { icon: <Upload size={14} />, label: 'Import triples', onClick: () => router.push(graphImportPath) },
           { icon: <Download size={14} />, label: 'Export triples', onClick: () => router.push(graphExportPath) },
         ].map((action) => (
-          <button
+          <SidebarToolbarButton
             key={action.label}
-            type="button"
+            icon={action.icon}
+            label={action.label}
             onClick={action.onClick}
-            title={action.label}
-            aria-label={action.label}
-            className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-workspace-accent-10 hover:text-workspace-accent"
-          >
-            {action.icon}
-          </button>
+          />
         ))}
-        <button
-          type="button"
+        <SidebarToolbarButton
+          icon={<RefreshCw size={14} />}
+          label="Refresh (clear cache)"
           onClick={() => void handleRefresh()}
           disabled={refreshing}
-          title="Refresh (clear cache)"
-          aria-label="Refresh (clear cache)"
-          className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-workspace-accent-10 hover:text-workspace-accent disabled:opacity-50"
-        >
-          <RefreshCw size={14} className={cn(refreshing && 'animate-spin')} />
-        </button>
-      </div>
+          spinning={refreshing}
+        />
+      </SidebarToolbar>
 
       {/* Network — pick which graph(s) to view */}
       <div className={cn('px-1', networkExpanded && 'pb-1')}>

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/ontology-section.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/ontology-section.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState, type MouseEvent } from 'react';
 import { createPortal } from 'react-dom';
 import {
   BrainCircuit, ChevronRight, Box, Link2,
-  RefreshCw, Import, BookOpen, FileCode,
+  RefreshCw, Upload, Download, BookOpen, FileCode,
 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { cn } from '@/lib/utils';
@@ -13,6 +13,7 @@ import { useWorkspaceStore } from '@/stores/workspace';
 import { authFetch } from '@/stores/auth';
 import { getApiUrl } from '@/lib/config';
 import { CollapsibleSection } from './collapsible-section';
+import { SidebarToolbar, SidebarToolbarButton } from './sidebar-toolbar';
 import { getWorkspacePath } from './utils';
 
 type OntologyFile = {
@@ -184,41 +185,35 @@ export function OntologySection({ collapsed, detailOnly }: { collapsed: boolean;
       detailOnly={detailOnly}
     >
       {/* Toolbar */}
-      <div className="flex items-center gap-0.5 px-1 pb-1">
-        <button
+      <SidebarToolbar>
+        <SidebarToolbarButton
+          icon={<Box size={14} />}
+          label="New Class"
           onClick={() => router.push(getWorkspacePath(currentWorkspaceId, '/ontology?view=create-entity'))}
-          className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-          title="New Class"
-        >
-          <Box size={14} />
-        </button>
-        <button
+        />
+        <SidebarToolbarButton
+          icon={<Link2 size={14} />}
+          label="New Object Property"
           onClick={() => router.push(getWorkspacePath(currentWorkspaceId, '/ontology?view=create-relationship'))}
-          className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-          title="New Object Property"
-        >
-          <Link2 size={14} />
-        </button>
-        <button
+        />
+        <SidebarToolbarButton
+          icon={<Upload size={14} />}
+          label="Import Ontology"
+          onClick={() => router.push(getWorkspacePath(currentWorkspaceId, '/ontology/import'))}
+        />
+        <SidebarToolbarButton
+          icon={<Download size={14} />}
+          label="Export Ontology"
+          onClick={() => router.push(getWorkspacePath(currentWorkspaceId, '/ontology/export'))}
+        />
+        <SidebarToolbarButton
+          icon={<RefreshCw size={14} />}
+          label="Refresh (clear cache)"
           onClick={() => clearOntologyCache()}
-          className={cn(
-            "flex h-6 w-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
-            ontologyLoading && "animate-spin"
-          )}
-          title="Refresh (clear cache)"
-        >
-          <RefreshCw size={14} />
-        </button>
-        <button
-          onClick={() => {
-            router.push(getWorkspacePath(currentWorkspaceId, '/ontology?view=import'));
-          }}
-          className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-          title="Import Reference Ontology"
-        >
-          <Import size={14} />
-        </button>
-      </div>
+          disabled={ontologyLoading}
+          spinning={ontologyLoading}
+        />
+      </SidebarToolbar>
       {ontologyTooltip && typeof document !== 'undefined' && createPortal(
         <div
           className="fixed z-[100] whitespace-nowrap rounded-md border border-border bg-popover px-3 py-2 text-sm shadow-lg animate-in fade-in-0 zoom-in-95 duration-100"

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/sidebar-toolbar.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/sidebar-toolbar.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+/**
+ * Horizontal container for a section's quick-action icon buttons.
+ * Standardises spacing/padding across every sidebar section.
+ */
+export function SidebarToolbar({
+  className,
+  children,
+}: {
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={cn('flex items-center gap-1 px-1 pb-1', className)}>
+      {children}
+    </div>
+  );
+}
+
+/**
+ * A single quick-action icon button used in sidebar section toolbars.
+ * Matches the Knowledge Graph section styling: 28px square, rounded-md,
+ * muted by default with a workspace-accent hover.
+ */
+export function SidebarToolbarButton({
+  icon,
+  label,
+  onClick,
+  disabled = false,
+  spinning = false,
+  active = false,
+  className,
+}: {
+  icon: React.ReactNode;
+  /** Used for both the tooltip (`title`) and the accessible name (`aria-label`). */
+  label: string;
+  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  disabled?: boolean;
+  /** Spins the icon — typically wired to a loading flag on a Refresh action. */
+  spinning?: boolean;
+  /** Highlights the button with the accent color (e.g. for the active view). */
+  active?: boolean;
+  className?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={(event) => onClick(event)}
+      disabled={disabled}
+      title={label}
+      aria-label={label}
+      className={cn(
+        'flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-workspace-accent-10 hover:text-workspace-accent disabled:opacity-50',
+        active && 'bg-workspace-accent-10 text-workspace-accent',
+        className,
+      )}
+    >
+      <span className={cn('flex items-center justify-center', spinning && 'animate-spin')}>
+        {icon}
+      </span>
+    </button>
+  );
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/ontology.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/ontology.ts
@@ -149,6 +149,7 @@ interface OntologyState {
 
   // Reference ontology actions
   importReferenceOntology: (filePath: string) => Promise<ReferenceOntology | null>;
+  importReferenceFromContent: (content: string, filename: string) => Promise<ReferenceOntology | null>;
   removeReferenceOntology: (id: string) => void;
   parseOntologyFile: (content: string, format: string, filePath: string) => ReferenceOntology;
   
@@ -574,6 +575,41 @@ export const useOntologyStore = create<OntologyState>()(
         }
       },
       
+      importReferenceFromContent: async (content: string, filename: string) => {
+        set({ loadingReference: true, error: null });
+        try {
+          const baseUrl = getApiUrl();
+          const response = await authFetch(`${baseUrl}/api/ontology/import`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ content, filename }),
+          });
+          if (!response.ok) {
+            const payload = await response.json().catch(() => ({}));
+            const detail = typeof payload?.detail === 'string' ? payload.detail : 'Failed to import ontology';
+            throw new Error(detail);
+          }
+          const data = await response.json();
+          set((state) => ({
+            referenceOntologies: [
+              ...state.referenceOntologies.filter((o) => o.id !== data.id),
+              data,
+            ],
+            expandedReferences: state.expandedReferences.includes(data.id)
+              ? state.expandedReferences
+              : [...state.expandedReferences, data.id],
+            loadingReference: false,
+          }));
+          return data;
+        } catch (err) {
+          set({
+            loadingReference: false,
+            error: err instanceof Error ? err.message : 'Failed to import ontology',
+          });
+          throw err;
+        }
+      },
+
       removeReferenceOntology: (id: string) => {
         set((state) => ({
           referenceOntologies: state.referenceOntologies.filter((o) => o.id !== id),


### PR DESCRIPTION
This pull request resolves #refactor-network-ontology

### Summary

This PR introduces a comprehensive refactor and enhancement of the ontology management features within the workspace, focusing on import and export functionalities and UI improvements.

### Key Changes

1. **New Ontology Import Page**
   - Added a dedicated client-side page for importing ontologies from files (.ttl, .owl, .rdf, .n3, .nt).
   - Supports drag-and-drop and file browsing for ontology files.
   - Displays import status, history, and detailed feedback with toast notifications.
   - Stores import records in localStorage per workspace.

2. **New Ontology Export Page**
   - Added a client-side page to export ontologies as Turtle (.ttl) files.
   - Lists available ontologies grouped by module.
   - Shows ontology statistics (classes, object properties, data properties) before export.
   - Handles file download with proper filename extraction from response headers.

3. **Ontology Main Page Cleanup**
   - Removed legacy import and export UI and logic from the main ontology page.
   - Removed unused state and handlers related to import/export.
   - Updated view mode handling to exclude import/export views.

4. **Sidebar Enhancements**
   - Introduced `SidebarToolbar` and `SidebarToolbarButton` components for consistent toolbar button styling.
   - Replaced multiple sidebar button implementations with these new components in Files, Knowledge Graph, and Ontology sections.
   - Added import/export and refresh buttons to the Ontology sidebar section.

5. **Store Enhancements**
   - Added `importReferenceFromContent` async action to the ontology store to support importing ontology content directly.

### Benefits

- Improved user experience with dedicated import/export pages.
- Cleaner and more maintainable codebase by removing legacy import/export code from the main ontology page.
- Consistent UI/UX across sidebar sections with reusable toolbar button components.
- Persistent import history per workspace for better tracking.

### Notes

- The import API expects JSON with content and filename; the store handles the API call and updates state accordingly.
- Export triggers a file download with the correct filename derived from the server response.

This refactor lays the groundwork for further enhancements in ontology management and integration within the workspace environment.