### PR TITLE
feat(email-service): add support for CC recipients in email service and adapters

### DIFF
--- a/libs/naas-abi-core/naas_abi_core/engine/EngineProxy_test.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/EngineProxy_test.py
@@ -24,6 +24,7 @@ class _DummyEmailAdapter(IEmailAdapter):
         reply_to: str | None = None,
         attachments: list[EmailAttachment] | None = None,
         to_emails: list[str] | str | None = None,
+        cc_emails: list[str] | str | None = None,
     ) -> None:
         return None
 

--- a/libs/naas-abi-core/naas_abi_core/services/email/EmailMessageBuilder.py
+++ b/libs/naas-abi-core/naas_abi_core/services/email/EmailMessageBuilder.py
@@ -17,9 +17,12 @@ def build_email_message(
     reply_to: str | None = None,
     attachments: list[EmailAttachment] | None = None,
     to_emails: list[str] | str | None = None,
+    cc_emails: list[str] | str | None = None,
 ) -> EmailMessage:
     msg = EmailMessage()
     msg["To"] = ", ".join(resolve_recipients(to_email, to_emails))
+    if cc_emails:
+        msg["Cc"] = ", ".join(resolve_recipients(None, cc_emails))
     msg["Subject"] = subject
     msg["From"] = (
         formataddr((from_name or "", from_email)) if from_name else from_email

--- a/libs/naas-abi-core/naas_abi_core/services/email/EmailPorts.py
+++ b/libs/naas-abi-core/naas_abi_core/services/email/EmailPorts.py
@@ -59,5 +59,6 @@ class IEmailAdapter(ABC):
         reply_to: str | None = None,
         attachments: list[EmailAttachment] | None = None,
         to_emails: list[str] | str | None = None,
+        cc_emails: list[str] | str | None = None,
     ) -> None:
         raise NotImplementedError()

--- a/libs/naas-abi-core/naas_abi_core/services/email/EmailService.py
+++ b/libs/naas-abi-core/naas_abi_core/services/email/EmailService.py
@@ -41,8 +41,15 @@ class EmailService(ServiceBase):
         reply_to: str | None = None,
         attachments: list[EmailAttachment] | None = None,
         to_emails: list[str] | str | None = None,
+        cc_emails: list[str] | str | None = None,
     ) -> None:
         recipients = ", ".join(resolve_recipients(to_email, to_emails))
+        cc_recipients = (
+            ", ".join(resolve_recipients(None, cc_emails)) if cc_emails else ""
+        )
+        display_recipients = (
+            f"{recipients}; cc: {cc_recipients}" if cc_recipients else recipients
+        )
         try:
             self._adapter.send(
                 to_email=to_email,
@@ -54,12 +61,13 @@ class EmailService(ServiceBase):
                 reply_to=reply_to,
                 attachments=attachments,
                 to_emails=to_emails,
+                cc_emails=cc_emails,
             )
         except Exception as exc:
             self.__publish_event(
-                EmailError(to=recipients, subject=subject, message=str(exc))
+                EmailError(to=display_recipients, subject=subject, message=str(exc))
             )
             raise
         self.__publish_event(
-            EmailSent(to=recipients, subject=subject, sender=from_email)
+            EmailSent(to=display_recipients, subject=subject, sender=from_email)
         )

--- a/libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/FilesystemAdapter.py
+++ b/libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/FilesystemAdapter.py
@@ -24,6 +24,7 @@ class FilesystemAdapter(IEmailAdapter):
         reply_to: str | None = None,
         attachments: list[EmailAttachment] | None = None,
         to_emails: list[str] | str | None = None,
+        cc_emails: list[str] | str | None = None,
     ) -> None:
         msg = build_email_message(
             to_email=to_email,
@@ -35,6 +36,7 @@ class FilesystemAdapter(IEmailAdapter):
             reply_to=reply_to,
             attachments=attachments,
             to_emails=to_emails,
+            cc_emails=cc_emails,
         )
 
         self._directory.mkdir(parents=True, exist_ok=True)

--- a/libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/MicrosoftOutlookAdapter.py
+++ b/libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/MicrosoftOutlookAdapter.py
@@ -114,6 +114,7 @@ class MicrosoftOutlookAdapter(IEmailAdapter):
         reply_to: str | None = None,
         attachments: list[EmailAttachment] | None = None,
         to_emails: list[str] | str | None = None,
