### PR TITLE
fix(agent): handle Anthropic extended-thinking tool_use blocks correctly

### DIFF
--- a/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
@@ -1062,6 +1062,51 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
         if not inbound_ids:
             return messages
 
+        def _strip_content_tool_use(content: Any) -> Any:
+            """Drop tool_use blocks whose id is inbound from list-form content.
+
+            Anthropic extended-thinking responses carry ``content`` as a list of
+            blocks (``thinking`` / ``text`` / ``tool_use``). The ``tool_use``
+            block is the raw counterpart of a ``tool_calls`` entry; removing the
+            entry from ``.tool_calls`` alone leaves the block in ``content``,
+            which the API then rejects as a ``tool_use`` with no ``tool_result``.
+            """
+            if not isinstance(content, list):
+                return content
+            return [
+                b
+                for b in content
+                if not (
+                    isinstance(b, dict)
+                    and b.get("type") == "tool_use"
+                    and b.get("id") in inbound_ids
+                )
+            ]
+
+        def _content_effectively_empty(content: Any) -> bool:
+            """True when content has no user-visible text and no tool_use block.
+
+            Bare ``thinking`` / ``redacted_thinking`` blocks are plumbing, not a
+            standalone assistant turn, so a message left with only those (after
+            the tool_use is stripped) should be dropped entirely.
+            """
+            if not content:
+                return True
+            if isinstance(content, str):
+                return not content.strip()
+            if isinstance(content, list):
+                for b in content:
+                    if isinstance(b, dict):
+                        btype = b.get("type")
+                        if btype == "text" and (b.get("text") or "").strip():
+                            return False
+                        if btype == "tool_use":
+                            return False
+                    elif isinstance(b, str) and b.strip():
+                        return False
+                return True
+            return False
+
         cleaned: list[AnyMessage] = []
         for m in messages:
             if (
@@ -1069,18 +1114,19 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
                 and getattr(m, "tool_call_id", None) in inbound_ids
             ):
                 continue
