### PR TITLE
feat(mobile-ios): ABI Mobile iOS chat client

### DIFF
--- a/libs/naas-abi/naas_abi/apps/mobile_ios/ABIChat.xcodeproj/project.pbxproj
+++ b/libs/naas-abi/naas_abi/apps/mobile_ios/ABIChat.xcodeproj/project.pbxproj
@@ -1,0 +1,348 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		0A0000010000000000000001 /* ABIChatApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A0000010000000000000011 /* ABIChatApp.swift */; };
+		0A0000010000000000000002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A0000010000000000000012 /* ContentView.swift */; };
+		0A0000010000000000000003 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A0000010000000000000013 /* Models.swift */; };
+		0A0000010000000000000004 /* ABIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A0000010000000000000014 /* ABIClient.swift */; };
+		0A0000010000000000000005 /* ChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A0000010000000000000015 /* ChatViewModel.swift */; };
+		0A0000010000000000000006 /* SettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A0000010000000000000016 /* SettingsStore.swift */; };
+		0A0000010000000000000007 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0A0000010000000000000018 /* Assets.xcassets */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		0A0000010000000000000010 /* ABIChat.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ABIChat.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		0A0000010000000000000011 /* ABIChatApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABIChatApp.swift; sourceTree = "<group>"; };
+		0A0000010000000000000012 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		0A0000010000000000000013 /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
+		0A0000010000000000000014 /* ABIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABIClient.swift; sourceTree = "<group>"; };
+		0A0000010000000000000015 /* ChatViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModel.swift; sourceTree = "<group>"; };
+		0A0000010000000000000016 /* SettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStore.swift; sourceTree = "<group>"; };
+		0A0000010000000000000017 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		0A0000010000000000000018 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		0A0000010000000000000020 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		0A0000010000000000000030 = {
+			isa = PBXGroup;
+			children = (
+				0A0000010000000000000031 /* ABIChat */,
+				0A0000010000000000000032 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		0A0000010000000000000031 /* ABIChat */ = {
+			isa = PBXGroup;
+			children = (
+				0A0000010000000000000011 /* ABIChatApp.swift */,
+				0A0000010000000000000012 /* ContentView.swift */,
+				0A0000010000000000000015 /* ChatViewModel.swift */,
+				0A0000010000000000000014 /* ABIClient.swift */,
+				0A0000010000000000000013 /* Models.swift */,
+				0A0000010000000000000016 /* SettingsStore.swift */,
+				0A0000010000000000000017 /* Info.plist */,
+				0A0000010000000000000018 /* Assets.xcassets */,
+			);
+			path = ABIChat;
+			sourceTree = "<group>";
+		};
+		0A0000010000000000000032 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				0A0000010000000000000010 /* ABIChat.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		0A0000010000000000000040 /* ABIChat */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0A0000010000000000000080 /* Build configuration list for PBXNativeTarget "ABIChat" */;
+			buildPhases = (
+				0A0000010000000000000050 /* Sources */,
+				0A0000010000000000000020 /* Frameworks */,
+				0A0000010000000000000060 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ABIChat;
+			productName = ABIChat;
+			productReference = 0A0000010000000000000010 /* ABIChat.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		0A0000010000000000000070 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1530;
+				LastUpgradeCheck = 1530;
+				TargetAttributes = {
+					0A0000010000000000000040 = {
+						CreatedOnToolsVersion = 15.3;
+					};
+				};
+			};
+			buildConfigurationList = 0A0000010000000000000071 /* Build configuration list for PBXProject "ABIChat" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 0A0000010000000000000030;
+			productRefGroup = 0A0000010000000000000032 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				0A0000010000000000000040 /* ABIChat */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		0A0000010000000000000060 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0A0000010000000000000007 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		0A0000010000000000000050 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0A0000010000000000000001 /* ABIChatApp.swift in Sources */,
+				0A0000010000000000000002 /* ContentView.swift in Sources */,
+				0A0000010000000000000003 /* Models.swift in Sources */,
+				0A0000010000000000000004 /* ABIClient.swift in Sources */,
+				0A0000010000000000000005 /* ChatViewModel.swift in Sources */,
+				0A0000010000000000000006 /* SettingsStore.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		0A0000010000000000000090 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		0A0000010000000000000091 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		0A0000010000000000000092 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "";
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = ABIChat/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = ai.naas.ABIChat;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		0A0000010000000000000093 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "";
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = ABIChat/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = ai.naas.ABIChat;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		0A0000010000000000000071 /* Build configuration list for PBXProject "ABIChat" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0A0000010000000000000090 /* Debug */,
+				0A0000010000000000000091 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		0A0000010000000000000080 /* Build configuration list for PBXNativeTarget "ABIChat" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0A0000010000000000000092 /* Debug */,
+				0A0000010000000000000093 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 0A0000010000000000000070 /* Project object */;
+}

