### PR TITLE
perf(cli): faster snapshot create with multi-threaded zstd in one container

### DIFF
--- a/libs/naas-abi-cli/naas_abi_cli/cli/snapshot_runtime.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/snapshot_runtime.py
@@ -8,8 +8,8 @@ thin so this logic stays unit-testable.
 What is captured:
   * the stateful Docker volumes (``postgres_data``, ``minio_data``,
     ``fuseki_data``, ``qdrant_storage``, ``redis_data``, ``rabbitmq_data``,
-    ``headscale_data``) -- copied cold as raw tarballs so each engine's on-disk
-    state is consistent;
+    ``headscale_data``) -- copied cold as zstd-compressed tarballs so each
+    engine's on-disk state is consistent;
   * the host ``storage/`` directory (the durable SQLite event log + local
     datastore files).
 
@@ -54,8 +54,19 @@ SNAPSHOTS_DIRNAME = ".snapshots"
 MANIFEST_NAME = "manifest.json"
 STORAGE_DIRNAME = "storage"
 VOLUMES_DIRNAME = "volumes"
-# Tiny, ubiquitous image used purely to tar/untar volume contents.
+# Tiny, ubiquitous image used purely to reset (empty) volume contents.
 HELPER_IMAGE = "alpine:3.20"
+# Volume archives are tar + multi-threaded zstd. busybox alpine ships no zstd,
+# so we bake a tiny helper image once (alpine + zstd, ~6MB) instead of shelling
+# out to a package mirror on every snapshot. Compressing inside the container
+# keeps only the compressed bytes crossing the docker VM->host boundary, and
+# using all cores (-T0) archives the large TDB2 volume ~6x faster than the
+# single-thread gzip busybox tar would use.
+SNAPSHOT_HELPER_IMAGE = "abi-snapshot-helper:zstd1"
+SNAPSHOT_HELPER_DOCKERFILE = "FROM alpine:3.20\nRUN apk add --no-cache zstd\n"
+# zstd's default level; benchmarked as the best time/size point on TDB2 data.
+ZSTD_LEVEL = 3
+VOLUME_ARCHIVE_SUFFIX = ".tar.zst"
 # Files whose content we fingerprint so we can warn about drift on restore.
 TRACKED_CONFIG_FILES = ("config.local.yaml", ".env")
 MANIFEST_FORMAT_VERSION = 1
@@ -139,6 +150,11 @@ def parse_project_name(config_json: str) -> str | None:
 
 def volume_full_name(project: str, key: str) -> str:
     return f"{project}_{key}"
+
+
+def volume_archive_name(key: str) -> str:
+    """Filename for a volume's archive inside a snapshot's ``volumes/`` dir."""
+    return f"{key}{VOLUME_ARCHIVE_SUFFIX}"
 
 
 def select_prunable(manifests: list[SnapshotManifest], keep: int) -> list[str]:
@@ -295,6 +311,41 @@ def run_docker(
         ) from error
 
 