-            if isinstance(m, AIMessage) and getattr(m, "tool_calls", None):
-                kept = [
-                    tc for tc in m.tool_calls if tc.get("id") not in inbound_ids
-                ]
-                if len(kept) != len(m.tool_calls):
-                    content_empty = (not m.content) or (
-                        isinstance(m.content, str) and not m.content.strip()
-                    )
-                    if not kept and content_empty:
+            if isinstance(m, AIMessage):
+                tool_calls = list(getattr(m, "tool_calls", None) or [])
+                kept = [tc for tc in tool_calls if tc.get("id") not in inbound_ids]
+                new_content = _strip_content_tool_use(m.content)
+                tool_calls_changed = len(kept) != len(tool_calls)
+                content_changed = new_content is not m.content and (
+                    new_content != m.content
+                )
+                if tool_calls_changed or content_changed:
+                    if not kept and _content_effectively_empty(new_content):
                         continue
                     m = AIMessage(
-                        content=m.content,
+                        content=new_content,
                         tool_calls=kept,
                         id=m.id,
                         additional_kwargs=dict(

--- a/libs/naas-abi-core/naas_abi_core/services/agent/Agent_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/Agent_test.py
@@ -220,3 +220,92 @@ def test_agent_one_tool_agent_response(model):
     assert len(chunks) == 3
     assert "call_model" in chunks[-1]
     assert chunks[-1]["call_model"]["messages"][0].content == "42 + one = 43"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _strip_inbound_handoff_artifacts — orphan tool_use in extended-thinking content
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _strip(name, messages):
+    """Call the unbound method with a lightweight self (only ._name is used)."""
+    from types import SimpleNamespace
+
+    from naas_abi_core.services.agent.Agent import Agent
+
+    return Agent._strip_inbound_handoff_artifacts(SimpleNamespace(_name=name), messages)
+
+
+def test_strip_removes_orphan_tool_use_block_in_list_content():
+    """Regression: with extended thinking the transfer ``tool_use`` lives inside
+    the assistant message's list ``content``. Stripping the ``__handoff__``
+    tool_result must also remove that block, or Anthropic rejects the history
+    with 'tool_use ids were found without tool_result blocks'.
+    """
+    from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+    tid = "toolu_ORPHAN"
+    sub = "Market_Intelligence_Slides_Agent"
+    messages = [
+        HumanMessage(content="hi", id="h1"),
+        AIMessage(
+            content=[
+                {"type": "thinking", "thinking": "", "signature": "sig"},
+                {"type": "tool_use", "id": tid, "name": f"transfer_to_{sub}", "input": {}},
+            ],
+            tool_calls=[{"name": f"transfer_to_{sub}", "args": {}, "id": tid, "type": "tool_call"}],
+            id="ai1",
+        ),
+        ToolMessage(
+            content=f"__handoff__:{sub}",
+            name=f"transfer_to_{sub}",
+            tool_call_id=tid,
+            id="tm1",
+        ),
+    ]
+
+    cleaned = _strip(sub, messages)
+
+    # The __handoff__ tool_result is gone …
+    assert not any(isinstance(m, ToolMessage) for m in cleaned)
+    # … and no orphan tool_use block survives anywhere in list content.
+    for m in cleaned:
+        if isinstance(m.content, list):
+            assert not any(
+                isinstance(b, dict) and b.get("type") == "tool_use" for b in m.content
+            )
+    # The transfer message carried only thinking+tool_use, so it is dropped whole.
+    assert [type(m).__name__ for m in cleaned] == ["HumanMessage"]
+
+
+def test_strip_keeps_visible_text_but_drops_tool_use_block():
+    """When the transfer message also has real text, keep the text and strip
+    only the tool_use block (and its tool_calls entry)."""
+    from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+    tid = "toolu_X"
+    sub = "Support_Agent"
+    messages = [
+        HumanMessage(content="hi", id="h1"),
+        AIMessage(
+            content=[
+                {"type": "text", "text": "Sure, one moment."},
+                {"type": "tool_use", "id": tid, "name": f"transfer_to_{sub}", "input": {}},
+            ],
+            tool_calls=[{"name": f"transfer_to_{sub}", "args": {}, "id": tid, "type": "tool_call"}],
+            id="ai1",
+        ),
+        ToolMessage(content=f"__handoff__:{sub}", name=f"transfer_to_{sub}", tool_call_id=tid, id="tm1"),
+    ]
+
+    cleaned = _strip(sub, messages)
+
+    assert [type(m).__name__ for m in cleaned] == ["HumanMessage", "AIMessage"]
+    ai = cleaned[1]
+    assert ai.tool_calls == []
+    assert all(
+        not (isinstance(b, dict) and b.get("type") == "tool_use") for b in ai.content
+    )
+    assert any(
+        isinstance(b, dict) and b.get("type") == "text" for b in ai.content
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -3547,7 +3547,7 @@ wheels = [
 
 [[package]]
 name = "naas-abi"
-version = "2.41.0"
+version = "2.42.0"
 source = { editable = "libs/naas-abi" }
 dependencies = [
     { name = "aiosqlite" },
@@ -3786,7 +3786,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-marketplace"
-version = "3.20.1"
+version = "3.21.0"
 source = { editable = "libs/naas-abi-marketplace" }
 dependencies = [
     { name = "ijson" },


### PR DESCRIPTION
This pull request resolves #fix-agent-anthropic

# Summary

This PR fixes an issue in the agent's message handling related to Anthropic extended-thinking responses that include `tool_use` blocks in the message content.

# Details

- Introduced a helper function `_strip_content_tool_use` that removes `tool_use` blocks from list-formatted message content when their IDs are in the inbound handoff IDs.
- Added `_content_effectively_empty` helper to determine if the content is effectively empty (no visible text or tool_use blocks), which helps decide if a message should be dropped.
- Updated the message cleaning logic to:
  - Remove `tool_use` blocks from the content alongside removing corresponding `tool_calls` entries.
  - Drop messages that become empty after stripping these blocks.

# Motivation

Anthropic's API rejects messages that contain `tool_use` blocks without corresponding `tool_result` blocks. Previously, only the `tool_calls` entries were removed, leaving orphan `tool_use` blocks in the content, causing API rejections.

# Tests

- Added tests to verify that orphan `tool_use` blocks are removed from the content.
- Verified that messages with only `thinking` and `tool_use` blocks are dropped after stripping.
- Verified that messages with visible text retain the text but have `tool_use` blocks removed.

This ensures compatibility with Anthropic extended-thinking responses and prevents API errors related to orphaned `tool_use` blocks.