### PR TITLE
feat(agent): opt-in sequential supervisor mode

### DIFF
--- a/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
@@ -420,6 +420,18 @@ class Agent(Expose):
     # He will be responsible to load them as tools.
     _agents: list["Agent"] = []
 
+    # Opt-in: when True, this agent is a *sequential supervisor*. Its sub-agents
+    # return control to it when they finish (instead of ending the turn), so it can
+    # delegate to them one after another in a single turn. Applied in __init__ so it
+    # survives per-request reconstruction (as_api / duplicate rebuild fresh state).
+    sequential_supervisor: bool = False
+
+    # Set on a *sub-agent instance* by a sequential_supervisor parent to the parent's
+    # name. Purely per-instance (never the shared state, which is tree-wide and would
+    # corrupt sibling agents). When set, call_model returns control to that supervisor
+    # on completion instead of ending the turn.
+    _returns_to_supervisor: Optional[str] = None
+
     _chekpointer: BaseCheckpointSaver
     _state: AgentSharedState
 
@@ -592,6 +604,17 @@ class Agent(Expose):
         )
         self._structured_tools = _structured_tools
         self._agents = _agents
+
+        # Sequential-supervisor wiring (opt-in via the class attribute). Tag each
+        # sub-agent *instance* (not the shared state — that is tree-wide and shared
+        # with any outer supervisor like AbiAgent, so mutating it corrupts siblings)
+        # with this agent's name, so that when the sub-agent finishes it returns
+        # control here instead of ending the turn (see call_model). Re-applied on
+        # every reconstruction because __init__ runs on duplicate/as_api.
+        if getattr(self, "sequential_supervisor", False):
+            for _sub_agent in self._agents:
+                if _sub_agent.name != self._name:
+                    _sub_agent._returns_to_supervisor = self._name
 
         # We assert that the tool that are provided are valid.
         for t in self._structured_tools:
@@ -1215,6 +1238,28 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
         if self._markdown_pretty_display:
             logger.debug("Applying Markdown pretty display to response")
             response = self._pretty_display_markdown(response)
+
+        # Sequential supervisor mode (opt-in): if a sequential_supervisor parent
+        # tagged this sub-agent instance, hand control back to that supervisor when
+        # we finish — so it can run the next step — instead of ending the whole turn.
+        # Mirrors the request_help return path but triggers on normal completion.
+        return_to = getattr(self, "_returns_to_supervisor", None)
+        if return_to is not None and return_to != self._name:
+            logger.debug(
+                f"↩️  Sub-agent '{self._name}' returning control to supervisor "
+                f"'{return_to}'"
+            )
+            self._state.set_current_active_agent(return_to)
+            return Command(
+                goto="current_active_agent",
+                graph=Command.PARENT,
+                update={
+                    **routing_update,
+                    "current_active_agent": return_to,
+                    "messages": [response],
+                },
+            )
+
         return Command(
             goto="__end__",
             update={**routing_update, "messages": [response]},


### PR DESCRIPTION
## Summary

Adds an opt-in `Agent.sequential_supervisor` class flag that lets a supervisor delegate to several sub-agents **in sequence within a single turn**.

Today, putting agents in `agents=[...]` uses a **terminal handoff**: when the supervisor hands off to a sub-agent, the sub-agent runs and the turn ends (`call_model` → `goto="__end__"`). Control never comes back, so a supervisor cannot run a second delegated step. The only way back is `request_help`, which a sub-agent calls when it is *stuck*, not on success.

This adds a supervisor pattern alongside the existing swarm/handoff one: with `sequential_supervisor = True`, a sub-agent **returns control to its supervisor when it finishes**, so the supervisor can call agent A, get the result back, then call agent B — all in one turn.

## Design

- New class attribute `Agent.sequential_supervisor: bool = False` (opt-in).
- A `sequential_supervisor` parent tags each sub-agent **instance** with `_returns_to_supervisor = <parent name>` in `__init__`.
  - Per-instance on purpose: the shared `AgentSharedState` is **tree-wide** and shared with any outer supervisor (e.g. a top-level `AbiAgent`), so mutating `supervisor_agent` there would corrupt sibling agents. The tag is a plain instance attribute instead.
  - Applied in `__init__` so it is re-applied on every reconstruction (`as_api` / `duplicate` build a fresh state per request).
- In `call_model`, when a tagged sub-agent produces its final answer, it returns control to its supervisor via `Command(goto="current_active_agent", graph=Command.PARENT, ...)` — the same routing the existing `request_help` path uses — instead of `goto="__end__"`.

## Backwards compatibility

- Default behaviour is **unchanged** for every agent that does not set the flag — the completion path still ends the turn as before.
- No change to `AgentSharedState` or any shared routing state, so existing supervisors (swarm-style handoff, `request_help`) are unaffected.

## Testing

- A supervisor with two sub-agents and `sequential_supervisor = True` now runs both delegated steps in one turn (each sub-agent returns control after completing; the supervisor continues to the next).
- Verified a default top-level supervisor agent (`agents=[...]` without the flag) still responds normally, and that no sibling agent's `supervisor_agent` is affected.