### PR TITLE
feat(object-storage): add Cloudflare R2 adapter support

### DIFF
--- a/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_ObjectStorageService.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_ObjectStorageService.py
@@ -67,18 +67,40 @@ class ObjectStorageAdapterNaasConfiguration(BaseModel):
     base_prefix: str = ""
 
 
+class ObjectStorageAdapterR2Configuration(BaseModel):
+    """Object storage adapter Cloudflare R2 configuration.
+
+    object_storage_adapter:
+      adapter: "r2"
+      config:
+        account_id: "{{ secret.R2_ACCOUNT_ID }}"
+        bucket_name: "my-bucket"
+        base_prefix: "my-prefix"
+        access_key_id: "{{ secret.R2_ACCESS_KEY_ID }}"
+        secret_access_key: "{{ secret.R2_SECRET_ACCESS_KEY }}"
+    """
+    model_config = ConfigDict(extra="forbid")
+
+    account_id: str
+    bucket_name: str
+    access_key_id: str
+    secret_access_key: str
+    base_prefix: str = ""
+
+
 class ObjectStorageAdapterConfiguration(GenericLoader):
-    adapter: Literal["fs", "s3", "naas", "custom"]
+    adapter: Literal["fs", "s3", "naas", "r2", "custom"]
     config: (
         Union[
             ObjectStorageAdapterFSConfiguration,
             ObjectStorageAdapterS3Configuration,
             ObjectStorageAdapterNaasConfiguration,
+            ObjectStorageAdapterR2Configuration,
         ]
         | None
     ) = None
 
