### PR TITLE
feat(event): add filtering support to event queries for consumers

### DIFF
--- a/libs/naas-abi-core/naas_abi_core/services/event/EventPort.py
+++ b/libs/naas-abi-core/naas_abi_core/services/event/EventPort.py
@@ -88,6 +88,13 @@ class IEventAdapter(ABC):
         ``json_filter`` is an EventBridge-style dict (same syntax as
         :meth:`query`) pushed down into the read; only matching events count
         against ``limit`` and advance the cursor.
+
+        The cursor advances to the last *matching* seq, so non-matching events
+        below it (interior or not) are skipped permanently. A given
+        ``(consumer_id, event_type)`` MUST therefore be drained with a stable
+        filter for its lifetime: the filter is not part of the cursor key, so
+        changing or dropping it permanently loses whatever a prior filter
+        skipped.
         """
 
 
@@ -145,6 +152,12 @@ class IEventService(ABC):
 
         ``filter`` is an EventBridge-style dict pushed down into the read; only
         matching events count against ``limit`` and advance the cursor.
+
+        WARNING: the cursor is keyed by ``(consumer_id, event_class)`` and does
+        not include the filter. The cursor advances past non-matching events, so
+        a given ``consumer_id`` must use a *stable* filter for its lifetime —
+        draining it later with a different filter (or none) permanently skips the
+        events that did not match the earlier filter.
         """
 
     @abstractmethod
@@ -161,6 +174,9 @@ class IEventService(ABC):
         Drains all currently-pending events in batches of `batch_size`. The
         cursor is advanced per batch (same atomic semantics as `query_for_consumer`).
         Stops when the consumer is caught up.
+
+        ``filter`` follows the same pushdown and stable-filter-per-consumer
+        contract as :meth:`query_for_consumer` — see its warning.
         """
 
     @abstractmethod

--- a/libs/naas-abi-core/naas_abi_core/services/event/EventPort.py
+++ b/libs/naas-abi-core/naas_abi_core/services/event/EventPort.py
@@ -77,12 +77,17 @@ class IEventAdapter(ABC):
         consumer_id: str,
         event_type: str,
         limit: int | None = None,
+        json_filter: dict | None = None,
     ) -> list[StoredEvent]:
         """Return events with seq > cursor, then advance cursor to the last seq read.
 
         Atomic: the cursor advance happens in the same transaction as the read,
         so a crashed caller cannot skip events — at-most-once delivery only if
         the caller processes successfully after this returns.
+
+        ``json_filter`` is an EventBridge-style dict (same syntax as
+        :meth:`query`) pushed down into the read; only matching events count
+        against ``limit`` and advance the cursor.
         """
 
 
@@ -134,8 +139,13 @@ class IEventService(ABC):
         consumer_id: str,
         event_class: type,
         limit: int | None = None,
+        filter: dict | None = None,
     ) -> list[Any]:
-        """Return undelivered events for `consumer_id` and advance the cursor."""
+        """Return undelivered events for `consumer_id` and advance the cursor.
+
+        ``filter`` is an EventBridge-style dict pushed down into the read; only
+        matching events count against ``limit`` and advance the cursor.
+        """
 
     @abstractmethod
     def iter_query_for_consumer(
@@ -144,6 +154,7 @@ class IEventService(ABC):
         event_class: type,
         limit: int | None = None,
         batch_size: int = 500,
+        filter: dict | None = None,
     ) -> Iterator[Any]:
         """Stream undelivered events for `consumer_id`, advancing the cursor.
 

--- a/libs/naas-abi-core/naas_abi_core/services/event/EventService.py
+++ b/libs/naas-abi-core/naas_abi_core/services/event/EventService.py
@@ -208,11 +208,13 @@ class EventService(ServiceBase, IEventService):
         consumer_id: str,
         event_class: type[LogProcess],
         limit: int | None = None,
