### PR TITLE
feat(cli): add 'abi stack snapshot' for stack snapshot / rollback / migrate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,8 @@ storage/vectorstore/*
 .abi/
 # Dagster local home dir created by `abi dev up`
 .dagster/
+# Local Docker stack snapshots (abi stack snapshot create)
+.snapshots/
 
 
 *.pid

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -359,6 +359,11 @@ services:
     image: rabbitmq:3-management
     pull_policy: always
     restart: unless-stopped
+    # Pin the node name (rabbit@rabbitmq). Without a stable hostname RabbitMQ
+    # derives its Mnesia dir from the random container id, so durable queues are
+    # lost whenever the container is recreated (e.g. `abi stack snapshot restore`
+    # or a host migration). Applying this resets the node once.
+    hostname: rabbitmq
     ports:
       - 5672:5672   # AMQP
       - 15672:15672 # Management UI - http://localhost:15672

--- a/libs/naas-abi-cli/README.md
+++ b/libs/naas-abi-cli/README.md
@@ -135,6 +135,79 @@ abi deploy naas
 abi deploy naas --env prod
 ```
 
+### Stack Management
+
+Commands for the local Docker Compose stack (`config.local.yaml`). `abi start`,
+`abi stop`, and `abi logs` are also exposed at the top level for convenience.
+
+#### `abi stack snapshot create [-m/--note <text>] [--name <label>]`
+Takes a point-in-time snapshot of the stack's stateful data so you can roll back
+later or move the deployment to another host.
+
+**What it does:**
+- Resolves the compose project and its stateful volumes (`postgres_data`,
+  `minio_data`, `fuseki_data`, `qdrant_storage`, `redis_data`, `rabbitmq_data`,
+  `headscale_data`); transient volumes (caddy certs, dagster history, caches,
+  the headscale socket dir) are skipped
+- Gracefully stops the stack so the copy is consistent, archives each volume plus
+  the host `storage/` directory, writes a `manifest.json` (timestamp, git commit,
+  config fingerprints), then restarts the stack
+
+> RabbitMQ note: durable queues only survive a restore if the broker's node name
+> is stable. The compose file pins `hostname: rabbitmq` for this reason.
+- Stores everything under `./.snapshots/<id>/` (gitignored)
+
+**Example:**
+```bash
+abi stack snapshot create -m "before v3.15 upgrade"
+```
+
+#### `abi stack snapshot list`
+Lists snapshots (newest first) with id, date, size, git commit, and note.
+
+#### `abi stack snapshot restore <id> [--yes] [--no-safety-snapshot]`
+Rolls the stack back to a snapshot. **Destructive** — it overwrites current data.
+
+**What it does:**
+- Validates the snapshot is complete *before* touching anything, so a corrupt or
+  partial snapshot aborts without wiping any live data
+- Warns if the git commit or `config.local.yaml`/`.env` have changed since capture
+- Takes an automatic safety snapshot of the current state first (opt out with
+  `--no-safety-snapshot`; skipped automatically on a fresh host with no data yet),
+  so a rollback is itself reversible
+- Stops the stack, restores the volumes + `storage/`, and brings it back up — and
+  if anything fails mid-restore it still brings the stack back up and prints the
+  safety-snapshot id to recover from
+
+**Example:**
+```bash
+abi stack snapshot restore 20260630-140509
+```
+
+#### `abi stack snapshot delete <id> [--yes]` / `abi stack snapshot prune [--keep N] [--yes]`
+Remove a single snapshot, or keep only the newest `N` (default 5).
+
+#### `abi stack snapshot export <id> <archive.tar.gz>` / `abi stack snapshot import <archive.tar.gz>`
+Bundle a snapshot into one portable archive and re-register it on another host —
+the supported way to migrate a local deployment to a new machine:
+
+```bash
+# On the source host
+abi stack snapshot create -m "migration"
+abi stack snapshot export 20260630-140509 abi-migration.tar.gz
+# copy abi-migration.tar.gz (and your .env) to the new host, then:
+abi stack snapshot import abi-migration.tar.gz
+abi stack snapshot restore 20260630-140509
+```
+
+`export` refuses to overwrite an existing file and `import` refuses to clobber a
+snapshot with the same id; pass `--force` to either to override. `import` also
+verifies the archive is complete (all volume tarballs + storage present) and
+rejects a partial one.
+
+> Note: the same `.env` (Postgres/MinIO/Fuseki credentials) must be present on the
+> destination host — those credentials are baked into the data being restored.
+
 ### Secret Management
 
 #### `abi secrets naas list`

--- a/libs/naas-abi-cli/naas_abi_cli/cli/__init__.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/__init__.py
@@ -15,6 +15,7 @@ from .new import new
 from .run import run
 from .secret import secrets
 from .setup import setup
+from .snapshot import snapshot
 from .stack import logs, stack, start, stop
 
 
@@ -37,6 +38,7 @@ _main.add_command(setup)
 _main.add_command(start)
 _main.add_command(stop)
 _main.add_command(logs)
+stack.add_command(snapshot)
 _main.add_command(stack)
 _main.add_command(dev)
 ran = False

--- a/libs/naas-abi-cli/naas_abi_cli/cli/snapshot.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/snapshot.py
@@ -1,0 +1,163 @@
+"""``abi stack snapshot`` -- capture, restore, and move the Docker stack's data.
+
+Snapshots are stored under ``./.snapshots/<id>/`` in the project root. Each one
+is a cold, consistent copy of the stateful volumes plus the host ``storage/``
+directory, taken while the stack is briefly stopped. See
+:mod:`naas_abi_cli.cli.snapshot_runtime` for the underlying logic.
+"""
+
+from datetime import datetime, timezone
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from . import snapshot_runtime as runtime
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _human_size(num_bytes: int) -> str:
+    size = float(num_bytes)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if size < 1024 or unit == "TB":
+            return f"{size:.0f}{unit}" if unit == "B" else f"{size:.1f}{unit}"
+        size /= 1024
+    return f"{size:.1f}TB"
+
+
+@click.group("snapshot")
+def snapshot() -> None:
+    """Create, restore, and move snapshots of the Docker stack's data."""
+
+
+@snapshot.command("create")
+@click.option("-m", "--note", default="", help="A note describing this snapshot.")
+@click.option(
+    "--name",
+    "slug",
+    default=None,
+    help="Optional label appended to the snapshot id.",
+)
+def snapshot_create(note: str, slug: str | None) -> None:
+    """Stop the stack, archive its data, then restart it."""
+    manifest = runtime.create_snapshot(note=note, slug=slug, now=_now())
+    click.echo(
+        f"Created snapshot '{manifest.id}' "
+        f"({_human_size(manifest.size_bytes)}, volumes: "
+        f"{', '.join(manifest.volumes) or 'none'})."
+    )
+
+
+@snapshot.command("list")
+def snapshot_list() -> None:
+    """List available snapshots, newest first."""
+    manifests = runtime.list_snapshots()
+    if not manifests:
+        click.echo("No snapshots yet. Create one with 'abi stack snapshot create'.")
+        return
+
+    table = Table(title="ABI Stack Snapshots")
+    table.add_column("ID")
+    table.add_column("Created (UTC)")
+    table.add_column("Size")
+    table.add_column("Commit")
+    table.add_column("Note")
+    for manifest in manifests:
+        table.add_row(
+            manifest.id,
+            manifest.created_at,
+            _human_size(manifest.size_bytes),
+            manifest.git_commit or "-",
+            manifest.note or "-",
+        )
+    Console().print(table)
+
+
+@snapshot.command("restore")
+@click.argument("snapshot_id")
+@click.option(
+    "--yes",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt.",
+)
+@click.option(
+    "--safety-snapshot/--no-safety-snapshot",
+    default=True,
+    show_default=True,
+    help="Take a safety snapshot of the current state before restoring.",
+)
+def snapshot_restore(snapshot_id: str, yes: bool, safety_snapshot: bool) -> None:
+    """Roll the stack back to snapshot SNAPSHOT_ID (destructive)."""
+    if not yes:
+        click.confirm(
+            f"This overwrites the current stack data with snapshot "
+            f"'{snapshot_id}'. Continue?",
+            abort=True,
+        )
+    runtime.restore_snapshot(snapshot_id, safety=safety_snapshot, now=_now())
+    click.echo(f"Restored snapshot '{snapshot_id}'.")
+
+
+@snapshot.command("delete")
+@click.argument("snapshot_id")
+@click.option("--yes", is_flag=True, default=False, help="Skip the confirmation prompt.")
+def snapshot_delete(snapshot_id: str, yes: bool) -> None:
+    """Delete a snapshot."""
+    if not yes:
+        click.confirm(f"Delete snapshot '{snapshot_id}'?", abort=True)
+    runtime.delete_snapshot(snapshot_id)
+    click.echo(f"Deleted snapshot '{snapshot_id}'.")
+
+
+@snapshot.command("prune")
+@click.option(
+    "--keep",
+    type=int,
+    default=5,
+    show_default=True,
+    help="Number of newest snapshots to keep.",
+)
+@click.option("--yes", is_flag=True, default=False, help="Skip the confirmation prompt.")
+def snapshot_prune(keep: int, yes: bool) -> None:
+    """Delete all but the newest --keep snapshots."""
+    victims = runtime.select_prunable(runtime.list_snapshots(), keep)
+    if not victims:
+        click.echo("Nothing to prune.")
+        return
+    if not yes:
+        click.confirm(
+            f"Delete {len(victims)} snapshot(s): {', '.join(victims)}?", abort=True
+        )
+    for snapshot_id in victims:
+        runtime.delete_snapshot(snapshot_id)
+    click.echo(f"Pruned {len(victims)} snapshot(s).")
+
+
+@snapshot.command("export")
+@click.argument("snapshot_id")
+@click.argument("destination", type=click.Path(dir_okay=False))
+@click.option("--force", is_flag=True, default=False, help="Overwrite the destination if it exists.")
+def snapshot_export(snapshot_id: str, destination: str, force: bool) -> None:
+    """Export a snapshot to a single portable archive for another host."""
+    from pathlib import Path
+
+    path = runtime.export_snapshot(snapshot_id, Path(destination), force=force)
+    click.echo(f"Exported snapshot '{snapshot_id}' to {path}.")
+
+
+@snapshot.command("import")
+@click.argument("archive", type=click.Path(exists=True, dir_okay=False))
+@click.option("--force", is_flag=True, default=False, help="Replace an existing snapshot with the same id.")
+def snapshot_import(archive: str, force: bool) -> None:
+    """Import a snapshot archive produced by 'export' on another host."""
+    from pathlib import Path
+
+    snapshot_id = runtime.import_snapshot(Path(archive), force=force)
+    click.echo(
+        f"Imported snapshot '{snapshot_id}'. "
+        f"Restore it with 'abi stack snapshot restore {snapshot_id}'."
+    )

--- a/libs/naas-abi-cli/naas_abi_cli/cli/snapshot_runtime.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/snapshot_runtime.py
@@ -1,0 +1,768 @@
+"""Point-in-time snapshots of the Docker stack's stateful data.
+
+This module owns the *logic* for capturing, restoring, and moving snapshots of
+the local Docker Compose deployment described by ``config.local.yaml``. The
+Click surface lives in :mod:`naas_abi_cli.cli.snapshot` and is intentionally
+thin so this logic stays unit-testable.
+
+What is captured:
+  * the stateful Docker volumes (``postgres_data``, ``minio_data``,
+    ``fuseki_data``, ``qdrant_storage``, ``redis_data``, ``rabbitmq_data``,
+    ``headscale_data``) -- copied cold as raw tarballs so each engine's on-disk
+    state is consistent;
+  * the host ``storage/`` directory (the durable SQLite event log + local
+    datastore files).
+
+Transient volumes (caddy certs, dagster run history, build/model caches, and
+the headscale ``headscale_run`` socket dir) are skipped -- they rebuild
+themselves.
+"""
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import tarfile
+from collections.abc import Callable
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from pathlib import Path
+
+import click
+
+from .bootstrap import find_abi_project_root
+from .stack_runtime import run_compose
+
+# Stateful volumes worth snapshotting, by their docker-compose volume key.
+# redis runs with --appendonly yes (durable KV, not just a cache); rabbitmq
+# holds durable queues (see the hostname note in docker-compose.yml -- the node
+# name must be stable for its data to survive a restore); headscale_data holds
+# the users/nodes SQLite DB + noise key. The headscale_run socket dir, caddy
+# certs, dagster run history, and build/model caches are intentionally excluded.
+DATA_VOLUMES: tuple[str, ...] = (
+    "postgres_data",
+    "minio_data",
+    "fuseki_data",
+    "qdrant_storage",
+    "redis_data",
+    "rabbitmq_data",
+    "headscale_data",
+)
+
+SNAPSHOTS_DIRNAME = ".snapshots"
+MANIFEST_NAME = "manifest.json"
+STORAGE_DIRNAME = "storage"
+VOLUMES_DIRNAME = "volumes"
+# Tiny, ubiquitous image used purely to tar/untar volume contents.
+HELPER_IMAGE = "alpine:3.20"
+# Files whose content we fingerprint so we can warn about drift on restore.
+TRACKED_CONFIG_FILES = ("config.local.yaml", ".env")
+MANIFEST_FORMAT_VERSION = 1
+
+
+# --------------------------------------------------------------------------- #
+# Manifest
+# --------------------------------------------------------------------------- #
+@dataclass
+class SnapshotManifest:
+    """Metadata persisted alongside every snapshot's tarballs."""
+
+    id: str
+    created_at: str
+    note: str = ""
+    project: str = ""
+    git_commit: str | None = None
+    cli_version: str = "unknown"
+    volumes: list[str] = field(default_factory=list)
+    storage_included: bool = False
+    config_hashes: dict[str, str] = field(default_factory=dict)
+    size_bytes: int = 0
+    format_version: int = MANIFEST_FORMAT_VERSION
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), indent=2, sort_keys=True)
+
+    @classmethod
+    def from_json(cls, raw: str) -> "SnapshotManifest":
+        data = json.loads(raw)
+        if not isinstance(data, dict):
+            raise ValueError("manifest must be a JSON object")
+        known = {f for f in cls.__dataclass_fields__}  # noqa: C416
+        return cls(**{k: v for k, v in data.items() if k in known})
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers (no side effects -- the easy-to-test core)
+# --------------------------------------------------------------------------- #
+def sanitize_slug(text: str) -> str:
+    """Reduce arbitrary text to a filesystem/id-safe slug."""
+    out: list[str] = []
+    for ch in text.strip().lower():
+        if ch.isalnum():
+            out.append(ch)
+        elif ch in {" ", "-", "_"}:
+            out.append("-")
+    slug = "".join(out)
+    while "--" in slug:
+        slug = slug.replace("--", "-")
+    return slug.strip("-")
+
+
+def generate_snapshot_id(now: datetime, slug: str | None = None) -> str:
+    stamp = now.strftime("%Y%m%d-%H%M%S")
+    if slug:
+        clean = sanitize_slug(slug)
+        if clean:
+            return f"{stamp}-{clean}"
+    return stamp
+
+
+def sanitize_project_name(name: str) -> str:
+    """Mimic docker compose's project-name normalisation."""
+    lowered = name.lower()
+    cleaned = "".join(ch for ch in lowered if ch.isalnum() or ch in {"_", "-"})
+    return cleaned.lstrip("_-")
+
+
+def parse_project_name(config_json: str) -> str | None:
+    """Extract the resolved project ``name`` from ``compose config --format json``."""
+    try:
+        data = json.loads(config_json)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    name = data.get("name")
+    return str(name) if name else None
+
+
+def volume_full_name(project: str, key: str) -> str:
+    return f"{project}_{key}"
+
+
+def select_prunable(manifests: list[SnapshotManifest], keep: int) -> list[str]:
+    """Return ids of snapshots to delete, keeping the ``keep`` newest."""
+    if keep < 0:
+        raise ValueError("keep must be >= 0")
+    ordered = sorted(manifests, key=lambda m: m.created_at, reverse=True)
+    return [m.id for m in ordered[keep:]]
+
+
+def detect_drift(
+    manifest: SnapshotManifest,
+    current_commit: str | None,
+    current_hashes: dict[str, str],
+) -> list[str]:
+    """Human-readable warnings when code/config differs from snapshot time."""
+    messages: list[str] = []
+    if (
+        manifest.git_commit
+        and current_commit
+        and manifest.git_commit != current_commit
+    ):
+        messages.append(
+            f"git commit differs: snapshot {manifest.git_commit} vs current "
+            f"{current_commit}"
+        )
+    for name, snapshot_hash in manifest.config_hashes.items():
+        current = current_hashes.get(name)
+        if current and current != snapshot_hash:
+            messages.append(f"{name} has changed since the snapshot was taken")
+    return messages
+
+
+# --------------------------------------------------------------------------- #
+# Filesystem layout
+# --------------------------------------------------------------------------- #
+def project_root() -> Path:
+    return find_abi_project_root() or Path.cwd()
+
+
+def snapshots_root(root: Path) -> Path:
+    return root / SNAPSHOTS_DIRNAME
+
+
+def _is_unsafe_component(name: str) -> bool:
+    """True if ``name`` is not a single, plain path component.
+
+    Anything absolute ('/'), a parent ref ('..'), '.', empty, or containing a
+    separator would make ``base / name`` resolve outside the snapshots dir --
+    dangerous because delete/restore/import act destructively on that path.
+    """
+    return (not name) or name in (".", "..") or Path(name).name != name
+
+
+def _validate_snapshot_id(snapshot_id: str) -> str:
+    if _is_unsafe_component(snapshot_id):
+        raise click.ClickException(f"Invalid snapshot id: '{snapshot_id}'.")
+    return snapshot_id
+
+
+def _sha256_file(path: Path) -> str | None:
+    try:
+        digest = hashlib.sha256()
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(65536), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+    except OSError:
+        return None
+
+
+def config_hashes(root: Path) -> dict[str, str]:
+    hashes: dict[str, str] = {}
+    for name in TRACKED_CONFIG_FILES:
+        digest = _sha256_file(root / name)
+        if digest:
+            hashes[name] = digest
+    return hashes
+
+
+def dir_size(path: Path) -> int:
+    total = 0
+    for entry in path.rglob("*"):
+        if entry.is_file():
+            try:
+                total += entry.stat().st_size
+            except OSError:
+                continue
+    return total
+
+
+def cli_version() -> str:
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+
+        try:
+            return version("naas-abi-cli")
+        except PackageNotFoundError:
+            return "unknown"
+    except Exception:
+        return "unknown"
+
+
+def current_git_commit(root: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "--short", "HEAD"],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+    commit = result.stdout.strip()
+    return commit or None
+
+
+def write_manifest(snap_dir: Path, manifest: SnapshotManifest) -> None:
+    (snap_dir / MANIFEST_NAME).write_text(manifest.to_json(), encoding="utf-8")
+
+
+def read_manifest(snap_dir: Path) -> SnapshotManifest:
+    manifest_path = snap_dir / MANIFEST_NAME
+    if not manifest_path.exists():
+        raise click.ClickException(f"No snapshot manifest at {manifest_path}.")
+    try:
+        return SnapshotManifest.from_json(manifest_path.read_text(encoding="utf-8"))
+    except (ValueError, TypeError) as error:
+        raise click.ClickException(
+            f"Snapshot manifest at {manifest_path} is invalid: {error}"
+        ) from error
+
+
+# --------------------------------------------------------------------------- #
+# Docker primitives (side-effecting -- mocked in tests)
+# --------------------------------------------------------------------------- #
+def run_docker(
+    args: list[str], capture_output: bool = False
+) -> subprocess.CompletedProcess:
+    try:
+        return subprocess.run(
+            ["docker", *args],
+            check=True,
+            text=True,
+            capture_output=capture_output,
+        )
+    except FileNotFoundError as error:
+        raise click.ClickException(
+            "Docker is not installed or not available in PATH."
+        ) from error
+    except subprocess.CalledProcessError as error:
+        raise click.ClickException(
+            f"docker {' '.join(args)} failed with exit code {error.returncode}."
+        ) from error
+
+
+def compose_project_name() -> str:
+    """Resolve the compose project name (the volume prefix).
+
+    Primary source is ``docker compose config --format json`` -- it honours
+    ``COMPOSE_PROJECT_NAME`` and ``.env``. Falls back to the env var, then to a
+    normalised project-directory name so the command still works when the stack
+    is fully down.
+    """
+    try:
+        result = run_compose(["config", "--format", "json"], capture_output=True)
+        name = parse_project_name(result.stdout or "")
+        if name:
+            return name
+    except click.ClickException:
+        pass
+
+    env_name = os.environ.get("COMPOSE_PROJECT_NAME")
+    if env_name:
+        return sanitize_project_name(env_name)
+
+    return sanitize_project_name(project_root().name)
+
+
+def volume_exists(name: str) -> bool:
+    """True if the named volume exists; raise if docker itself is unreachable.
+
+    ``docker volume inspect`` exits non-zero both when a volume is genuinely
+    absent and when the daemon is down / unreachable. We must not treat the
+    latter as "absent" -- otherwise create would report "no data volumes found"
+    when the real problem is a stopped Docker. Only a "no such volume" stderr
+    means absent; anything else re-raises.
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "volume", "inspect", name],
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+    except FileNotFoundError as error:
+        raise click.ClickException(
+            "Docker is not installed or not available in PATH."
+        ) from error
+    if result.returncode == 0:
+        return True
+    stderr = (result.stderr or "").lower()
+    # Only the exact "no such volume" message means genuinely absent. A broader
+    # match (e.g. "not found") would misread docker context/daemon errors as
+    # "volume absent" and silently skip work or the safety snapshot.
+    if "no such volume" in stderr:
+        return False
+    raise click.ClickException(
+        f"Could not query docker volume '{name}': "
+        f"{(result.stderr or 'docker error').strip()}. Is the Docker daemon running?"
+    )
+
+
+def archive_volume(volume: str, dest_dir: Path, key: str) -> None:
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    # --mount long-form (not -v) so host paths containing ':' are unambiguous.
+    run_docker(
+        [
+            "run",
+            "--rm",
+            "--mount",
+            f"type=volume,source={volume},destination=/from,readonly",
+            "--mount",
+            f"type=bind,source={dest_dir.resolve()},destination=/to",
+            HELPER_IMAGE,
+            "tar",
+            "czf",
+            f"/to/{key}.tar.gz",
+            "-C",
+            "/from",
+            ".",
+        ]
+    )
+
+
+def extract_volume(volume: str, src_dir: Path, key: str) -> None:
+    run_docker(
+        [
+            "run",
+            "--rm",
+            "--mount",
+            f"type=volume,source={volume},destination=/to",
+            "--mount",
+            f"type=bind,source={src_dir.resolve()},destination=/from,readonly",
+            HELPER_IMAGE,
+            "sh",
+            "-c",
+            f"cd /to && tar xzf /from/{key}.tar.gz",
+        ]
+    )
+
+
+def reset_volume(volume: str) -> None:
+    """Empty a volume in place so a restore lands on pristine contents.
+
+    Contents are cleared rather than the volume being removed/recreated, so the
+    compose-managed volume and its labels stay intact (a manually recreated
+    volume can make ``docker compose up`` complain about external volumes). A
+    non-existent named volume is auto-created empty by the mount.
+    """
+    run_docker(
+        [
+            "run",
+            "--rm",
+            "--mount",
+            f"type=volume,source={volume},destination=/to",
+            HELPER_IMAGE,
+            "sh",
+            "-c",
+            "find /to -mindepth 1 -delete",
+        ]
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Tar helpers for the host storage/ dir and snapshot export/import
+# --------------------------------------------------------------------------- #
+def archive_storage(root: Path, dest_file: Path) -> None:
+    storage_dir = root / STORAGE_DIRNAME
+    # Resolve a symlinked storage/ so we capture its contents, not the bare link.
+    source = storage_dir.resolve() if storage_dir.is_symlink() else storage_dir
+    with tarfile.open(dest_file, "w:gz") as tar:
+        tar.add(source, arcname=STORAGE_DIRNAME)
+
+
+def _assert_safe_members(tar: tarfile.TarFile, dest: Path) -> None:
+    """Reject archive members -- and link targets -- that escape ``dest``.
+
+    Guards plain path traversal AND symlink/hardlink members whose target points
+    outside dest. The link check matters because the Python 3.11.0-3.11.3
+    fallback in ``_safe_extract`` extracts without the built-in ``data``
+    filter, so it would otherwise honour an escaping link.
+    """
+    dest_resolved = dest.resolve()
+
+    def _within(path: Path) -> bool:
+        resolved = path.resolve()
+        return resolved == dest_resolved or dest_resolved in resolved.parents
+
+    for member in tar.getmembers():
+        if not _within(dest_resolved / member.name):
+            raise click.ClickException(
+                f"Refusing to extract unsafe path from archive: {member.name}"
+            )
+        if member.issym() or member.islnk():
+            if member.issym():
+                link_target = (
+                    dest_resolved / os.path.dirname(member.name) / member.linkname
+                )
+            else:  # hardlink target is relative to the archive root
+                link_target = dest_resolved / member.linkname
+            if os.path.isabs(member.linkname) or not _within(link_target):
+                raise click.ClickException(
+                    "Refusing to extract unsafe link from archive: "
+                    f"{member.name} -> {member.linkname}"
+                )
+
+
+def _safe_extract(tar: tarfile.TarFile, dest: Path) -> None:
+    """Extract with the 3.12 data filter, falling back for Python 3.11.0-3.11.3.
+
+    The ``filter`` kwarg only landed in 3.11.4; our requires-python allows
+    earlier 3.11.x. ``_assert_safe_members`` guards path traversal *and* escaping
+    link targets, so the unfiltered fallback stays safe.
+    """
+    _assert_safe_members(tar, dest)
+    try:
+        tar.extractall(dest, filter="data")
+    except TypeError:
+        # Safe: _assert_safe_members above already rejected any traversal or
+        # escaping-link members, which is exactly what the "data" filter enforces.
+        tar.extractall(dest)  # nosec B202
+
+
+def extract_storage(root: Path, src_file: Path) -> None:
+    # Clear the destination first so restore is a faithful point-in-time copy:
+    # otherwise files created after the snapshot (e.g. a stale SQLite -wal or an
+    # extra events db) survive and leave storage/ inconsistent with the volumes.
+    storage_dir = root / STORAGE_DIRNAME
+    if storage_dir.is_symlink():
+        # rmtree() raises on a symlink; unlink it so the extract lands a real dir.
+        storage_dir.unlink()
+    elif storage_dir.exists():
+        shutil.rmtree(storage_dir)
+    with tarfile.open(src_file, "r:gz") as tar:
+        _safe_extract(tar, root)
+
+
+def _snapshot_artifacts_ok(snap_dir: Path, manifest: SnapshotManifest) -> list[str]:
+    """Return a list of missing-artifact messages for a snapshot dir (empty=ok)."""
+    problems: list[str] = []
+    for key in manifest.volumes:
+        tarball = snap_dir / VOLUMES_DIRNAME / f"{key}.tar.gz"
+        if not tarball.exists():
+            problems.append(f"missing volume archive for '{key}' ({tarball.name})")
+    if manifest.storage_included and not (snap_dir / "storage.tar.gz").exists():
+        problems.append("manifest says storage was captured but storage.tar.gz is missing")
+    return problems
+
+
+def export_snapshot(
+    snapshot_id: str, dest: Path, root: Path | None = None, force: bool = False
+) -> Path:
+    _validate_snapshot_id(snapshot_id)
+    root = root or project_root()
+    snap_dir = snapshots_root(root) / snapshot_id
+    read_manifest(snap_dir)  # validate it exists and is well-formed
+    dest = Path(dest)
+    if dest.exists() and not force:
+        raise click.ClickException(
+            f"Destination '{dest}' already exists. Use --force to overwrite."
+        )
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(dest, "w:gz") as tar:
+        tar.add(snap_dir, arcname=snapshot_id)
+    return dest
+
+
+def import_snapshot(src: Path, root: Path | None = None, force: bool = False) -> str:
+    root = root or project_root()
+    src = Path(src)
+    if not src.exists():
+        raise click.ClickException(f"Archive not found: {src}")
+    base = snapshots_root(root)
+    base.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(src, "r:gz") as tar:
+        # Skip members with no path parts ('.', './', '') so a `tar -C dir .`
+        # style archive resolves to its real top-level entries instead of raising
+        # IndexError on Path('.').parts[0].
+        top_levels = {
+            parts[0] for m in tar.getmembers() if (parts := Path(m.name).parts)
+        }
+        if len(top_levels) != 1:
+            raise click.ClickException(
+                "Archive does not contain a single snapshot directory."
+            )
+        snapshot_id = next(iter(top_levels))
+        # The snapshot id must be a single, plain directory name. A member rooted
+        # at '/' collapses `base / snapshot_id` to '/', and '..' escapes the
+        # snapshots dir -- either would make the shutil.rmtree below catastrophic
+        # (rmtree of '/' or the project dir) on a malicious/malformed archive.
+        if _is_unsafe_component(snapshot_id):
+            raise click.ClickException(
+                "Archive does not contain a valid snapshot directory."
+            )
+        dest_dir = base / snapshot_id
+        # Defense in depth: dest_dir must be a direct child of the snapshots dir.
+        if dest_dir.resolve().parent != base.resolve():
+            raise click.ClickException(
+                "Archive does not contain a valid snapshot directory."
+            )
+        if dest_dir.exists():
+            # Never merge onto an existing snapshot -- tar would overwrite some
+            # files and leave others orphaned, producing a dir that no longer
+            # matches its own manifest.
+            if not force:
+                raise click.ClickException(
+                    f"Snapshot '{snapshot_id}' already exists locally. "
+                    "Delete it first or pass --force to replace it."
+                )
+            shutil.rmtree(dest_dir)
+        _safe_extract(tar, base)
+    manifest = read_manifest(dest_dir)  # validate JSON
+    problems = _snapshot_artifacts_ok(dest_dir, manifest)
+    if problems:
+        shutil.rmtree(dest_dir, ignore_errors=True)
+        raise click.ClickException(
+            "Imported archive is incomplete: " + "; ".join(problems)
+        )
+    # The manifest id must match the directory name -- list_snapshots reports
+    # manifest.id while restore/delete/export/prune locate by directory name, so a
+    # mismatch makes the snapshot unusable (and could point prune at the wrong dir).
+    if manifest.id != snapshot_id:
+        shutil.rmtree(dest_dir, ignore_errors=True)
+        raise click.ClickException(
+            f"Imported archive is inconsistent: manifest id '{manifest.id}' does "
+            f"not match its directory '{snapshot_id}'."
+        )
+    # Only ever manage the known data volumes -- a crafted manifest must not make
+    # restore wipe an out-of-band host volume.
+    unknown = [k for k in manifest.volumes if k not in DATA_VOLUMES]
+    if unknown:
+        shutil.rmtree(dest_dir, ignore_errors=True)
+        raise click.ClickException(
+            "Imported archive lists volumes ABI does not manage: "
+            + ", ".join(unknown)
+        )
+    return snapshot_id
+
+
+# --------------------------------------------------------------------------- #
+# High-level orchestration
+# --------------------------------------------------------------------------- #
+def list_snapshots(root: Path | None = None) -> list[SnapshotManifest]:
+    base = snapshots_root(root or project_root())
+    if not base.exists():
+        return []
+    manifests: list[SnapshotManifest] = []
+    for entry in base.iterdir():
+        if not entry.is_dir() or not (entry / MANIFEST_NAME).exists():
+            continue
+        try:
+            manifests.append(read_manifest(entry))
+        except click.ClickException:
+            continue
+    manifests.sort(key=lambda m: m.created_at, reverse=True)
+    return manifests
+
+
+def delete_snapshot(snapshot_id: str, root: Path | None = None) -> None:
+    _validate_snapshot_id(snapshot_id)
+    base = snapshots_root(root or project_root())
+    snap_dir = base / snapshot_id
+    if not snap_dir.exists():
+        raise click.ClickException(f"Snapshot '{snapshot_id}' not found.")
+    shutil.rmtree(snap_dir)
+
+
+def create_snapshot(
+    *,
+    note: str = "",
+    slug: str | None = None,
+    now: datetime,
+    root: Path | None = None,
+    echo: Callable[[str], None] | None = None,
+) -> SnapshotManifest:
+    emit = echo if echo is not None else click.echo
+    root = root or project_root()
+    project = compose_project_name()
+
+    present = [k for k in DATA_VOLUMES if volume_exists(volume_full_name(project, k))]
+    if not present:
+        raise click.ClickException(
+            f"No ABI data volumes found for project '{project}'. "
+            "Verify the running stack with 'docker volume ls'."
+        )
+    missing = [k for k in DATA_VOLUMES if k not in present]
+    if missing:
+        emit(f"Note: skipping volumes not present on this stack: {', '.join(missing)}")
+
+    snapshot_id = generate_snapshot_id(now, slug)
+    snap_dir = snapshots_root(root) / snapshot_id
+    if snap_dir.exists():
+        raise click.ClickException(f"Snapshot '{snapshot_id}' already exists.")
+    volumes_dir = snap_dir / VOLUMES_DIRNAME
+    volumes_dir.mkdir(parents=True)
+
+    emit("Stopping stack for a consistent copy...")
+    run_compose(["stop"])
+    try:
+        try:
+            for key in present:
+                emit(f"  - archiving volume {key}")
+                archive_volume(volume_full_name(project, key), volumes_dir, key)
+
+            storage_dir = root / STORAGE_DIRNAME
+            storage_included = storage_dir.exists()
+            if storage_included:
+                emit("  - archiving storage/")
+                archive_storage(root, snap_dir / "storage.tar.gz")
+
+            manifest = SnapshotManifest(
+                id=snapshot_id,
+                created_at=now.isoformat(),
+                note=note,
+                project=project,
+                git_commit=current_git_commit(root),
+                cli_version=cli_version(),
+                volumes=present,
+                storage_included=storage_included,
+                config_hashes=config_hashes(root),
+                size_bytes=dir_size(snap_dir),
+            )
+            write_manifest(snap_dir, manifest)
+        except BaseException:
+            shutil.rmtree(snap_dir, ignore_errors=True)
+            raise
+    finally:
+        # `up -d` (not `start`) so the stack is brought back even if it had been
+        # fully `down` (volumes retained) rather than merely stopped.
+        emit("Restarting stack...")
+        run_compose(["up", "-d"])
+
+    return manifest
+
+
+def restore_snapshot(
+    snapshot_id: str,
+    *,
+    safety: bool = True,
+    now: datetime,
+    root: Path | None = None,
+    echo: Callable[[str], None] | None = None,
+) -> SnapshotManifest:
+    emit = echo if echo is not None else click.echo
+    _validate_snapshot_id(snapshot_id)
+    root = root or project_root()
+    snap_dir = snapshots_root(root) / snapshot_id
+    manifest = read_manifest(snap_dir)
+    project = compose_project_name()
+
+    # Pre-flight: validate BEFORE any destructive step so a corrupt/incomplete or
+    # tampered snapshot aborts without having wiped a live volume.
+    # Allowlist first: never wipe/overwrite a volume outside the managed set even
+    # if a hand-crafted (imported) manifest names one.
+    unknown = [k for k in manifest.volumes if k not in DATA_VOLUMES]
+    if unknown:
+        raise click.ClickException(
+            f"Refusing to restore '{snapshot_id}': it lists volumes ABI does not "
+            f"manage ({', '.join(unknown)})."
+        )
+    problems = _snapshot_artifacts_ok(snap_dir, manifest)
+    if problems:
+        raise click.ClickException(
+            f"Refusing to restore '{snapshot_id}': " + "; ".join(problems)
+        )
+
+    drift = detect_drift(manifest, current_git_commit(root), config_hashes(root))
+    for message in drift:
+        emit(f"Warning: {message}")
+
+    # Safety snapshot -- best-effort. On a fresh host (import -> restore) there is
+    # nothing to snapshot yet, so skip rather than abort the whole restore.
+    safety_id: str | None = None
+    if safety:
+        if any(volume_exists(volume_full_name(project, k)) for k in DATA_VOLUMES):
+            emit("Taking a safety snapshot of the current state first...")
+            safety_id = create_snapshot(
+                note=f"auto-safety before restore of {snapshot_id}",
+                slug="safety",
+                now=now,
+                root=root,
+                echo=emit,
+            ).id
+        else:
+            emit("No existing stack data found; skipping safety snapshot.")
+
+    emit(f"Restoring snapshot {snapshot_id}...")
+    run_compose(["down"])
+    try:
+        for key in manifest.volumes:
+            volume = volume_full_name(project, key)
+            emit(f"  - restoring volume {key}")
+            reset_volume(volume)
+            extract_volume(volume, snap_dir / VOLUMES_DIRNAME, key)
+
+        if manifest.storage_included:
+            emit("  - restoring storage/")
+            extract_storage(root, snap_dir / "storage.tar.gz")
+    except BaseException:
+        # A failure here can leave volumes half-restored. Never leave the stack
+        # down, and tell the operator how to recover from the safety snapshot.
+        emit("ERROR: restore failed partway through; stack data may be inconsistent.")
+        if safety_id:
+            emit(
+                "Recover the previous state with: "
+                f"abi stack snapshot restore {safety_id} --no-safety-snapshot"
+            )
+        try:
+            run_compose(["up", "-d"])
+        except click.ClickException:
+            pass
+        raise
+
+    emit("Starting stack...")
+    run_compose(["up", "-d"])
+    return manifest

--- a/libs/naas-abi-cli/naas_abi_cli/cli/snapshot_runtime_test.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/snapshot_runtime_test.py
@@ -1,0 +1,715 @@
+import io
+import tarfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import click
+import pytest
+
+from naas_abi_cli.cli import snapshot_runtime as rt
+from naas_abi_cli.cli.snapshot_runtime import SnapshotManifest
+
+FIXED_NOW = datetime(2026, 6, 30, 14, 5, 9, tzinfo=timezone.utc)
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers
+# --------------------------------------------------------------------------- #
+def test_sanitize_slug_normalises_text() -> None:
+    assert rt.sanitize_slug("  Before Big Migration!! ") == "before-big-migration"
+    assert rt.sanitize_slug("a___b") == "a-b"
+    assert rt.sanitize_slug("!!!") == ""
+
+
+def test_generate_snapshot_id_with_and_without_slug() -> None:
+    assert rt.generate_snapshot_id(FIXED_NOW) == "20260630-140509"
+    assert rt.generate_snapshot_id(FIXED_NOW, "Pre Upgrade") == "20260630-140509-pre-upgrade"
+    # A slug that sanitises to empty is dropped.
+    assert rt.generate_snapshot_id(FIXED_NOW, "***") == "20260630-140509"
+
+
+def test_sanitize_project_name_matches_compose_rules() -> None:
+    assert rt.sanitize_project_name("My.Project Name") == "myprojectname"
+    assert rt.sanitize_project_name("__abi-core") == "abi-core"
+
+
+def test_parse_project_name() -> None:
+    assert rt.parse_project_name('{"name": "abi"}') == "abi"
+    assert rt.parse_project_name('{"name": ""}') is None
+    assert rt.parse_project_name("not json") is None
+    assert rt.parse_project_name("[1, 2]") is None
+
+
+def test_volume_full_name() -> None:
+    assert rt.volume_full_name("abi", "postgres_data") == "abi_postgres_data"
+
+
+def test_select_prunable_keeps_newest() -> None:
+    manifests = [
+        SnapshotManifest(id="a", created_at="2026-01-01T00:00:00"),
+        SnapshotManifest(id="b", created_at="2026-03-01T00:00:00"),
+        SnapshotManifest(id="c", created_at="2026-02-01T00:00:00"),
+    ]
+    assert rt.select_prunable(manifests, keep=1) == ["c", "a"]
+    assert rt.select_prunable(manifests, keep=0) == ["b", "c", "a"]
+    assert rt.select_prunable(manifests, keep=5) == []
+
+
+def test_select_prunable_rejects_negative_keep() -> None:
+    with pytest.raises(ValueError):
+        rt.select_prunable([], keep=-1)
+
+
+def test_detect_drift_reports_commit_and_config_changes() -> None:
+    manifest = SnapshotManifest(
+        id="x",
+        created_at="2026-01-01T00:00:00",
+        git_commit="aaaaaaa",
+        config_hashes={"config.local.yaml": "h1", ".env": "h2"},
+    )
+    messages = rt.detect_drift(
+        manifest,
+        current_commit="bbbbbbb",
+        current_hashes={"config.local.yaml": "h1", ".env": "DIFFERENT"},
+    )
+    assert any("git commit differs" in m for m in messages)
+    assert any(".env has changed" in m for m in messages)
+    assert not any("config.local.yaml has changed" in m for m in messages)
+
+
+def test_detect_drift_silent_when_unchanged() -> None:
+    manifest = SnapshotManifest(
+        id="x",
+        created_at="2026-01-01T00:00:00",
+        git_commit="aaaaaaa",
+        config_hashes={"config.local.yaml": "h1"},
+    )
+    assert rt.detect_drift(manifest, "aaaaaaa", {"config.local.yaml": "h1"}) == []
+
+
+def test_manifest_json_round_trip() -> None:
+    manifest = SnapshotManifest(
+        id="20260630-140509",
+        created_at=FIXED_NOW.isoformat(),
+        note="hello",
+        project="abi",
+        volumes=["postgres_data", "minio_data"],
+        storage_included=True,
+        config_hashes={".env": "abc"},
+        size_bytes=1234,
+    )
+    restored = SnapshotManifest.from_json(manifest.to_json())
+    assert restored == manifest
+
+
+def test_manifest_from_json_ignores_unknown_fields() -> None:
+    restored = SnapshotManifest.from_json(
+        '{"id": "x", "created_at": "t", "surprise_field": 1}'
+    )
+    assert restored.id == "x"
+    assert restored.created_at == "t"
+
+
+# --------------------------------------------------------------------------- #
+# Filesystem helpers
+# --------------------------------------------------------------------------- #
+def test_config_hashes_only_includes_present_files(tmp_path: Path) -> None:
+    (tmp_path / "config.local.yaml").write_text("a: 1", encoding="utf-8")
+    hashes = rt.config_hashes(tmp_path)
+    assert "config.local.yaml" in hashes
+    assert ".env" not in hashes
+
+
+def test_archive_and_extract_storage_round_trip(tmp_path: Path) -> None:
+    source_root = tmp_path / "source"
+    (source_root / "storage" / "events").mkdir(parents=True)
+    (source_root / "storage" / "events" / "events.sqlite").write_text(
+        "data", encoding="utf-8"
+    )
+    archive = tmp_path / "storage.tar.gz"
+    rt.archive_storage(source_root, archive)
+
+    dest_root = tmp_path / "dest"
+    dest_root.mkdir()
+    rt.extract_storage(dest_root, archive)
+    assert (dest_root / "storage" / "events" / "events.sqlite").read_text() == "data"
+
+
+def test_extract_storage_rejects_path_traversal(tmp_path: Path) -> None:
+    evil = tmp_path / "evil.tar.gz"
+    with tarfile.open(evil, "w:gz") as tar:
+        member = tarfile.TarInfo(name="../escape.txt")
+        payload = b"x"
+        import io
+
+        member.size = len(payload)
+        tar.addfile(member, io.BytesIO(payload))
+    with pytest.raises(click.ClickException, match="unsafe path"):
+        rt.extract_storage(tmp_path / "dest", evil)
+
+
+def _make_snapshot_dir(base: Path, snapshot_id: str) -> Path:
+    snap_dir = base / snapshot_id
+    (snap_dir / "volumes").mkdir(parents=True)
+    (snap_dir / "volumes" / "postgres_data.tar.gz").write_bytes(b"vol")
+    manifest = SnapshotManifest(
+        id=snapshot_id,
+        # created_at tracks the id so list ordering is deterministic in tests.
+        created_at=snapshot_id,
+        volumes=["postgres_data"],
+    )
+    rt.write_manifest(snap_dir, manifest)
+    return snap_dir
+
+
+def test_export_then_import_round_trip(tmp_path: Path) -> None:
+    source_root = tmp_path / "source"
+    rt.snapshots_root(source_root).mkdir(parents=True)
+    _make_snapshot_dir(rt.snapshots_root(source_root), "20260630-140509")
+
+    archive = tmp_path / "snap.tar.gz"
+    rt.export_snapshot("20260630-140509", archive, root=source_root)
+    assert archive.exists()
+
+    dest_root = tmp_path / "dest"
+    imported_id = rt.import_snapshot(archive, root=dest_root)
+    assert imported_id == "20260630-140509"
+    manifest = rt.read_manifest(
+        rt.snapshots_root(dest_root) / "20260630-140509"
+    )
+    assert manifest.volumes == ["postgres_data"]
+
+
+def test_list_snapshots_sorted_desc_and_skips_invalid(tmp_path: Path) -> None:
+    base = rt.snapshots_root(tmp_path)
+    base.mkdir(parents=True)
+    _make_snapshot_dir(base, "20260101-000000")
+    _make_snapshot_dir(base, "20260301-000000")
+    # A directory with no manifest is ignored.
+    (base / "garbage").mkdir()
+
+    listed = rt.list_snapshots(tmp_path)
+    assert [m.id for m in listed] == ["20260301-000000", "20260101-000000"]
+
+
+def test_delete_snapshot(tmp_path: Path) -> None:
+    base = rt.snapshots_root(tmp_path)
+    base.mkdir(parents=True)
+    _make_snapshot_dir(base, "20260101-000000")
+    rt.delete_snapshot("20260101-000000", root=tmp_path)
+    assert not (base / "20260101-000000").exists()
+    with pytest.raises(click.ClickException, match="not found"):
+        rt.delete_snapshot("missing", root=tmp_path)
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration (docker primitives mocked)
+# --------------------------------------------------------------------------- #
+def test_create_snapshot_stops_archives_and_restarts(
+    tmp_path: Path, monkeypatch
+) -> None:
+    (tmp_path / "storage").mkdir()
+    compose_calls: list[list[str]] = []
+    archived: list[str] = []
+
+    monkeypatch.setattr(rt, "compose_project_name", lambda: "abi")
+    monkeypatch.setattr(rt, "volume_exists", lambda name: True)
+    monkeypatch.setattr(rt, "current_git_commit", lambda root: "abc1234")
+    monkeypatch.setattr(rt, "config_hashes", lambda root: {})
+    monkeypatch.setattr(rt, "run_compose", lambda args, **kw: compose_calls.append(args))
+    monkeypatch.setattr(
+        rt, "archive_volume", lambda volume, dest, key: archived.append(key)
+    )
+    monkeypatch.setattr(
+        rt, "archive_storage", lambda root, dest: Path(dest).write_bytes(b"s")
+    )
+
+    manifest = rt.create_snapshot(
+        note="pre-migration", now=FIXED_NOW, root=tmp_path, echo=lambda m: None
+    )
+
+    assert manifest.id == "20260630-140509"
+    assert manifest.note == "pre-migration"
+    assert set(manifest.volumes) == set(rt.DATA_VOLUMES)
+    assert manifest.storage_included is True
+    assert sorted(archived) == sorted(rt.DATA_VOLUMES)
+    # Stack is stopped first and restarted afterwards.
+    assert ["stop"] in compose_calls
+    assert ["up", "-d"] in compose_calls
+    assert compose_calls.index(["stop"]) < compose_calls.index(["up", "-d"])
+    # Manifest persisted on disk.
+    assert (rt.snapshots_root(tmp_path) / manifest.id / "manifest.json").exists()
+
+
+def test_create_snapshot_errors_when_no_volumes(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(rt, "compose_project_name", lambda: "abi")
+    monkeypatch.setattr(rt, "volume_exists", lambda name: False)
+    monkeypatch.setattr(rt, "run_compose", lambda args, **kw: None)
+    with pytest.raises(click.ClickException, match="No ABI data volumes"):
+        rt.create_snapshot(now=FIXED_NOW, root=tmp_path, echo=lambda m: None)
+
+
+def test_create_snapshot_cleans_up_and_restarts_on_failure(
+    tmp_path: Path, monkeypatch
+) -> None:
+    compose_calls: list[list[str]] = []
+    monkeypatch.setattr(rt, "compose_project_name", lambda: "abi")
+    monkeypatch.setattr(rt, "volume_exists", lambda name: True)
+    monkeypatch.setattr(rt, "run_compose", lambda args, **kw: compose_calls.append(args))
+
+    def _boom(volume: str, dest: Path, key: str) -> None:
+        raise click.ClickException("archive blew up")
+
+    monkeypatch.setattr(rt, "archive_volume", _boom)
+
+    with pytest.raises(click.ClickException, match="archive blew up"):
+        rt.create_snapshot(now=FIXED_NOW, root=tmp_path, echo=lambda m: None)
+
+    # Partial snapshot dir removed, stack still restarted.
+    assert not (rt.snapshots_root(tmp_path) / "20260630-140509").exists()
+    assert ["up", "-d"] in compose_calls
+
+
+def test_restore_snapshot_takes_safety_snapshot_and_restores(
+    tmp_path: Path, monkeypatch
+) -> None:
+    base = rt.snapshots_root(tmp_path)
+    base.mkdir(parents=True)
+    snap_dir = _make_snapshot_dir(base, "20260101-000000")
+    (snap_dir / "storage.tar.gz").write_bytes(b"s")
+    # Mark storage as included in the manifest.
+    manifest = rt.read_manifest(snap_dir)
+    manifest.storage_included = True
+    rt.write_manifest(snap_dir, manifest)
+
+    compose_calls: list[list[str]] = []
+    reset: list[str] = []
+    extracted: list[str] = []
+    safety_calls: list[str] = []
+
+    monkeypatch.setattr(rt, "compose_project_name", lambda: "abi")
+    monkeypatch.setattr(rt, "current_git_commit", lambda root: "abc1234")
+    monkeypatch.setattr(rt, "config_hashes", lambda root: {})
+    monkeypatch.setattr(rt, "volume_exists", lambda name: True)
+    monkeypatch.setattr(rt, "run_compose", lambda args, **kw: compose_calls.append(args))
+    monkeypatch.setattr(rt, "reset_volume", lambda vol: reset.append(vol))
+    monkeypatch.setattr(
+        rt, "extract_volume", lambda vol, src, key: extracted.append(key)
+    )
+    monkeypatch.setattr(rt, "extract_storage", lambda root, src: None)
+
+    def _fake_safety(**kw):
+        safety_calls.append(kw.get("slug"))
+        return SnapshotManifest(id="20260630-140509-safety", created_at="t")
+
+    monkeypatch.setattr(rt, "create_snapshot", _fake_safety)
+
+    rt.restore_snapshot(
+        "20260101-000000", safety=True, now=FIXED_NOW, root=tmp_path, echo=lambda m: None
+    )
+
+    assert safety_calls == ["safety"]
+    assert reset == ["abi_postgres_data"]
+    assert extracted == ["postgres_data"]
+    assert ["down"] in compose_calls
+    assert ["up", "-d"] in compose_calls
+
+
+def test_restore_snapshot_can_skip_safety(tmp_path: Path, monkeypatch) -> None:
+    base = rt.snapshots_root(tmp_path)
+    base.mkdir(parents=True)
+    _make_snapshot_dir(base, "20260101-000000")
+
+    safety_calls: list[str] = []
+    monkeypatch.setattr(rt, "compose_project_name", lambda: "abi")
+    monkeypatch.setattr(rt, "current_git_commit", lambda root: None)
+    monkeypatch.setattr(rt, "config_hashes", lambda root: {})
+    monkeypatch.setattr(rt, "run_compose", lambda args, **kw: None)
+    monkeypatch.setattr(rt, "reset_volume", lambda vol: None)
+    monkeypatch.setattr(rt, "extract_volume", lambda vol, src, key: None)
+
+    def _record_safety(**kw):
+        safety_calls.append("called")
+
+    monkeypatch.setattr(rt, "create_snapshot", _record_safety)
+
+    rt.restore_snapshot(
+        "20260101-000000", safety=False, now=FIXED_NOW, root=tmp_path, echo=lambda m: None
+    )
+    assert safety_calls == []
+
+
+# --------------------------------------------------------------------------- #
+# Regression tests for review findings
+# --------------------------------------------------------------------------- #
+def test_extract_storage_clears_stale_files(tmp_path: Path) -> None:
+    # Archive captures only a.sqlite.
+    source_root = tmp_path / "source"
+    (source_root / "storage" / "events").mkdir(parents=True)
+    (source_root / "storage" / "events" / "a.sqlite").write_text("SNAP", encoding="utf-8")
+    archive = tmp_path / "storage.tar.gz"
+    rt.archive_storage(source_root, archive)
+
+    # Destination has an extra file created after the snapshot + a stale a.sqlite.
+    dest_root = tmp_path / "dest"
+    (dest_root / "storage" / "events").mkdir(parents=True)
+    (dest_root / "storage" / "events" / "a.sqlite").write_text("LIVE", encoding="utf-8")
+    (dest_root / "storage" / "events" / "b.sqlite").write_text("ORPHAN", encoding="utf-8")
+
+    rt.extract_storage(dest_root, archive)
+
+    assert (dest_root / "storage" / "events" / "a.sqlite").read_text() == "SNAP"
+    # The post-snapshot orphan must be gone -- restore is point-in-time.
+    assert not (dest_root / "storage" / "events" / "b.sqlite").exists()
+
+
+def test_import_rejects_colliding_id_and_force_replaces(tmp_path: Path) -> None:
+    source_root = tmp_path / "source"
+    rt.snapshots_root(source_root).mkdir(parents=True)
+    _make_snapshot_dir(rt.snapshots_root(source_root), "20260630-140509")
+    archive = tmp_path / "snap.tar.gz"
+    rt.export_snapshot("20260630-140509", archive, root=source_root)
+
+    dest_root = tmp_path / "dest"
+    dest_base = rt.snapshots_root(dest_root)
+    dest_base.mkdir(parents=True)
+    _make_snapshot_dir(dest_base, "20260630-140509")
+    # Give the existing snapshot an extra tarball to prove no silent merge.
+    (dest_base / "20260630-140509" / "volumes" / "minio_data.tar.gz").write_bytes(b"x")
+
+    with pytest.raises(click.ClickException, match="already exists locally"):
+        rt.import_snapshot(archive, root=dest_root)
+
+    # --force replaces cleanly (the orphan minio tarball must not survive).
+    rt.import_snapshot(archive, root=dest_root, force=True)
+    assert not (dest_base / "20260630-140509" / "volumes" / "minio_data.tar.gz").exists()
+
+
+def test_import_rejects_incomplete_archive(tmp_path: Path) -> None:
+    source_root = tmp_path / "source"
+    base = rt.snapshots_root(source_root)
+    snap_dir = _make_snapshot_dir(base, "20260630-140509")
+    # Manifest claims storage but no storage.tar.gz is present.
+    manifest = rt.read_manifest(snap_dir)
+    manifest.storage_included = True
+    rt.write_manifest(snap_dir, manifest)
+    archive = tmp_path / "snap.tar.gz"
+    rt.export_snapshot("20260630-140509", archive, root=source_root)
+
+    dest_root = tmp_path / "dest"
+    with pytest.raises(click.ClickException, match="incomplete"):
+        rt.import_snapshot(archive, root=dest_root)
+    # A rejected import leaves nothing behind.
+    assert not (rt.snapshots_root(dest_root) / "20260630-140509").exists()
+
+
+def test_export_rejects_existing_dest_and_force_overwrites(tmp_path: Path) -> None:
+    base = rt.snapshots_root(tmp_path)
+    base.mkdir(parents=True)
+    _make_snapshot_dir(base, "20260630-140509")
+    dest = tmp_path / "out.tar.gz"
+    dest.write_bytes(b"existing")
+
+    with pytest.raises(click.ClickException, match="already exists"):
+        rt.export_snapshot("20260630-140509", dest, root=tmp_path)
+
+    rt.export_snapshot("20260630-140509", dest, root=tmp_path, force=True)
+    assert dest.stat().st_size > len(b"existing")
+
+
+def test_restore_preflight_rejects_missing_volume_tarball(
+    tmp_path: Path, monkeypatch
+) -> None:
+    base = rt.snapshots_root(tmp_path)
+    snap_dir = base / "20260101-000000"
+    (snap_dir / "volumes").mkdir(parents=True)
+    (snap_dir / "volumes" / "postgres_data.tar.gz").write_bytes(b"ok")
+    # Manifest lists minio_data too, but its tarball is absent.
+    rt.write_manifest(
+        snap_dir,
+        SnapshotManifest(
+            id="20260101-000000",
+            created_at="20260101-000000",
+            volumes=["postgres_data", "minio_data"],
+        ),
+    )
+
+    compose_calls: list[list[str]] = []
+    reset: list[str] = []
+    monkeypatch.setattr(rt, "compose_project_name", lambda: "abi")
+    monkeypatch.setattr(rt, "current_git_commit", lambda root: None)
+    monkeypatch.setattr(rt, "config_hashes", lambda root: {})
+    monkeypatch.setattr(rt, "run_compose", lambda args, **kw: compose_calls.append(args))
+    monkeypatch.setattr(rt, "reset_volume", lambda vol: reset.append(vol))
+
+    with pytest.raises(click.ClickException, match="Refusing to restore"):
+        rt.restore_snapshot(
+            "20260101-000000", now=FIXED_NOW, root=tmp_path, echo=lambda m: None
+        )
+    # Aborted before any destructive action.
+    assert compose_calls == []
+    assert reset == []
+
+
+def test_restore_skips_safety_on_fresh_host(tmp_path: Path, monkeypatch) -> None:
+    base = rt.snapshots_root(tmp_path)
+    base.mkdir(parents=True)
+    _make_snapshot_dir(base, "20260101-000000")
+
+    compose_calls: list[list[str]] = []
+    reset: list[str] = []
+    safety_calls: list[str] = []
+    monkeypatch.setattr(rt, "compose_project_name", lambda: "abi")
+    monkeypatch.setattr(rt, "current_git_commit", lambda root: None)
+    monkeypatch.setattr(rt, "config_hashes", lambda root: {})
+    monkeypatch.setattr(rt, "volume_exists", lambda name: False)  # fresh host
+    monkeypatch.setattr(rt, "run_compose", lambda args, **kw: compose_calls.append(args))
+    monkeypatch.setattr(rt, "reset_volume", lambda vol: reset.append(vol))
+    monkeypatch.setattr(rt, "extract_volume", lambda vol, src, key: None)
+    monkeypatch.setattr(
+        rt, "create_snapshot", lambda **kw: safety_calls.append("called")
+    )
+
+    rt.restore_snapshot(
+        "20260101-000000", safety=True, now=FIXED_NOW, root=tmp_path, echo=lambda m: None
+    )
+    # Safety was skipped (nothing to snapshot) but the restore still ran.
+    assert safety_calls == []
+    assert reset == ["abi_postgres_data"]
+    assert ["up", "-d"] in compose_calls
+
+
+def test_restore_brings_stack_up_when_extract_fails(tmp_path: Path, monkeypatch) -> None:
+    base = rt.snapshots_root(tmp_path)
+    base.mkdir(parents=True)
+    _make_snapshot_dir(base, "20260101-000000")
+
+    compose_calls: list[list[str]] = []
+    monkeypatch.setattr(rt, "compose_project_name", lambda: "abi")
+    monkeypatch.setattr(rt, "current_git_commit", lambda root: None)
+    monkeypatch.setattr(rt, "config_hashes", lambda root: {})
+    monkeypatch.setattr(rt, "volume_exists", lambda name: True)
+    monkeypatch.setattr(rt, "run_compose", lambda args, **kw: compose_calls.append(args))
+    monkeypatch.setattr(rt, "reset_volume", lambda vol: None)
+    monkeypatch.setattr(
+        rt,
+        "create_snapshot",
+        lambda **kw: SnapshotManifest(id="20260101-000000-safety", created_at="t"),
+    )
+
+    def _boom(vol, src, key):
+        raise click.ClickException("tar truncated")
+
+    monkeypatch.setattr(rt, "extract_volume", _boom)
+
+    with pytest.raises(click.ClickException, match="tar truncated"):
+        rt.restore_snapshot(
+            "20260101-000000", safety=True, now=FIXED_NOW, root=tmp_path, echo=lambda m: None
+        )
+    # Stack is brought back up despite the mid-restore failure.
+    assert ["down"] in compose_calls
+    assert ["up", "-d"] in compose_calls
+
+
+def test_volume_exists_distinguishes_absent_from_docker_down(monkeypatch) -> None:
+    class _Proc:
+        def __init__(self, returncode: int, stderr: str = "") -> None:
+            self.returncode = returncode
+            self.stderr = stderr
+            self.stdout = ""
+
+    # returncode 0 -> exists
+    monkeypatch.setattr(rt.subprocess, "run", lambda *a, **k: _Proc(0))
+    assert rt.volume_exists("abi_postgres_data") is True
+
+    # "no such volume" -> genuinely absent
+    monkeypatch.setattr(
+        rt.subprocess, "run", lambda *a, **k: _Proc(1, "Error: No such volume: x")
+    )
+    assert rt.volume_exists("x") is False
+
+    # any other error (daemon down) -> raise, do NOT report absent
+    monkeypatch.setattr(
+        rt.subprocess,
+        "run",
+        lambda *a, **k: _Proc(1, "Cannot connect to the Docker daemon"),
+    )
+    with pytest.raises(click.ClickException, match="Docker daemon"):
+        rt.volume_exists("x")
+
+    # a generic "not found" (e.g. context error) must NOT be read as absent
+    monkeypatch.setattr(
+        rt.subprocess, "run", lambda *a, **k: _Proc(1, "context 'foo' not found")
+    )
+    with pytest.raises(click.ClickException):
+        rt.volume_exists("x")
+
+
+def test_import_dotslash_archive_gives_clean_error(tmp_path: Path) -> None:
+    # An archive made with `tar -C dir .` has members '.', './manifest.json', ...
+    staging = tmp_path / "staging"
+    (staging / "volumes").mkdir(parents=True)
+    (staging / "volumes" / "postgres_data.tar.gz").write_bytes(b"x")
+    rt.write_manifest(
+        staging, SnapshotManifest(id="x", created_at="t", volumes=["postgres_data"])
+    )
+    archive = tmp_path / "snap.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(staging, arcname=".")
+
+    # Must be a clean ClickException, not an IndexError stacktrace.
+    with pytest.raises(click.ClickException, match="single snapshot directory"):
+        rt.import_snapshot(archive, root=tmp_path / "dest")
+
+
+def test_id_taking_commands_reject_traversal_ids(tmp_path: Path) -> None:
+    proj = tmp_path / "proj"
+    rt.snapshots_root(proj).mkdir(parents=True)
+    sentinel = proj / "keep.txt"  # would be inside rmtree('..') blast radius
+    sentinel.write_text("keep", encoding="utf-8")
+
+    for bad in ("..", "/", "a/b", "."):
+        with pytest.raises(click.ClickException, match="Invalid snapshot id"):
+            rt.delete_snapshot(bad, root=proj)
+        with pytest.raises(click.ClickException, match="Invalid snapshot id"):
+            rt.export_snapshot(bad, tmp_path / "o.tar.gz", root=proj)
+        with pytest.raises(click.ClickException, match="Invalid snapshot id"):
+            rt.restore_snapshot(bad, now=FIXED_NOW, root=proj, echo=lambda m: None)
+
+    # The parent dir and its files are untouched.
+    assert sentinel.exists()
+    assert rt.snapshots_root(proj).exists()
+
+
+def _build_snapshot_archive(
+    tmp_path: Path,
+    dir_name: str,
+    *,
+    manifest_id: str,
+    volumes: list[str],
+) -> Path:
+    staging = tmp_path / f"staging-{dir_name}"
+    (staging / "volumes").mkdir(parents=True)
+    for key in volumes:
+        (staging / "volumes" / f"{key}.tar.gz").write_bytes(b"x")
+    rt.write_manifest(
+        staging, SnapshotManifest(id=manifest_id, created_at="t", volumes=volumes)
+    )
+    archive = tmp_path / f"{dir_name}.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(staging, arcname=dir_name)
+    return archive
+
+
+def test_import_rejects_manifest_id_mismatch(tmp_path: Path) -> None:
+    archive = _build_snapshot_archive(
+        tmp_path, "dirX", manifest_id="20260101-000000", volumes=["postgres_data"]
+    )
+    dest = tmp_path / "dest"
+    with pytest.raises(click.ClickException, match="does not match its directory"):
+        rt.import_snapshot(archive, root=dest)
+    assert not (rt.snapshots_root(dest) / "dirX").exists()
+
+
+def test_import_rejects_unmanaged_volume(tmp_path: Path) -> None:
+    archive = _build_snapshot_archive(
+        tmp_path, "20260101-000000", manifest_id="20260101-000000", volumes=["caddy_data"]
+    )
+    dest = tmp_path / "dest"
+    with pytest.raises(click.ClickException, match="does not manage"):
+        rt.import_snapshot(archive, root=dest)
+    assert not (rt.snapshots_root(dest) / "20260101-000000").exists()
+
+
+def test_restore_rejects_unmanaged_volume_before_destruction(
+    tmp_path: Path, monkeypatch
+) -> None:
+    base = rt.snapshots_root(tmp_path)
+    snap_dir = base / "20260101-000000"
+    (snap_dir / "volumes").mkdir(parents=True)
+    (snap_dir / "volumes" / "caddy_data.tar.gz").write_bytes(b"x")
+    rt.write_manifest(
+        snap_dir,
+        SnapshotManifest(
+            id="20260101-000000", created_at="20260101-000000", volumes=["caddy_data"]
+        ),
+    )
+
+    compose_calls: list[list[str]] = []
+    reset: list[str] = []
+    monkeypatch.setattr(rt, "compose_project_name", lambda: "abi")
+    monkeypatch.setattr(rt, "run_compose", lambda args, **kw: compose_calls.append(args))
+    monkeypatch.setattr(rt, "reset_volume", lambda vol: reset.append(vol))
+
+    with pytest.raises(click.ClickException, match="does not manage"):
+        rt.restore_snapshot(
+            "20260101-000000", now=FIXED_NOW, root=tmp_path, echo=lambda m: None
+        )
+    # Nothing destructive ran.
+    assert compose_calls == []
+    assert reset == []
+
+
+def _tar_with_member(archive: Path, member_name: str) -> None:
+    with tarfile.open(archive, "w:gz") as tar:
+        info = tarfile.TarInfo(member_name)
+        payload = b"x"
+        info.size = len(payload)
+        tar.addfile(info, io.BytesIO(payload))
+
+
+def test_import_rejects_absolute_top_level_member(tmp_path: Path) -> None:
+    # snapshot_id would be '/', collapsing `base / snapshot_id` to '/'.
+    archive = tmp_path / "evil_abs.tar.gz"
+    _tar_with_member(archive, "/manifest.json")
+    proj = tmp_path / "proj"
+    with pytest.raises(click.ClickException, match="valid snapshot directory"):
+        rt.import_snapshot(archive, root=proj, force=True)
+
+
+def test_import_rejects_parent_top_level_member(tmp_path: Path) -> None:
+    # snapshot_id would be '..', escaping .snapshots/ -> rmtree of the parent.
+    archive = tmp_path / "evil_parent.tar.gz"
+    _tar_with_member(archive, "../escape.txt")
+    proj = tmp_path / "proj"
+    rt.snapshots_root(proj).mkdir(parents=True)
+    sentinel = proj / "sentinel.txt"  # sibling of .snapshots -> would die on rmtree('..')
+    sentinel.write_text("keep", encoding="utf-8")
+
+    with pytest.raises(click.ClickException, match="valid snapshot directory"):
+        rt.import_snapshot(archive, root=proj, force=True)
+    # Nothing outside the snapshot dir was touched.
+    assert sentinel.exists()
+
+
+def test_extract_storage_rejects_escaping_symlink(tmp_path: Path) -> None:
+    archive = tmp_path / "evil.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        info = tarfile.TarInfo("storage/link")
+        info.type = tarfile.SYMTYPE
+        info.linkname = "/etc/attacker"  # absolute, escapes dest
+        tar.addfile(info)
+    with pytest.raises(click.ClickException, match="unsafe link"):
+        rt.extract_storage(tmp_path / "dest", archive)
+
+
+def test_extract_storage_replaces_symlinked_storage(tmp_path: Path) -> None:
+    source_root = tmp_path / "source"
+    (source_root / "storage").mkdir(parents=True)
+    (source_root / "storage" / "a.txt").write_text("SNAP", encoding="utf-8")
+    archive = tmp_path / "s.tar.gz"
+    rt.archive_storage(source_root, archive)
+
+    # Destination storage/ is a symlink to a dir elsewhere (relocated disk).
+    dest_root = tmp_path / "dest"
+    dest_root.mkdir()
+    real = tmp_path / "real_storage"
+    real.mkdir()
+    (real / "stale.txt").write_text("STALE", encoding="utf-8")
+    (dest_root / "storage").symlink_to(real)
+
+    rt.extract_storage(dest_root, archive)
+
+    assert not (dest_root / "storage").is_symlink()
+    assert (dest_root / "storage" / "a.txt").read_text() == "SNAP"
+    assert not (dest_root / "storage" / "stale.txt").exists()

--- a/libs/naas-abi-cli/naas_abi_cli/cli/snapshot_test.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/snapshot_test.py
@@ -1,0 +1,142 @@
+from click.testing import CliRunner
+
+from naas_abi_cli.cli import snapshot_runtime as rt
+from naas_abi_cli.cli.snapshot import snapshot as snapshot_group
+from naas_abi_cli.cli.snapshot_runtime import SnapshotManifest
+
+
+def _manifest(snapshot_id: str = "20260630-140509") -> SnapshotManifest:
+    return SnapshotManifest(
+        id=snapshot_id,
+        created_at="2026-06-30T14:05:09+00:00",
+        note="pre-migration",
+        git_commit="abc1234",
+        volumes=["postgres_data", "minio_data"],
+        size_bytes=2048,
+    )
+
+
+def test_create_reports_new_snapshot(monkeypatch) -> None:
+    captured: dict = {}
+
+    def _create(**kwargs):
+        captured.update(kwargs)
+        return _manifest()
+
+    monkeypatch.setattr(rt, "create_snapshot", _create)
+    result = CliRunner().invoke(snapshot_group, ["create", "-m", "pre-migration"])
+
+    assert result.exit_code == 0
+    assert "20260630-140509" in result.output
+    assert captured["note"] == "pre-migration"
+
+
+def test_list_renders_rows(monkeypatch) -> None:
+    monkeypatch.setattr(rt, "list_snapshots", lambda: [_manifest()])
+    result = CliRunner().invoke(snapshot_group, ["list"])
+    assert result.exit_code == 0
+    assert "20260630-140509" in result.output
+
+
+def test_list_handles_empty(monkeypatch) -> None:
+    monkeypatch.setattr(rt, "list_snapshots", lambda: [])
+    result = CliRunner().invoke(snapshot_group, ["list"])
+    assert result.exit_code == 0
+    assert "No snapshots yet" in result.output
+
+
+def test_restore_with_yes_skips_prompt_and_keeps_safety_default(monkeypatch) -> None:
+    captured: dict = {}
+
+    def _restore(snapshot_id, **kwargs):
+        captured["id"] = snapshot_id
+        captured.update(kwargs)
+        return _manifest(snapshot_id)
+
+    monkeypatch.setattr(rt, "restore_snapshot", _restore)
+    result = CliRunner().invoke(
+        snapshot_group, ["restore", "20260630-140509", "--yes"]
+    )
+
+    assert result.exit_code == 0
+    assert captured["id"] == "20260630-140509"
+    assert captured["safety"] is True
+
+
+def test_restore_prompts_when_not_confirmed(monkeypatch) -> None:
+    called = {"count": 0}
+    monkeypatch.setattr(
+        rt, "restore_snapshot", lambda *a, **k: called.__setitem__("count", 1)
+    )
+    # Decline the confirmation prompt.
+    result = CliRunner().invoke(
+        snapshot_group, ["restore", "20260630-140509"], input="n\n"
+    )
+    assert result.exit_code != 0
+    assert called["count"] == 0
+
+
+def test_restore_no_safety_flag(monkeypatch) -> None:
+    captured: dict = {}
+    monkeypatch.setattr(
+        rt, "restore_snapshot", lambda snapshot_id, **k: captured.update(k)
+    )
+    result = CliRunner().invoke(
+        snapshot_group,
+        ["restore", "20260630-140509", "--yes", "--no-safety-snapshot"],
+    )
+    assert result.exit_code == 0
+    assert captured["safety"] is False
+
+
+def test_delete_with_yes(monkeypatch) -> None:
+    deleted: list[str] = []
+    monkeypatch.setattr(rt, "delete_snapshot", lambda sid: deleted.append(sid))
+    result = CliRunner().invoke(
+        snapshot_group, ["delete", "20260630-140509", "--yes"]
+    )
+    assert result.exit_code == 0
+    assert deleted == ["20260630-140509"]
+
+
+def test_prune_deletes_selected(monkeypatch) -> None:
+    deleted: list[str] = []
+    monkeypatch.setattr(rt, "list_snapshots", lambda: [_manifest("a"), _manifest("b")])
+    monkeypatch.setattr(rt, "select_prunable", lambda manifests, keep: ["b"])
+    monkeypatch.setattr(rt, "delete_snapshot", lambda sid: deleted.append(sid))
+    result = CliRunner().invoke(snapshot_group, ["prune", "--keep", "1", "--yes"])
+    assert result.exit_code == 0
+    assert deleted == ["b"]
+
+
+def test_prune_nothing_to_do(monkeypatch) -> None:
+    monkeypatch.setattr(rt, "list_snapshots", lambda: [])
+    monkeypatch.setattr(rt, "select_prunable", lambda manifests, keep: [])
+    result = CliRunner().invoke(snapshot_group, ["prune", "--yes"])
+    assert result.exit_code == 0
+    assert "Nothing to prune" in result.output
+
+
+def test_export_reports_destination(monkeypatch, tmp_path) -> None:
+    from pathlib import Path
+
+    monkeypatch.setattr(
+        rt, "export_snapshot", lambda sid, dest, **k: Path(dest)
+    )
+    out = tmp_path / "snap.tar.gz"
+    result = CliRunner().invoke(
+        snapshot_group, ["export", "20260630-140509", str(out)]
+    )
+    assert result.exit_code == 0
+    assert str(out) in result.output
+
+
+def test_import_reports_snapshot_id(monkeypatch, tmp_path) -> None:
+    archive = tmp_path / "snap.tar.gz"
+    archive.write_bytes(b"x")
+    monkeypatch.setattr(rt, "import_snapshot", lambda src, **k: "20260630-140509")
+    result = CliRunner().invoke(
+        snapshot_group, ["import", str(archive)]
+    )
+    assert result.exit_code == 0
+    assert "20260630-140509" in result.output


### PR DESCRIPTION
## What

Adds a first-class **`abi stack snapshot`** command group to the CLI for taking point-in-time snapshots of the local Docker stack's stateful data, rolling back to them, and moving a deployment to another host.

Motivation: migrating/rolling back a `config.local.yaml` deployment was previously manual and error-prone. This makes it a safe, one-command operation.

## Commands

| Command | Description |
|---|---|
| `create [-m NOTE] [--name LABEL]` | Stop the stack, archive its data, restart it |
| `list` | Snapshots newest-first (id, date, size, commit, note) |
| `restore <id> [--yes] [--no-safety-snapshot]` | Roll back (destructive; auto safety-snapshot first) |
| `delete <id>` / `prune [--keep N]` | Housekeeping |
| `export <id> <archive> [--force]` / `import <archive> [--force]` | Move a snapshot to another host |

## What it captures

The 7 stateful Docker volumes — `postgres_data` (nexus + dagster DBs), `minio_data`, `fuseki_data`, `qdrant_storage`, `redis_data` (durable KV, `--appendonly yes`), `rabbitmq_data` (durable queues), `headscale_data` (users/nodes) — plus the host `storage/` dir (event-log SQLite). Cold, graceful copy: `compose stop` → tar each volume via an `alpine` helper → `up -d`. Snapshots live in `./.snapshots/<id>/` (gitignored) with a `manifest.json` recording git commit + config hashes for drift warnings. Transient volumes (caddy/dagster/caches/headscale socket) are skipped.

## Safety

- **Restore is fail-safe**: validates all artifacts and that every volume is in the managed set *before* any destructive step; auto-takes a safety snapshot; clears each volume in place; and always brings the stack back up (with a recovery hint on mid-restore failure).
- **Import is treated as untrusted**: rejects unsafe snapshot ids (traversal/absolute), `manifest.id` ↔ directory mismatch, unmanaged volume keys, incomplete archives, and escaping tar symlink/hardlink targets.

## Also

Pins `hostname: rabbitmq` in `docker-compose.yml` so RabbitMQ's Mnesia node name is stable — otherwise durable queues are lost whenever the container is recreated (e.g. on restore or migration). Applying it resets the node once.

## Testing / review

- 50 unit + regression tests (colocated `*_test.py`), full CLI suite green, mypy clean, bandit clean.
- Hardened over a multi-round adversarial code review (16 → 4 → 1 critical → 2 → 0 findings), each finding fixed with a regression test. The critical was an `import` path-traversal that could `rmtree('/')` under `--force`.