-    __MAPPING: Dict[Literal["fs", "s3", "naas"], Tuple[str, str]] = {
+    __MAPPING: Dict[Literal["fs", "s3", "naas", "r2"], Tuple[str, str]] = {
         "fs": (
             "abi.services.object_storage.adapters.secondary.ObjectStorageSecondaryAdapterFS",
             "ObjectStorageSecondaryAdapterFS",
@@ -90,6 +112,10 @@ class ObjectStorageAdapterConfiguration(GenericLoader):
         "naas": (
             "abi.services.object_storage.adapters.secondary.ObjectStorageSecondaryAdapterNaas",
             "ObjectStorageSecondaryAdapterNaas",
+        ),
+        "r2": (
+            "abi.services.object_storage.adapters.secondary.ObjectStorageSecondaryAdapterR2",
+            "ObjectStorageSecondaryAdapterR2",
         ),
     }
 
@@ -118,6 +144,12 @@ class ObjectStorageAdapterConfiguration(GenericLoader):
                 self.config,
                 "Invalid configuration for services.object_storage.object_storage_adapter 'naas' adapter",
             )
+        if self.adapter == "r2":
+            pydantic_model_validator(
+                ObjectStorageAdapterR2Configuration,
+                self.config,
+                "Invalid configuration for services.object_storage.object_storage_adapter 'r2' adapter",
+            )
 
         return self
 
@@ -142,6 +174,11 @@ class ObjectStorageAdapterConfiguration(GenericLoader):
                     ObjectStorageSecondaryAdapterNaas
 
                 return ObjectStorageSecondaryAdapterNaas(**self.config.model_dump())
+            elif self.adapter == "r2":
+                from naas_abi_core.services.object_storage.adapters.secondary.ObjectStorageSecondaryAdapterR2 import \
+                    ObjectStorageSecondaryAdapterR2
+
+                return ObjectStorageSecondaryAdapterR2(**self.config.model_dump())
             else:
                 raise ValueError(f"Unknown adapter: {self.adapter}")
             # return GenericLoader(

--- a/libs/naas-abi-core/naas_abi_core/services/object_storage/AGENTS.md
+++ b/libs/naas-abi-core/naas_abi_core/services/object_storage/AGENTS.md
@@ -17,7 +17,8 @@ object_storage/
 ├── adapters/secondary/
 │   ├── ObjectStorageSecondaryAdapterFS.py
 │   ├── ObjectStorageSecondaryAdapterS3.py
-│   └── ObjectStorageSecondaryAdapterNaas.py
+│   ├── ObjectStorageSecondaryAdapterNaas.py
+│   └── ObjectStorageSecondaryAdapterR2.py
 └── ontologies/                     # ObjectPut, ObjectDeleted
 ```
 
@@ -63,6 +64,7 @@ get_object_metadata(prefix, key) -> ObjectMetaData
 | `ObjectStorageSecondaryAdapterFS` | Local filesystem |
 | `ObjectStorageSecondaryAdapterS3` | AWS S3 (boto3). `endpoint_url` enables MinIO |
 | `ObjectStorageSecondaryAdapterNaas` | Naas workspace storage (wraps S3 with credential refresh) |
+| `ObjectStorageSecondaryAdapterR2` | Cloudflare R2 (subclasses S3 adapter, derives endpoint from `account_id`, forces `region_name="auto"`) |
 
 ## Factory (`ObjectStorageFactory.py`)
 
@@ -74,6 +76,9 @@ ObjectStorageFactory.ObjectStorageServiceS3(
 )
 ObjectStorageFactory.ObjectStorageServiceNaas(
     naas_api_key, workspace_id, storage_name, base_prefix="",
+)
+ObjectStorageFactory.ObjectStorageServiceR2(
+    account_id, access_key_id, secret_access_key, bucket_name, base_prefix="",
 )
 ```
 

--- a/libs/naas-abi-core/naas_abi_core/services/object_storage/ObjectStorageFactory.py
+++ b/libs/naas-abi-core/naas_abi_core/services/object_storage/ObjectStorageFactory.py
@@ -4,6 +4,9 @@ from naas_abi_core.services.object_storage.adapters.secondary.ObjectStorageSecon
 from naas_abi_core.services.object_storage.adapters.secondary.ObjectStorageSecondaryAdapterNaas import (
     ObjectStorageSecondaryAdapterNaas,
 )
+from naas_abi_core.services.object_storage.adapters.secondary.ObjectStorageSecondaryAdapterR2 import (
+    ObjectStorageSecondaryAdapterR2,
+)
 from naas_abi_core.services.object_storage.adapters.secondary.ObjectStorageSecondaryAdapterS3 import (
     ObjectStorageSecondaryAdapterS3,
 )
@@ -53,5 +56,23 @@ class ObjectStorageFactory:
         return ObjectStorageService(
             ObjectStorageSecondaryAdapterNaas(
                 naas_api_key, workspace_id, storage_name, base_prefix
+            )
+        )
+
+    @staticmethod
+    def ObjectStorageServiceR2(
+        account_id: str,
+        access_key_id: str,
+        secret_access_key: str,
+        bucket_name: str,
+        base_prefix: str = "",
+    ) -> ObjectStorageService:
+        return ObjectStorageService(
+            ObjectStorageSecondaryAdapterR2(
+                account_id,
+                bucket_name,
+                access_key_id,
+                secret_access_key,
+                base_prefix,
             )
         )

--- a/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterR2.py
+++ b/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterR2.py
@@ -1,0 +1,40 @@
+from naas_abi_core.services.object_storage.adapters.secondary.ObjectStorageSecondaryAdapterS3 import (
+    ObjectStorageSecondaryAdapterS3,
+)
+
+R2_REGION = "auto"
+
+
+class ObjectStorageSecondaryAdapterR2(ObjectStorageSecondaryAdapterS3):
+    """Cloudflare R2 implementation of the Object Storage adapter.
+
+    R2 exposes an S3-compatible API, so this adapter reuses the S3 adapter
+    wholesale and only derives the account-scoped endpoint and the "auto"
+    region R2 requires for request signing.
+    """
+
+    def __init__(
+        self,
+        account_id: str,
+        bucket_name: str,
+        access_key_id: str,
+        secret_access_key: str,
+        base_prefix: str = "",
+    ):
+        """Initialize R2 adapter with account id, bucket name and credentials.
+
+        Args:
+            account_id (str): Cloudflare account ID (used to derive the R2 endpoint)
+            bucket_name (str): Name of the R2 bucket to use
+            access_key_id (str): R2 access key ID
+            secret_access_key (str): R2 secret access key
+            base_prefix (str, optional): Base prefix to prepend to all operations. Defaults to ""
+        """
+        super().__init__(
+            bucket_name=bucket_name,
+            access_key_id=access_key_id,
+            secret_access_key=secret_access_key,
+            base_prefix=base_prefix,
+            endpoint_url=f"https://{account_id}.r2.cloudflarestorage.com",
+            region_name=R2_REGION,
+        )

--- a/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterR2_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterR2_test.py
@@ -1,0 +1,32 @@
+from naas_abi_core.services.object_storage.adapters.secondary.ObjectStorageSecondaryAdapterR2 import (
+    ObjectStorageSecondaryAdapterR2,
+)
+
+
+def test_init_derives_endpoint_url_and_forces_auto_region(monkeypatch):
+    captured_kwargs = {}
+
+    def fake_client(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(
+        "naas_abi_core.services.object_storage.adapters.secondary.ObjectStorageSecondaryAdapterS3.boto3.client",
+        fake_client,
+    )
+
+    adapter = ObjectStorageSecondaryAdapterR2(
+        account_id="my-account",
+        bucket_name="my-bucket",
+        access_key_id="id",
+        secret_access_key="secret",
+        base_prefix="datastore",
+    )
+
+    assert adapter.bucket_name == "my-bucket"
+    assert adapter.base_prefix == "datastore"
+    assert (
+        captured_kwargs["endpoint_url"]
+        == "https://my-account.r2.cloudflarestorage.com"
+    )
+    assert captured_kwargs["region_name"] == "auto"

--- a/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterS3.py
+++ b/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterS3.py
@@ -23,6 +23,7 @@ class ObjectStorageSecondaryAdapterS3(IObjectStorageAdapter):
         base_prefix: str = "",
         session_token: str | None = None,
         endpoint_url: str | None = None,
+        region_name: str | None = None,
     ):
         """Initialize S3 adapter with bucket name and credentials.
 
@@ -32,6 +33,9 @@ class ObjectStorageSecondaryAdapterS3(IObjectStorageAdapter):
             secret_access_key (str): AWS secret access key
             base_prefix (str, optional): Base prefix to prepend to all operations. Defaults to ""
             session_token (str, optional): AWS session token. Defaults to None
+            endpoint_url (str, optional): Custom endpoint (MinIO, R2, ...). Defaults to None
+            region_name (str, optional): Region to sign requests with (e.g. "auto" for
+                Cloudflare R2). Defaults to None
         """
         self.bucket_name = bucket_name
         self.base_prefix = base_prefix.rstrip("/")  # Remove trailing slash if present
@@ -43,6 +47,7 @@ class ObjectStorageSecondaryAdapterS3(IObjectStorageAdapter):
                 aws_secret_access_key=secret_access_key,
                 aws_session_token=session_token,
                 endpoint_url=endpoint_url,
+                region_name=region_name,
             )
         else:
             self.s3_client = boto3.client(
@@ -50,6 +55,7 @@ class ObjectStorageSecondaryAdapterS3(IObjectStorageAdapter):
                 aws_access_key_id=access_key_id,
                 aws_secret_access_key=secret_access_key,
                 aws_session_token=session_token,
+                region_name=region_name,
             )
 
     def __get_full_key(self, prefix: str, key: str | None = None) -> str:


