### PR TITLE
feat(skills): add reusable prompt skills with slash command integration

### DIFF
--- a/libs/naas-abi-cli/uv.lock
+++ b/libs/naas-abi-cli/uv.lock
@@ -2384,7 +2384,7 @@ wheels = [
 
 [[package]]
 name = "naas-abi"
-version = "2.42.2"
+version = "2.43.1"
 source = { editable = "../naas-abi" }
 dependencies = [
     { name = "aiosqlite" },
@@ -2499,7 +2499,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-core"
-version = "2.18.2"
+version = "2.19.0"
 source = { editable = "../naas-abi-core" }
 dependencies = [
     { name = "click" },
@@ -2615,7 +2615,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-marketplace"
-version = "3.22.1"
+version = "3.22.2"
 source = { editable = "../naas-abi-marketplace" }
 dependencies = [
     { name = "ijson" },
@@ -4550,8 +4550,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [

--- a/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
@@ -1162,7 +1162,7 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
     def call_model(
         self,
         state: ABIAgentState,
-    ) -> Command[Literal["call_tools", "__end__"]]:
+    ) -> Command[Literal["call_tools", "__end__", "current_active_agent"]]:
         self._state.set_current_active_agent(self.name)
         logger.debug(f"🧠 Calling model for agent '{self._name}'")
         self._notify_call_model(self._name)

--- a/libs/naas-abi-marketplace/uv.lock
+++ b/libs/naas-abi-marketplace/uv.lock
@@ -782,7 +782,7 @@ name = "cuda-bindings"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/a9/3a8241c6e19483ac1f1dcf5c10238205dcb8a6e9d0d4d4709240dff28ff4/cuda_bindings-13.2.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:721104c603f059780d287969be3d194a18d0cc3b713ed9049065a1107706759d", size = 5730273, upload-time = "2026-03-11T00:12:37.18Z" },
@@ -815,37 +815,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
 ]
 cufft = [
-    { name = "nvidia-cufft" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
 ]
 cufile = [
-    { name = "nvidia-cufile" },
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
 ]
 curand = [
-    { name = "nvidia-curand" },
+    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx" },
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -3312,7 +3312,7 @@ wheels = [
 
 [[package]]
 name = "naas-abi-core"
-version = "2.18.2"
+version = "2.19.0"
 source = { editable = "../naas-abi-core" }
 dependencies = [
     { name = "click" },
@@ -3739,7 +3739,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
@@ -3751,7 +3751,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -3781,9 +3781,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cusparse", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -3795,7 +3795,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3955,7 +3955,7 @@ resolution-markers = [
     "(python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/17/06/68c27a523103dad5837dc5b87e71285280c4f098c60e4fe8a8db6486ab09/opencv-python-4.11.0.86.tar.gz", hash = "sha256:03d60ccae62304860d232272e4a4fda93c39d595780cb40b161b310244b736a4", size = 95171956, upload-time = "2025-01-16T13:52:24.737Z" }
 wheels = [
@@ -3983,7 +3983,7 @@ resolution-markers = [
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/6f/5a28fef4c4a382be06afe3938c64cc168223016fa520c5abaf37e8862aa5/opencv_python-4.13.0.92-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:caf60c071ec391ba51ed00a4a920f996d0b64e3e46068aac1f646b5de0326a19", size = 46247052, upload-time = "2026-02-05T07:01:25.046Z" },
@@ -5955,8 +5955,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "jeepney", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [

--- a/libs/naas-abi/naas_abi/__init__.py
+++ b/libs/naas-abi/naas_abi/__init__.py
@@ -181,18 +181,23 @@ FeatureKey = Literal[
     "chat",
     "files",
     "agents",
+    "skills",
     "apps",
     "marketplace",
     "search",
     "ontology",
     "graph",
     "settings",
+    # Opt-in: only when listed in enabled_features + role_baseline.
+    "code",
 ]
 
+# Default catalog (excludes opt-in features like "code").
 _ALL_FEATURES: list[FeatureKey] = [
     "chat",
     "files",
     "agents",
+    "skills",
     "apps",
     "marketplace",
     "search",
@@ -210,8 +215,8 @@ def _default_role_baseline() -> dict[str, list[FeatureKey]]:
     return {
         "owner": list(_ALL_FEATURES),
         "admin": list(_ALL_FEATURES),
-        "member": ["chat", "files"],
-        "viewer": ["chat", "files"],
+        "member": ["chat", "files", "skills"],
+        "viewer": ["chat", "files", "skills"],
     }
 
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/api/router.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/api/router.py
@@ -36,6 +36,7 @@ from naas_abi.apps.nexus.apps.api.app.services.platform.handlers import (
     router as platform_router,
 )
 from naas_abi.apps.nexus.apps.api.app.services.providers.handlers import router as providers_router
+from naas_abi.apps.nexus.apps.api.app.services.skills.handlers import router as skills_router
 from naas_abi.apps.nexus.apps.api.app.services.workspaces.handlers import (
     router as workspaces_router,
 )
@@ -61,6 +62,7 @@ api_router.include_router(ontology.router, prefix="/ontology", tags=["ontology"]
 api_router.include_router(graph.router, prefix="/graph", tags=["graph"])
 api_router.include_router(view.router, prefix="/view", tags=["view"])
 api_router.include_router(agents_router, prefix="/agents", tags=["agents"])
+api_router.include_router(skills_router, prefix="/skills", tags=["skills"])
 api_router.include_router(modules_router, prefix="/modules", tags=["modules"])
 api_router.include_router(apps_router, prefix="/apps", tags=["apps"])
 api_router.include_router(files_router, prefix="/files", tags=["files"])

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/config.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/config.py
@@ -163,6 +163,7 @@ FeatureKey = Literal[
     "chat",
     "files",
     "agents",
+    "skills",
     "apps",
     "marketplace",
     "search",
@@ -183,6 +184,7 @@ class FeatureFlagsConfig(BaseModel):
             "chat",
             "files",
             "agents",
+            "skills",
             "apps",
             "marketplace",
             "search",
@@ -197,6 +199,7 @@ class FeatureFlagsConfig(BaseModel):
                 "chat",
                 "files",
                 "agents",
+                "skills",
                 "apps",
                 "marketplace",
                 "search",
@@ -208,6 +211,7 @@ class FeatureFlagsConfig(BaseModel):
                 "chat",
                 "files",
                 "agents",
+                "skills",
                 "apps",
                 "marketplace",
                 "search",
@@ -215,8 +219,8 @@ class FeatureFlagsConfig(BaseModel):
                 "graph",
                 "settings",
             ],
-            "member": ["chat", "files"],
-            "viewer": ["chat", "files"],
+            "member": ["chat", "files", "skills"],
+            "viewer": ["chat", "files", "skills"],
         }
     )
     workspace_overrides: dict[str, dict[FeatureKey, bool]] = Field(default_factory=dict)

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/feature_flags.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/feature_flags.py
@@ -8,6 +8,7 @@ KNOWN_FEATURE_KEYS: tuple[str, ...] = (
     "chat",
     "files",
     "agents",
+    "skills",
     "apps",
     "marketplace",
     "search",

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/models.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/models.py
@@ -646,6 +646,37 @@ class AgentConfigModel(Base):
 
 
 # ============================================
+# Skills (user-created reusable prompt skills)
+# ============================================
+
+
+class SkillModel(Base):
+    __tablename__ = "skills"
+
+    id = Column(String, primary_key=True)
+    workspace_id = Column(
+        String, ForeignKey("workspaces.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    # Denormalized from the workspace at creation time so organization-scoped
+    # skills can be listed across all workspaces of the org with one filter.
+    organization_id = Column(
+        String, ForeignKey("organizations.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    user_id = Column(
+        String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )  # Creator
+    name = Column(String, nullable=False)
+    slug = Column(String, nullable=False, index=True)  # Chat command: /<slug>
+    description = Column(Text, nullable=True)
+    prompt = Column(Text, nullable=False)  # Reusable prompt applied by the current agent
+    scope = Column(String, nullable=False, default="user")  # user | workspace | organization
+    enabled = Column(Boolean, nullable=False, default=True)
+    last_used_at = Column(DateTime(timezone=False), nullable=True)  # Drives "latest used" ordering
+    created_at = Column(DateTime(timezone=False), nullable=False, default=_utcnow)
+    updated_at = Column(DateTime(timezone=False), nullable=False, default=_utcnow, onupdate=_utcnow)
+
+
+# ============================================
 # App Configurations (per-workspace enable state)
 # ============================================
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__streaming.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__streaming.py
@@ -240,6 +240,9 @@ async def stream_chat_response(
                     explicit_system_prompt=request.system_prompt,
                     prior_messages=prior_messages,
                     user_id=current_user.id,
+                    workspace_id=request.workspace_id,
+                    conversation_id=conversation_id,
+                    context=request_context(current_user),
                 )
                 user_context_preamble = await registry.chat.build_user_context_addendum(
                     prior_messages=prior_messages,

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/service.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/service.py
@@ -45,6 +45,7 @@ from naas_abi.apps.nexus.apps.api.app.services.provider_runtime import (
     complete_chat as complete_with_provider,
 )
 from naas_abi.apps.nexus.apps.api.app.services.secrets_crypto import decrypt_secret_value
+from naas_abi.apps.nexus.apps.api.app.services.skills.service import SkillService
 
 
 @dataclass
@@ -109,6 +110,32 @@ _MULTI_AGENT_NOTICE = (
     "said. Each assistant message may be from a different AI - treat them as separate participants."
 )
 
+logger = logging.getLogger(__name__)
+
+_CREATE_SKILL_INSTRUCTIONS = (
+    "\n\n## Creating skills\n"
+    "If the user's message starts with `/create-skill`, help them turn the rest of it (a short "
+    "description of a recurring task) into a reusable skill. Propose a name, a url-safe "
+    "kebab-case slug, a one-sentence description, and a well-written prompt that captures the "
+    "task with a clear goal, constraints, and expected output format. Present the draft as a "
+    "fenced code block using the language tag `skill` containing a single JSON object with "
+    "exactly these keys: name, slug, description, prompt. Briefly explain your choices outside "
+    "the code block. Do not attempt to save it yourself — the user reviews and saves it from "
+    "the UI with one click.\n"
+)
+
+_SKILLS_CATALOG_HEADER = (
+    "\n## Available skills\n"
+    "The workspace has the following user-created skills. Each is a prompt someone wrote for a "
+    "recurring task. Apply them proactively: whenever the user's message matches what a skill "
+    "is for, based on everything you know from the conversation so far, follow that skill's "
+    "instructions in your response — the user does not need to name it explicitly. If a skill "
+    "seems to apply but you don't have enough information from the conversation to follow it "
+    "correctly, ask the user for the specific details you need before proceeding, rather than "
+    "guessing or skipping it. A skill can also be invoked explicitly with `/<slug> [args]`; "
+    "treat any args as additional input to that skill.\n\n"
+)
+
 
 def _render_user_context_block(
     user: AuthUserRecord,
@@ -149,10 +176,12 @@ class ChatService:
         adapter: ChatPersistencePort,
         iam_service: IAMService | None = None,
         auth_adapter: AuthPersistencePort | None = None,
+        skills_service: SkillService | None = None,
     ):
         self.adapter = adapter
         self.iam_service = iam_service
         self.auth_adapter = auth_adapter
+        self.skills_service = skills_service
 
     async def build_system_prompt(
         self,
@@ -162,10 +191,13 @@ class ChatService:
         user_id: str | None,
         workspace_id: str | None = None,
         conversation_id: str | None = None,
+        context: RequestContext | None = None,
     ) -> str:
         system_prompt = explicit_system_prompt or AGENT_SYSTEM_PROMPTS.get(
             agent, AGENT_SYSTEM_PROMPTS["aia"]
         )
+        system_prompt += await self._build_skills_block(context, workspace_id)
+
         has_prior_assistant = any(getattr(m, "role", None) == "assistant" for m in prior_messages)
         if has_prior_assistant:
             system_prompt += _MULTI_AGENT_NOTICE
@@ -173,6 +205,33 @@ class ChatService:
 
         addendum = await self.build_user_context_addendum(prior_messages, user_id, workspace_id, conversation_id)
         return system_prompt + addendum
+
+    async def _build_skills_block(
+        self, context: RequestContext | None, workspace_id: str | None
+    ) -> str:
+        """Skills catalog + built-in command instructions, injected fresh into the
+        system prompt on every turn. Keeping it always-resident (rather than a
+        one-off prompt expansion at invocation time) is what lets the agent decide
+        on its own, turn after turn, whether a skill applies — mirroring how
+        Claude's own Skills stay visible in context instead of being invoked once
+        and forgotten."""
+        block = _CREATE_SKILL_INSTRUCTIONS
+        if not self.skills_service or not context or not workspace_id:
+            return block
+        try:
+            skills = await self.skills_service.list_visible_skills(context, workspace_id)
+        except Exception:
+            logger.warning("Failed to load skills catalog for system prompt", exc_info=True)
+            return block
+        enabled = [s for s in skills if s.enabled]
+        if not enabled:
+            return block
+        lines = [
+            f"- `/{s.slug}` — {s.name}{f': {s.description}' if s.description else ''}\n"
+            f"  Instructions: {s.prompt}"
+            for s in enabled
+        ]
+        return block + _SKILLS_CATALOG_HEADER + "\n".join(lines) + "\n"
 
     async def build_user_context_addendum(
         self,
@@ -682,6 +741,7 @@ class ChatService:
                     user_id=context.actor_user_id,
                     workspace_id=request.workspace_id,
                     conversation_id=conversation_id,
+                    context=context,
                 )
 
                 response_content = await complete_with_provider(

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/service_test.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/service_test.py
@@ -13,6 +13,7 @@ from naas_abi.apps.nexus.apps.api.app.services.chat.chat__schema import (
 )
 from naas_abi.apps.nexus.apps.api.app.services.chat.port import ChatConversationRecord
 from naas_abi.apps.nexus.apps.api.app.services.chat.service import (
+    _CREATE_SKILL_INSTRUCTIONS,
     AGENT_SYSTEM_PROMPTS,
     ChatService,
     ResolvedProvider,
@@ -701,7 +702,7 @@ async def test_build_system_prompt_without_auth_adapter_returns_base() -> None:
         user_id="user-1",
     )
 
-    assert prompt == AGENT_SYSTEM_PROMPTS["aia"]
+    assert prompt == AGENT_SYSTEM_PROMPTS["aia"] + _CREATE_SKILL_INSTRUCTIONS
 
 
 @pytest.mark.asyncio
@@ -718,7 +719,77 @@ async def test_build_system_prompt_swallows_auth_errors() -> None:
         user_id="user-1",
     )
 
-    assert prompt == AGENT_SYSTEM_PROMPTS["aia"]
+    assert prompt == AGENT_SYSTEM_PROMPTS["aia"] + _CREATE_SKILL_INSTRUCTIONS
+
+
+@pytest.mark.asyncio
+async def test_build_system_prompt_includes_enabled_skills_catalog() -> None:
+    skill = SimpleNamespace(
+        slug="weekly-report",
+        name="Weekly report",
+        description="Summarize the week",
+        prompt="Summarize this week's activity in bullet points.",
+        enabled=True,
+    )
+    disabled_skill = SimpleNamespace(
+        slug="disabled-one", name="Disabled", description="", prompt="x", enabled=False
+    )
+    skills_service = SimpleNamespace(
+        list_visible_skills=AsyncMock(return_value=[skill, disabled_skill])
+    )
+    service = ChatService(adapter=SimpleNamespace(), skills_service=skills_service)
+    context = SimpleNamespace(actor_user_id="user-1")
+
+    prompt = await service.build_system_prompt(
+        agent="aia",
+        explicit_system_prompt=None,
+        prior_messages=[],
+        user_id="user-1",
+        workspace_id="ws-1",
+        context=context,
+    )
+
+    assert "/weekly-report" in prompt
+    assert "Summarize this week's activity in bullet points." in prompt
+    assert "disabled-one" not in prompt
+    skills_service.list_visible_skills.assert_awaited_once_with(context, "ws-1")
+
+
+@pytest.mark.asyncio
+async def test_build_system_prompt_skips_skills_catalog_without_context() -> None:
+    skills_service = SimpleNamespace(list_visible_skills=AsyncMock())
+    service = ChatService(adapter=SimpleNamespace(), skills_service=skills_service)
+
+    prompt = await service.build_system_prompt(
+        agent="aia",
+        explicit_system_prompt=None,
+        prior_messages=[],
+        user_id="user-1",
+        workspace_id="ws-1",
+    )
+
+    assert prompt == AGENT_SYSTEM_PROMPTS["aia"] + _CREATE_SKILL_INSTRUCTIONS
+    skills_service.list_visible_skills.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_build_system_prompt_swallows_skills_catalog_errors() -> None:
+    skills_service = SimpleNamespace(
+        list_visible_skills=AsyncMock(side_effect=RuntimeError("db down"))
+    )
+    service = ChatService(adapter=SimpleNamespace(), skills_service=skills_service)
+    context = SimpleNamespace(actor_user_id="user-1")
+
+    prompt = await service.build_system_prompt(
+        agent="aia",
+        explicit_system_prompt=None,
+        prior_messages=[],
+        user_id="user-1",
+        workspace_id="ws-1",
+        context=context,
+    )
+
+    assert prompt == AGENT_SYSTEM_PROMPTS["aia"] + _CREATE_SKILL_INSTRUCTIONS
 
 
 @pytest.mark.asyncio

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/registry.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/registry.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from naas_abi.apps.nexus.apps.api.app.services.ontology.service import OntologyService
     from naas_abi.apps.nexus.apps.api.app.services.organizations.service import OrganizationService
     from naas_abi.apps.nexus.apps.api.app.services.search.service import SearchService
+    from naas_abi.apps.nexus.apps.api.app.services.skills.service import SkillService
     from naas_abi.apps.nexus.apps.api.app.services.workspaces.service import WorkspaceService
 
 
@@ -29,6 +30,7 @@ class RegistryServices:
     chat: ChatService
     search: SearchService
     agents: AgentService
+    skills: SkillService
     apps: AppsService
     workspaces: WorkspaceService
     organizations: OrganizationService
@@ -64,6 +66,10 @@ class ServiceRegistry:
     @property
     def agents(self) -> AgentService:
         return self._services.agents
+
+    @property
+    def skills(self) -> SkillService:
+        return self._services.skills
 
     @property
     def apps(self) -> AppsService:

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/registry_bootstrap.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/registry_bootstrap.py
@@ -33,6 +33,10 @@ from naas_abi.apps.nexus.apps.api.app.services.registry import (
     ServiceRegistry,
 )
 from naas_abi.apps.nexus.apps.api.app.services.search.service import SearchService
+from naas_abi.apps.nexus.apps.api.app.services.skills.adapters.secondary.postgres import (
+    SkillSecondaryAdapterPostgres,
+)
+from naas_abi.apps.nexus.apps.api.app.services.skills.service import SkillService
 from naas_abi.apps.nexus.apps.api.app.services.workspaces.adapters.secondary.postgres import (
     WorkspaceSecondaryAdapterPostgres,
 )
@@ -63,6 +67,10 @@ def initialize_nexus_service_registry() -> ServiceRegistry:
         AgentSecondaryAdapterPostgres(db_getter=db_getter),
         iam_service=iam_service,
     )
+    skills_service = SkillService(
+        SkillSecondaryAdapterPostgres(db_getter=db_getter),
+        iam_service=iam_service,
+    )
     apps_service = AppsService(AppSecondaryAdapterPostgres(db_getter=db_getter))
     graph_service = GraphService()
     ontology_service = OntologyService()
@@ -73,6 +81,7 @@ def initialize_nexus_service_registry() -> ServiceRegistry:
             chat=chat_service,
             search=search_service,
             agents=agents_service,
+            skills=skills_service,
             apps=apps_service,
             workspaces=workspace_service,
             organizations=organization_service,

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/registry_bootstrap.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/registry_bootstrap.py
@@ -57,18 +57,19 @@ def initialize_nexus_service_registry() -> ServiceRegistry:
     organization_service = OrganizationService(
         OrganizationSecondaryAdapterPostgres(db_getter=db_getter)
     )
+    skills_service = SkillService(
+        SkillSecondaryAdapterPostgres(db_getter=db_getter),
+        iam_service=iam_service,
+    )
     chat_service = ChatService(
         adapter=ChatSecondaryAdapterPostgres(db_getter=db_getter),
         iam_service=iam_service,
         auth_adapter=AuthSecondaryAdapterPostgres(db_getter=db_getter),
+        skills_service=skills_service,
     )
     search_service = SearchService()
     agents_service = AgentService(
         AgentSecondaryAdapterPostgres(db_getter=db_getter),
-        iam_service=iam_service,
-    )
-    skills_service = SkillService(
-        SkillSecondaryAdapterPostgres(db_getter=db_getter),
         iam_service=iam_service,
     )
     apps_service = AppsService(AppSecondaryAdapterPostgres(db_getter=db_getter))

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/skills/__init__.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/skills/__init__.py
@@ -1,0 +1,13 @@
+from naas_abi.apps.nexus.apps.api.app.services.skills.port import (
+    SkillCreateInput,
+    SkillRecord,
+    SkillUpdateInput,
+)
+from naas_abi.apps.nexus.apps.api.app.services.skills.service import SkillService
+
+__all__ = [
+    "SkillCreateInput",
+    "SkillRecord",
+    "SkillService",
+    "SkillUpdateInput",
+]

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/skills/adapters/__init__.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/skills/adapters/__init__.py
@@ -1,0 +1,6 @@
+from naas_abi.apps.nexus.apps.api.app.services.skills.adapters.primary import router
+from naas_abi.apps.nexus.apps.api.app.services.skills.adapters.secondary import (
+    SkillSecondaryAdapterPostgres,
+)
+
+__all__ = ["SkillSecondaryAdapterPostgres", "router"]

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/skills/adapters/primary/__init__.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/skills/adapters/primary/__init__.py
@@ -1,0 +1,6 @@
+from naas_abi.apps.nexus.apps.api.app.services.skills.adapters.primary.skills__primary_adapter__FastAPI import (  # noqa: E501
+    SkillsFastAPIPrimaryAdapter,
+    router,
+)
+
+__all__ = ["SkillsFastAPIPrimaryAdapter", "router"]

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/skills/adapters/primary/skills__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/skills/adapters/primary/skills__primary_adapter__FastAPI.py
@@ -1,0 +1,192 @@
+"""Skills FastAPI primary adapter."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException
+from naas_abi.apps.nexus.apps.api.app.api.endpoints.auth import (
+    User,
+    get_current_user_required,
+    require_workspace_access,
+)
+from naas_abi.apps.nexus.apps.api.app.core.datetime_compat import UTC
+from naas_abi.apps.nexus.apps.api.app.services.iam.port import RequestContext, TokenData
+from naas_abi.apps.nexus.apps.api.app.services.registry import (
+    ServiceRegistry,
+    get_service_registry,
+)
+from naas_abi.apps.nexus.apps.api.app.services.skills import (
+    SkillCreateInput,
+    SkillRecord,
+    SkillService,
+    SkillUpdateInput,
+)
+from naas_abi.apps.nexus.apps.api.app.services.skills.service import (
+    SkillPermissionError,
+    SkillValidationError,
+    normalize_slug,
+)
+from pydantic import BaseModel, Field
+
+router = APIRouter(dependencies=[Depends(get_current_user_required)])
+
+
+class SkillsFastAPIPrimaryAdapter:
+    def __init__(self) -> None:
+        self.router = router
+
+
+def get_skill_service(
+    registry: ServiceRegistry = Depends(get_service_registry),
+) -> SkillService:
+    return registry.skills
+
+
+def request_context(current_user: User) -> RequestContext:
+    return RequestContext(
+        token_data=TokenData(user_id=current_user.id, scopes={"*"}, is_authenticated=True)
+    )
+
+
+def _now() -> datetime:
+    return datetime.now(UTC).replace(tzinfo=None)
+
+
+class SkillCreateBody(BaseModel):
+    workspace_id: str = Field(..., min_length=1, max_length=100)
+    name: str = Field(..., min_length=1, max_length=200)
+    prompt: str = Field(..., min_length=1)
+    slug: str | None = Field(default=None, max_length=100)  # Defaults to slugified name
+    description: str | None = Field(default=None, max_length=2000)
+    scope: str = Field(default="user")  # user | workspace | organization
+    enabled: bool = True
+
+
+class SkillUpdateBody(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=200)
+    slug: str | None = Field(default=None, min_length=1, max_length=100)
+    description: str | None = Field(default=None, max_length=2000)
+    prompt: str | None = Field(default=None, min_length=1)
+    scope: str | None = None
+    enabled: bool | None = None
+
+
+@router.get("/")
+async def list_skills(
+    workspace_id: str,
+    current_user: User = Depends(get_current_user_required),
+    skill_service: SkillService = Depends(get_skill_service),
+) -> list[SkillRecord]:
+    await require_workspace_access(current_user.id, workspace_id)
+    return await skill_service.list_visible_skills(
+        context=request_context(current_user),
+        workspace_id=workspace_id,
+    )
+
+
+@router.post("/")
+async def create_skill(
+    body: SkillCreateBody,
+    current_user: User = Depends(get_current_user_required),
+    skill_service: SkillService = Depends(get_skill_service),
+) -> SkillRecord:
+    await require_workspace_access(current_user.id, body.workspace_id)
+    try:
+        return await skill_service.create_skill(
+            context=request_context(current_user),
+            data=SkillCreateInput(
+                workspace_id=body.workspace_id,
+                user_id=current_user.id,
+                name=body.name,
+                slug=body.slug or normalize_slug(body.name),
+                prompt=body.prompt,
+                description=body.description,
+                scope=body.scope,
+                enabled=body.enabled,
+            ),
+        )
+    except SkillValidationError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+
+@router.get("/{skill_id}")
+async def get_skill(
+    skill_id: str,
+    current_user: User = Depends(get_current_user_required),
+    skill_service: SkillService = Depends(get_skill_service),
+) -> SkillRecord:
+    try:
+        skill = await skill_service.get_skill(
+            context=request_context(current_user),
+            skill_id=skill_id,
+        )
+    except SkillPermissionError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+    if not skill:
+        raise HTTPException(status_code=404, detail="Skill not found")
+    await require_workspace_access(current_user.id, skill.workspace_id)
+    return skill
+
+
+@router.patch("/{skill_id}")
+async def update_skill(
+    skill_id: str,
+    body: SkillUpdateBody,
+    current_user: User = Depends(get_current_user_required),
+    skill_service: SkillService = Depends(get_skill_service),
+) -> SkillRecord:
+    try:
+        skill = await skill_service.update_skill(
+            context=request_context(current_user),
+            skill_id=skill_id,
+            updates=SkillUpdateInput(
+                name=body.name,
+                slug=body.slug,
+                description=body.description,
+                prompt=body.prompt,
+                scope=body.scope,
+                enabled=body.enabled,
+            ),
+        )
+    except SkillPermissionError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+    except SkillValidationError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    if not skill:
+        raise HTTPException(status_code=404, detail="Skill not found")
+    return skill
+
+
+@router.post("/{skill_id}/use")
+async def mark_skill_used(
+    skill_id: str,
+    current_user: User = Depends(get_current_user_required),
+    skill_service: SkillService = Depends(get_skill_service),
+) -> SkillRecord:
+    skill = await skill_service.mark_skill_used(
+        context=request_context(current_user),
+        skill_id=skill_id,
+        now=_now(),
+    )
+    if not skill:
+        raise HTTPException(status_code=404, detail="Skill not found")
+    return skill
+
+
+@router.delete("/{skill_id}")
+async def delete_skill(
+    skill_id: str,
+    current_user: User = Depends(get_current_user_required),
+    skill_service: SkillService = Depends(get_skill_service),
+) -> dict[str, str]:
+    try:
+        deleted = await skill_service.delete_skill(
+            context=request_context(current_user),
+            skill_id=skill_id,
+        )
+    except SkillPermissionError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Skill not found")
+    return {"status": "deleted"}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/skills/adapters/secondary/__init__.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/skills/adapters/secondary/__init__.py
@@ -1,0 +1,5 @@
+from naas_abi.apps.nexus.apps.api.app.services.skills.adapters.secondary.postgres import (
+    SkillSecondaryAdapterPostgres,
+)
+
+__all__ = ["SkillSecondaryAdapterPostgres"]

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/skills/adapters/secondary/postgres.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/skills/adapters/secondary/postgres.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime
+from uuid import uuid4
+
+from naas_abi.apps.nexus.apps.api.app.models import SkillModel, WorkspaceModel
+from naas_abi.apps.nexus.apps.api.app.services.skills.port import (
+    SkillCreateInput,
+    SkillPersistencePort,
+    SkillRecord,
+    SkillUpdateInput,
+)
+from sqlalchemy import and_, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+AsyncSessionGetter = Callable[[], AsyncSession | None]
+
+
+class SkillSecondaryAdapterPostgres(SkillPersistencePort):
+    def __init__(self, db: AsyncSession | None = None, db_getter: AsyncSessionGetter | None = None):
+        self._db = db
+        self._db_getter = db_getter
+
+    @property
+    def db(self) -> AsyncSession:
+        if self._db is not None:
+            return self._db
+        if self._db_getter is None:
+            raise RuntimeError("SkillSecondaryAdapterPostgres has no database binding")
+        db = self._db_getter()
+        if db is None:
+            raise RuntimeError("No database session bound in ServiceRegistry context")
+        return db
+
+    @staticmethod
+    def _to_record(model: SkillModel) -> SkillRecord:
+        return SkillRecord(
+            id=str(model.id),
+            workspace_id=str(model.workspace_id),
+            organization_id=str(model.organization_id) if model.organization_id else None,
+            user_id=str(model.user_id),
+            name=str(model.name),
+            slug=str(model.slug),
+            description=str(model.description) if model.description else "",
+            prompt=str(model.prompt),
+            scope=str(model.scope),
+            enabled=bool(model.enabled),
+            last_used_at=(
+                datetime.fromisoformat(str(model.last_used_at)) if model.last_used_at else None
+            ),
+            created_at=datetime.fromisoformat(str(model.created_at)),
+            updated_at=datetime.fromisoformat(str(model.updated_at)),
+        )
+
+    @staticmethod
+    def _visibility_filter(workspace_id: str, user_id: str):
+        # Organization of the target workspace, resolved in-query so callers
+        # don't have to pass it around.
+        org_id_subq = (
+            select(WorkspaceModel.organization_id)
+            .where(WorkspaceModel.id == workspace_id)
+            .scalar_subquery()
+        )
+        return or_(
+            and_(
+                SkillModel.scope == "user",
+                SkillModel.user_id == user_id,
+                SkillModel.workspace_id == workspace_id,
+            ),
+            and_(
+                SkillModel.scope == "workspace",
+                SkillModel.workspace_id == workspace_id,
+            ),
+            and_(
+                SkillModel.scope == "organization",
+                SkillModel.organization_id.is_not(None),
+                SkillModel.organization_id == org_id_subq,
+            ),
+        )
+
+    async def list_visible(self, workspace_id: str, user_id: str) -> list[SkillRecord]:
+        result = await self.db.execute(
+            select(SkillModel)
+            .where(self._visibility_filter(workspace_id, user_id))
+            .order_by(SkillModel.last_used_at.desc().nulls_last(), SkillModel.updated_at.desc())
+        )
+        return [self._to_record(row) for row in result.scalars().all()]
+
+    async def get_by_id(self, skill_id: str) -> SkillRecord | None:
+        result = await self.db.execute(select(SkillModel).where(SkillModel.id == skill_id))
+        skill = result.scalar_one_or_none()
+        return self._to_record(skill) if skill else None
+
+    async def get_visible_by_slug(
+        self, workspace_id: str, user_id: str, slug: str
+    ) -> SkillRecord | None:
+        result = await self.db.execute(
+            select(SkillModel).where(
+                SkillModel.slug == slug,
+                self._visibility_filter(workspace_id, user_id),
+            )
+        )
+        skill = result.scalars().first()
+        return self._to_record(skill) if skill else None
+
+    async def create(self, data: SkillCreateInput) -> SkillRecord:
+        # Denormalize the workspace's organization so organization-scoped
+        # skills can be matched across the org with a single column filter.
+        org_result = await self.db.execute(
+            select(WorkspaceModel.organization_id).where(WorkspaceModel.id == data.workspace_id)
+        )
+        organization_id = org_result.scalar_one_or_none()
+
+        skill_model = SkillModel(
+            id=str(uuid4()),
+            workspace_id=data.workspace_id,
+            organization_id=organization_id,
+            user_id=data.user_id,
+            name=data.name,
+            slug=data.slug,
+            description=data.description,
+            prompt=data.prompt,
+            scope=data.scope,
+            enabled=data.enabled,
+        )
+        self.db.add(skill_model)
+        await self.db.commit()
+        await self.db.refresh(skill_model)
+        return self._to_record(skill_model)
+
+    async def update(self, skill_id: str, updates: SkillUpdateInput) -> SkillRecord | None:
+        result = await self.db.execute(select(SkillModel).where(SkillModel.id == skill_id))
+        skill_model = result.scalar_one_or_none()
+        if skill_model is None:
+            return None
+
+        if updates.name is not None:
+            skill_model.name = str(updates.name)
+        if updates.slug is not None:
+            skill_model.slug = str(updates.slug)
+        if updates.description is not None:
+            skill_model.description = str(updates.description)
+        if updates.prompt is not None:
+            skill_model.prompt = str(updates.prompt)
+        if updates.scope is not None:
+            skill_model.scope = str(updates.scope)
+        if updates.enabled is not None:
+            skill_model.enabled = bool(updates.enabled)
+
+        await self.db.commit()
+        await self.db.refresh(skill_model)
+        return self._to_record(skill_model)
+
+    async def mark_used(self, skill_id: str, now: datetime) -> SkillRecord | None:
+        result = await self.db.execute(select(SkillModel).where(SkillModel.id == skill_id))
+        skill_model = result.scalar_one_or_none()
+        if skill_model is None:
+            return None
+        skill_model.last_used_at = now
+        await self.db.commit()
+        await self.db.refresh(skill_model)
+        return self._to_record(skill_model)
+
+    async def delete(self, skill_id: str) -> bool:
+        result = await self.db.execute(select(SkillModel).where(SkillModel.id == skill_id))
+        skill_model = result.scalar_one_or_none()
+        if skill_model is None:
+            return False
+        await self.db.delete(skill_model)
+        await self.db.commit()
+        return True

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/skills/handlers/__init__.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/skills/handlers/__init__.py
@@ -1,0 +1,5 @@
+from naas_abi.apps.nexus.apps.api.app.services.skills.handlers.skills__http_handler import (
+    router,
+)
+
+__all__ = ["router"]

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/skills/handlers/skills__http_handler.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/skills/handlers/skills__http_handler.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from naas_abi.apps.nexus.apps.api.app.services.skills.adapters.primary import router
+
+__all__ = ["router"]

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/skills/port.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/skills/port.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime
+
+SKILL_SCOPES = ("user", "workspace", "organization")
+
+
+@dataclass
+class SkillRecord:
+    id: str
+    workspace_id: str
+    organization_id: str | None
+    user_id: str
+    name: str
+    slug: str
+    description: str
+    prompt: str
+    scope: str
+    enabled: bool
+    last_used_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass
+class SkillCreateInput:
+    workspace_id: str
+    user_id: str
+    name: str
+    slug: str
+    prompt: str
+    description: str | None = None
+    scope: str = "user"
+    enabled: bool = True
+
+
+@dataclass
+class SkillUpdateInput:
+    name: str | None = None
+    slug: str | None = None
+    description: str | None = None
+    prompt: str | None = None
+    scope: str | None = None
+    enabled: bool | None = None
+
+
+class SkillPersistencePort(ABC):
+    @abstractmethod
+    async def list_visible(self, workspace_id: str, user_id: str) -> list[SkillRecord]:
+        """Skills visible to ``user_id`` in ``workspace_id``: their own user-scoped
+        skills, the workspace's workspace-scoped skills, and organization-scoped
+        skills of the workspace's organization."""
+
+    @abstractmethod
+    async def get_by_id(self, skill_id: str) -> SkillRecord | None:
+        pass
+
+    @abstractmethod
+    async def get_visible_by_slug(
+        self, workspace_id: str, user_id: str, slug: str
+    ) -> SkillRecord | None:
+        pass
+
+    @abstractmethod
+    async def create(self, data: SkillCreateInput) -> SkillRecord:
+        pass
+
+    @abstractmethod
+    async def update(self, skill_id: str, updates: SkillUpdateInput) -> SkillRecord | None:
+        pass
+
+    @abstractmethod
+    async def mark_used(self, skill_id: str, now: datetime) -> SkillRecord | None:
+        pass
+
+    @abstractmethod
+    async def delete(self, skill_id: str) -> bool:
+        pass

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/skills/service.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/skills/service.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime
+
+from naas_abi.apps.nexus.apps.api.app.services.iam.authorization import (
+    ensure_scope,
+    ensure_workspace_access,
+)
+from naas_abi.apps.nexus.apps.api.app.services.iam.port import RequestContext
+from naas_abi.apps.nexus.apps.api.app.services.iam.service import IAMService
+from naas_abi.apps.nexus.apps.api.app.services.skills.port import (
+    SKILL_SCOPES,
+    SkillCreateInput,
+    SkillPersistencePort,
+    SkillRecord,
+    SkillUpdateInput,
+)
+
+# Reserved chat commands that can never be used as skill slugs.
+RESERVED_SLUGS = {"skills", "create-skill"}
+
+_SLUG_RE = re.compile(r"[^a-z0-9-]+")
+
+
+def normalize_slug(value: str) -> str:
+    """Normalize a raw name/slug to a chat-command slug: lowercase, hyphenated."""
+    slug = _SLUG_RE.sub("-", value.strip().lower().replace("_", "-"))
+    return slug.strip("-")
+
+
+class SkillValidationError(ValueError):
+    pass
+
+
+class SkillPermissionError(PermissionError):
+    pass
+
+
+class SkillService:
+    def __init__(self, adapter: SkillPersistencePort, iam_service: IAMService | None = None):
+        self.adapter = adapter
+        self.iam_service = iam_service
+
+    def _ensure_scope(
+        self, context: RequestContext, required_scope: str, denied_message: str
+    ) -> None:
+        ensure_scope(
+            context=context,
+            required_scope=required_scope,
+            denied_message=denied_message,
+            iam_service=self.iam_service,
+        )
+
+    async def _ensure_workspace_access(self, context: RequestContext, workspace_id: str) -> None:
+        await ensure_workspace_access(
+            context=context,
+            workspace_id=workspace_id,
+            denied_message="Workspace access denied",
+            required_scope="workspace.read",
+            iam_service=self.iam_service,
+            workspace_service=None,
+        )
+
+    def _ensure_can_modify(self, context: RequestContext, skill: SkillRecord) -> None:
+        # User-scoped skills are private to their creator; wider scopes are
+        # editable by anyone with access to the skill's workspace (checked by
+        # the caller via _ensure_workspace_access).
+        if skill.scope == "user" and skill.user_id != context.actor_user_id:
+            raise SkillPermissionError("Only the creator can modify this skill")
+
+    @staticmethod
+    def _validate_scope(scope: str) -> None:
+        if scope not in SKILL_SCOPES:
+            raise SkillValidationError(
+                f"Invalid scope '{scope}'. Must be one of: {', '.join(SKILL_SCOPES)}"
+            )
+
+    async def _validate_slug(
+        self,
+        workspace_id: str,
+        user_id: str,
+        slug: str,
+        exclude_skill_id: str | None = None,
+    ) -> str:
+        normalized = normalize_slug(slug)
+        if not normalized:
+            raise SkillValidationError("Slug cannot be empty")
+        if normalized in RESERVED_SLUGS:
+            raise SkillValidationError(f"'/{normalized}' is a reserved command")
+        existing = await self.adapter.get_visible_by_slug(workspace_id, user_id, normalized)
+        if existing and existing.id != exclude_skill_id:
+            raise SkillValidationError(f"A skill with slug '/{normalized}' already exists")
+        return normalized
+
+    async def list_visible_skills(
+        self,
+        context: RequestContext,
+        workspace_id: str,
+    ) -> list[SkillRecord]:
+        self._ensure_scope(context, "skill.read", "Skill access denied")
+        await self._ensure_workspace_access(context, workspace_id)
+        return await self.adapter.list_visible(workspace_id, context.actor_user_id)
+
+    async def get_skill(self, context: RequestContext, skill_id: str) -> SkillRecord | None:
+        self._ensure_scope(context, "skill.read", "Skill access denied")
+        skill = await self.adapter.get_by_id(skill_id)
+        if skill:
+            await self._ensure_workspace_access(context, skill.workspace_id)
+            if skill.scope == "user" and skill.user_id != context.actor_user_id:
+                raise SkillPermissionError("Skill access denied")
+        return skill
+
+    async def create_skill(self, context: RequestContext, data: SkillCreateInput) -> SkillRecord:
+        self._ensure_scope(context, "skill.create", "Skill access denied")
+        await self._ensure_workspace_access(context, data.workspace_id)
+        self._validate_scope(data.scope)
+        data.slug = await self._validate_slug(data.workspace_id, data.user_id, data.slug)
+        if not data.name.strip():
+            raise SkillValidationError("Name cannot be empty")
+        if not data.prompt.strip():
+            raise SkillValidationError("Prompt cannot be empty")
+        return await self.adapter.create(data)
+
+    async def update_skill(
+        self,
+        context: RequestContext,
+        skill_id: str,
+        updates: SkillUpdateInput,
+    ) -> SkillRecord | None:
+        self._ensure_scope(context, "skill.update", "Skill access denied")
+        existing = await self.adapter.get_by_id(skill_id)
+        if not existing:
+            return None
+        await self._ensure_workspace_access(context, existing.workspace_id)
+        self._ensure_can_modify(context, existing)
+        if updates.scope is not None:
+            self._validate_scope(updates.scope)
+        if updates.slug is not None:
+            updates.slug = await self._validate_slug(
+                existing.workspace_id,
+                context.actor_user_id,
+                updates.slug,
+                exclude_skill_id=skill_id,
+            )
+        return await self.adapter.update(skill_id, updates)
+
+    async def mark_skill_used(
+        self,
+        context: RequestContext,
+        skill_id: str,
+        now: datetime,
+    ) -> SkillRecord | None:
+        self._ensure_scope(context, "skill.read", "Skill access denied")
+        existing = await self.adapter.get_by_id(skill_id)
+        if not existing:
+            return None
+        await self._ensure_workspace_access(context, existing.workspace_id)
+        return await self.adapter.mark_used(skill_id, now)
+
+    async def delete_skill(self, context: RequestContext, skill_id: str) -> bool:
+        self._ensure_scope(context, "skill.delete", "Skill access denied")
+        existing = await self.adapter.get_by_id(skill_id)
+        if not existing:
+            return False
+        await self._ensure_workspace_access(context, existing.workspace_id)
+        self._ensure_can_modify(context, existing)
+        return await self.adapter.delete(skill_id)

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/skills/service_test.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/skills/service_test.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from naas_abi.apps.nexus.apps.api.app.services.skills.adapters.secondary.postgres import (
+    SkillSecondaryAdapterPostgres,
+)
+from naas_abi.apps.nexus.apps.api.app.services.skills.port import (
+    SkillCreateInput,
+    SkillRecord,
+    SkillUpdateInput,
+)
+from naas_abi.apps.nexus.apps.api.app.services.skills.service import (
+    SkillPermissionError,
+    SkillService,
+    SkillValidationError,
+    normalize_slug,
+)
+
+
+def _record(**overrides) -> SkillRecord:
+    defaults: dict = {
+        "id": "skill-1",
+        "workspace_id": "ws-1",
+        "organization_id": None,
+        "user_id": "user-1",
+        "name": "Summarize",
+        "slug": "summarize",
+        "description": "",
+        "prompt": "Summarize the following",
+        "scope": "user",
+        "enabled": True,
+        "last_used_at": None,
+        "created_at": datetime.now(),
+        "updated_at": datetime.now(),
+    }
+    defaults.update(overrides)
+    return SkillRecord(**defaults)
+
+
+def _context(user_id: str = "user-1"):
+    from naas_abi.apps.nexus.apps.api.app.services.iam.port import RequestContext, TokenData
+
+    return RequestContext(
+        token_data=TokenData(user_id=user_id, scopes={"*"}, is_authenticated=True)
+    )
+
+
+def _service(adapter) -> SkillService:
+    service = SkillService(adapter)
+    service._ensure_workspace_access = AsyncMock()  # type: ignore[method-assign]
+    return service
+
+
+def test_normalize_slug() -> None:
+    assert normalize_slug("My Cool Skill!") == "my-cool-skill"
+    assert normalize_slug("  weekly_report  ") == "weekly-report"
+    assert normalize_slug("/slash") == "slash"
+
+
+@pytest.mark.asyncio
+async def test_create_skill_normalizes_slug_and_creates() -> None:
+    adapter = AsyncMock()
+    adapter.get_visible_by_slug = AsyncMock(return_value=None)
+    adapter.create = AsyncMock(side_effect=lambda data: _record(slug=data.slug))
+    service = _service(adapter)
+
+    created = await service.create_skill(
+        _context(),
+        SkillCreateInput(
+            workspace_id="ws-1",
+            user_id="user-1",
+            name="Weekly Report",
+            slug="Weekly Report",
+            prompt="Write the weekly report",
+        ),
+    )
+
+    assert created.slug == "weekly-report"
+    adapter.create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_create_skill_rejects_reserved_and_duplicate_slug() -> None:
+    adapter = AsyncMock()
+    adapter.get_visible_by_slug = AsyncMock(return_value=None)
+    service = _service(adapter)
+
+    with pytest.raises(SkillValidationError):
+        await service.create_skill(
+            _context(),
+            SkillCreateInput(
+                workspace_id="ws-1",
+                user_id="user-1",
+                name="Skills",
+                slug="skills",
+                prompt="x",
+            ),
+        )
+
+    adapter.get_visible_by_slug = AsyncMock(return_value=_record(id="other"))
+    with pytest.raises(SkillValidationError):
+        await service.create_skill(
+            _context(),
+            SkillCreateInput(
+                workspace_id="ws-1",
+                user_id="user-1",
+                name="Summarize",
+                slug="summarize",
+                prompt="x",
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_skill_rejects_invalid_scope() -> None:
+    adapter = AsyncMock()
+    service = _service(adapter)
+
+    with pytest.raises(SkillValidationError):
+        await service.create_skill(
+            _context(),
+            SkillCreateInput(
+                workspace_id="ws-1",
+                user_id="user-1",
+                name="S",
+                slug="s",
+                prompt="x",
+                scope="global",
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_user_scoped_skill_rejected_for_non_creator() -> None:
+    adapter = AsyncMock()
+    adapter.get_by_id = AsyncMock(return_value=_record(user_id="creator"))
+    service = _service(adapter)
+
+    with pytest.raises(SkillPermissionError):
+        await service.update_skill(
+            _context(user_id="someone-else"),
+            "skill-1",
+            SkillUpdateInput(name="New"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_workspace_scoped_skill_allowed_for_member() -> None:
+    adapter = AsyncMock()
+    adapter.get_by_id = AsyncMock(return_value=_record(scope="workspace", user_id="creator"))
+    adapter.update = AsyncMock(return_value=_record(scope="workspace", name="New"))
+    service = _service(adapter)
+
+    updated = await service.update_skill(
+        _context(user_id="someone-else"),
+        "skill-1",
+        SkillUpdateInput(name="New"),
+    )
+
+    assert updated is not None
+    assert updated.name == "New"
+
+
+@pytest.mark.asyncio
+async def test_delete_user_scoped_skill_rejected_for_non_creator() -> None:
+    adapter = AsyncMock()
+    adapter.get_by_id = AsyncMock(return_value=_record(user_id="creator"))
+    service = _service(adapter)
+
+    with pytest.raises(SkillPermissionError):
+        await service.delete_skill(_context(user_id="someone-else"), "skill-1")
+
+
+@pytest.mark.asyncio
+async def test_adapter_maps_row_to_record() -> None:
+    row = SimpleNamespace(
+        id="skill-1",
+        workspace_id="ws-1",
+        organization_id="org-1",
+        user_id="user-1",
+        name="Summarize",
+        slug="summarize",
+        description="Sums things up",
+        prompt="Summarize the following",
+        scope="organization",
+        enabled=True,
+        last_used_at=datetime.now(),
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    db = AsyncMock()
+    scalars = SimpleNamespace(all=lambda: [row], first=lambda: row)
+    db.execute = AsyncMock(
+        return_value=SimpleNamespace(scalar_one_or_none=lambda: row, scalars=lambda: scalars)
+    )
+
+    adapter = SkillSecondaryAdapterPostgres(db=db)
+    skills = await adapter.list_visible("ws-1", "user-1")
+
+    assert len(skills) == 1
+    assert skills[0].slug == "summarize"
+    assert skills[0].scope == "organization"
+    assert skills[0].organization_id == "org-1"

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/migrations/0037_add_skills.sql
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/migrations/0037_add_skills.sql
@@ -1,0 +1,24 @@
+-- Migration: Add skills table (user-created reusable prompt skills)
+-- A skill is a named prompt invocable from the chat bar via /<slug>.
+-- scope controls visibility: user (creator only), workspace, organization.
+
+CREATE TABLE IF NOT EXISTS skills (
+    id VARCHAR PRIMARY KEY,
+    workspace_id VARCHAR NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    organization_id VARCHAR REFERENCES organizations(id) ON DELETE SET NULL,
+    user_id VARCHAR NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name VARCHAR NOT NULL,
+    slug VARCHAR NOT NULL,
+    description TEXT,
+    prompt TEXT NOT NULL,
+    scope VARCHAR NOT NULL DEFAULT 'user',
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    last_used_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_skills_workspace_id ON skills(workspace_id);
+CREATE INDEX IF NOT EXISTS idx_skills_organization_id ON skills(organization_id);
+CREATE INDEX IF NOT EXISTS idx_skills_user_id ON skills(user_id);
+CREATE INDEX IF NOT EXISTS idx_skills_slug ON skills(slug);

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/skills/[skillId]/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/skills/[skillId]/page.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { ArrowLeft, Loader2 } from 'lucide-react';
+import { useSkillsStore, type SkillScope } from '@/stores/skills';
+import { useAuthStore } from '@/stores/auth';
+
+export default function SkillEditorPage() {
+  const params = useParams();
+  const router = useRouter();
+  const workspaceId = params.workspaceId as string;
+  const skillId = params.skillId as string;
+
+  const { skillsByWorkspace, fetchSkills, updateSkill } = useSkillsStore();
+  const currentUserId = useAuthStore((s) => s.user?.id);
+
+  const skill = useMemo(
+    () => (skillsByWorkspace[workspaceId] ?? []).find((s) => s.id === skillId),
+    [skillsByWorkspace, workspaceId, skillId]
+  );
+
+  const [name, setName] = useState('');
+  const [slug, setSlug] = useState('');
+  const [description, setDescription] = useState('');
+  const [prompt, setPrompt] = useState('');
+  const [scope, setScope] = useState<SkillScope>('user');
+  const [enabled, setEnabled] = useState(true);
+  const [loadedId, setLoadedId] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    if (workspaceId) void fetchSkills(workspaceId, true);
+  }, [workspaceId, fetchSkills]);
+
+  // Seed the form once per skill load.
+  useEffect(() => {
+    if (skill && loadedId !== skill.id) {
+      setName(skill.name);
+      setSlug(skill.slug);
+      setDescription(skill.description);
+      setPrompt(skill.prompt);
+      setScope(skill.scope);
+      setEnabled(skill.enabled);
+      setLoadedId(skill.id);
+    }
+  }, [skill, loadedId]);
+
+  const canModify = skill ? skill.scope !== 'user' || skill.userId === currentUserId : false;
+
+  const handleSave = async () => {
+    if (!skill) return;
+    setSaving(true);
+    setError(null);
+    setSaved(false);
+    try {
+      await updateSkill(skill.id, {
+        name: name.trim(),
+        slug: slug.trim(),
+        description: description.trim(),
+        prompt,
+        scope,
+        enabled,
+      });
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save skill');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!skill) {
+    return (
+      <div className="flex items-center gap-2 p-8 text-muted-foreground">
+        <Loader2 size={16} className="animate-spin" />
+        Loading skill...
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => router.push(`/workspace/${workspaceId}/settings/skills`)}
+            className="rounded-lg border p-2 hover:bg-muted"
+            title="Back to skills"
+          >
+            <ArrowLeft size={16} />
+          </button>
+          <div>
+            <h2 className="text-lg font-semibold">{skill.name}</h2>
+            <p className="font-mono text-sm text-workspace-accent">/{skill.slug}</p>
+          </div>
+        </div>
+        <button
+          onClick={handleSave}
+          disabled={saving || !canModify}
+          className="flex items-center gap-2 rounded-lg bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+        >
+          {saving && <Loader2 size={14} className="animate-spin" />}
+          {saved ? 'Saved' : 'Save'}
+        </button>
+      </div>
+
+      {!canModify && (
+        <p className="rounded-lg border border-border bg-muted/30 p-3 text-sm text-muted-foreground">
+          Only the creator can modify this private skill.
+        </p>
+      )}
+      {error && <p className="text-sm text-destructive">{error}</p>}
+
+      <div className="grid gap-4">
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="mb-1 block text-sm font-medium">Name</label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              disabled={!canModify}
+              className="w-full rounded-lg border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-60"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium">Slug</label>
+            <input
+              type="text"
+              value={slug}
+              onChange={(e) => setSlug(e.target.value)}
+              disabled={!canModify}
+              className="w-full rounded-lg border bg-background px-3 py-2 font-mono text-sm outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-60"
+            />
+          </div>
+        </div>
+        <div>
+          <label className="mb-1 block text-sm font-medium">Description</label>
+          <input
+            type="text"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            disabled={!canModify}
+            className="w-full rounded-lg border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-60"
+          />
+        </div>
+        <div>
+          <label className="mb-1 block text-sm font-medium">Prompt</label>
+          <textarea
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            disabled={!canModify}
+            rows={12}
+            className="w-full rounded-lg border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-60"
+          />
+        </div>
+        <div className="flex items-center gap-6">
+          <div>
+            <label className="mb-1 block text-sm font-medium">Visibility</label>
+            <select
+              value={scope}
+              onChange={(e) => setScope(e.target.value as SkillScope)}
+              disabled={!canModify}
+              className="rounded-lg border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-60"
+            >
+              <option value="user">Private (only me)</option>
+              <option value="workspace">Workspace</option>
+              <option value="organization">Organization</option>
+            </select>
+          </div>
+          <label className="flex items-center gap-2 pt-5 text-sm">
+            <input
+              type="checkbox"
+              checked={enabled}
+              onChange={(e) => setEnabled(e.target.checked)}
+              disabled={!canModify}
+            />
+            Enabled
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/skills/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/skills/page.tsx
@@ -1,0 +1,315 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { Plus, Search, X, Zap } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useSkillsStore, type SkillScope } from '@/stores/skills';
+import { useAuthStore } from '@/stores/auth';
+
+const SCOPE_LABELS: Record<SkillScope, string> = {
+  user: 'Private',
+  workspace: 'Workspace',
+  organization: 'Organization',
+};
+
+export default function SkillsSettingsPage() {
+  const params = useParams();
+  const router = useRouter();
+  const workspaceId = params.workspaceId as string;
+
+  const { skillsByWorkspace, fetchSkills, createSkill, updateSkill, deleteSkill } =
+    useSkillsStore();
+  const currentUserId = useAuthStore((s) => s.user?.id);
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [newSkill, setNewSkill] = useState({
+    name: '',
+    slug: '',
+    description: '',
+    prompt: '',
+    scope: 'user' as SkillScope,
+  });
+
+  useEffect(() => {
+    if (workspaceId) void fetchSkills(workspaceId, true);
+  }, [workspaceId, fetchSkills]);
+
+  const skills = useMemo(
+    () => skillsByWorkspace[workspaceId] ?? [],
+    [skillsByWorkspace, workspaceId]
+  );
+
+  const filteredSkills = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return skills;
+    return skills.filter(
+      (s) =>
+        s.name.toLowerCase().includes(q) ||
+        s.slug.toLowerCase().includes(q) ||
+        s.description.toLowerCase().includes(q)
+    );
+  }, [skills, searchQuery]);
+
+  const handleAddSkill = async () => {
+    if (!newSkill.name.trim() || !newSkill.prompt.trim()) {
+      setFormError('Name and prompt are required');
+      return;
+    }
+    setFormError(null);
+    try {
+      await createSkill(workspaceId, {
+        name: newSkill.name.trim(),
+        slug: newSkill.slug.trim() || undefined,
+        description: newSkill.description.trim() || undefined,
+        prompt: newSkill.prompt,
+        scope: newSkill.scope,
+      });
+      setNewSkill({ name: '', slug: '', description: '', prompt: '', scope: 'user' });
+      setShowAddForm(false);
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Failed to create skill');
+    }
+  };
+
+  const handleToggleEnabled = async (id: string, enabled: boolean) => {
+    try {
+      await updateSkill(id, { enabled });
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Failed to update skill');
+    }
+  };
+
+  const handleDelete = async (id: string, slug: string) => {
+    if (!confirm(`Delete skill "/${slug}"?`)) return;
+    try {
+      await deleteSkill(id);
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Failed to delete skill');
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="flex items-center gap-2">
+            <h2 className="text-lg font-semibold">Skills</h2>
+            <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-medium">
+              {filteredSkills.length}
+            </span>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Reusable prompts invocable in the chat with /&lt;slug&gt; — or type /create-skill in
+            the chat to let the agent draft one
+          </p>
+        </div>
+        <button
+          onClick={() => setShowAddForm(true)}
+          className="flex items-center gap-2 rounded-lg bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          <Plus size={16} />
+          Add Skill
+        </button>
+      </div>
+
+      {/* Add Form */}
+      {showAddForm && (
+        <div className="rounded-lg border bg-muted/30 p-4">
+          <h3 className="mb-4 font-medium">Add New Skill</h3>
+          <div className="grid gap-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="mb-1 block text-sm font-medium">Name *</label>
+                <input
+                  type="text"
+                  value={newSkill.name}
+                  onChange={(e) => setNewSkill({ ...newSkill, name: e.target.value })}
+                  placeholder="Weekly report"
+                  className="w-full rounded-lg border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-sm font-medium">Slug</label>
+                <input
+                  type="text"
+                  value={newSkill.slug}
+                  onChange={(e) => setNewSkill({ ...newSkill, slug: e.target.value })}
+                  placeholder="weekly-report (defaults from name)"
+                  className="w-full rounded-lg border bg-background px-3 py-2 font-mono text-sm outline-none focus:ring-2 focus:ring-primary/30"
+                />
+              </div>
+            </div>
+            <div>
+              <label className="mb-1 block text-sm font-medium">Description</label>
+              <input
+                type="text"
+                value={newSkill.description}
+                onChange={(e) => setNewSkill({ ...newSkill, description: e.target.value })}
+                placeholder="One sentence describing what this skill does"
+                className="w-full rounded-lg border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-sm font-medium">Prompt *</label>
+              <textarea
+                value={newSkill.prompt}
+                onChange={(e) => setNewSkill({ ...newSkill, prompt: e.target.value })}
+                placeholder="The reusable prompt the agent will apply when this skill is invoked"
+                rows={5}
+                className="w-full rounded-lg border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-sm font-medium">Visibility</label>
+              <select
+                value={newSkill.scope}
+                onChange={(e) => setNewSkill({ ...newSkill, scope: e.target.value as SkillScope })}
+                className="rounded-lg border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+              >
+                <option value="user">Private (only me)</option>
+                <option value="workspace">Workspace</option>
+                <option value="organization">Organization</option>
+              </select>
+            </div>
+            {formError && <p className="text-sm text-destructive">{formError}</p>}
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => {
+                  setShowAddForm(false);
+                  setFormError(null);
+                }}
+                className="rounded-lg border px-3 py-2 text-sm hover:bg-muted"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleAddSkill}
+                className="rounded-lg bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+              >
+                Add Skill
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Search */}
+      {skills.length > 0 && (
+        <div className="relative">
+          <Search
+            size={16}
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+          />
+          <input
+            type="text"
+            placeholder="Search skills..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="w-full rounded-lg border bg-background py-2 pl-10 pr-10 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+          />
+          {searchQuery && (
+            <button
+              onClick={() => setSearchQuery('')}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            >
+              <X size={16} />
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Table */}
+      <div className="overflow-hidden rounded-lg border">
+        <table className="w-full">
+          <thead>
+            <tr className="border-b bg-muted/50 text-left text-sm">
+              <th className="p-3 font-medium">Skill</th>
+              <th className="p-3 font-medium">Command</th>
+              <th className="p-3 font-medium">Visibility</th>
+              <th className="p-3 font-medium">Last used</th>
+              <th className="w-24 p-3 font-medium">Enabled</th>
+              <th className="w-24 p-3 font-medium">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filteredSkills.length === 0 ? (
+              <tr>
+                <td colSpan={6} className="p-8 text-center text-muted-foreground">
+                  {searchQuery
+                    ? `No skills match "${searchQuery}"`
+                    : 'No skills yet. Type /create-skill in the chat or add one here.'}
+                </td>
+              </tr>
+            ) : (
+              filteredSkills.map((skill) => {
+                const canModify = skill.scope !== 'user' || skill.userId === currentUserId;
+                return (
+                  <tr
+                    key={skill.id}
+                    onClick={() =>
+                      router.push(`/workspace/${workspaceId}/settings/skills/${skill.id}`)
+                    }
+                    className="cursor-pointer border-b transition-colors hover:bg-muted/30"
+                  >
+                    <td className="p-3">
+                      <div className="flex items-center gap-3">
+                        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-muted">
+                          <Zap size={16} className="text-muted-foreground" />
+                        </div>
+                        <div className="min-w-0">
+                          <p className="font-medium">{skill.name}</p>
+                          {skill.description && (
+                            <p className="truncate text-xs text-muted-foreground">
+                              {skill.description}
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                    </td>
+                    <td className="p-3 font-mono text-sm text-workspace-accent">/{skill.slug}</td>
+                    <td className="p-3 text-sm">{SCOPE_LABELS[skill.scope]}</td>
+                    <td className="p-3 text-sm text-muted-foreground">
+                      {skill.lastUsedAt ? new Date(skill.lastUsedAt).toLocaleDateString() : '—'}
+                    </td>
+                    <td className="p-3" onClick={(e) => e.stopPropagation()}>
+                      <button
+                        onClick={() => handleToggleEnabled(skill.id, !skill.enabled)}
+                        disabled={!canModify}
+                        className={cn(
+                          'relative h-5 w-9 rounded-full transition-colors disabled:opacity-50',
+                          skill.enabled ? 'bg-primary' : 'bg-muted-foreground/30'
+                        )}
+                        title={skill.enabled ? 'Disable' : 'Enable'}
+                      >
+                        <span
+                          className={cn(
+                            'absolute top-0.5 h-4 w-4 rounded-full bg-white transition-all',
+                            skill.enabled ? 'left-[18px]' : 'left-0.5'
+                          )}
+                        />
+                      </button>
+                    </td>
+                    <td className="p-3" onClick={(e) => e.stopPropagation()}>
+                      {canModify && (
+                        <button
+                          onClick={() => handleDelete(skill.id, skill.slug)}
+                          className="rounded-md px-2 py-1 text-xs text-destructive hover:bg-destructive/10"
+                        >
+                          Delete
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
@@ -78,26 +78,6 @@ function formatSkillListing(skills: Skill[]): string {
   ].join('\n');
 }
 
-function buildCreateSkillInstruction(description: string): string {
-  const goal =
-    description || 'Not provided — infer the most useful skill from this conversation so far.';
-  return [
-    'You are helping the user create a reusable "skill": a saved prompt they can re-run in this chat with a /slash command.',
-    '',
-    `The user's description of the skill: ${goal}`,
-    '',
-    'Design the best possible skill. Reply with:',
-    '1. One short paragraph explaining what the skill does and when to use it.',
-    '2. A fenced code block with language `skill` containing ONLY a valid JSON object with exactly these fields:',
-    '   - "name": short human-readable name',
-    '   - "slug": short kebab-case command (lowercase letters, digits, hyphens)',
-    '   - "description": one sentence describing the skill',
-    '   - "prompt": the full reusable prompt — self-contained, with a clear task, constraints, and expected output format',
-    '',
-    'The user will review the draft and save it with one click.',
-  ].join('\n');
-}
-
 /** Card rendered for ```skill fenced blocks in assistant messages: shows the
  *  agent's skill draft with a scope picker and a one-click save. */
 function SkillDraftCard({ raw }: { raw: string }) {
@@ -1637,13 +1617,12 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
     }
 
     // ---- Slash commands: /skills, /create-skill <desc>, /<skill_slug> [args] ----
-    // The chat shows the compact "/command" the user typed; when a skill matches,
-    // the expanded prompt is what gets sent to the model.
-    let modelMessageOverride: string | null = null;
+    // The compact "/command" the user typed is what gets displayed, persisted, and
+    // sent to the model as-is — the agent already knows how to handle it from the
+    // skills catalog the backend injects into the system prompt on every turn.
     const slashMatch = sourceText.trim().match(SLASH_COMMAND_RE);
     if (slashMatch) {
       const command = slashMatch[1].toLowerCase();
-      const args = (slashMatch[2] || '').trim();
       const skillsStore = useSkillsStore.getState();
       const workspaceIdNow = useWorkspaceStore.getState().currentWorkspaceId;
 
@@ -1666,14 +1645,9 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
         finishLocalCommand();
         return;
       }
-      if (command === 'create-skill') {
-        modelMessageOverride = buildCreateSkillInstruction(args);
-      } else {
+      if (command !== 'create-skill') {
         const skill = skillsStore.getSkillBySlug(workspaceIdNow, command);
         if (skill) {
-          modelMessageOverride = args
-            ? `${skill.prompt}\n\n---\n\nAdditional input from the user:\n${args}`
-            : skill.prompt;
           void skillsStore.markSkillUsed(skill.id);
         } else {
           addMessage(conversationId, { role: 'user', content: sourceText.trim() });
@@ -1685,6 +1659,8 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
           return;
         }
       }
+      // command === 'create-skill', or a matched skill slug: fall through to the
+      // normal send flow below, unmodified.
     }
 
     const currentImages = [...attachedImages]; // Copy before clearing
@@ -1755,15 +1731,6 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
         images: m.images || null,
         agent: m.agent || null,  // Include agent ID for multi-agent conversations
       }));
-
-      // Skill invocations: the stored/displayed message is the compact
-      // "/command", but the model receives the expanded skill prompt.
-      if (modelMessageOverride && fullHistory.length > 0) {
-        fullHistory[fullHistory.length - 1] = {
-          ...fullHistory[fullHistory.length - 1],
-          content: modelMessageOverride,
-        };
-      }
 
       // Use streaming for Ollama, Cloudflare and ABI, regular for others
       // Default to streaming if no provider (Ollama fallback)
@@ -2012,7 +1979,7 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
           body: JSON.stringify({
             conversation_id: conversationId,
             workspace_id: workspaceId,
-            message: modelMessageOverride ?? userMessage,
+            message: userMessage,
             images: currentImages.length > 0 ? currentImages : null,
             messages: fullHistory,
             agent: effectiveAgent,
@@ -2222,7 +2189,7 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
           body: JSON.stringify({
             conversation_id: conversationId,
             workspace_id: workspaceId,
-            message: modelMessageOverride ?? userMessage,
+            message: userMessage,
             images: currentImages.length > 0 ? currentImages : null,
             messages: fullHistory,
             agent: effectiveAgent,

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
@@ -11,6 +11,7 @@ import { cn } from '@/lib/utils';
 import { useWorkspaceStore, type AgentType, type Message, type MessageFeedback, type MessageFeedbackDetails, type SidebarSection, type ToolCall } from '@/stores/workspace';
 import { useIntegrationsStore } from '@/stores/integrations';
 import { useAgentsStore } from '@/stores/agents';
+import { useSkillsStore, type Skill, type SkillScope } from '@/stores/skills';
 import { useSecretsStore } from '@/stores/secrets';
 import { useAuthStore, authFetch } from '@/stores/auth';
 import { useWebSocket } from '@/contexts/websocket-context';
@@ -38,6 +39,183 @@ const ATTACHMENT_ACCEPT = 'image/jpeg,image/png,image/gif,image/webp,.pdf,.docx,
 
 // Match http(s) URLs for linkification and preview
 const URL_REGEX = /https?:\/\/[^\s<>\]\)]+?(?=[\s<>\]\)]|$)/g;
+
+// ---------- Skills slash commands ----------
+
+// "/command optional args" at the start of a message
+const SLASH_COMMAND_RE = /^\/([a-zA-Z0-9][a-zA-Z0-9_-]*)\s*([\s\S]*)$/;
+
+const BUILTIN_SLASH_COMMANDS = [
+  {
+    slug: 'skills',
+    name: 'List skills',
+    description: 'Show all skills available in this workspace',
+  },
+  {
+    slug: 'create-skill',
+    name: 'Create a skill',
+    description: 'Ask the agent to draft a reusable skill prompt',
+  },
+];
+
+function formatSkillListing(skills: Skill[]): string {
+  const enabled = skills.filter((s) => s.enabled);
+  if (enabled.length === 0) {
+    return 'No skills yet. Type `/create-skill <what the skill should do>` and I will draft one for you.';
+  }
+  const lines = [...enabled]
+    .sort((a, b) => a.slug.localeCompare(b.slug))
+    .map(
+      (s) =>
+        `- \`/${s.slug}\` — **${s.name}**${s.description ? `: ${s.description}` : ''} _(${s.scope})_`
+    );
+  return [
+    `**Available skills (${enabled.length})**`,
+    '',
+    ...lines,
+    '',
+    'Run one with `/<slug> [extra instructions]`, or `/create-skill <description>` to create a new one.',
+  ].join('\n');
+}
+
+function buildCreateSkillInstruction(description: string): string {
+  const goal =
+    description || 'Not provided — infer the most useful skill from this conversation so far.';
+  return [
+    'You are helping the user create a reusable "skill": a saved prompt they can re-run in this chat with a /slash command.',
+    '',
+    `The user's description of the skill: ${goal}`,
+    '',
+    'Design the best possible skill. Reply with:',
+    '1. One short paragraph explaining what the skill does and when to use it.',
+    '2. A fenced code block with language `skill` containing ONLY a valid JSON object with exactly these fields:',
+    '   - "name": short human-readable name',
+    '   - "slug": short kebab-case command (lowercase letters, digits, hyphens)',
+    '   - "description": one sentence describing the skill',
+    '   - "prompt": the full reusable prompt — self-contained, with a clear task, constraints, and expected output format',
+    '',
+    'The user will review the draft and save it with one click.',
+  ].join('\n');
+}
+
+/** Card rendered for ```skill fenced blocks in assistant messages: shows the
+ *  agent's skill draft with a scope picker and a one-click save. */
+function SkillDraftCard({ raw }: { raw: string }) {
+  const currentWorkspaceId = useWorkspaceStore((s) => s.currentWorkspaceId);
+  const createSkill = useSkillsStore((s) => s.createSkill);
+  const [saveState, setSaveState] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [scope, setScope] = useState<SkillScope>('user');
+  const [showPrompt, setShowPrompt] = useState(false);
+
+  const draft = useMemo(() => {
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed.name === 'string' && typeof parsed.prompt === 'string') {
+        return {
+          name: parsed.name as string,
+          slug: typeof parsed.slug === 'string' ? (parsed.slug as string) : undefined,
+          description:
+            typeof parsed.description === 'string' ? (parsed.description as string) : undefined,
+          prompt: parsed.prompt as string,
+        };
+      }
+    } catch {
+      // Partial JSON while the message is still streaming
+    }
+    return null;
+  }, [raw]);
+
+  const handleSave = async () => {
+    if (!currentWorkspaceId || !draft) return;
+    setSaveState('saving');
+    setSaveError(null);
+    try {
+      await createSkill(currentWorkspaceId, {
+        name: draft.name,
+        slug: draft.slug,
+        description: draft.description,
+        prompt: draft.prompt,
+        scope,
+      });
+      setSaveState('saved');
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Failed to save skill');
+      setSaveState('error');
+    }
+  };
+
+  if (!draft) {
+    return (
+      <div className="my-3 flex items-center gap-2 rounded-lg border border-border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+        <Loader2 size={12} className="animate-spin" />
+        Drafting skill…
+      </div>
+    );
+  }
+
+  return (
+    <div className="my-3 rounded-lg border border-border bg-muted/30 p-3">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-foreground">{draft.name}</p>
+          {draft.slug && (
+            <p className="font-mono text-xs text-workspace-accent">/{draft.slug}</p>
+          )}
+          {draft.description && (
+            <p className="mt-1 text-xs text-muted-foreground">{draft.description}</p>
+          )}
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => setShowPrompt(!showPrompt)}
+        className="mt-2 text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+      >
+        {showPrompt ? 'Hide prompt' : 'Show prompt'}
+      </button>
+      {showPrompt && (
+        <pre className="mt-2 max-h-48 overflow-y-auto whitespace-pre-wrap rounded-md border border-border bg-background p-2 text-xs text-muted-foreground">
+          {draft.prompt}
+        </pre>
+      )}
+
+      <div className="mt-3 flex items-center gap-2">
+        <select
+          value={scope}
+          onChange={(e) => setScope(e.target.value as SkillScope)}
+          disabled={saveState === 'saved' || saveState === 'saving'}
+          className="rounded-md border border-border bg-background px-2 py-1 text-xs"
+        >
+          <option value="user">Private (only me)</option>
+          <option value="workspace">Workspace</option>
+          <option value="organization">Organization</option>
+        </select>
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={saveState === 'saved' || saveState === 'saving'}
+          className={cn(
+            'flex items-center gap-1.5 rounded-md px-3 py-1 text-xs font-medium transition-colors',
+            saveState === 'saved'
+              ? 'bg-workspace-accent/15 text-workspace-accent'
+              : 'bg-workspace-accent text-white hover:opacity-90'
+          )}
+        >
+          {saveState === 'saving' && <Loader2 size={12} className="animate-spin" />}
+          {saveState === 'saved' && <Check size={12} />}
+          {saveState === 'saved'
+            ? `Saved — use /${draft.slug ?? ''}`
+            : saveState === 'saving'
+              ? 'Saving…'
+              : 'Save skill'}
+        </button>
+      </div>
+      {saveError && <p className="mt-2 text-xs text-destructive">{saveError}</p>}
+    </div>
+  );
+}
 
 /** Split text into segments; URLs become anchor elements so they get href styling and preview */
 function linkifyText(text: string, isUser: boolean): React.ReactNode {
@@ -651,6 +829,59 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
     if (!mounted) return;
     focusChatInput();
   }, [activeConversationId, mounted, focusChatInput]);
+
+  // Consume one-shot composer seeds (e.g. "/skill-slug " from the sidebar).
+  const pendingComposerText = useWorkspaceStore((s) => s.pendingComposerText);
+  useEffect(() => {
+    if (!mounted || !pendingComposerText) return;
+    setInput(pendingComposerText);
+    useWorkspaceStore.getState().setPendingComposerText(null);
+    focusChatInput();
+  }, [pendingComposerText, mounted, focusChatInput]);
+
+  // ---------- Slash-command autocomplete ----------
+  const [slashIndex, setSlashIndex] = useState(0);
+  const [slashDismissed, setSlashDismissed] = useState(false);
+  const workspaceSkills = useSkillsStore((s) =>
+    currentWorkspaceId ? (s.skillsByWorkspace[currentWorkspaceId] ?? null) : null
+  );
+
+  // Active while the input is only "/partial-command" (no space typed yet).
+  const slashQuery = useMemo(() => {
+    const m = input.match(/^\/([a-zA-Z0-9_-]*)$/);
+    return m ? m[1].toLowerCase() : null;
+  }, [input]);
+
+  const slashOptions = useMemo(() => {
+    if (slashQuery === null) return [];
+    const skills = workspaceSkills ?? [];
+    const skillOptions = skills
+      .filter((s) => s.enabled && s.slug.toLowerCase().includes(slashQuery))
+      .sort((a, b) => {
+        const ta = a.lastUsedAt ? new Date(a.lastUsedAt).getTime() : 0;
+        const tb = b.lastUsedAt ? new Date(b.lastUsedAt).getTime() : 0;
+        if (ta !== tb) return tb - ta;
+        return a.slug.localeCompare(b.slug);
+      })
+      .map((s) => ({ slug: s.slug, name: s.name, description: s.description }));
+    const builtinOptions = BUILTIN_SLASH_COMMANDS.filter((c) => c.slug.includes(slashQuery));
+    return [...skillOptions, ...builtinOptions].slice(0, 8);
+  }, [slashQuery, workspaceSkills]);
+
+  useEffect(() => {
+    setSlashIndex(0);
+    setSlashDismissed(false);
+  }, [slashQuery]);
+
+  const showSlashMenu = slashOptions.length > 0 && !slashDismissed;
+
+  const applySlashOption = useCallback(
+    (slug: string) => {
+      setInput(`/${slug} `);
+      focusChatInput();
+    },
+    [focusChatInput]
+  );
 
   // Listen for new messages from WebSocket
   useEffect(() => {
@@ -1405,6 +1636,57 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
       useWorkspaceStore.getState().setConversationAgent(conversationId, effectiveAgent);
     }
 
+    // ---- Slash commands: /skills, /create-skill <desc>, /<skill_slug> [args] ----
+    // The chat shows the compact "/command" the user typed; when a skill matches,
+    // the expanded prompt is what gets sent to the model.
+    let modelMessageOverride: string | null = null;
+    const slashMatch = sourceText.trim().match(SLASH_COMMAND_RE);
+    if (slashMatch) {
+      const command = slashMatch[1].toLowerCase();
+      const args = (slashMatch[2] || '').trim();
+      const skillsStore = useSkillsStore.getState();
+      const workspaceIdNow = useWorkspaceStore.getState().currentWorkspaceId;
+
+      const finishLocalCommand = () => {
+        if (messageOverride === undefined) {
+          handleInputChange('');
+        } else {
+          setInput('');
+        }
+        isSubmittingRef.current = false;
+      };
+
+      if (command === 'skills') {
+        addMessage(conversationId, { role: 'user', content: sourceText.trim() });
+        addMessage(conversationId, {
+          role: 'assistant',
+          agent: effectiveAgent,
+          content: formatSkillListing(skillsStore.getWorkspaceSkills(workspaceIdNow)),
+        });
+        finishLocalCommand();
+        return;
+      }
+      if (command === 'create-skill') {
+        modelMessageOverride = buildCreateSkillInstruction(args);
+      } else {
+        const skill = skillsStore.getSkillBySlug(workspaceIdNow, command);
+        if (skill) {
+          modelMessageOverride = args
+            ? `${skill.prompt}\n\n---\n\nAdditional input from the user:\n${args}`
+            : skill.prompt;
+          void skillsStore.markSkillUsed(skill.id);
+        } else {
+          addMessage(conversationId, { role: 'user', content: sourceText.trim() });
+          addMessage(conversationId, {
+            role: 'system',
+            content: `Unknown command \`/${command}\`. Type \`/skills\` to see available skills or \`/create-skill <description>\` to create one.`,
+          });
+          finishLocalCommand();
+          return;
+        }
+      }
+    }
+
     const currentImages = [...attachedImages]; // Copy before clearing
     const currentFileAttachments = [...pendingFileAttachments]; // Copy before clearing
 
@@ -1473,6 +1755,15 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
         images: m.images || null,
         agent: m.agent || null,  // Include agent ID for multi-agent conversations
       }));
+
+      // Skill invocations: the stored/displayed message is the compact
+      // "/command", but the model receives the expanded skill prompt.
+      if (modelMessageOverride && fullHistory.length > 0) {
+        fullHistory[fullHistory.length - 1] = {
+          ...fullHistory[fullHistory.length - 1],
+          content: modelMessageOverride,
+        };
+      }
 
       // Use streaming for Ollama, Cloudflare and ABI, regular for others
       // Default to streaming if no provider (Ollama fallback)
@@ -1721,7 +2012,7 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
           body: JSON.stringify({
             conversation_id: conversationId,
             workspace_id: workspaceId,
-            message: userMessage,
+            message: modelMessageOverride ?? userMessage,
             images: currentImages.length > 0 ? currentImages : null,
             messages: fullHistory,
             agent: effectiveAgent,
@@ -1931,7 +2222,7 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
           body: JSON.stringify({
             conversation_id: conversationId,
             workspace_id: workspaceId,
-            message: userMessage,
+            message: modelMessageOverride ?? userMessage,
             images: currentImages.length > 0 ? currentImages : null,
             messages: fullHistory,
             agent: effectiveAgent,
@@ -2361,12 +2652,73 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
               />
               
               {/* Row 1: Textarea */}
-              <div className="px-4 pt-3 pb-1">
+              <div className="relative px-4 pt-3 pb-1">
+                {/* Slash-command autocomplete */}
+                {showSlashMenu && (
+                  <div className="absolute bottom-full left-2 right-2 z-50 mb-2 max-h-64 overflow-y-auto rounded-xl border border-border bg-popover p-1 shadow-lg">
+                    {slashOptions.map((option, index) => (
+                      <button
+                        key={option.slug}
+                        type="button"
+                        onMouseDown={(e) => {
+                          e.preventDefault();
+                          applySlashOption(option.slug);
+                        }}
+                        onMouseEnter={() => setSlashIndex(index)}
+                        className={cn(
+                          'flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left transition-colors',
+                          index === slashIndex ? 'bg-workspace-accent-10' : ''
+                        )}
+                      >
+                        <span className="pt-0.5 font-mono text-xs text-workspace-accent">
+                          /{option.slug}
+                        </span>
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate text-xs font-medium text-foreground">
+                            {option.name}
+                          </span>
+                          {option.description && (
+                            <span className="block truncate text-[11px] text-muted-foreground">
+                              {option.description}
+                            </span>
+                          )}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                )}
                 <textarea
                   ref={textareaRef}
                   value={input}
                   onChange={(e) => handleInputChange(e.target.value)}
                   onKeyDown={(e) => {
+                    if (showSlashMenu) {
+                      if (e.key === 'ArrowDown') {
+                        e.preventDefault();
+                        setSlashIndex((i) => (i + 1) % slashOptions.length);
+                        return;
+                      }
+                      if (e.key === 'ArrowUp') {
+                        e.preventDefault();
+                        setSlashIndex((i) => (i - 1 + slashOptions.length) % slashOptions.length);
+                        return;
+                      }
+                      if (e.key === 'Tab' || e.key === 'Enter') {
+                        const selected = slashOptions[slashIndex] ?? slashOptions[0];
+                        // Enter on a fully-typed command submits it; otherwise
+                        // Enter/Tab completes the highlighted option.
+                        if (!(e.key === 'Enter' && selected.slug === slashQuery)) {
+                          e.preventDefault();
+                          applySlashOption(selected.slug);
+                          return;
+                        }
+                      }
+                      if (e.key === 'Escape') {
+                        e.preventDefault();
+                        setSlashDismissed(true);
+                        return;
+                      }
+                    }
                     if (e.key === 'Enter' && !e.shiftKey) {
                       e.preventDefault();
                       handleSubmit(e);
@@ -3337,6 +3689,11 @@ const MessageBubble = React.memo(function MessageBubble({
                 .join('')
               : '';
         const copyKey = `${language || 'plain'}:${codeContent}`;
+
+        // ```skill blocks are agent-drafted skills — render the save card.
+        if (language === 'skill') {
+          return <SkillDraftCard raw={codeContent} />;
+        }
 
         return (
           <div className="my-5">

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/settings-nav.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/settings-nav.tsx
@@ -8,6 +8,7 @@ import {
   Server,
   Shield,
   Users,
+  Zap,
   type LucideIcon,
 } from 'lucide-react';
 
@@ -47,6 +48,7 @@ export const SETTINGS_GROUPS: SettingsNavGroup[] = [
     label: 'Components',
     items: [
       { href: '/settings/agents', label: 'Agents', icon: Bot },
+      { href: '/settings/skills', label: 'Skills', icon: Zap },
       { href: '/settings/apps', label: 'Apps', icon: AppWindow },
       { href: '/settings/models', label: 'Models', icon: Cpu },
       { href: '/settings/drives', label: 'Drives', icon: HardDrive },

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/chat-section.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/chat-section.tsx
@@ -2,11 +2,13 @@
 
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import Link from 'next/link';
-import { MessageSquare, ChevronRight, Plus, Pin, Folder, MoreVertical, Archive, Edit2, Trash2, Star } from 'lucide-react';
+import { MessageSquare, ChevronRight, Plus, Pin, Folder, MoreVertical, Archive, Edit2, Trash2, Star, Zap } from 'lucide-react';
 import { useRouter, usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
 import { useWorkspaceStore } from '@/stores/workspace';
 import { useAgentsStore } from '@/stores/agents';
+import { useSkillsStore } from '@/stores/skills';
+import { useAuthStore } from '@/stores/auth';
 import { CollapsibleSection } from './collapsible-section';
 import { getWorkspacePath } from './utils';
 import { AgentAvatar } from '@/components/chat/agent-selector';
@@ -228,6 +230,8 @@ export function ChatSection({ collapsed, detailOnly }: { collapsed: boolean; det
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [showAllAgents, setShowAllAgents] = useState(false);
   const [agentMenuId, setAgentMenuId] = useState<string | null>(null);
+  const [showAllSkills, setShowAllSkills] = useState(false);
+  const [skillMenuId, setSkillMenuId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState('');
 
   const {
@@ -249,6 +253,10 @@ export function ChatSection({ collapsed, detailOnly }: { collapsed: boolean; det
   const { agents, setDefaultAgent } = useAgentsStore();
   // "agents" feature flag gates agent administration (edit, settings access).
   const canManageAgents = useFeature('agents');
+  const canUseSkills = useFeature('skills');
+  const { skillsByWorkspace, deleteSkill } = useSkillsStore();
+  const currentUserId = useAuthStore((s) => s.user?.id);
+  const setPendingComposerText = useWorkspaceStore((s) => s.setPendingComposerText);
   const safeAgents = useMemo(() => (Array.isArray(agents) ? agents : []), [agents]);
 
   // Derive from the reactive conversations state — calling the store's
@@ -300,6 +308,34 @@ export function ChatSection({ collapsed, detailOnly }: { collapsed: boolean; det
   const AGENTS_PREVIEW_COUNT = 5;
   const visibleAgents = showAllAgents ? sortedAgents : sortedAgents.slice(0, AGENTS_PREVIEW_COUNT);
   const hiddenAgentCount = sortedAgents.length - AGENTS_PREVIEW_COUNT;
+
+  // Latest-used skills first (never-used last, by recency of update).
+  const sortedSkills = useMemo(() => {
+    const workspaceSkills = currentWorkspaceId
+      ? (skillsByWorkspace[currentWorkspaceId] ?? [])
+      : [];
+    return workspaceSkills
+      .filter((s) => s.enabled)
+      .sort((a, b) => {
+        const ta = a.lastUsedAt ? new Date(a.lastUsedAt).getTime() : 0;
+        const tb = b.lastUsedAt ? new Date(b.lastUsedAt).getTime() : 0;
+        if (ta !== tb) return tb - ta;
+        return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+      });
+  }, [skillsByWorkspace, currentWorkspaceId]);
+
+  const SKILLS_PREVIEW_COUNT = 3;
+  const visibleSkills = showAllSkills ? sortedSkills : sortedSkills.slice(0, SKILLS_PREVIEW_COUNT);
+  const hiddenSkillCount = sortedSkills.length - SKILLS_PREVIEW_COUNT;
+
+  // Clicking a skill seeds the composer with "/slug " on the chat route.
+  const handleUseSkill = useCallback(
+    (slug: string) => {
+      setPendingComposerText(`/${slug} `);
+      router.push(getWorkspacePath(currentWorkspaceId, '/chat'));
+    },
+    [setPendingComposerText, router, currentWorkspaceId]
+  );
 
   const pinnedConvs = useMemo(() => conversations.filter((c) => c.pinned), [conversations]);
   const recentConvs = useMemo(() => conversations.filter((c) => !c.pinned && !c.projectId), [conversations]);
@@ -482,6 +518,99 @@ export function ChatSection({ collapsed, detailOnly }: { collapsed: boolean; det
           </button>
         )}
       </div>
+
+      {/* Skills */}
+      {canUseSkills && (
+        <div className="space-y-0.5">
+          <Link
+            href={getWorkspacePath(currentWorkspaceId, '/settings/skills')}
+            className="block px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground hover:text-foreground"
+          >
+            Skills
+          </Link>
+          {sortedSkills.length === 0 && (
+            <p className="px-2 py-1 text-xs text-muted-foreground">
+              Type /create-skill in the chat to add one
+            </p>
+          )}
+          {visibleSkills.map((skill) => (
+            <div key={skill.id} className="relative">
+              <button
+                onClick={() => handleUseSkill(skill.slug)}
+                title={skill.description || skill.name}
+                className={cn(
+                  'group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors',
+                  'hover:bg-workspace-accent-10'
+                )}
+              >
+                <Zap size={12} className="flex-shrink-0 text-muted-foreground" />
+                <span className="flex-1 truncate">
+                  {skill.name}
+                  <span className="ml-1 text-muted-foreground">/{skill.slug}</span>
+                </span>
+                <div
+                  className="flex-shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-muted group-hover:opacity-100 cursor-pointer"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setSkillMenuId(skillMenuId === skill.id ? null : skill.id);
+                  }}
+                >
+                  <MoreVertical size={12} />
+                </div>
+              </button>
+
+              {skillMenuId === skill.id && (
+                <>
+                  <div className="fixed inset-0 z-40" onClick={() => setSkillMenuId(null)} />
+                  <div className="absolute right-0 top-full z-50 mt-1 w-40 rounded-md border border-border bg-popover p-1 shadow-lg">
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setSkillMenuId(null);
+                        router.push(getWorkspacePath(currentWorkspaceId, `/settings/skills/${skill.id}`));
+                      }}
+                      className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs hover:bg-accent"
+                    >
+                      <Edit2 size={12} />
+                      Edit skill
+                    </button>
+                    {(skill.scope !== 'user' || skill.userId === currentUserId) && (
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setSkillMenuId(null);
+                          if (confirm(`Delete skill "/${skill.slug}"?`)) {
+                            void deleteSkill(skill.id).catch((err) =>
+                              alert(err instanceof Error ? err.message : 'Failed to delete skill')
+                            );
+                          }
+                        }}
+                        className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs text-destructive hover:bg-destructive/10"
+                      >
+                        <Trash2 size={12} />
+                        Delete
+                      </button>
+                    )}
+                  </div>
+                </>
+              )}
+            </div>
+          ))}
+          {hiddenSkillCount > 0 && (
+            <button
+              type="button"
+              onClick={() => setShowAllSkills(!showAllSkills)}
+              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:text-foreground"
+            >
+              <ChevronRight
+                size={12}
+                className={cn('flex-shrink-0 transition-transform', showAllSkills && 'rotate-90')}
+              />
+              <span>{showAllSkills ? 'Show less' : `Show ${hiddenSkillCount} more`}</span>
+            </button>
+          )}
+        </div>
+      )}
 
       {/* Pinned */}
       {pinnedConvs.length > 0 && (

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/workspace-layout.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/workspace-layout.tsx
@@ -122,7 +122,7 @@ export function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentWorkspaceId]);
 
-  // Fetch agents when workspace loads
+  // Fetch agents and skills when workspace loads
   useEffect(() => {
     const loadAgents = async () => {
       if (currentWorkspaceId) {
@@ -130,7 +130,14 @@ export function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
         await useAgentsStore.getState().fetchAgents(currentWorkspaceId);
       }
     };
+    const loadSkills = async () => {
+      if (currentWorkspaceId) {
+        const { useSkillsStore } = await import('@/stores/skills');
+        await useSkillsStore.getState().fetchSkills(currentWorkspaceId);
+      }
+    };
     loadAgents();
+    loadSkills();
   }, [currentWorkspaceId]);
 
   // Keyboard shortcut: Cmd+K to toggle AI pane

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/feature-access.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/feature-access.ts
@@ -2,6 +2,7 @@ export type FeatureKey =
   | 'chat'
   | 'files'
   | 'agents'
+  | 'skills'
   | 'apps'
   | 'marketplace'
   | 'search'
@@ -18,6 +19,7 @@ export const FEATURE_KEYS: FeatureKey[] = [
   'chat',
   'files',
   'agents',
+  'skills',
   'apps',
   'marketplace',
   'search',
@@ -37,14 +39,15 @@ const OPT_IN_FEATURES: FeatureKey[] = ['code'];
 const DEFAULT_ROLE_BASELINE: Record<string, FeatureKey[]> = {
   owner: FEATURE_KEYS.filter((f) => !OPT_IN_FEATURES.includes(f)),
   admin: FEATURE_KEYS.filter((f) => !OPT_IN_FEATURES.includes(f)),
-  member: ['chat', 'files'],
-  viewer: ['chat', 'files'],
+  member: ['chat', 'files', 'skills'],
+  viewer: ['chat', 'files', 'skills'],
 };
 
 const FEATURE_FALLBACK_ROUTE: Record<FeatureKey, string> = {
   chat: '/chat',
   files: '/files',
   agents: '/lab',
+  skills: '/chat',
   apps: '/apps',
   marketplace: '/marketplace',
   search: '/search',
@@ -123,6 +126,9 @@ export function getFeatureForWorkspacePath(pathname: string): FeatureKey | null 
     (firstSegment === 'settings' && parts[workspaceIndex + 3] === 'agents')
   ) {
     return 'agents';
+  }
+  if (firstSegment === 'settings' && parts[workspaceIndex + 3] === 'skills') {
+    return 'skills';
   }
   if (firstSegment === 'settings') {
     return 'settings.workspace';

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/auth.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/auth.ts
@@ -208,6 +208,7 @@ export const useAuthStore = create<AuthState>()(
           'nexus-workspace-storage',
           'nexus-integrations',
           'nexus-agents',
+          'nexus-skills',
           'nexus-search',
           'nexus-ontology',
           'nexus-knowledge-graph',

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/skills.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/skills.ts
@@ -1,0 +1,226 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type SkillScope = 'user' | 'workspace' | 'organization';
+
+export interface Skill {
+  id: string;
+  workspaceId: string; // Workspace the skill was created in
+  organizationId: string | null;
+  userId: string; // Creator
+  name: string;
+  slug: string; // Chat command: /<slug>
+  description: string;
+  prompt: string;
+  scope: SkillScope;
+  enabled: boolean;
+  lastUsedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SkillCreateInput {
+  name: string;
+  prompt: string;
+  slug?: string;
+  description?: string;
+  scope?: SkillScope;
+  enabled?: boolean;
+}
+
+export interface SkillUpdateInput {
+  name?: string;
+  slug?: string;
+  description?: string;
+  prompt?: string;
+  scope?: SkillScope;
+  enabled?: boolean;
+}
+
+interface SkillsState {
+  // Visible skills keyed by the workspace they were fetched FOR (an
+  // organization-scoped skill created elsewhere is visible here too, so the
+  // skill's own workspaceId cannot be used to reconstruct visibility).
+  skillsByWorkspace: Record<string, Skill[]>;
+  lastFetchedAt: Record<string, number>;
+  fetchSkills: (workspaceId: string, force?: boolean) => Promise<void>;
+  createSkill: (workspaceId: string, input: SkillCreateInput) => Promise<Skill>;
+  updateSkill: (id: string, updates: SkillUpdateInput) => Promise<Skill>;
+  deleteSkill: (id: string) => Promise<void>;
+  markSkillUsed: (id: string) => Promise<void>;
+  getWorkspaceSkills: (workspaceId: string | null) => Skill[];
+  getSkillBySlug: (workspaceId: string | null, slug: string) => Skill | undefined;
+}
+
+const SKILLS_CACHE_TTL_MS = 5 * 60 * 1000;
+
+const mapApiSkill = (s: any): Skill => ({
+  id: s.id,
+  workspaceId: s.workspace_id,
+  organizationId: s.organization_id ?? null,
+  userId: s.user_id,
+  name: s.name,
+  slug: s.slug,
+  description: s.description ?? '',
+  prompt: s.prompt,
+  scope: s.scope === 'workspace' || s.scope === 'organization' ? s.scope : 'user',
+  enabled: Boolean(s.enabled),
+  lastUsedAt: s.last_used_at ?? null,
+  createdAt: s.created_at,
+  updatedAt: s.updated_at,
+});
+
+const apiHelpers = async () => {
+  const { authFetch } = await import('./auth');
+  const { getApiUrl } = await import('@/lib/config');
+  return { authFetch, API_BASE: getApiUrl() };
+};
+
+const readDetail = async (response: Response, fallback: string): Promise<string> => {
+  try {
+    const body = await response.json();
+    return body?.detail || fallback;
+  } catch {
+    return fallback;
+  }
+};
+
+const mapAllWorkspaces = (
+  byWorkspace: Record<string, Skill[]>,
+  fn: (skills: Skill[]) => Skill[]
+): Record<string, Skill[]> =>
+  Object.fromEntries(Object.entries(byWorkspace).map(([ws, skills]) => [ws, fn(skills)]));
+
+export const useSkillsStore = create<SkillsState>()(
+  persist(
+    (set, get) => ({
+      skillsByWorkspace: {},
+      lastFetchedAt: {},
+
+      fetchSkills: async (workspaceId, force = false) => {
+        if (!workspaceId) return;
+        const last = get().lastFetchedAt[workspaceId] ?? 0;
+        if (!force && Date.now() - last < SKILLS_CACHE_TTL_MS) return;
+
+        try {
+          const { authFetch, API_BASE } = await apiHelpers();
+          const response = await authFetch(
+            `${API_BASE}/api/skills/?workspace_id=${encodeURIComponent(workspaceId)}`
+          );
+          if (!response.ok) {
+            console.error('Failed to fetch skills:', response.status);
+            return;
+          }
+          const data = await response.json();
+          const skills = Array.isArray(data) ? data.map(mapApiSkill) : [];
+          set((state) => ({
+            skillsByWorkspace: { ...state.skillsByWorkspace, [workspaceId]: skills },
+            lastFetchedAt: { ...state.lastFetchedAt, [workspaceId]: Date.now() },
+          }));
+        } catch (error) {
+          console.error('Failed to fetch skills:', error);
+        }
+      },
+
+      createSkill: async (workspaceId, input) => {
+        const { authFetch, API_BASE } = await apiHelpers();
+        const response = await authFetch(`${API_BASE}/api/skills/`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            workspace_id: workspaceId,
+            name: input.name,
+            slug: input.slug,
+            description: input.description,
+            prompt: input.prompt,
+            scope: input.scope ?? 'user',
+            enabled: input.enabled ?? true,
+          }),
+        });
+        if (!response.ok) {
+          throw new Error(await readDetail(response, 'Failed to create skill'));
+        }
+        const skill = mapApiSkill(await response.json());
+        set((state) => ({
+          skillsByWorkspace: {
+            ...state.skillsByWorkspace,
+            [workspaceId]: [skill, ...(state.skillsByWorkspace[workspaceId] ?? [])],
+          },
+        }));
+        return skill;
+      },
+
+      updateSkill: async (id, updates) => {
+        const { authFetch, API_BASE } = await apiHelpers();
+        const response = await authFetch(`${API_BASE}/api/skills/${id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: updates.name,
+            slug: updates.slug,
+            description: updates.description,
+            prompt: updates.prompt,
+            scope: updates.scope,
+            enabled: updates.enabled,
+          }),
+        });
+        if (!response.ok) {
+          throw new Error(await readDetail(response, 'Failed to update skill'));
+        }
+        const skill = mapApiSkill(await response.json());
+        set((state) => ({
+          skillsByWorkspace: mapAllWorkspaces(state.skillsByWorkspace, (skills) =>
+            skills.map((s) => (s.id === id ? skill : s))
+          ),
+        }));
+        return skill;
+      },
+
+      deleteSkill: async (id) => {
+        const { authFetch, API_BASE } = await apiHelpers();
+        const response = await authFetch(`${API_BASE}/api/skills/${id}`, {
+          method: 'DELETE',
+        });
+        if (!response.ok && response.status !== 404) {
+          throw new Error(await readDetail(response, 'Failed to delete skill'));
+        }
+        set((state) => ({
+          skillsByWorkspace: mapAllWorkspaces(state.skillsByWorkspace, (skills) =>
+            skills.filter((s) => s.id !== id)
+          ),
+        }));
+      },
+
+      markSkillUsed: async (id) => {
+        // Optimistic local stamp so "latest used" ordering updates instantly.
+        const now = new Date().toISOString();
+        set((state) => ({
+          skillsByWorkspace: mapAllWorkspaces(state.skillsByWorkspace, (skills) =>
+            skills.map((s) => (s.id === id ? { ...s, lastUsedAt: now } : s))
+          ),
+        }));
+        try {
+          const { authFetch, API_BASE } = await apiHelpers();
+          await authFetch(`${API_BASE}/api/skills/${id}/use`, { method: 'POST' });
+        } catch (error) {
+          console.error('Failed to mark skill used:', error);
+        }
+      },
+
+      getWorkspaceSkills: (workspaceId) =>
+        workspaceId ? (get().skillsByWorkspace[workspaceId] ?? []) : [],
+
+      getSkillBySlug: (workspaceId, slug) =>
+        get()
+          .getWorkspaceSkills(workspaceId)
+          .find((s) => s.slug === slug && s.enabled),
+    }),
+    {
+      name: 'nexus-skills',
+      partialize: (state) => ({
+        skillsByWorkspace: state.skillsByWorkspace,
+        lastFetchedAt: state.lastFetchedAt,
+      }),
+    }
+  )
+);

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
@@ -231,6 +231,10 @@ interface WorkspaceState {
   /** Drop the explicit selection without changing the agent — landing back on
    *  the chat route will then reset to the workspace default. */
   clearAgentExplicitSelection: () => void;
+  /** One-shot text to seed the chat composer with (e.g. "/skill-slug " from the
+   *  sidebar). Consumed and cleared by ChatInterface. Not persisted. */
+  pendingComposerText: string | null;
+  setPendingComposerText: (text: string | null) => void;
   paneAgent: AgentType; // AI Pane agent selection
   setPaneAgent: (agent: AgentType) => void;
   createConversation: (projectId?: string) => string;
@@ -406,6 +410,8 @@ export const useWorkspaceStore = create<WorkspaceState>()(
   setSelectedAgent: (agent, explicit = false) =>
     set({ selectedAgent: agent, agentExplicitlySelected: explicit }),
   clearAgentExplicitSelection: () => set({ agentExplicitlySelected: false }),
+  pendingComposerText: null,
+  setPendingComposerText: (text) => set({ pendingComposerText: text }),
   paneAgent: 'abi', // Default to SupervisorAgent - omniscient supervisor agent for AI Pane
   setPaneAgent: (agent) => set({ paneAgent: agent }),
 

--- a/libs/naas-abi/uv.lock
+++ b/libs/naas-abi/uv.lock
@@ -2518,7 +2518,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-marketplace"
-version = "3.22.1"
+version = "3.22.2"
 source = { editable = "../naas-abi-marketplace" }
 dependencies = [
     { name = "ijson" },
@@ -4362,8 +4362,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -3547,7 +3547,7 @@ wheels = [
 
 [[package]]
 name = "naas-abi"
-version = "2.42.3"
+version = "2.43.1"
 source = { editable = "libs/naas-abi" }
 dependencies = [
     { name = "aiosqlite" },
@@ -3655,7 +3655,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-core"
-version = "2.18.2"
+version = "2.19.0"
 source = { editable = "libs/naas-abi-core" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
This pull request resolves #nexus-skills

# Summary

This PR introduces a new "Skills" feature to the Nexus application, enabling user-created reusable prompt skills that can be invoked via slash commands in the chat interface. It includes backend API, database schema, service layer, and frontend UI components for managing and using skills.

# Key Changes

## Backend
- Added a new `skills` feature key and enabled it for member and viewer roles.
- Created a new `SkillModel` SQLAlchemy model representing skills with fields like `id`, `workspace_id`, `user_id`, `name`, `slug`, `description`, `prompt`, `scope`, `enabled`, and timestamps.
- Added a new database migration `0037_add_skills.sql` to create the `skills` table with appropriate indexes.
- Implemented a `SkillPersistencePort` interface and a Postgres adapter `SkillSecondaryAdapterPostgres` for database operations.
- Developed a `SkillService` with methods for creating, updating, deleting, listing, and marking skills as used, including permission and validation logic.
- Added FastAPI primary adapter routes for skills CRUD operations and usage marking.
- Registered the skills service and API router in the Nexus service registry and API router.

## Frontend
- Added a new Zustand store `useSkillsStore` for managing skills state, including fetching, creating, updating, deleting, and marking skills used.
- Extended the chat interface to support slash commands for skills:
  - `/skills` lists all available skills in the workspace.
  - `/create-skill <description>` prompts the agent to draft a new skill.
  - `/<skill_slug> [args]` invokes a skill with optional additional input.
- Added a skill draft card UI to display agent-drafted skill prompts with save functionality.
- Added a new Skills section in the chat sidebar showing latest-used skills with quick access and management options.
- Added a new Skills settings page and skill editor page for managing skills with forms for name, slug, description, prompt, scope, and enabled state.
- Updated workspace layout to fetch skills on workspace load.
- Added skills feature flag support in frontend feature access and auth store.
- Added UI icons and navigation links for skills in settings and sidebar.

# Permissions & Validation
- Skills have scopes: `user` (private), `workspace`, and `organization`.
- Only creators can modify or delete user-scoped skills.
- Workspace access is required to view or modify skills.
- Slugs are normalized and validated against reserved commands and duplicates.

# Testing
- Added comprehensive unit tests for the SkillService covering slug normalization, creation, update permissions, and adapter mapping.

# Migration
- Includes a SQL migration to add the `skills` table with indexes.

# Summary
This PR adds a fully integrated "Skills" feature to Nexus, enabling reusable prompt skills with chat slash command integration, management UI, and backend support.