--- a/libs/naas-abi/naas_abi/apps/mobile_ios/ABIChat/ABIChatApp.swift
+++ b/libs/naas-abi/naas_abi/apps/mobile_ios/ABIChat/ABIChatApp.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+@main
+struct ABIChatApp: App {
+    @StateObject private var settings = SettingsStore()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(settings)
+        }
+    }
+}
+

--- a/libs/naas-abi/naas_abi/apps/mobile_ios/ABIChat/ABIClient.swift
+++ b/libs/naas-abi/naas_abi/apps/mobile_ios/ABIChat/ABIClient.swift
@@ -1,0 +1,153 @@
+import Foundation
+
+enum ABIClientError: LocalizedError {
+    case invalidServerURL
+    case invalidResponse
+    case httpStatus(Int, String)
+    case malformedEvent
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidServerURL:
+            return "The ABI server URL is invalid."
+        case .invalidResponse:
+            return "The ABI server returned an invalid response."
+        case .httpStatus(let status, let body):
+            return "ABI server returned \(status): \(body)"
+        case .malformedEvent:
+            return "The ABI stream returned malformed data."
+        }
+    }
+}
+
+final class ABIClient {
+    private let baseURL: URL
+    private let session: URLSession
+    private let decoder: JSONDecoder
+    private let encoder: JSONEncoder
+
+    init(baseURL: URL, session: URLSession = .shared) {
+        self.baseURL = baseURL
+        self.session = session
+        decoder = JSONDecoder()
+        encoder = JSONEncoder()
+    }
+
+    func listChats() async throws -> [Chat] {
+        try await get("/api/chats?section=chat")
+    }
+
+    func createChat(title: String = "New chat") async throws -> Chat {
+        try await post(
+            "/api/chats",
+            body: ChatCreateRequest(title: title, section: "chat", model: nil)
+        )
+    }
+
+    func listMessages(chatId: String) async throws -> [ChatMessage] {
+        try await get("/api/chats/\(chatId)/messages")
+    }
+
+    func abort(chatId: String) async throws {
+        let _: EmptyResponse = try await post("/api/chats/\(chatId)/abort", body: EmptyBody())
+    }
+
+    func streamMessage(chatId: String, text: String) -> AsyncThrowingStream<ChatEvent, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    var request = try makeRequest(path: "/api/chats/\(chatId)/messages")
+                    request.httpMethod = "POST"
+                    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                    request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+                    request.httpBody = try encoder.encode(MessageSendRequest(text: text, model: nil))
+
+                    let (bytes, response) = try await session.bytes(for: request)
+                    try validate(response: response, body: "")
+
+                    for try await line in bytes.lines {
+                        guard line.hasPrefix("data:") else { continue }
+                        let payload = String(line.dropFirst(5)).trimmingCharacters(in: .whitespaces)
+                        guard !payload.isEmpty else { continue }
+                        let event = try Self.decodeEvent(payload)
+                        continuation.yield(event)
+                        if event == .end {
+                            continuation.finish()
+                            return
+                        }
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+    }
+
+    private func get<T: Decodable>(_ path: String) async throws -> T {
+        var request = try makeRequest(path: path)
+        request.httpMethod = "GET"
+        let (data, response) = try await session.data(for: request)
+        try validate(response: response, body: String(data: data, encoding: .utf8) ?? "")
+        return try decoder.decode(T.self, from: data)
+    }
+
+    private func post<Request: Encodable, Response: Decodable>(
+        _ path: String,
+        body: Request
+    ) async throws -> Response {
+        var request = try makeRequest(path: path)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try encoder.encode(body)
+
+        let (data, response) = try await session.data(for: request)
+        try validate(response: response, body: String(data: data, encoding: .utf8) ?? "")
+        return try decoder.decode(Response.self, from: data)
+    }
+
+    private func makeRequest(path: String) throws -> URLRequest {
+        guard let url = URL(string: path, relativeTo: baseURL) else {
+            throw ABIClientError.invalidServerURL
+        }
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 120
+        return request
+    }
+
+    private func validate(response: URLResponse, body: String) throws {
+        guard let http = response as? HTTPURLResponse else {
+            throw ABIClientError.invalidResponse
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw ABIClientError.httpStatus(http.statusCode, body)
+        }
+    }
+
+    private static func decodeEvent(_ payload: String) throws -> ChatEvent {
+        guard let data = payload.data(using: .utf8),
+              let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let type = object["type"] as? String else {
+            throw ABIClientError.malformedEvent
+        }
+
+        switch type {
+        case "text", "complete":
+            return .text(object["text"] as? String ?? "")
+        case "error":
+            return .error(object["message"] as? String ?? "Unknown ABI stream error")
+        case "end":
+            return .end
+        default:
+            return .text("")
+        }
+    }
+}
+
+private struct EmptyBody: Encodable {}
+private struct EmptyResponse: Decodable {}
+