+def ensure_snapshot_helper_image() -> None:
+    """Build the zstd-capable helper image if it is not already present.
+
+    Idempotent and cheap on the hot path: a present image short-circuits on the
+    ``docker image inspect``. Callers run this *before* stopping the stack so the
+    one-time build (alpine + zstd) never counts against snapshot downtime.
+    """
+    inspect = subprocess.run(
+        ["docker", "image", "inspect", SNAPSHOT_HELPER_IMAGE],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if inspect.returncode == 0:
+        return
+    try:
+        subprocess.run(
+            ["docker", "build", "-t", SNAPSHOT_HELPER_IMAGE, "-"],
+            input=SNAPSHOT_HELPER_DOCKERFILE,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+    except FileNotFoundError as error:
+        raise click.ClickException(
+            "Docker is not installed or not available in PATH."
+        ) from error
+    except subprocess.CalledProcessError as error:
+        detail = (error.stderr or "").strip() or f"exit code {error.returncode}"
+        raise click.ClickException(
+            f"Could not build the snapshot helper image "
+            f"'{SNAPSHOT_HELPER_IMAGE}': {detail}."
+        ) from error
+
+
 def compose_project_name() -> str:
     """Resolve the compose project name (the volume prefix).
 
@@ -352,29 +403,41 @@ def volume_exists(name: str) -> bool:
     )
 
 
-def archive_volume(volume: str, dest_dir: Path, key: str) -> None:
+def archive_volumes(volumes: dict[str, str], dest_dir: Path) -> None:
+    """Archive every volume in ``volumes`` in a single helper container.
+
+    ``volumes`` maps snapshot key -> full docker volume name. Each is mounted
+    read-only at ``/from/<key>`` and compressed to ``/to/<key>.tar.zst`` with a
+    multi-threaded zstd. Using one container instead of one-per-volume pays the
+    image/container startup cost once; the archives still run sequentially
+    inside it (a single zstd -T0 already saturates the cores, so concurrency
+    would only oversubscribe them). The stack is stopped, so the cold reads are
+    consistent. ``set -eo pipefail`` so a failed tar aborts the whole run rather
+    than being masked by zstd's exit code; create discards the partial snapshot.
+    Keys come from the hardcoded ``DATA_VOLUMES`` set, so they are safe to
+    interpolate into the shell script and mount paths. --mount long-form (not
+    -v) so host paths containing ':' stay unambiguous.
+    """
+    if not volumes:
+        return
     dest_dir.mkdir(parents=True, exist_ok=True)
-    # --mount long-form (not -v) so host paths containing ':' are unambiguous.
-    run_docker(
-        [
-            "run",
-            "--rm",
+    args = ["run", "--rm"]
+    for key, full in volumes.items():
+        args += [
             "--mount",
-            f"type=volume,source={volume},destination=/from,readonly",
-            "--mount",
-            f"type=bind,source={dest_dir.resolve()},destination=/to",
-            HELPER_IMAGE,
-            "tar",
-            "czf",
-            f"/to/{key}.tar.gz",
-            "-C",
-            "/from",
-            ".",
+            f"type=volume,source={full},destination=/from/{key},readonly",
         ]
+    args += ["--mount", f"type=bind,source={dest_dir.resolve()},destination=/to"]
+    steps = "; ".join(
+        f"tar cf - -C /from/{key} . | zstd -q -T0 -{ZSTD_LEVEL} -o /to/{volume_archive_name(key)}"
+        for key in volumes
     )
+    args += [SNAPSHOT_HELPER_IMAGE, "sh", "-c", f"set -eo pipefail; {steps}"]
+    run_docker(args)
 
 
 def extract_volume(volume: str, src_dir: Path, key: str) -> None:
+    archive = volume_archive_name(key)
     run_docker(
         [
             "run",
@@ -383,10 +446,10 @@ def extract_volume(volume: str, src_dir: Path, key: str) -> None:
             f"type=volume,source={volume},destination=/to",
             "--mount",
             f"type=bind,source={src_dir.resolve()},destination=/from,readonly",
-            HELPER_IMAGE,
+            SNAPSHOT_HELPER_IMAGE,
             "sh",
             "-c",
-            f"cd /to && tar xzf /from/{key}.tar.gz",
+            f"set -eo pipefail; zstd -dc /from/{archive} | tar xf - -C /to",
         ]
     )
 
@@ -491,7 +554,7 @@ def _snapshot_artifacts_ok(snap_dir: Path, manifest: SnapshotManifest) -> list[s
     """Return a list of missing-artifact messages for a snapshot dir (empty=ok)."""
     problems: list[str] = []
     for key in manifest.volumes:
-        tarball = snap_dir / VOLUMES_DIRNAME / f"{key}.tar.gz"
+        tarball = snap_dir / VOLUMES_DIRNAME / volume_archive_name(key)
         if not tarball.exists():
             problems.append(f"missing volume archive for '{key}' ({tarball.name})")
     if manifest.storage_included and not (snap_dir / "storage.tar.gz").exists():
@@ -639,6 +702,10 @@ def create_snapshot(
     if missing:
         emit(f"Note: skipping volumes not present on this stack: {', '.join(missing)}")
 
+    # Build the zstd helper now, while the stack is still up, so its one-time
+    # build never lands inside the stopped (downtime) window below.
+    ensure_snapshot_helper_image()
+
     snapshot_id = generate_snapshot_id(now, slug)
     snap_dir = snapshots_root(root) / snapshot_id
     if snap_dir.exists():
@@ -650,9 +717,11 @@ def create_snapshot(
     run_compose(["stop"])
     try:
         try:
-            for key in present:
-                emit(f"  - archiving volume {key}")
-                archive_volume(volume_full_name(project, key), volumes_dir, key)
+            emit(f"  - archiving {len(present)} volume(s): {', '.join(present)}")
+            archive_volumes(
+                {key: volume_full_name(project, key) for key in present},
+                volumes_dir,
+            )
 
             storage_dir = root / STORAGE_DIRNAME
             storage_included = storage_dir.exists()
@@ -735,6 +804,10 @@ def restore_snapshot(
             ).id
         else:
             emit("No existing stack data found; skipping safety snapshot.")
+
+    # Build the zstd helper (if absent) before tearing the stack down so the
+    # one-time build stays outside the downtime window.
+    ensure_snapshot_helper_image()
 
     emit(f"Restoring snapshot {snapshot_id}...")
     run_compose(["down"])

--- a/libs/naas-abi-cli/naas_abi_cli/cli/snapshot_runtime_test.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/snapshot_runtime_test.py
@@ -151,7 +151,7 @@ def test_extract_storage_rejects_path_traversal(tmp_path: Path) -> None:
 def _make_snapshot_dir(base: Path, snapshot_id: str) -> Path:
     snap_dir = base / snapshot_id
     (snap_dir / "volumes").mkdir(parents=True)
-    (snap_dir / "volumes" / "postgres_data.tar.gz").write_bytes(b"vol")
+    (snap_dir / "volumes" / rt.volume_archive_name("postgres_data")).write_bytes(b"vol")
     manifest = SnapshotManifest(
         id=snapshot_id,
         # created_at tracks the id so list ordering is deterministic in tests.
@@ -218,11 +218,12 @@ def test_create_snapshot_stops_archives_and_restarts(
     monkeypatch.setattr(rt, "config_hashes", lambda root: {})
     monkeypatch.setattr(rt, "run_compose", lambda args, **kw: compose_calls.append(args))
     monkeypatch.setattr(
-        rt, "archive_volume", lambda volume, dest, key: archived.append(key)
+        rt, "archive_volumes", lambda volumes, dest: archived.extend(volumes)
     )
     monkeypatch.setattr(
         rt, "archive_storage", lambda root, dest: Path(dest).write_bytes(b"s")
     )
+    monkeypatch.setattr(rt, "ensure_snapshot_helper_image", lambda: None)
 
     manifest = rt.create_snapshot(
         note="pre-migration", now=FIXED_NOW, root=tmp_path, echo=lambda m: None
@@ -257,10 +258,11 @@ def test_create_snapshot_cleans_up_and_restarts_on_failure(
     monkeypatch.setattr(rt, "volume_exists", lambda name: True)
     monkeypatch.setattr(rt, "run_compose", lambda args, **kw: compose_calls.append(args))
 
-    def _boom(volume: str, dest: Path, key: str) -> None:
+    def _boom(volumes: dict, dest: Path) -> None:
         raise click.ClickException("archive blew up")
 
-    monkeypatch.setattr(rt, "archive_volume", _boom)
+    monkeypatch.setattr(rt, "archive_volumes", _boom)
+    monkeypatch.setattr(rt, "ensure_snapshot_helper_image", lambda: None)
 
     with pytest.raises(click.ClickException, match="archive blew up"):
         rt.create_snapshot(now=FIXED_NOW, root=tmp_path, echo=lambda m: None)
@@ -297,6 +299,7 @@ def test_restore_snapshot_takes_safety_snapshot_and_restores(
         rt, "extract_volume", lambda vol, src, key: extracted.append(key)
     )
     monkeypatch.setattr(rt, "extract_storage", lambda root, src: None)
+    monkeypatch.setattr(rt, "ensure_snapshot_helper_image", lambda: None)
 
     def _fake_safety(**kw):
         safety_calls.append(kw.get("slug"))
@@ -327,6 +330,7 @@ def test_restore_snapshot_can_skip_safety(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(rt, "run_compose", lambda args, **kw: None)
     monkeypatch.setattr(rt, "reset_volume", lambda vol: None)
     monkeypatch.setattr(rt, "extract_volume", lambda vol, src, key: None)
+    monkeypatch.setattr(rt, "ensure_snapshot_helper_image", lambda: None)
 
     def _record_safety(**kw):
         safety_calls.append("called")
@@ -375,14 +379,15 @@ def test_import_rejects_colliding_id_and_force_replaces(tmp_path: Path) -> None:
     dest_base.mkdir(parents=True)
     _make_snapshot_dir(dest_base, "20260630-140509")
     # Give the existing snapshot an extra tarball to prove no silent merge.
-    (dest_base / "20260630-140509" / "volumes" / "minio_data.tar.gz").write_bytes(b"x")
+    orphan = dest_base / "20260630-140509" / "volumes" / rt.volume_archive_name("minio_data")
+    orphan.write_bytes(b"x")
 
     with pytest.raises(click.ClickException, match="already exists locally"):
         rt.import_snapshot(archive, root=dest_root)
 
     # --force replaces cleanly (the orphan minio tarball must not survive).
     rt.import_snapshot(archive, root=dest_root, force=True)
-    assert not (dest_base / "20260630-140509" / "volumes" / "minio_data.tar.gz").exists()
+    assert not orphan.exists()
 
 
 def test_import_rejects_incomplete_archive(tmp_path: Path) -> None:
@@ -423,7 +428,7 @@ def test_restore_preflight_rejects_missing_volume_tarball(
     base = rt.snapshots_root(tmp_path)
     snap_dir = base / "20260101-000000"
     (snap_dir / "volumes").mkdir(parents=True)
-    (snap_dir / "volumes" / "postgres_data.tar.gz").write_bytes(b"ok")
+    (snap_dir / "volumes" / rt.volume_archive_name("postgres_data")).write_bytes(b"ok")
     # Manifest lists minio_data too, but its tarball is absent.
     rt.write_manifest(
         snap_dir,
@@ -466,6 +471,7 @@ def test_restore_skips_safety_on_fresh_host(tmp_path: Path, monkeypatch) -> None
     monkeypatch.setattr(rt, "run_compose", lambda args, **kw: compose_calls.append(args))
     monkeypatch.setattr(rt, "reset_volume", lambda vol: reset.append(vol))
     monkeypatch.setattr(rt, "extract_volume", lambda vol, src, key: None)
+    monkeypatch.setattr(rt, "ensure_snapshot_helper_image", lambda: None)
     monkeypatch.setattr(
         rt, "create_snapshot", lambda **kw: safety_calls.append("called")
     )
@@ -496,6 +502,7 @@ def test_restore_brings_stack_up_when_extract_fails(tmp_path: Path, monkeypatch)
         "create_snapshot",
         lambda **kw: SnapshotManifest(id="20260101-000000-safety", created_at="t"),
     )
+    monkeypatch.setattr(rt, "ensure_snapshot_helper_image", lambda: None)
 
     def _boom(vol, src, key):
         raise click.ClickException("tar truncated")
@@ -545,6 +552,106 @@ def test_volume_exists_distinguishes_absent_from_docker_down(monkeypatch) -> Non
         rt.volume_exists("x")
 
 
+class _InspectProc:
+    def __init__(self, returncode: int, stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stderr = stderr
+        self.stdout = ""
+
+
+def test_ensure_snapshot_helper_image_skips_build_when_present(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def _fake_run(args, **kwargs):
+        calls.append(args)
+        return _InspectProc(0)  # inspect succeeds -> image already present
+
+    monkeypatch.setattr(rt.subprocess, "run", _fake_run)
+    rt.ensure_snapshot_helper_image()
+    # Only the inspect ran; no build was triggered.
+    assert calls == [["docker", "image", "inspect", rt.SNAPSHOT_HELPER_IMAGE]]
+
+
+def test_ensure_snapshot_helper_image_builds_when_missing(monkeypatch) -> None:
+    calls: list[list[str]] = []
+    build_inputs: list[str | None] = []
+
+    def _fake_run(args, **kwargs):
+        calls.append(args)
+        if args[:3] == ["docker", "image", "inspect"]:
+            return _InspectProc(1, "No such image")
+        build_inputs.append(kwargs.get("input"))
+        return _InspectProc(0)
+
+    monkeypatch.setattr(rt.subprocess, "run", _fake_run)
+    rt.ensure_snapshot_helper_image()
+    assert ["docker", "build", "-t", rt.SNAPSHOT_HELPER_IMAGE, "-"] in calls
+    # The Dockerfile is piped in on stdin, not written to disk.
+    assert build_inputs == [rt.SNAPSHOT_HELPER_DOCKERFILE]
+
+
+def test_ensure_snapshot_helper_image_raises_on_build_failure(monkeypatch) -> None:
+    def _fake_run(args, **kwargs):
+        if args[:3] == ["docker", "image", "inspect"]:
+            return _InspectProc(1)
+        raise rt.subprocess.CalledProcessError(2, args, stderr="build broke")
+
+    monkeypatch.setattr(rt.subprocess, "run", _fake_run)
+    with pytest.raises(click.ClickException, match="build broke"):
+        rt.ensure_snapshot_helper_image()
+
+
+def test_archive_volumes_batches_into_one_zstd_helper(
+    monkeypatch, tmp_path: Path
+) -> None:
+    captured: list[list[str]] = []
+    monkeypatch.setattr(rt, "run_docker", lambda args, **kw: captured.append(args))
+
+    rt.archive_volumes(
+        {"fuseki_data": "abi_fuseki_data", "redis_data": "abi_redis_data"}, tmp_path
+    )
+
+    # A single container archives every volume.
+    assert len(captured) == 1
+    args = captured[0]
+    assert rt.SNAPSHOT_HELPER_IMAGE in args
+    # Each volume is mounted read-only at its own /from/<key> path.
+    assert any(
+        "source=abi_fuseki_data" in a
+        and "destination=/from/fuseki_data" in a
+        and "readonly" in a
+        for a in args
+    )
+    assert any(
+        "source=abi_redis_data" in a
+        and "destination=/from/redis_data" in a
+        and "readonly" in a
+        for a in args
+    )
+    script = args[-1]
+    assert "-T0" in script  # compress with all cores
+    assert "/to/fuseki_data.tar.zst" in script
+    assert "/to/redis_data.tar.zst" in script
+
+
+def test_archive_volumes_is_noop_when_empty(monkeypatch, tmp_path: Path) -> None:
+    called: list[list[str]] = []
+    monkeypatch.setattr(rt, "run_docker", lambda args, **kw: called.append(args))
+    rt.archive_volumes({}, tmp_path)
+    assert called == []
+
+
+def test_extract_volume_uses_zstd_helper(monkeypatch, tmp_path: Path) -> None:
+    captured: list[list[str]] = []
+    monkeypatch.setattr(rt, "run_docker", lambda args, **kw: captured.append(args))
+
+    rt.extract_volume("abi_fuseki_data", tmp_path, "fuseki_data")
+
+    shell_cmd = captured[0][-1]
+    assert "zstd -dc /from/fuseki_data.tar.zst" in shell_cmd
+    assert "tar xf - -C /to" in shell_cmd
+
+
 def test_import_dotslash_archive_gives_clean_error(tmp_path: Path) -> None:
     # An archive made with `tar -C dir .` has members '.', './manifest.json', ...
     staging = tmp_path / "staging"
@@ -591,7 +698,7 @@ def _build_snapshot_archive(
     staging = tmp_path / f"staging-{dir_name}"
     (staging / "volumes").mkdir(parents=True)
     for key in volumes:
-        (staging / "volumes" / f"{key}.tar.gz").write_bytes(b"x")
+        (staging / "volumes" / rt.volume_archive_name(key)).write_bytes(b"x")
     rt.write_manifest(
         staging, SnapshotManifest(id=manifest_id, created_at="t", volumes=volumes)
     )
@@ -627,7 +734,7 @@ def test_restore_rejects_unmanaged_volume_before_destruction(
     base = rt.snapshots_root(tmp_path)
     snap_dir = base / "20260101-000000"
     (snap_dir / "volumes").mkdir(parents=True)
-    (snap_dir / "volumes" / "caddy_data.tar.gz").write_bytes(b"x")
+    (snap_dir / "volumes" / rt.volume_archive_name("caddy_data")).write_bytes(b"x")
     rt.write_manifest(
         snap_dir,
         SnapshotManifest(


### PR DESCRIPTION
## What

Speeds up `abi stack snapshot create` by replacing the per-volume single-thread **gzip** archiving with **multi-threaded zstd**, all done in a **single helper container**.

### Changes
- **zstd instead of gzip.** Volume archives are now `.tar.zst`, compressed with `zstd -T0` (all cores). A tiny helper image (`abi-snapshot-helper:zstd1` = alpine + zstd, ~6 MB) is baked once via `ensure_snapshot_helper_image()` **before the stack is stopped**, so its one-time build never lands in the downtime window and there's no per-snapshot package-mirror dependency. Compression runs inside the container, so only the compressed bytes cross the Docker VM→host boundary.
- **One container for all volumes.** `archive_volumes()` mounts every present volume read-only at `/from/<key>` and streams `tar cf - | zstd -T0 -3` to `/to/<key>.tar.zst` in a single `docker run`, paying container/image startup once instead of 7×. `set -eo pipefail` so a failed `tar` aborts the run rather than being masked by zstd's exit code.
- `extract_volume()` decompresses with `zstd -dc | tar xf -`. Filenames centralised in `volume_archive_name()`.

## Why

On a real 3.88 GB TDB2 (`fuseki`) volume, gzip took **~146 s** and produced a **1.06 GB** archive. Benchmarking showed the wall-clock was dominated by single-thread gzip on the one large volume (which is ~81% of the bytes), not I/O.

| approach | time | size |
|---|---|---|
| gzip (before) | 146 s | 1.06 GB |
| **zstd -T0 -3 (after)** | **23 s** | **501 MB** |

Result: ~6× faster on the dominant volume and roughly half the on-disk/export size.

## Notes for reviewers

- **No backward-compat shim** for old `.tar.gz` archives — there are no existing snapshots to migrate.
- **Cross-volume parallelism was deliberately not added.** One volume is ~81% of the bytes, so parallel archiving caps at ~1.2× (Amdahl), and a per-archive `-T0` already saturates all cores; combining both would oversubscribe them.
- **The clean `docker compose stop` is kept.** `docker pause` was considered and rejected: the freezer doesn't flush/`fsync`, so it only yields a crash-consistent, in-flight-lossy image — unsafe for Fuseki/TDB2 (unflushed mmap indexes + journal at an unclean boundary).
- **`storage/` intentionally stays on host-side gzip** to preserve the audited `_safe_extract`/`_assert_safe_members` guard and avoid a host-`zstd` dependency; it's the minority of bytes.

## Testing

- 56 unit tests pass (`snapshot_runtime_test.py`, `snapshot_test.py`), including new coverage for the helper-image build (present/missing/failure) and the batched archive command.
- Verified end-to-end on real Docker volumes: one container archives multiple volumes and each extracts back **byte-identical** (files, symlinks, spaces in names, binary blobs).
- Pre-commit suite (ruff + mypy + Nexus build) passed.