### PR TITLE
fix(nexus): stop magic-link login loop when localStorage is blocked

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/layout.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/layout.tsx
@@ -6,6 +6,7 @@ import { isWorkspacePathAllowed } from '@/lib/feature-access';
 import { WorkspaceLayout } from '@/components/shell/workspace-layout';
 import { GraphExportToastHost } from '@/components/graph/graph-export-toast-host';
 import { useWorkspaceStore } from '@/stores/workspace';
+import { clearAuthFlagCookie } from '@/lib/auth-session';
 import { useAuthStore } from '@/stores/auth';
 
 // Catches unhandled promise rejections (not caught by React error boundaries)
@@ -175,6 +176,8 @@ export default function WorkspaceIdLayout({
   // Redirect to login if not authenticated (after hydration)
   useEffect(() => {
     if (authReady && !token) {
+      // Drop stale middleware cookie so /auth/login is not bounced back here.
+      clearAuthFlagCookie();
       router.replace(`/auth/login?redirect=/workspace/${workspaceId}/chat`);
     }
   }, [authReady, token, router, workspaceId]);

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/auth-session.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/auth-session.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { mergeAuthPersistedState } from './auth-session';
+
+describe('mergeAuthPersistedState', () => {
+  it('keeps live session when persisted storage is empty', () => {
+    const current = {
+      user: { id: '1', email: 'a@b.com', name: 'A', createdAt: new Date() },
+      token: 'live-token',
+      refreshToken: 'live-refresh',
+      isAuthenticated: true,
+      isLoading: false,
+      error: null,
+    };
+
+    const merged = mergeAuthPersistedState(
+      { user: null, token: null, refreshToken: null, isAuthenticated: false },
+      current,
+    );
+
+    expect(merged.token).toBe('live-token');
+    expect(merged.refreshToken).toBe('live-refresh');
+    expect(merged.isAuthenticated).toBe(true);
+  });
+
+  it('applies persisted session when storage has tokens', () => {
+    const current = {
+      user: null,
+      token: null,
+      refreshToken: null,
+      isAuthenticated: false,
+      isLoading: false,
+      error: null,
+    };
+
+    const merged = mergeAuthPersistedState(
+      {
+        user: { id: '2', email: 'c@d.com', name: 'C' },
+        token: 'stored-token',
+        refreshToken: 'stored-refresh',
+        isAuthenticated: true,
+      },
+      current,
+    );
+
+    expect(merged.token).toBe('stored-token');
+    expect(merged.refreshToken).toBe('stored-refresh');
+    expect(merged.isAuthenticated).toBe(true);
+  });
+});

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/auth-session.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/auth-session.ts
@@ -1,0 +1,41 @@
+/**
+ * Auth session helpers shared by the auth store and route guards.
+ */
+
+export interface PersistedAuthSnapshot {
+  user?: unknown;
+  token?: string | null;
+  refreshToken?: string | null;
+  isAuthenticated?: boolean;
+}
+
+/** Set the lightweight auth flag cookie used by edge middleware. */
+export function setAuthFlagCookie(): void {
+  if (typeof document === 'undefined') return;
+  document.cookie = 'nexus-auth-flag=true; path=/; max-age=2592000; SameSite=Lax';
+}
+
+/** Clear the auth flag cookie so middleware stops treating the user as signed in. */
+export function clearAuthFlagCookie(): void {
+  if (typeof document === 'undefined') return;
+  document.cookie = 'nexus-auth-flag=; path=/; max-age=0; SameSite=Lax';
+}
+
+/**
+ * Zustand persist merge: keep an active in-memory session when storage failed
+ * to persist tokens (blocked localStorage, hydration race after magic-link).
+ */
+export function mergeAuthPersistedState<T extends PersistedAuthSnapshot>(
+  persisted: unknown,
+  current: T,
+): T {
+  const stored = (persisted ?? {}) as PersistedAuthSnapshot;
+  const liveHasSession = Boolean(current.token);
+  const storedHasSession = Boolean(stored.token);
+
+  if (liveHasSession && !storedHasSession) {
+    return current;
+  }
+
+  return { ...current, ...stored } as T;
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/safe-storage.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/safe-storage.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import { getSafeStorage, resetSafeStorageForTests } from './safe-storage';
+
+describe('getSafeStorage', () => {
+  const originalWindow = globalThis.window;
+  const originalLocal = globalThis.localStorage;
+  const originalSession = globalThis.sessionStorage;
+
+  beforeEach(() => {
+    resetSafeStorageForTests();
+  });
+
+  afterEach(() => {
+    resetSafeStorageForTests();
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: originalWindow,
+    });
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: originalLocal,
+    });
+    Object.defineProperty(globalThis, 'sessionStorage', {
+      configurable: true,
+      value: originalSession,
+    });
+  });
+
+  it('falls back to memory when browser storage throws', () => {
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: globalThis,
+    });
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: {
+        setItem: () => {
+          throw new DOMException('blocked', 'QuotaExceededError');
+        },
+        getItem: () => null,
+        removeItem: () => undefined,
+      },
+    });
+    Object.defineProperty(globalThis, 'sessionStorage', {
+      configurable: true,
+      value: {
+        setItem: () => {
+          throw new DOMException('blocked', 'QuotaExceededError');
+        },
+        getItem: () => null,
+        removeItem: () => undefined,
+      },
+    });
+
+    const storage = getSafeStorage();
+    expect(storage.backend).toBe('memory');
+    storage.setItem('nexus-auth', '{"token":"abc"}');
+    expect(storage.getItem('nexus-auth')).toBe('{"token":"abc"}');
+    storage.removeItem('nexus-auth');
+    expect(storage.getItem('nexus-auth')).toBeNull();
+  });
+
+  it('prefers sessionStorage when localStorage is blocked', () => {
+    const sessionBacking = new Map<string, string>();
+
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: globalThis,
+    });
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: {
+        setItem: () => {
+          throw new DOMException('blocked', 'QuotaExceededError');
+        },
+        getItem: () => null,
+        removeItem: () => undefined,
+      },
+    });
+    Object.defineProperty(globalThis, 'sessionStorage', {
+      configurable: true,
+      value: {
+        setItem: (key: string, value: string) => {
+          sessionBacking.set(key, value);
+        },
+        getItem: (key: string) => sessionBacking.get(key) ?? null,
+        removeItem: (key: string) => {
+          sessionBacking.delete(key);
+        },
+      },
+    });
+
+    const storage = getSafeStorage();
+    expect(storage.backend).toBe('sessionStorage');
+    storage.setItem('nexus-auth', '{"token":"session"}');
+    expect(storage.getItem('nexus-auth')).toBe('{"token":"session"}');
+  });
+});

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/safe-storage.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/safe-storage.ts
@@ -1,0 +1,96 @@
+/**
+ * Browser storage with graceful degradation.
+ *
+ * Some environments block localStorage (strict privacy, enterprise policy,
+ * Safari ITP). Auth must still work for the current tab via sessionStorage
+ * or an in-memory fallback.
+ */
+
+export type SafeStorage = {
+  getItem: (name: string) => string | null;
+  setItem: (name: string, value: string) => void;
+  removeItem: (name: string) => void;
+  /** Which backend is active; useful for diagnostics. */
+  backend: 'localStorage' | 'sessionStorage' | 'memory';
+};
+
+const memoryStore = new Map<string, string>();
+
+function canUseStorage(storage: Storage | undefined): storage is Storage {
+  if (!storage) return false;
+  try {
+    const probeKey = '__nexus_storage_probe__';
+    storage.setItem(probeKey, '1');
+    storage.removeItem(probeKey);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function wrapStorage(storage: Storage, backend: SafeStorage['backend']): SafeStorage {
+  return {
+    backend,
+    getItem: (name) => {
+      try {
+        return storage.getItem(name);
+      } catch {
+        return null;
+      }
+    },
+    setItem: (name, value) => {
+      try {
+        storage.setItem(name, value);
+      } catch {
+        // Quota exceeded or storage blocked — caller may fall back elsewhere.
+      }
+    },
+    removeItem: (name) => {
+      try {
+        storage.removeItem(name);
+      } catch {
+        // ignore
+      }
+    },
+  };
+}
+
+function createMemoryStorage(): SafeStorage {
+  return {
+    backend: 'memory',
+    getItem: (name) => memoryStore.get(name) ?? null,
+    setItem: (name, value) => {
+      memoryStore.set(name, value);
+    },
+    removeItem: (name) => {
+      memoryStore.delete(name);
+    },
+  };
+}
+
+let cachedStorage: SafeStorage | null = null;
+
+/** Resolve the best available storage backend for this browser context. */
+export function getSafeStorage(): SafeStorage {
+  if (cachedStorage) return cachedStorage;
+
+  if (typeof window !== 'undefined') {
+    if (canUseStorage(window.localStorage)) {
+      cachedStorage = wrapStorage(window.localStorage, 'localStorage');
+      return cachedStorage;
+    }
+    if (canUseStorage(window.sessionStorage)) {
+      cachedStorage = wrapStorage(window.sessionStorage, 'sessionStorage');
+      return cachedStorage;
+    }
+  }
+
+  cachedStorage = createMemoryStorage();
+  return cachedStorage;
+}
+
+/** Reset cached backend (tests only). */
+export function resetSafeStorageForTests(): void {
+  cachedStorage = null;
+  memoryStore.clear();
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/middleware.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/middleware.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import { middleware } from './middleware';
+
+function requestFor(pathname: string, cookies: Record<string, string> = {}): NextRequest {
+  const url = `https://nexus.example.com${pathname}`;
+  const req = new NextRequest(url);
+  for (const [name, value] of Object.entries(cookies)) {
+    req.cookies.set(name, value);
+  }
+  return req;
+}
+
+describe('middleware auth redirects', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it('allows magic-link confirmation when auth cookie is present', () => {
+    process.env.NODE_ENV = 'production';
+
+    const response = middleware(
+      requestFor('/auth/magic-link?token=abc', { 'nexus-auth-flag': 'true' }),
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get('location')).toBeNull();
+  });
+
+  it('redirects other auth routes when auth cookie is present', () => {
+    process.env.NODE_ENV = 'production';
+
+    const response = middleware(
+      requestFor('/auth/login', { 'nexus-auth-flag': 'true' }),
+    );
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toMatch(/\/workspace\/.+\/chat/);
+  });
+});

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/middleware.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/middleware.ts
@@ -107,7 +107,9 @@ export function middleware(request: NextRequest) {
     return NextResponse.redirect(loginUrl);
   }
 
-  if (isAuthRoute && hasAuthCookie) {
+  // Let users finish magic-link confirmation even when a stale auth cookie exists.
+  const isMagicLinkRoute = pathname === '/auth/magic-link' || pathname.startsWith('/auth/magic-link/');
+  if (isAuthRoute && hasAuthCookie && !isMagicLinkRoute) {
     return NextResponse.redirect(new URL(`/workspace/${resolveDefaultWorkspace(request)}/chat`, request.url));
   }
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/auth.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/auth.ts
@@ -4,7 +4,9 @@
  */
 
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { createJSONStorage, persist } from 'zustand/middleware';
+import { clearAuthFlagCookie, mergeAuthPersistedState, setAuthFlagCookie } from '@/lib/auth-session';
+import { getSafeStorage } from '@/lib/safe-storage';
 
 export interface User {
   id: string;
@@ -102,7 +104,7 @@ export const useAuthStore = create<AuthState>()(
           const data = await response.json();
           const normalizeAvatar = (a?: string) => (a && a.startsWith('/') ? `${apiBase}${a}` : a);
 
-          document.cookie = 'nexus-auth-flag=true; path=/; max-age=2592000';
+          setAuthFlagCookie();
 
           set({
             user: { ...data.user, avatar: normalizeAvatar(data.user?.avatar) },
@@ -115,6 +117,7 @@ export const useAuthStore = create<AuthState>()(
 
           return true;
         } catch (error) {
+          clearAuthFlagCookie();
           set({
             isLoading: false,
             error: error instanceof Error ? error.message : 'Magic link verification failed',
@@ -142,7 +145,7 @@ export const useAuthStore = create<AuthState>()(
           const data = await response.json();
           const normalizeAvatar = (a?: string) => (a && a.startsWith('/') ? `${apiBase}${a}` : a);
 
-          document.cookie = 'nexus-auth-flag=true; path=/; max-age=2592000; SameSite=Lax';
+          setAuthFlagCookie();
 
           set({
             user: { ...data.user, avatar: normalizeAvatar(data.user?.avatar) },
@@ -191,8 +194,7 @@ export const useAuthStore = create<AuthState>()(
 
       // Logout - clears auth state and ALL persisted store data
       logout: () => {
-        // Clear auth cookie
-        document.cookie = 'nexus-auth-flag=; path=/; max-age=0';
+        clearAuthFlagCookie();
 
         set({
           user: null,
@@ -324,6 +326,8 @@ export const useAuthStore = create<AuthState>()(
     }),
     {
       name: 'nexus-auth',
+      storage: createJSONStorage(() => getSafeStorage()),
+      merge: mergeAuthPersistedState,
       partialize: (state) => ({
         user: state.user,
         token: state.token,


### PR DESCRIPTION
## Summary

Fixes the Nexus magic-link sign-in loop reported in #1075 when the browser blocks or restricts `localStorage`.

- Add resilient auth storage (`localStorage` -> `sessionStorage` -> in-memory fallback).
- Prevent Zustand hydration from overwriting a just-verified in-memory session.
- Clear stale `nexus-auth-flag` cookies when the workspace layout detects no client token.
- Keep `/auth/magic-link` reachable even when a stale auth cookie exists, so users can always confirm the link.

## Root cause

Auth relied on default `localStorage` persistence. When storage was blocked, tokens were lost after confirm, while the middleware cookie still marked the user as signed in. That bounced users between `/auth/login` and `/workspace/...`.

## Test plan

- [x] `pnpx vitest run src/lib/safe-storage.test.ts src/lib/auth-session.test.ts src/middleware.test.ts` (6 tests)
- [x] Pre-commit Nexus `next build` passed
- [ ] Manual: block site storage in browser devtools, request magic link, confirm sign-in, verify workspace loads without redirect loop
- [ ] Manual: confirm `/auth/login` no longer loops when `nexus-auth-flag` is set but tokens are missing

Closes #1075