--- a/libs/naas-abi/naas_abi/apps/mobile_ios/ABIChat/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/libs/naas-abi/naas_abi/apps/mobile_ios/ABIChat/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,21 @@
+{
+  "colors": [
+    {
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "alpha": "1.000",
+          "blue": "0.341",
+          "green": "0.408",
+          "red": "0.118"
+        }
+      },
+      "idiom": "universal"
+    }
+  ],
+  "info": {
+    "author": "xcode",
+    "version": 1
+  }
+}
+

--- a/libs/naas-abi/naas_abi/apps/mobile_ios/ABIChat/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/libs/naas-abi/naas_abi/apps/mobile_ios/ABIChat/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,14 @@
+{
+  "images": [
+    {
+      "idiom": "universal",
+      "platform": "ios",
+      "size": "1024x1024"
+    }
+  ],
+  "info": {
+    "author": "xcode",
+    "version": 1
+  }
+}
+

--- a/libs/naas-abi/naas_abi/apps/mobile_ios/ABIChat/Assets.xcassets/Contents.json
+++ b/libs/naas-abi/naas_abi/apps/mobile_ios/ABIChat/Assets.xcassets/Contents.json
@@ -1,0 +1,7 @@
+{
+  "info": {
+    "author": "xcode",
+    "version": 1
+  }
+}
+