+        filter: dict | None = None,
     ) -> list[Any]:
         rows = self._adapter.query_for_consumer(
             consumer_id=consumer_id,
             event_type=str(event_class._class_uri),
             limit=limit,
+            json_filter=filter,
         )
         return [self._reconstruct(row, event_class) for row in rows]
 
@@ -222,6 +224,7 @@ class EventService(ServiceBase, IEventService):
         event_class: type[LogProcess],
         limit: int | None = None,
         batch_size: int = 500,
+        filter: dict | None = None,
     ) -> Iterator[Any]:
         """Drain pending events for `consumer_id` in batches, advancing the cursor.
 
@@ -246,6 +249,7 @@ class EventService(ServiceBase, IEventService):
                 consumer_id=consumer_id,
                 event_type=event_type,
                 limit=fetch_size,
+                json_filter=filter,
             )
             if not rows:
                 return

--- a/libs/naas-abi-core/naas_abi_core/services/event/EventService_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/event/EventService_test.py
@@ -433,6 +433,25 @@ def test_query_filter_operators(tmp_path):
     assert sorted(r.user_id for r in rows) == ["alice-1", "alice-2"]
 
 
+def test_query_for_consumer_pushes_down_filter(tmp_path):
+    service, _, _ = _make_service(tmp_path)
+    service.publish(UserAuthenticated(user_id="alice-1"))
+    service.publish(UserAuthenticated(user_id="bob"))
+    service.publish(UserAuthenticated(user_id="alice-2"))
+
+    rows = service.query_for_consumer(
+        "c1", UserAuthenticated, filter={"user_id": {"prefix": "alice"}}
+    )
+    assert sorted(r.user_id for r in rows) == ["alice-1", "alice-2"]
+
+    # Cursor advanced past the last matching seq (alice-2 @ seq 3), so the
+    # non-matching "bob" below it is skipped permanently for this consumer.
+    assert service.query_for_consumer(
+        "c1", UserAuthenticated, filter={"user_id": {"prefix": "alice"}}
+    ) == []
+    assert service.query_for_consumer("c1", UserAuthenticated) == []
+
+
 def test_query_filter_multiple_keys_anded(tmp_path):
     service, _, _ = _make_service(tmp_path)
     service.publish(UserAuthenticated(user_id="alice"))

--- a/libs/naas-abi-core/naas_abi_core/services/event/EventService_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/event/EventService_test.py
@@ -452,6 +452,56 @@ def test_query_for_consumer_pushes_down_filter(tmp_path):
     assert service.query_for_consumer("c1", UserAuthenticated) == []
 
 
+def test_query_for_consumer_filter_trailing_nonmatch_stays_pending(tmp_path):
+    # The SAFE half of the cursor contract: a non-matching event published
+    # ABOVE the last match must stay pending — the cursor only advances to the
+    # last matching seq, so a later drain still delivers it.
+    service, adapter, _ = _make_service(tmp_path)
+    service.publish(UserAuthenticated(user_id="alice-1"))  # seq 1, matches
+    service.publish(UserAuthenticated(user_id="bob"))      # seq 2, trailing non-match
+
+    rows = service.query_for_consumer(
+        "c1", UserAuthenticated, filter={"user_id": {"prefix": "alice"}}
+    )
+    assert [r.user_id for r in rows] == ["alice-1"]
+    # Cursor parked at seq 1 (the last match), NOT at the table max.
+    assert adapter.get_cursor("c1", UserAuthenticated._class_uri) == 1
+
+    # bob (seq 2) is above the last match, so it is still pending for a later drain.
+    rest = service.query_for_consumer("c1", UserAuthenticated)
+    assert [r.user_id for r in rest] == ["bob"]
+
+
+def test_iter_query_for_consumer_pushes_down_filter(tmp_path):
+    service, adapter, _ = _make_service(tmp_path)
+    # Interleave matching/non-matching events across more than one batch.
+    for i in range(6):
+        service.publish(UserAuthenticated(user_id=f"alice-{i}"))  # matches
+        service.publish(UserAuthenticated(user_id=f"bob-{i}"))    # non-match
+
+    streamed = list(
+        service.iter_query_for_consumer(
+            "c1",
+            UserAuthenticated,
+            batch_size=2,
+            filter={"user_id": {"prefix": "alice"}},
+        )
+    )
+    # Only matching events stream, in seq order, across multiple batches; the
+    # interleaved non-matching events never surface and never blow the budget.
+    assert [e.user_id for e in streamed] == [f"alice-{i}" for i in range(6)]
+    # Cursor advanced to the last matching seq (alice-5 @ seq 11), leaving the
+    # trailing non-match (bob-5 @ seq 12) pending.
+    assert adapter.get_cursor("c1", UserAuthenticated._class_uri) == 11
+
+    # A second filtered drain is empty (no matching events remain).
+    assert list(
+        service.iter_query_for_consumer(
+            "c1", UserAuthenticated, filter={"user_id": {"prefix": "alice"}}
+        )
+    ) == []
+
+
 def test_query_filter_multiple_keys_anded(tmp_path):
     service, _, _ = _make_service(tmp_path)
     service.publish(UserAuthenticated(user_id="alice"))

--- a/libs/naas-abi-core/naas_abi_core/services/event/adapters/secondary/EventSQLiteAdapter.py
+++ b/libs/naas-abi-core/naas_abi_core/services/event/adapters/secondary/EventSQLiteAdapter.py
@@ -166,6 +166,30 @@ class EventSQLiteAdapter(IEventAdapter):
         limit: int | None = None,
         json_filter: dict | None = None,
     ) -> list[StoredEvent]:
+        # Translate the filter BEFORE BEGIN IMMEDIATE: build_where is pure
+        # string work that can raise FilterError on a malformed filter, and we
+        # don't want a bad filter to abort a transaction or hold the write lock
+        # — it should fail fast as a plain caller error.
+        #
+        # Pushdown payload filter (EventBridge-style) so the per-tick `limit`
+        # budget and the cursor advance only over events the consumer wants.
+        # CURSOR SEMANTICS: the cursor advances to the last *matching* seq read,
+        # so ANY non-matching event whose seq is below a matching one — interior
+        # or not — is skipped *permanently* for this consumer (the cursor never
+        # moves backward). Only non-matching events ABOVE the last match stay
+        # pending. The filter predicate is an unindexed JSON extraction
+        # (`payload ->> '$.path'`), so a long trailing run of non-matching
+        # events is fully re-scanned on every tick until a matching event
+        # advances the cursor past them — not free. And because the cursor key
+        # is (consumer_id, event_type) and does NOT include the filter, a
+        # consumer_id MUST use a stable filter for its lifetime; draining it
+        # with a different filter (or none) permanently drops whatever an
+        # earlier filter skipped.
+        where_sql = ""
+        where_params: list[object] = []
+        if json_filter:
+            where_sql, where_params = build_where(json_filter, column="payload")
+
         with self._lock:
             self._conn.execute("BEGIN IMMEDIATE")
             try:
@@ -181,19 +205,9 @@ class EventSQLiteAdapter(IEventAdapter):
                     "WHERE event_type = ? AND seq > ?"
                 )
                 params: list[object] = [event_type, last_seq]
-                # Pushdown payload filter (EventBridge-style) so the per-tick
-                # `limit` budget and the cursor advance only over events the
-                # consumer actually wants. The cursor still advances to the last
-                # *matching* seq read, so non-matching events below it are
-                # skipped for this consumer; trailing non-matching events stay
-                # pending (cheap indexed re-scan) until a matching one arrives.
-                if json_filter:
-                    where_sql, where_params = build_where(
-                        json_filter, column="payload"
-                    )
-                    if where_sql:
-                        sql += " AND " + where_sql
-                        params.extend(where_params)
+                if where_sql:
+                    sql += " AND " + where_sql
+                    params.extend(where_params)
                 sql += " ORDER BY seq ASC"
                 if limit is not None:
                     sql += " LIMIT ?"

--- a/libs/naas-abi-core/naas_abi_core/services/event/adapters/secondary/EventSQLiteAdapter.py
+++ b/libs/naas-abi-core/naas_abi_core/services/event/adapters/secondary/EventSQLiteAdapter.py
@@ -164,6 +164,7 @@ class EventSQLiteAdapter(IEventAdapter):
         consumer_id: str,
         event_type: str,
         limit: int | None = None,
+        json_filter: dict | None = None,
     ) -> list[StoredEvent]:
         with self._lock:
             self._conn.execute("BEGIN IMMEDIATE")
@@ -177,9 +178,23 @@ class EventSQLiteAdapter(IEventAdapter):
 
                 sql = (
                     "SELECT id, event_type, seq, timestamp, payload FROM events "
-                    "WHERE event_type = ? AND seq > ? ORDER BY seq ASC"
+                    "WHERE event_type = ? AND seq > ?"
                 )
                 params: list[object] = [event_type, last_seq]
+                # Pushdown payload filter (EventBridge-style) so the per-tick
+                # `limit` budget and the cursor advance only over events the
+                # consumer actually wants. The cursor still advances to the last
+                # *matching* seq read, so non-matching events below it are
+                # skipped for this consumer; trailing non-matching events stay
+                # pending (cheap indexed re-scan) until a matching one arrives.
+                if json_filter:
+                    where_sql, where_params = build_where(
+                        json_filter, column="payload"
+                    )
+                    if where_sql:
+                        sql += " AND " + where_sql
+                        params.extend(where_params)
+                sql += " ORDER BY seq ASC"
                 if limit is not None:
                     sql += " LIMIT ?"
                     params.append(limit)

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/XSearchRecentTweetsEventOrchestration.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/XSearchRecentTweetsEventOrchestration.py
@@ -253,8 +253,13 @@ def _build_search_recent_tweets_event_sensor(
                 # budget and the durable cursor only advance over puts under
                 # this entry's prefix. `_is_search_recent_tweets_put` below
                 # stays the authoritative check (exact prefix boundary, file
-                # extension, non-empty size).
-                filter={"prefix": {"prefix": event_cfg.prefix}},
+                # extension, non-empty size). Strip surrounding slashes so this
+                # coarse `LIKE 'prefix%'` pushdown stays a true *superset* of the
+                # authoritative check, which normalizes both sides with
+                # `.strip("/")`. Without the strip, a configured prefix like
+                # "x/foo/" would filter out events the fine check accepts — and,
+                # because the cursor advances past them, drop them permanently.
+                filter={"prefix": {"prefix": event_cfg.prefix.strip("/")}},
             )
         except Exception as exc:  # noqa: BLE001
             return dg.SkipReason(
@@ -287,6 +292,20 @@ def _build_search_recent_tweets_event_sensor(
                     f"exists in storage"
                 )
                 continue
+            except Exception as exc:  # noqa: BLE001
+                # A *transient* storage error (throttling, 5xx, timeout, auth
+                # expiry) must not drop the event. `query_for_consumer` has
+                # already advanced the durable cursor past this whole batch, so
+                # a `continue` here — or letting the error escape the sensor —
+                # would lose the event permanently. Fail open and enqueue: the
+                # ingestion op re-reads the object and harmlessly no-ops/dedupes
+                # if it really is gone, so a redundant run is cheap, whereas a
+                # silently dropped event is not recoverable.
+                logger.warning(
+                    f"XSearchRecentTweetsEventOrchestration[{event_cfg.name}]: "
+                    f"metadata probe failed for {prefix}/{key} ({exc}); "
+                    f"enqueuing anyway rather than risk dropping the event"
+                )
             run_requests.append(
                 dg.RunRequest(
                     # Run-key includes prefix+key so the same envelope can't be

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/XSearchRecentTweetsEventOrchestration.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/XSearchRecentTweetsEventOrchestration.py
@@ -44,6 +44,7 @@ import posixpath
 import dagster as dg
 from naas_abi_core import logger
 from naas_abi_core.orchestrations.DagsterOrchestration import DagsterOrchestration
+from naas_abi_core.services.object_storage.ObjectStoragePort import Exceptions
 from naas_abi_marketplace.applications.x import (
     ABIModule,
     XSearchRecentTweetsEventConfiguration,
@@ -248,6 +249,12 @@ def _build_search_recent_tweets_event_sensor(
                 consumer_id=sensor_name,
                 event_class=ObjectPut,
                 limit=event_cfg.events_per_tick,
+                # Push the watched-prefix filter into the query so the per-tick
+                # budget and the durable cursor only advance over puts under
+                # this entry's prefix. `_is_search_recent_tweets_put` below
+                # stays the authoritative check (exact prefix boundary, file
+                # extension, non-empty size).
+                filter={"prefix": {"prefix": event_cfg.prefix}},
             )
         except Exception as exc:  # noqa: BLE001
             return dg.SkipReason(
@@ -257,6 +264,7 @@ def _build_search_recent_tweets_event_sensor(
         if not new_events:
             return dg.SkipReason("no new ObjectPut events")
 
+        object_storage = module.engine.services.object_storage
         run_requests: list[dg.RunRequest] = []
         for evt in new_events:
             prefix = evt.prefix or ""
@@ -264,6 +272,20 @@ def _build_search_recent_tweets_event_sensor(
             if not _is_search_recent_tweets_put(
                 prefix, key, evt.size_bytes, event_cfg.prefix
             ):
+                continue
+            # The ObjectPut event is a durable record of a *past* write; the
+            # envelope may since have been deleted (e.g. a delete_after_ingest
+            # pass on a redundant run). Probe storage and skip stale events here
+            # so we don't enqueue a run the ingestion op would only fail on a
+            # missing object.
+            try:
+                object_storage.get_object_metadata(prefix, key)
+            except Exceptions.ObjectNotFound:
+                logger.info(
+                    f"XSearchRecentTweetsEventOrchestration[{event_cfg.name}]: "
+                    f"skipping ObjectPut for {prefix}/{key}; object no longer "
+                    f"exists in storage"
+                )
                 continue
             run_requests.append(
                 dg.RunRequest(


### PR DESCRIPTION
This pull request resolves #filter-events

### Summary

This PR introduces support for filtering events when querying for consumer events in the event service and adapter layers.

### Changes

- Added a `json_filter` parameter to the `IEventAdapter.query_for_consumer` method to allow pushing down an EventBridge-style filter dict into the event query.
- Updated `IEventService.query_for_consumer` and `iter_query_for_consumer` to accept a `filter` parameter and pass it down to the adapter.
- Modified `EventService` implementation to support the new filter parameter and pass it to the adapter.
- Enhanced `EventSQLiteAdapter` to apply the JSON filter as a SQL WHERE clause on the event payload, ensuring only matching events count against the limit and advance the cursor.
- Added a new test `test_query_for_consumer_pushes_down_filter` to verify that filtering works correctly and that the cursor advances only past matching events.
- Updated the `XSearchRecentTweetsEventOrchestration` to push a prefix filter into the event query, optimizing event retrieval by limiting to relevant events.
- Added logic to skip processing of stale ObjectPut events if the underlying object no longer exists in storage.

### Impact

- This filtering enhancement allows consumers to efficiently query only relevant events, improving performance and correctness.
- Cursor advancement semantics ensure that non-matching events are skipped permanently for a consumer, preventing re-processing.
- The orchestration now avoids unnecessary runs for deleted objects, improving robustness.

### Testing

- Added unit tests for filtering behavior.
- Manual testing of orchestration event filtering and skipping stale events.

This is a backward-compatible enhancement to event querying with added filtering capabilities.