### PR TITLE
feat(dagster): add launchpad override support for x app orchestrations

### DIFF
--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/XReprocessOrchestration.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/XReprocessOrchestration.py
@@ -2,9 +2,8 @@
 
 A single job — **no sensor, no schedule, no X API call** — that re-runs the
 tweet mapping pipeline over every persisted search envelope under a given
-object-storage folder. Launch it from the Dagster UI and set the ``prefix`` in
-the run config to pick the folder to reprocess (defaults to the
-``x/search_recent_tweets`` envelopes).
+object-storage folder. Launch it from the Dagster launchpad and set ``prefix``
+to pick the folder to reprocess (defaults to ``x/search_recent_tweets``).
 
 Pipeline-only: each envelope is fed straight to
 :class:`XSearchRecentTweetsPipeline` in ``file_path`` mode (via the shared
@@ -12,6 +11,15 @@ Pipeline-only: each envelope is fed straight to
 SearchResultSet / SearchRecentTweets / Tweet structure from the file. Use it to
 backfill the graph after a mapping change without re-querying the X API.
 Idempotent — the pipeline's label-based dedupe makes a re-run a no-op.
+
+Launchpad example::
+
+    ops:
+      x_reprocess_envelopes_op:
+        config:
+          prefix: x/search_recent_tweets/ai_llms
+          persist: true
+          graph_name: http://ontology.naas.ai/graph/x
 """
 
 import posixpath
@@ -21,6 +29,7 @@ from naas_abi_core import logger
 from naas_abi_core.orchestrations.DagsterOrchestration import DagsterOrchestration
 from naas_abi_marketplace.applications.x import ABIModule
 from naas_abi_marketplace.applications.x.orchestrations.utils import (
+    launchpad_override,
     run_search_pipeline_for_file,
 )
 
@@ -31,6 +40,27 @@ _ENVELOPE_EXTENSIONS = (".json", ".ndjson", ".json.gz", ".ndjson.gz")
 
 _JOB_NAME = "x_reprocess_envelopes"
 _OP_NAME = "x_reprocess_envelopes_op"
+
+_REPROCESS_CONFIG_SCHEMA = {
+    "prefix": dg.Field(
+        str,
+        is_required=False,
+        description=(
+            "Object-storage folder to reprocess (recursively). "
+            f"Defaults to {_DEFAULT_PREFIX!r}."
+        ),
+    ),
+    "persist": dg.Field(
+        bool,
+        is_required=False,
+        description="Persist mapped triples to the triple store.",
+    ),
+    "graph_name": dg.Field(
+        str,
+        is_required=False,
+        description="Named graph IRI for mapped triples (ABI config default).",
+    ),
+}
 
 
 def _list_envelope_paths(object_storage, prefix: str) -> list[str]:
@@ -57,20 +87,15 @@ def _list_envelope_paths(object_storage, prefix: str) -> list[str]:
     return paths
 
 
-@dg.op(
-    name=_OP_NAME,
-    config_schema={
-        "prefix": dg.Field(
-            str,
-            default_value=_DEFAULT_PREFIX,
-            description="Object-storage folder to reprocess (recursively).",
-        )
-    },
-)
-def reprocess_envelopes_op(context: dg.OpExecutionContext) -> dict:
+def _reprocess_envelopes(op_cfg: dict | None = None) -> dict:
+    op_cfg = op_cfg or {}
     module = ABIModule.get_instance()
     object_storage = module.engine.services.object_storage
-    prefix = context.op_config["prefix"]
+    prefix = launchpad_override(op_cfg, "prefix", _DEFAULT_PREFIX)
+    persist = launchpad_override(op_cfg, "persist", True)
+    graph_name = launchpad_override(
+        op_cfg, "graph_name", module.configuration.graph_name
+    )
 
     paths = _list_envelope_paths(object_storage, prefix)
     logger.info(
@@ -82,7 +107,9 @@ def reprocess_envelopes_op(context: dg.OpExecutionContext) -> dict:
     failed = 0
     for file_path in paths:
         try:
-            run_search_pipeline_for_file(file_path)
+            run_search_pipeline_for_file(
+                file_path, persist=persist, graph_name=graph_name
+            )
             processed += 1
         except Exception as exc:  # noqa: BLE001
             # Don't let one bad envelope abort the whole reprocess run.
@@ -95,6 +122,11 @@ def reprocess_envelopes_op(context: dg.OpExecutionContext) -> dict:
     summary = {"prefix": prefix, "processed": processed, "failed": failed}
     logger.info(f"XReprocessOrchestration: done — {summary}")
     return summary
+
+
+@dg.op(name=_OP_NAME, config_schema=_REPROCESS_CONFIG_SCHEMA)
+def reprocess_envelopes_op(context) -> dict:
+    return _reprocess_envelopes(context.op_config or {})
 
 
 # Single-op job, no schedule and no sensor → launch manually from the Dagster
@@ -110,7 +142,15 @@ class XReprocessOrchestration(DagsterOrchestration):
     envelopes under a configurable object-storage folder.
 
     Exposes a single job with no sensor/schedule, so it only runs when launched
-    from the Dagster UI; set ``prefix`` in the run config to choose the folder.
+    from the Dagster launchpad; set ``prefix`` (and optional ``persist`` /
+    ``graph_name``) in the run config to tune the run.
+
+    Launchpad example::
+
+        ops:
+          x_reprocess_envelopes_op:
+            config:
+              prefix: x/search_recent_tweets
     """
 
     @classmethod

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/XSearchRecentTweetsEventOrchestration.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/XSearchRecentTweetsEventOrchestration.py
@@ -10,6 +10,22 @@ search lands an envelope, the put event drives ingestion with no polling.
 The sensor is **disabled by default** (``DefaultSensorStatus.STOPPED``); enable
 it explicitly from the Dagster UI.
 
+Launch manually from the Dagster launchpad to replay a single envelope: set
+``prefix`` and ``key`` on the ingestion op (required). Optional fields fall back
+to ABI module defaults.
+
+Launchpad example::
+
+    ops:
+      x_search_recent_tweets_ingestion_op:
+        config:
+          prefix: x/search_recent_tweets/ai_llms
+          key: 2026-06-30T12:00:00_ai_llms.json
+          batch_size: 500
+      x_search_recent_tweets_pipeline_op:
+        config:
+          persist: true
+
 ⚠️ Double-execution note: this sensor watches the very prefix the
 :class:`XSearchWorkflowOrchestration` writes to. If both are enabled, each
 envelope is mapped into the graph twice (once directly by the workflow job, once
@@ -25,6 +41,7 @@ from naas_abi_core import logger
 from naas_abi_core.orchestrations.DagsterOrchestration import DagsterOrchestration
 from naas_abi_marketplace.applications.x import ABIModule
 from naas_abi_marketplace.applications.x.orchestrations.utils import (
+    launchpad_override,
     run_search_pipeline_for_file,
 )
 from rdflib import URIRef
@@ -40,6 +57,45 @@ _SEARCH_INGESTION_JOB = "x_search_recent_tweets_ingestion"
 _SEARCH_INGESTION_OP = "x_search_recent_tweets_ingestion_op"
 _SEARCH_PIPELINE_OP = "x_search_recent_tweets_pipeline_op"
 
+_INGESTION_CONFIG_SCHEMA = {
+    "prefix": dg.Field(
+        str,
+        description="Object-storage prefix of the search envelope.",
+    ),
+    "key": dg.Field(
+        str,
+        description="Object key of the search envelope under prefix.",
+    ),
+    "graph_name": dg.Field(
+        str,
+        is_required=False,
+        description="Named graph IRI for ingested triples (ABI config default).",
+    ),
+    "batch_size": dg.Field(
+        int,
+        is_required=False,
+        description="Batch size for XFileIngestionPipeline (default: 500).",
+    ),
+    "delete_after_ingest": dg.Field(
+        bool,
+        is_required=False,
+        description="Delete the envelope from object storage after ingestion.",
+    ),
+}
+
+_PIPELINE_CONFIG_SCHEMA = {
+    "persist": dg.Field(
+        bool,
+        is_required=False,
+        description="Persist mapped triples to the triple store.",
+    ),
+    "graph_name": dg.Field(
+        str,
+        is_required=False,
+        description="Named graph IRI for mapped triples (ABI config default).",
+    ),
+}
+
 
 def _is_search_recent_tweets_put(prefix: str, key: str, size_bytes: int | None) -> bool:
     """True when an ObjectPut targets a tweet envelope under the watched prefix."""
@@ -54,6 +110,47 @@ def _is_search_recent_tweets_put(prefix: str, key: str, size_bytes: int | None) 
     ):
         return False
     return key.lower().endswith(_TWEET_FILE_EXTENSIONS)
+
+
+def _ingest_search_envelope(op_cfg: dict) -> str:
+    from naas_abi_marketplace.applications.x.pipelines.XFileIngestionPipeline import (
+        XFileIngestionPipeline,
+        XFileIngestionPipelineConfiguration,
+        XFileIngestionPipelineParameters,
+    )
+
+    module = ABIModule.get_instance()
+    prefix = op_cfg["prefix"]
+    key = op_cfg["key"]
+    graph_name = launchpad_override(
+        op_cfg, "graph_name", module.configuration.graph_name
+    )
+    batch_size = launchpad_override(op_cfg, "batch_size", 500)
+    delete_after_ingest = launchpad_override(op_cfg, "delete_after_ingest", False)
+
+    logger.info(
+        f"XSearchRecentTweetsEventOrchestration: ingesting search_recent_tweets "
+        f"envelope {prefix}/{key} via XFileIngestionPipeline"
+    )
+    pipeline = XFileIngestionPipeline(
+        XFileIngestionPipelineConfiguration(
+            object_storage=module.engine.services.object_storage,
+            triple_store=module.engine.services.triple_store,
+            graph_name=URIRef(graph_name),
+            batch_size=batch_size,
+        )
+    )
+    pipeline.run(
+        XFileIngestionPipelineParameters(
+            prefix=prefix,
+            key=key,
+            delete_after_ingest=delete_after_ingest,
+        )
+    )
+
+    # Emit the envelope path so the downstream op maps the full search
+    # structure from the same file via XSearchRecentTweetsPipeline.
+    return posixpath.join(prefix, key)
 
 
 def _build_search_recent_tweets_event_sensor() -> tuple[
@@ -74,45 +171,21 @@ def _build_search_recent_tweets_event_sensor() -> tuple[
     and races the api on oxigraph / nexus.db.
     """
 
-    @dg.op(name=_SEARCH_INGESTION_OP, config_schema={"prefix": str, "key": str})
-    def search_ingestion_op(context: dg.OpExecutionContext) -> str:
-        from naas_abi_marketplace.applications.x.pipelines.XFileIngestionPipeline import (
-            XFileIngestionPipeline,
-            XFileIngestionPipelineConfiguration,
-            XFileIngestionPipelineParameters,
-        )
+    @dg.op(name=_SEARCH_INGESTION_OP, config_schema=_INGESTION_CONFIG_SCHEMA)
+    def search_ingestion_op(context) -> str:
+        return _ingest_search_envelope(context.op_config or {})
 
+    @dg.op(name=_SEARCH_PIPELINE_OP, config_schema=_PIPELINE_CONFIG_SCHEMA)
+    def search_pipeline_op(context, file_path: str) -> None:
+        op_cfg = context.op_config or {}
         module = ABIModule.get_instance()
-        prefix = context.op_config["prefix"]
-        key = context.op_config["key"]
-
-        logger.info(
-            f"XSearchRecentTweetsEventOrchestration: ingesting search_recent_tweets "
-            f"envelope {prefix}/{key} via XFileIngestionPipeline"
+        run_search_pipeline_for_file(
+            file_path,
+            persist=launchpad_override(op_cfg, "persist", True),
+            graph_name=launchpad_override(
+                op_cfg, "graph_name", module.configuration.graph_name
+            ),
         )
-        pipeline = XFileIngestionPipeline(
-            XFileIngestionPipelineConfiguration(
-                object_storage=module.engine.services.object_storage,
-                triple_store=module.engine.services.triple_store,
-                graph_name=URIRef(module.configuration.graph_name),
-                batch_size=500,
-            )
-        )
-        pipeline.run(
-            XFileIngestionPipelineParameters(
-                prefix=prefix,
-                key=key,
-                delete_after_ingest=False,
-            )
-        )
-
-        # Emit the envelope path so the downstream op maps the full search
-        # structure from the same file via XSearchRecentTweetsPipeline.
-        return posixpath.join(prefix, key)
-
-    @dg.op(name=_SEARCH_PIPELINE_OP)
-    def search_pipeline_op(file_path: str) -> None:
-        run_search_pipeline_for_file(file_path)
 
     @dg.graph(name=_SEARCH_INGESTION_JOB)
     def search_ingestion_graph():
@@ -198,6 +271,14 @@ class XSearchRecentTweetsEventOrchestration(DagsterOrchestration):
     events and ingests every new envelope written under ``x/search_recent_tweets``
     via :class:`XFileIngestionPipeline` then :class:`XSearchRecentTweetsPipeline`.
     Sensor disabled by default.
+
+    Launchpad example (manual replay of one envelope)::
+
+        ops:
+          x_search_recent_tweets_ingestion_op:
+            config:
+              prefix: x/search_recent_tweets/my_filter
+              key: 2026-06-30T12:00:00_my_filter.json
     """
 
     @classmethod

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/XSearchWorkflowOrchestration.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/XSearchWorkflowOrchestration.py
@@ -9,6 +9,21 @@ then feeds each persisted envelope's ``file_path`` to
 
 All sensors are **disabled by default** (``DefaultSensorStatus.STOPPED``); enable
 them explicitly from the Dagster UI.
+
+Launch from the Dagster launchpad to override per-run workflow/pipeline
+parameters. Omitted fields use the matching ``search_recent_tweets_workflow``
+entry from the ABI config.
+
+Launchpad example (for a filter named ``ai_llms``)::
+
+    ops:
+      x_search_workflow_op_ai_llms:
+        config:
+          max_pages: 2
+          daily_max_usd: 5.0
+      x_search_workflow_pipeline_op_ai_llms:
+        config:
+          persist: true
 """
 
 import dagster as dg
@@ -20,9 +35,155 @@ from naas_abi_marketplace.applications.x import (
 )
 from naas_abi_marketplace.applications.x.orchestrations.utils import (
     has_in_progress_run,
+    launchpad_override,
     run_search_pipeline_for_file,
     safe_name,
 )
+
+_SEARCH_WORKFLOW_OP_CONFIG_SCHEMA = {
+    "query": dg.Field(
+        str,
+        is_required=False,
+        description="X v2 search query (ABI filter config default).",
+    ),
+    "max_results": dg.Field(
+        int,
+        is_required=False,
+        description="Page size forwarded to search_recent_tweets.",
+    ),
+    "max_pages": dg.Field(
+        int,
+        is_required=False,
+        description="Maximum pages to fetch per run (null = no limit).",
+    ),
+    "sort_order": dg.Field(
+        str,
+        is_required=False,
+        description="Result order: recency or relevancy.",
+    ),
+    "persist": dg.Field(
+        bool,
+        is_required=False,
+        description="Write mapped tweet triples to the triple store.",
+    ),
+    "cost_per_tweet_usd": dg.Field(
+        float,
+        is_required=False,
+        description="USD billed per tweet returned by search_recent_tweets.",
+    ),
+    "daily_max_tweets": dg.Field(
+        int,
+        is_required=False,
+        description="Max tweets this filter may retrieve per UTC day.",
+    ),
+    "daily_max_usd": dg.Field(
+        float,
+        is_required=False,
+        description="Max USD this filter may spend per UTC day.",
+    ),
+    "monthly_max_tweets": dg.Field(
+        int,
+        is_required=False,
+        description="Max tweets this filter may retrieve per calendar month.",
+    ),
+    "monthly_max_usd": dg.Field(
+        float,
+        is_required=False,
+        description="Max USD this filter may spend per calendar month.",
+    ),
+}
+
+_PIPELINE_OP_CONFIG_SCHEMA = {
+    "persist": dg.Field(
+        bool,
+        is_required=False,
+        description="Persist mapped triples to the triple store.",
+    ),
+    "graph_name": dg.Field(
+        str,
+        is_required=False,
+        description="Named graph IRI for mapped triples (ABI config default).",
+    ),
+}
+
+
+def _run_search_workflow(
+    filter_config: XTweetSearchWorkflowConfiguration,
+    op_cfg: dict | None = None,
+) -> list[str]:
+    from naas_abi_marketplace.applications.x.integrations.XIntegration import (
+        XIntegration,
+        XIntegrationConfiguration,
+    )
+    from naas_abi_marketplace.applications.x.workflows.XSearchRecentTweetsWorkflow import (
+        XSearchRecentTweetsWorkflow,
+        XSearchRecentTweetsWorkflowConfiguration,
+        XSearchRecentTweetsWorkflowParameters,
+    )
+
+    op_cfg = op_cfg or {}
+    module = ABIModule.get_instance()
+    query = launchpad_override(op_cfg, "query", filter_config.query)
+    max_results = launchpad_override(op_cfg, "max_results", filter_config.max_results)
+    max_pages = launchpad_override(op_cfg, "max_pages", filter_config.max_pages)
+    sort_order = launchpad_override(op_cfg, "sort_order", filter_config.sort_order)
+    persist = launchpad_override(op_cfg, "persist", filter_config.persist)
+
+    options: dict = {
+        "max_results": max_results,
+        "max_pages": max_pages,
+        "sort_order": sort_order,
+    }
+
+    logger.info(
+        f"XSearchWorkflowOrchestration[{filter_config.name}]: running "
+        f"XSearchRecentTweetsWorkflow(query={query!r}, persist={persist})"
+    )
+
+    # XIntegration and the workflow both default datastore_path to the
+    # module's configuration, so the envelopes the integration writes are
+    # the same ones the workflow scans to recover since_id.
+    x_integration = XIntegration(
+        XIntegrationConfiguration(bearer_token=module.configuration.bearer_token)
+    )
+    workflow = XSearchRecentTweetsWorkflow(
+        XSearchRecentTweetsWorkflowConfiguration(
+            x_integration=x_integration,
+            object_storage=module.engine.services.object_storage,
+            budget_key=filter_config.name,
+            cost_per_tweet_usd=launchpad_override(
+                op_cfg, "cost_per_tweet_usd", filter_config.cost_per_tweet_usd
+            ),
+            daily_max_tweets=launchpad_override(
+                op_cfg, "daily_max_tweets", filter_config.daily_max_tweets
+            ),
+            daily_max_usd=launchpad_override(
+                op_cfg, "daily_max_usd", filter_config.daily_max_usd
+            ),
+            monthly_max_tweets=launchpad_override(
+                op_cfg, "monthly_max_tweets", filter_config.monthly_max_tweets
+            ),
+            monthly_max_usd=launchpad_override(
+                op_cfg, "monthly_max_usd", filter_config.monthly_max_usd
+            ),
+        )
+    )
+    output = workflow.run(
+        XSearchRecentTweetsWorkflowParameters(
+            queries=[query],
+            options=options,
+            persist=persist,
+        )
+    )
+
+    # Hand each persisted envelope's path to the downstream pipeline op so
+    # the full SearchQuery / SearchRecentTweets structure is mapped from the
+    # same file the workflow just wrote.
+    return [
+        item["file_path"]
+        for item in output.get("results", [])
+        if item.get("file_path")
+    ]
 
 
 def _build_search_workflow_job_sensor(
@@ -46,70 +207,22 @@ def _build_search_workflow_job_sensor(
     pipeline_op_name = f"x_search_workflow_pipeline_op_{safe}"
     sensor_name = f"x_search_workflow_sensor_{safe}"
 
-    @dg.op(name=op_name)
-    def search_workflow_op() -> list[str]:
-        from naas_abi_marketplace.applications.x.integrations.XIntegration import (
-            XIntegration,
-            XIntegrationConfiguration,
-        )
-        from naas_abi_marketplace.applications.x.workflows.XSearchRecentTweetsWorkflow import (
-            XSearchRecentTweetsWorkflow,
-            XSearchRecentTweetsWorkflowConfiguration,
-            XSearchRecentTweetsWorkflowParameters,
-        )
+    @dg.op(name=op_name, config_schema=_SEARCH_WORKFLOW_OP_CONFIG_SCHEMA)
+    def search_workflow_op(context) -> list[str]:
+        return _run_search_workflow(config, context.op_config or {})
 
+    @dg.op(name=pipeline_op_name, config_schema=_PIPELINE_OP_CONFIG_SCHEMA)
+    def search_workflow_pipeline_op(context, file_paths: list[str]) -> None:
+        op_cfg = context.op_config or {}
         module = ABIModule.get_instance()
-
-        # Request the rich fields the rest of the pipeline maps into the graph
-        # (XUser via author_id, TweetPublicMetrics via public_metrics,
-        # TweetLanguage via lang, tweet_created_at). Without these the X v2
-        # search endpoint only returns {id, text} and the agent's engagement /
-        # language / author queries all come up empty.
-        options: dict = {
-            "max_results": config.max_results,
-            "max_pages": config.max_pages,
-            "sort_order": config.sort_order,
-        }
-
-        logger.info(
-            f"XSearchWorkflowOrchestration[{config.name}]: running "
-            f"XSearchRecentTweetsWorkflow(query={config.query!r}, "
-            f"persist={config.persist})"
+        persist = launchpad_override(op_cfg, "persist", config.persist)
+        graph_name = launchpad_override(
+            op_cfg, "graph_name", module.configuration.graph_name
         )
-
-        # XIntegration and the workflow both default datastore_path to the
-        # module's configuration, so the envelopes the integration writes are
-        # the same ones the workflow scans to recover since_id.
-        x_integration = XIntegration(
-            XIntegrationConfiguration(bearer_token=module.configuration.bearer_token)
-        )
-        workflow = XSearchRecentTweetsWorkflow(
-            XSearchRecentTweetsWorkflowConfiguration(
-                x_integration=x_integration,
-                object_storage=module.engine.services.object_storage,
-            )
-        )
-        output = workflow.run(
-            XSearchRecentTweetsWorkflowParameters(
-                queries=[config.query],
-                options=options,
-                persist=config.persist,
-            )
-        )
-
-        # Hand each persisted envelope's path to the downstream pipeline op so
-        # the full SearchQuery / SearchRecentTweets structure is mapped from the
-        # same file the workflow just wrote.
-        return [
-            item["file_path"]
-            for item in output.get("results", [])
-            if item.get("file_path")
-        ]
-
-    @dg.op(name=pipeline_op_name)
-    def search_workflow_pipeline_op(file_paths: list[str]) -> None:
         for file_path in file_paths:
-            run_search_pipeline_for_file(file_path)
+            run_search_pipeline_for_file(
+                file_path, persist=persist, graph_name=graph_name
+            )
 
     # In-process executor: share the code-server's warm engine instead of
     # forking a subprocess that has to re-bootstrap and race the api on
@@ -147,6 +260,14 @@ class XSearchWorkflowOrchestration(DagsterOrchestration):
     """One (job, sensor) pair per configured ``search_recent_tweets_workflow``
     filter, each driving :class:`XSearchRecentTweetsWorkflow` then
     :class:`XSearchRecentTweetsPipeline`. Sensors disabled by default.
+
+    Launchpad example (replace ``ai_llms`` with your filter name)::
+
+        ops:
+          x_search_workflow_op_ai_llms:
+            config:
+              query: "(openai OR anthropic) lang:en -is:retweet"
+              max_results: 50
     """
 
     @classmethod

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/utils/__init__.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/utils/__init__.py
@@ -8,6 +8,7 @@ safe_name, has_in_progress_run, run_search_pipeline_for_file)``.
 from naas_abi_marketplace.applications.x.orchestrations.utils._common import (
     IN_PROGRESS_RUN_STATUSES,
     has_in_progress_run,
+    launchpad_override,
     run_search_pipeline_for_file,
     safe_name,
 )
@@ -15,6 +16,7 @@ from naas_abi_marketplace.applications.x.orchestrations.utils._common import (
 __all__ = [
     "IN_PROGRESS_RUN_STATUSES",
     "has_in_progress_run",
+    "launchpad_override",
     "run_search_pipeline_for_file",
     "safe_name",
 ]

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/utils/_common.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/utils/_common.py
@@ -29,6 +29,16 @@ def safe_name(value: str) -> str:
     return re.sub(r"[^a-zA-Z0-9]", "_", value) or "filter"
 
 
+def launchpad_override(op_cfg: dict, key: str, default_value):
+    """Return launchpad value when explicitly set, else the ABI default."""
+    if key not in op_cfg:
+        return default_value
+    value = op_cfg[key]
+    if value is None and default_value is not None:
+        return default_value
+    return value
+
+
 def has_in_progress_run(context: dg.SensorEvaluationContext, job_name: str) -> bool:
     """True iff a run for *job_name* is still queued/starting/running."""
     runs = context.instance.get_runs(
@@ -41,7 +51,12 @@ def has_in_progress_run(context: dg.SensorEvaluationContext, job_name: str) -> b
     return len(runs) > 0
 
 
-def run_search_pipeline_for_file(file_path: str) -> None:
+def run_search_pipeline_for_file(
+    file_path: str,
+    *,
+    persist: bool | None = None,
+    graph_name: str | None = None,
+) -> None:
     """Map a persisted search_recent_tweets envelope into the graph.
 
     Runs :class:`XSearchRecentTweetsPipeline` in its ``file_path`` mode: it
@@ -73,7 +88,7 @@ def run_search_pipeline_for_file(file_path: str) -> None:
             x_integration=x_integration,
             triple_store=module.engine.services.triple_store,
             object_storage=module.engine.services.object_storage,
-            graph_name=URIRef(module.configuration.graph_name),
+            graph_name=URIRef(graph_name or module.configuration.graph_name),
         )
     )
     logger.info(
@@ -81,5 +96,8 @@ def run_search_pipeline_for_file(file_path: str) -> None:
         f"XSearchRecentTweetsPipeline"
     )
     pipeline.run(
-        XSearchRecentTweetsPipelineParameters(file_path=file_path, persist=True)
+        XSearchRecentTweetsPipelineParameters(
+            file_path=file_path,
+            persist=True if persist is None else persist,
+        )
     )

--- a/uv.lock
+++ b/uv.lock
@@ -3547,7 +3547,7 @@ wheels = [
 
 [[package]]
 name = "naas-abi"
-version = "2.37.0"
+version = "2.38.1"
 source = { editable = "libs/naas-abi" }
 dependencies = [
     { name = "aiosqlite" },
@@ -3655,7 +3655,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-core"
-version = "2.9.1"
+version = "2.9.2"
 source = { editable = "libs/naas-abi-core" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
This pull request resolves #dagster-launchpad-override

### Summary

This PR enhances the Dagster orchestrations for the `x` application in the ABI Marketplace by adding support for launchpad overrides in the run configurations. This allows manual runs from the Dagster launchpad UI to override default ABI configuration values for various orchestration jobs and ops.

### Key Changes

1. **XReprocessOrchestration:**
   - Added a `_reprocess_envelopes` function that supports launchpad overrides for `prefix`, `persist`, and `graph_name` config values.
   - Updated the `reprocess_envelopes_op` to use this new function and accept launchpad config overrides.
   - Added detailed launchpad usage examples in the docstring.

2. **XSearchRecentTweetsEventOrchestration:**
   - Added launchpad override support for ingestion and pipeline ops.
   - Introduced config schemas for ingestion and pipeline ops with optional override fields.
   - Added launchpad usage examples for manual replay of envelopes.

3. **XSearchWorkflowOrchestration:**
   - Added launchpad override support for workflow and pipeline ops.
   - Defined detailed config schemas for workflow ops and pipeline ops.
   - Updated orchestration to use launchpad overrides for all relevant parameters like query, max_results, persist, cost limits, etc.
   - Added launchpad usage examples for manual runs with custom parameters.

4. **Orchestration Utils:**
   - Added a new utility function `launchpad_override` to return the launchpad config value if set, otherwise fallback to the ABI default.
   - Updated `run_search_pipeline_for_file` to accept optional `persist` and `graph_name` parameters for flexible pipeline runs.

### Benefits

- Enables flexible manual runs from the Dagster launchpad with custom parameters without changing ABI config files.
- Improves usability and control over orchestration jobs and pipelines.
- Provides clear documentation and examples for launchpad usage.

### Example Launchpad Usage

```yaml
ops:
  x_reprocess_envelopes_op:
    config:
      prefix: x/search_recent_tweets/ai_llms
      persist: true
      graph_name: http://ontology.naas.ai/graph/x

  x_search_recent_tweets_ingestion_op:
    config:
      prefix: x/search_recent_tweets/ai_llms
      key: 2026-06-30T12:00:00_ai_llms.json
      batch_size: 500

  x_search_recent_tweets_pipeline_op:
    config:
      persist: true

  x_search_workflow_op_ai_llms:
    config:
      query: "(openai OR anthropic) lang:en -is:retweet"
      max_results: 50
```

This PR overall improves the orchestration flexibility and manual run capabilities for the `x` application in the ABI Marketplace.