### PR DESCRIPTION
This pull request resolves #object-storage-r2

### Summary

This PR introduces support for Cloudflare R2 as a new object storage adapter in the naas-abi-core library.

### Changes

- Added `ObjectStorageAdapterR2Configuration` Pydantic model for R2 adapter configuration.
- Extended `ObjectStorageAdapterConfiguration` to include the `r2` adapter type.
- Added mapping and validation for the `r2` adapter.
- Implemented `ObjectStorageSecondaryAdapterR2` class that subclasses the S3 adapter, customizing the endpoint URL and region for Cloudflare R2.
- Updated `ObjectStorageFactory` to provide a factory method for creating R2 object storage services.
- Added documentation updates in `AGENTS.md` to include the new R2 adapter.
- Added unit tests for `ObjectStorageSecondaryAdapterR2` to verify correct initialization and endpoint derivation.
- Modified the S3 adapter to accept an optional `region_name` parameter to support R2's "auto" region.

### Details

- The R2 adapter derives the endpoint URL from the provided Cloudflare account ID and forces the region name to "auto" as required by R2.
- The adapter reuses the existing S3 adapter logic, ensuring compatibility and reducing code duplication.

### Impact

This enables users to configure and use Cloudflare R2 as an object storage backend seamlessly alongside existing adapters like FS, S3, and Naas.

### Testing

- Added tests to verify the R2 adapter initializes with the correct endpoint and region.
- Monkeypatching boto3 client to capture initialization parameters.

This enhancement broadens the supported object storage options and facilitates integration with Cloudflare's R2 service.