### PR TITLE
feat(openrouter): expose OpenAI text-embedding-3-small and ada-002

### DIFF
--- a/libs/naas-abi-core/naas_abi_core/models/Model.py
+++ b/libs/naas-abi-core/naas_abi_core/models/Model.py
@@ -59,6 +59,7 @@ class CanonicalModelId(StrEnum):
     # Embedding — OpenAI family
     TEXT_EMBEDDING_3_LARGE = "text-embedding-3-large"
     TEXT_EMBEDDING_3_SMALL = "text-embedding-3-small"
+    TEXT_EMBEDDING_ADA_002 = "text-embedding-ada-002"
 
     # Chat — OpenAI family
     GPT_5 = "gpt-5"

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/models/openai/text_embedding_3_small.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/models/openai/text_embedding_3_small.py
@@ -1,0 +1,30 @@
+from langchain_openai import OpenAIEmbeddings
+from naas_abi_core.models.Model import (
+    CanonicalModelId,
+    EmbeddingModel,
+    ModelDefinition,
+    ModelProvider,
+)
+from naas_abi_marketplace.ai.openrouter import ABIModule
+from pydantic import SecretStr
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+class TextEmbedding3SmallModel(ModelDefinition):
+    CANONICAL_ID = CanonicalModelId.TEXT_EMBEDDING_3_SMALL
+    MODEL_ID = "openai/text-embedding-3-small"
+    PROVIDER = ModelProvider.OPENROUTER
+
+    model: EmbeddingModel = EmbeddingModel(
+        model_id=MODEL_ID,
+        provider=PROVIDER,
+        model=OpenAIEmbeddings(
+            model=MODEL_ID,
+            api_key=SecretStr(ABIModule.get_instance().configuration.openrouter_api_key),
+            base_url=OPENROUTER_BASE_URL,
+        ),
+    )
+
+
+model: EmbeddingModel = TextEmbedding3SmallModel.model

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/models/openai/text_embedding_ada_002.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/models/openai/text_embedding_ada_002.py
@@ -1,0 +1,30 @@
+from langchain_openai import OpenAIEmbeddings
+from naas_abi_core.models.Model import (
+    CanonicalModelId,
+    EmbeddingModel,
+    ModelDefinition,
+    ModelProvider,
+)
+from naas_abi_marketplace.ai.openrouter import ABIModule
+from pydantic import SecretStr
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+class TextEmbeddingAda002Model(ModelDefinition):
+    CANONICAL_ID = CanonicalModelId.TEXT_EMBEDDING_ADA_002
+    MODEL_ID = "openai/text-embedding-ada-002"
+    PROVIDER = ModelProvider.OPENROUTER
+
+    model: EmbeddingModel = EmbeddingModel(
+        model_id=MODEL_ID,
+        provider=PROVIDER,
+        model=OpenAIEmbeddings(
+            model=MODEL_ID,
+            api_key=SecretStr(ABIModule.get_instance().configuration.openrouter_api_key),
+            base_url=OPENROUTER_BASE_URL,
+        ),
+    )
+
+
+model: EmbeddingModel = TextEmbeddingAda002Model.model

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/on_load_test.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/on_load_test.py
@@ -1,0 +1,76 @@
+"""Tests that the openrouter module registers its models against the
+ModelRegistry during on_load — focused on the OpenAI embedding models
+routed through the OpenRouter gateway."""
+
+from __future__ import annotations
+
+from naas_abi_core.engine.EngineProxy import EngineProxy
+from naas_abi_core.engine.IEngine import IEngine
+from naas_abi_core.engine.engine_configuration.EngineConfiguration import GlobalConfig
+from naas_abi_core.models.Model import (
+    CanonicalModelId,
+    EmbeddingModel,
+    ModelProvider,
+)
+from naas_abi_core.module.Module import ModuleDependencies
+from naas_abi_core.services.model_registry.ModelRegistryService import (
+    ModelRegistryService,
+)
+
+
+class _DummyEngine:
+    def __init__(self, services: IEngine.Services) -> None:
+        self.services = services
+        self.modules: dict[str, object] = {}
+
+
+def _make_module():
+    from naas_abi_marketplace.ai.openrouter import ABIModule
+
+    registry = ModelRegistryService()
+    services = IEngine.Services(model_registry=registry)
+    engine = _DummyEngine(services=services)
+    proxy = EngineProxy(
+        engine=engine,
+        module_name="naas_abi_marketplace.ai.openrouter",
+        module_dependencies=ModuleDependencies(
+            modules=[], services=[ModelRegistryService]
+        ),
+    )
+    config = ABIModule.Configuration(
+        global_config=GlobalConfig(ai_mode="cloud"),
+        openrouter_api_key="test-key-not-used",
+    )
+    module = ABIModule(proxy, config)
+    return module, registry
+
+
+def test_on_load_registers_openai_embedding_models() -> None:
+    module, registry = _make_module()
+    module.on_load()
+
+    expected = {
+        CanonicalModelId.TEXT_EMBEDDING_3_SMALL,
+        CanonicalModelId.TEXT_EMBEDDING_3_LARGE,
+        CanonicalModelId.TEXT_EMBEDDING_ADA_002,
+    }
+    registered = set(registry.list_canonical_ids())
+    assert {str(c) for c in expected} <= registered
+
+
+def test_openai_embeddings_register_as_embedding_models_on_openrouter() -> None:
+    module, registry = _make_module()
+    module.on_load()
+
+    cases = {
+        CanonicalModelId.TEXT_EMBEDDING_3_SMALL: "openai/text-embedding-3-small",
+        CanonicalModelId.TEXT_EMBEDDING_3_LARGE: "openai/text-embedding-3-large",
+        CanonicalModelId.TEXT_EMBEDDING_ADA_002: "openai/text-embedding-ada-002",
+    }
+    for canonical_id, model_id in cases.items():
+        got = registry.get_embedding_model(
+            canonical_id, provider=ModelProvider.OPENROUTER
+        )
+        assert isinstance(got, EmbeddingModel)
+        assert got.provider == ModelProvider.OPENROUTER
+        assert got.model_id == model_id

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/workflows/GenerateProviderModels.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/workflows/GenerateProviderModels.py
@@ -184,6 +184,7 @@ CANONICAL_MAP: dict[str, str] = {
     # OpenAI — embeddings
     "text-embedding-3-large": "TEXT_EMBEDDING_3_LARGE",
     "text-embedding-3-small": "TEXT_EMBEDDING_3_SMALL",
+    "text-embedding-ada-002": "TEXT_EMBEDDING_ADA_002",
     # OpenAI — chat
     "gpt-5": "GPT_5",
     "gpt-5-mini": "GPT_5_MINI",


### PR DESCRIPTION
## What

Exposes the remaining OpenAI embedding models through the OpenRouter module. Previously the module shipped only `text-embedding-3-large`; this adds `text-embedding-3-small` and `text-embedding-ada-002` so all three of OpenAI's embedding models resolve through the OpenRouter gateway.

## Why

`text-embedding-3-small` is the codebase-wide **default** embedding model (used in `chat_file_embeddings.py`, `document/`, the chat ingestion worker, etc.), yet the OpenRouter module didn't expose it — only the large variant. This closes that gap and rounds out OpenAI's embedding lineup.

## Changes

- **`ai/openrouter/models/openai/text_embedding_3_small.py`** — new `EmbeddingModel` for `openai/text-embedding-3-small`, canonical id `TEXT_EMBEDDING_3_SMALL` (already existed in the enum). Mirrors the existing `text_embedding_3_large.py`.
- **`ai/openrouter/models/openai/text_embedding_ada_002.py`** — new `EmbeddingModel` for `openai/text-embedding-ada-002`.
- **`naas_abi_core/models/Model.py`** — added `TEXT_EMBEDDING_ADA_002 = "text-embedding-ada-002"` to `CanonicalModelId`, beside the other OpenAI embedding ids.
- **`ai/openrouter/workflows/GenerateProviderModels.py`** — mapped `text-embedding-ada-002` in `CANONICAL_MAP` so future regenerations keep the canonical id.
- **`ai/openrouter/on_load_test.py`** — new test (mirrors the `chatgpt` module's) asserting all three OpenAI embedding models register as `EmbeddingModel` pinned to the `OPENROUTER` provider.

## Notes for reviewers

- No registration wiring needed — `ModuleModelLoader` auto-discovers every `ModelDefinition` under `models/`.
- All three models route embeddings through the OpenRouter gateway (`https://openrouter.ai/api/v1`), consistent with the pre-existing `text-embedding-3-large` file.
- `TEXT_EMBEDDING_ADA_002` is the only change touching `naas_abi_core`. It's included to round out OpenAI's (legacy) embedding lineup; happy to drop it if you'd prefer to keep this to the actively-used `-3-small`.

## Testing

- New `on_load_test.py`: 2 passed.
- Sibling `chatgpt` on_load + `ModelRegistryService` suites: 24 passed, no regressions.
- `ruff` clean; pre-commit quality hook (ruff/mypy/bandit) passed.