--- a/libs/naas-abi/naas_abi/apps/mobile_ios/ABIChat/ChatViewModel.swift
+++ b/libs/naas-abi/naas_abi/apps/mobile_ios/ABIChat/ChatViewModel.swift
@@ -1,0 +1,149 @@
+import Foundation
+
+@MainActor
+final class ChatViewModel: ObservableObject {
+    @Published private(set) var chats: [Chat] = []
+    @Published private(set) var selectedChat: Chat?
+    @Published private(set) var messages: [ChatMessage] = []
+    @Published private(set) var streamingMessage: StreamingMessage?
+    @Published private(set) var isLoading = false
+    @Published private(set) var isStreaming = false
+    @Published var draft = ""
+    @Published var errorMessage: String?
+
+    private var client: ABIClient?
+    private var streamTask: Task<Void, Never>?
+
+    func configure(serverURL: URL?) {
+        guard let serverURL else {
+            errorMessage = ABIClientError.invalidServerURL.localizedDescription
+            client = nil
+            return
+        }
+        client = ABIClient(baseURL: serverURL)
+    }
+
+    func load() async {
+        guard let client else { return }
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+
+        do {
+            chats = try await client.listChats()
+            if selectedChat == nil {
+                selectedChat = chats.first
+            }
+            if selectedChat == nil {
+                selectedChat = try await client.createChat()
+                chats = try await client.listChats()
+            }
+            if let selectedChat {
+                messages = try await client.listMessages(chatId: selectedChat.id)
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func select(_ chat: Chat) async {
+        guard let client else { return }
+        selectedChat = chat
+        errorMessage = nil
+        do {
+            messages = try await client.listMessages(chatId: chat.id)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func createChat() async {
+        guard let client else { return }
+        errorMessage = nil
+        do {
+            let chat = try await client.createChat()
+            selectedChat = chat
+            chats = try await client.listChats()
+            messages = []
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func sendDraft() {
+        let text = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty, !isStreaming, let selectedChat, let client else { return }
+
+        draft = ""
+        errorMessage = nil
+        let localUserMessage = ChatMessage(
+            id: UUID().uuidString,
+            chatId: selectedChat.id,
+            role: .user,
+            content: text,
+            createdAt: Date().timeIntervalSince1970
+        )
+        messages.append(localUserMessage)
+        streamingMessage = StreamingMessage(content: "")
+        isStreaming = true
+
+        streamTask = Task { [weak self] in
+            do {
+                for try await event in client.streamMessage(chatId: selectedChat.id, text: text) {
+                    await self?.handle(event, chatId: selectedChat.id)
+                }
+                await self?.finishStream(chatId: selectedChat.id)
+            } catch {
+                await MainActor.run {
+                    self?.errorMessage = error.localizedDescription
+                    self?.isStreaming = false
+                }
+            }
+        }
+    }
+
+    func abort() {
+        guard let selectedChat, let client else { return }
+        streamTask?.cancel()
+        streamTask = nil
+        isStreaming = false
+        Task {
+            try? await client.abort(chatId: selectedChat.id)
+            await refreshMessages(chatId: selectedChat.id)
+        }
+    }
+
+    private func handle(_ event: ChatEvent, chatId: String) {
+        switch event {
+        case .text(let text):
+            streamingMessage = StreamingMessage(content: text)
+        case .error(let message):
+            errorMessage = message
+        case .end:
+            isStreaming = false
+            Task { await refreshMessages(chatId: chatId) }
+        }
+    }
+
+    private func finishStream(chatId: String) async {
+        isStreaming = false
+        await refreshMessages(chatId: chatId)
+        do {
+            chats = try await client?.listChats() ?? chats
+            selectedChat = chats.first { $0.id == chatId } ?? selectedChat
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func refreshMessages(chatId: String) async {
+        guard let client else { return }
+        do {
+            messages = try await client.listMessages(chatId: chatId)
+            streamingMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+

--- a/libs/naas-abi/naas_abi/apps/mobile_ios/ABIChat/ContentView.swift
+++ b/libs/naas-abi/naas_abi/apps/mobile_ios/ABIChat/ContentView.swift
@@ -1,0 +1,216 @@
+import SwiftUI
+
+struct ContentView: View {
+    @EnvironmentObject private var settings: SettingsStore
+    @StateObject private var viewModel = ChatViewModel()
+    @State private var showingSettings = false
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                if let error = viewModel.errorMessage {
+                    ErrorBanner(message: error)
+                }
+
+                MessageList(
+                    messages: viewModel.messages,
+                    streamingMessage: viewModel.streamingMessage
+                )
+
+                Composer(
+                    draft: $viewModel.draft,
+                    isStreaming: viewModel.isStreaming,
+                    send: viewModel.sendDraft,
+                    abort: viewModel.abort
+                )
+            }
+            .navigationTitle(viewModel.selectedChat?.title ?? "ABI")
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Menu {
+                        Button("New Chat") {
+                            Task { await viewModel.createChat() }
+                        }
+                        Divider()
+                        ForEach(viewModel.chats) { chat in
+                            Button(chat.title) {
+                                Task { await viewModel.select(chat) }
+                            }
+                        }
+                    } label: {
+                        Image(systemName: "sidebar.left")
+                    }
+                }
+
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        showingSettings = true
+                    } label: {
+                        Image(systemName: "gearshape")
+                    }
+                }
+            }
+            .sheet(isPresented: $showingSettings) {
+                SettingsView(serverURLString: $settings.serverURLString) {
+                    viewModel.configure(serverURL: settings.serverURL)
+                    Task { await viewModel.load() }
+                }
+            }
+            .task {
+                viewModel.configure(serverURL: settings.serverURL)
+                await viewModel.load()
+            }
+            .refreshable {
+                await viewModel.load()
+            }
+        }
+    }
+}
+
+private struct MessageList: View {
+    let messages: [ChatMessage]
+    let streamingMessage: StreamingMessage?
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 12) {
+                    ForEach(messages) { message in
+                        MessageBubble(role: message.role, text: message.content)
+                            .id(message.id)
+                    }
+                    if let streamingMessage {
+                        MessageBubble(role: .assistant, text: streamingMessage.content)
+                            .id(streamingMessage.id)
+                    }
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+            }
+            .background(Color(.systemGroupedBackground))
+            .onChange(of: messages.count) { _ in
+                scrollToBottom(proxy: proxy)
+            }
+            .onChange(of: streamingMessage?.content) { _ in
+                scrollToBottom(proxy: proxy)
+            }
+        }
+    }
+
+    private func scrollToBottom(proxy: ScrollViewProxy) {
+        let target = streamingMessage?.id ?? messages.last?.id
+        guard let target else { return }
+        withAnimation(.easeOut(duration: 0.2)) {
+            proxy.scrollTo(target, anchor: .bottom)
+        }
+    }
+}
+
+private struct MessageBubble: View {
+    let role: ChatMessage.Role
+    let text: String
+
+    var body: some View {
+        HStack {
+            if role == .user { Spacer(minLength: 48) }
+            Text(text.isEmpty ? "..." : text)
+                .font(.body)
+                .textSelection(.enabled)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .foregroundStyle(role == .user ? .white : .primary)
+                .background(role == .user ? Color.accentColor : Color(.secondarySystemGroupedBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+            if role == .assistant { Spacer(minLength: 48) }
+        }
+    }
+}
+
+private struct Composer: View {
+    @Binding var draft: String
+    let isStreaming: Bool
+    let send: () -> Void
+    let abort: () -> Void
+
+    var body: some View {
+        HStack(alignment: .bottom, spacing: 10) {
+            TextField("Message ABI", text: $draft, axis: .vertical)
+                .textFieldStyle(.plain)
+                .lineLimit(1...6)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .background(Color(.secondarySystemBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+
+            Button {
+                isStreaming ? abort() : send()
+            } label: {
+                Image(systemName: isStreaming ? "stop.fill" : "arrow.up")
+                    .font(.system(size: 16, weight: .semibold))
+                    .frame(width: 36, height: 36)
+                    .foregroundStyle(.white)
+                    .background(isStreaming ? Color.red : Color.accentColor)
+                    .clipShape(Circle())
+            }
+            .disabled(!isStreaming && draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        }
+        .padding(.horizontal, 12)
+        .padding(.top, 10)
+        .padding(.bottom, 12)
+        .background(.regularMaterial)
+    }
+}
+
+private struct ErrorBanner: View {
+    let message: String
+
+    var body: some View {
+        Text(message)
+            .font(.footnote)
+            .foregroundStyle(.white)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+            .background(Color.red)
+    }
+}
+
+private struct SettingsView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Binding var serverURLString: String
+    let onSave: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("ABI server") {
+                    TextField("Server URL", text: $serverURLString)
+                        .textInputAutocapitalization(.never)
+                        .keyboardType(.URL)
+                        .autocorrectionDisabled()
+                }
+            }
+            .navigationTitle("Settings")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") {
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        onSave()
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+            .environmentObject(SettingsStore())
+    }
+}

--- a/libs/naas-abi/naas_abi/apps/mobile_ios/ABIChat/Info.plist
+++ b/libs/naas-abi/naas_abi/apps/mobile_ios/ABIChat/Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>ABI Chat</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+	</dict>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>
+

--- a/libs/naas-abi/naas_abi/apps/mobile_ios/ABIChat/Models.swift
+++ b/libs/naas-abi/naas_abi/apps/mobile_ios/ABIChat/Models.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+struct Chat: Codable, Identifiable, Equatable {
+    let id: String
+    var title: String
+    let section: String
+    let model: String?
+    let createdAt: Double
+    let updatedAt: Double
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case section
+        case model
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+    }
+}
+
+struct ChatMessage: Codable, Identifiable, Equatable {
+    let id: String
+    let chatId: String
+    let role: Role
+    var content: String
+    let createdAt: Double
+
+    enum Role: String, Codable {
+        case user
+        case assistant
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case chatId = "chat_id"
+        case role
+        case content
+        case createdAt = "created_at"
+    }
+}
+
+struct StreamingMessage: Identifiable, Equatable {
+    let id = "streaming-assistant"
+    var content: String
+}
+
+enum ChatEvent: Equatable {
+    case text(String)
+    case error(String)
+    case end
+}
+
+struct ChatCreateRequest: Encodable {
+    let title: String
+    let section: String
+    let model: String?
+}
+
+struct MessageSendRequest: Encodable {
+    let text: String
+    let model: String?
+}
+

--- a/libs/naas-abi/naas_abi/apps/mobile_ios/ABIChat/SettingsStore.swift
+++ b/libs/naas-abi/naas_abi/apps/mobile_ios/ABIChat/SettingsStore.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+@MainActor
+final class SettingsStore: ObservableObject {
+    @Published var serverURLString: String {
+        didSet {
+            UserDefaults.standard.set(serverURLString, forKey: Self.serverURLKey)
+        }
+    }
+
+    private static let serverURLKey = "abi.mobile.serverURL"
+
+    init() {
+        serverURLString = UserDefaults.standard.string(forKey: Self.serverURLKey)
+            ?? "http://127.0.0.1:55031"
+    }
+
+    var serverURL: URL? {
+        URL(string: serverURLString.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+}
+

--- a/libs/naas-abi/naas_abi/apps/mobile_ios/AGENTS.md
+++ b/libs/naas-abi/naas_abi/apps/mobile_ios/AGENTS.md
@@ -1,0 +1,44 @@
+# ABI Mobile iOS - AGENTS.md
+
+> Scope: `libs/naas-abi/naas_abi/apps/mobile_ios/`. A native iOS chat-only client for ABI.
+
+## Purpose
+
+Small SwiftUI iOS app that talks to the ABI Desktop local HTTP API. The first
+iteration intentionally contains only chat: conversation list, message history,
+streamed assistant replies, and a configurable server URL.
+
+## Architecture
+
+- `ABIChat.xcodeproj/` is the Xcode project.
+- `ABIChat/` contains app source.
+- No Python imports and no dependency on the ABI engine.
+- Network access goes through `ABIClient`.
+- UI state and chat orchestration live in `ChatViewModel`.
+- User-configurable settings live in `SettingsStore`.
+
+## API Surface
+
+The app targets the desktop backend chat endpoints:
+
+- `GET /api/chats?section=chat`
+- `POST /api/chats`
+- `GET /api/chats/{id}/messages`
+- `POST /api/chats/{id}/messages` as `text/event-stream`
+- `POST /api/chats/{id}/abort`
+
+## Run
+
+1. Start ABI Desktop or its backend.
+2. Open `ABIChat.xcodeproj` in Xcode.
+3. Run the `ABIChat` scheme on an iOS simulator.
+4. Use `http://127.0.0.1:55031` for simulator-to-Mac local backend access.
+
+For a physical iPhone, set the server URL to the Mac LAN address and make sure
+the backend binds to an address reachable from the phone.
+
+## Tests
+
+There are no automated iOS tests yet. For now, verify by running the simulator
+against a live desktop backend and sending a chat message.
+

--- a/libs/naas-abi/naas_abi/apps/mobile_ios/README.md
+++ b/libs/naas-abi/naas_abi/apps/mobile_ios/README.md
@@ -1,0 +1,50 @@
+# ABI Chat for iOS
+
+Native SwiftUI iOS client for the ABI Desktop chat API.
+
+Target: iOS 16+ with Xcode 15 or newer.
+
+## What is included
+
+- Chat list for `section=chat`
+- New chat creation
+- Message history
+- Server-sent event streaming for assistant replies
+- Abort generation
+- Configurable backend URL stored on device
+
+## Run locally
+
+Start the desktop backend:
+
+```bash
+uv run python libs/naas-abi/naas_abi/apps/desktop/run.py
+```
+
+Then open:
+
+```bash
+open libs/naas-abi/naas_abi/apps/mobile_ios/ABIChat.xcodeproj
+```
+
+For the iOS simulator, keep the server URL as:
+
+```text
+http://127.0.0.1:55031
+```
+
+For a physical iPhone, use your Mac's LAN IP address and run the ABI backend on
+a reachable host/port.
+
+## Backend contract
+
+The app talks to the existing ABI Desktop endpoints:
+
+- `GET /api/chats?section=chat`
+- `POST /api/chats`
+- `GET /api/chats/{id}/messages`
+- `POST /api/chats/{id}/messages`
+- `POST /api/chats/{id}/abort`
+
+`POST /messages` is consumed as `text/event-stream`; cumulative `text` and
+`complete` events update the visible assistant draft, and `end` finalizes it.


### PR DESCRIPTION
## Summary

- Adds **ABI Chat for iOS**, a native SwiftUI client at `libs/naas-abi/naas_abi/apps/mobile_ios/`
- Chat-only first iteration: conversation list, message history, SSE streaming, abort, and configurable backend URL
- No Python/ABI engine dependency at runtime; talks to ABI Desktop HTTP chat API

Closes #1071

## Related work

- Desktop backend (required for manual testing): #1069 / PR #1070

## Scope

**In scope (this PR):**
- Xcode project + SwiftUI app source (`ABIChat/`)
- `ABIClient` HTTP/SSE layer, `ChatViewModel`, `SettingsStore`
- `README.md` and scoped `AGENTS.md`

**Out of scope:**
- Desktop app changes (tracked in PR #1070)
- Automated iOS unit/UI tests (future work)
- App Store packaging / TestFlight

## Test plan

- [ ] Start ABI Desktop backend: `uv run python libs/naas-abi/naas_abi/apps/desktop/run.py`
- [ ] Open `libs/naas-abi/naas_abi/apps/mobile_ios/ABIChat.xcodeproj` in Xcode 15+
- [ ] Run `ABIChat` scheme on iOS Simulator (iOS 16+)
- [ ] Verify server URL defaults to `http://127.0.0.1:55031`
- [ ] Load chat list, create a new chat, send a message, confirm streamed assistant reply
- [ ] Change server URL in settings and confirm persistence across relaunch
- [ ] Tap abort during generation and confirm stream stops