+        cc_emails: list[str] | str | None = None,
     ) -> None:
         mailbox = quote(from_email or self._user)
         url = f"{_GRAPH_BASE}/users/{mailbox}/sendMail"
@@ -132,6 +133,11 @@ class MicrosoftOutlookAdapter(IEmailAdapter):
                 for addr in resolve_recipients(to_email, to_emails)
             ],
         }
+        if cc_emails:
+            message["ccRecipients"] = [
+                {"emailAddress": {"address": addr}}
+                for addr in resolve_recipients(None, cc_emails)
+            ]
 
         if reply_to:
             message["replyTo"] = [{"emailAddress": {"address": reply_to}}]

--- a/libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/SESAdapter.py
+++ b/libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/SESAdapter.py
@@ -57,8 +57,15 @@ class SESAdapter(IEmailAdapter):
         reply_to: str | None = None,
         attachments: list[EmailAttachment] | None = None,
         to_emails: list[str] | str | None = None,
+        cc_emails: list[str] | str | None = None,
     ) -> None:
         destinations = resolve_recipients(to_email, to_emails)
+        if cc_emails:
+            destinations.extend(
+                address
+                for address in resolve_recipients(None, cc_emails)
+                if address not in destinations
+            )
         msg = build_email_message(
             to_email=to_email,
             subject=subject,
@@ -69,6 +76,7 @@ class SESAdapter(IEmailAdapter):
             reply_to=reply_to,
             attachments=attachments,
             to_emails=to_emails,
+            cc_emails=cc_emails,
         )
 
         self._get_client().send_raw_email(

--- a/libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/SMTPAdapter.py
+++ b/libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/SMTPAdapter.py
@@ -40,6 +40,7 @@ class SMTPAdapter(IEmailAdapter):
         reply_to: str | None = None,
         attachments: list[EmailAttachment] | None = None,
         to_emails: list[str] | str | None = None,
+        cc_emails: list[str] | str | None = None,
     ) -> None:
         msg = build_email_message(
             to_email=to_email,
@@ -51,6 +52,7 @@ class SMTPAdapter(IEmailAdapter):
             reply_to=reply_to,
             attachments=attachments,
             to_emails=to_emails,
+            cc_emails=cc_emails,
         )
 
         smtp_cls = smtplib.SMTP_SSL if self._use_ssl else smtplib.SMTP

--- a/libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/SendGridAdapter.py
+++ b/libs/naas-abi-core/naas_abi_core/services/email/adapters/secondary/SendGridAdapter.py
@@ -72,6 +72,7 @@ class SendGridAdapter(IEmailAdapter):
         reply_to: str | None = None,
         attachments: list[EmailAttachment] | None = None,
         to_emails: list[str] | str | None = None,
+        cc_emails: list[str] | str | None = None,
     ) -> None:
         content: list[dict[str, str]] = []
         if text_body:
@@ -85,10 +86,16 @@ class SendGridAdapter(IEmailAdapter):
         if from_name:
             from_payload["name"] = from_name
 
+        personalization: dict[str, Any] = {
+            "to": [{"email": addr} for addr in resolve_recipients(to_email, to_emails)]
+        }
+        if cc_emails:
+            personalization["cc"] = [
+                {"email": addr} for addr in resolve_recipients(None, cc_emails)
+            ]
+
         payload: dict[str, Any] = {
-            "personalizations": [
-                {"to": [{"email": addr} for addr in resolve_recipients(to_email, to_emails)]}
-            ],
+            "personalizations": [personalization],
             "from": from_payload,
             "subject": subject,
             "content": content,


### PR DESCRIPTION
This pull request resolves #fix-email-service

### Summary
This PR introduces support for CC (carbon copy) email recipients across the email service and its adapters.

### Changes
- Added `cc_emails` parameter to the email service interface and all email adapter implementations (Filesystem, Microsoft Outlook, SES, SMTP, SendGrid).
- Updated the `EmailMessageBuilder` to include CC recipients in the email headers.
- Modified the `EmailService` to handle CC recipients, including updating event messages to reflect CC recipients.
- Ensured all adapters properly handle and send CC recipients when sending emails.

### Impact
This enhancement allows sending emails with CC recipients, improving the flexibility and completeness of the email sending functionality.

### Testing
- Verified that emails sent include CC recipients in headers and payloads.
- Confirmed that error and sent events correctly display CC recipients.

This update fixes the missing CC functionality in the email service and adapters.