### PR TITLE
fix(nexus): stop stale localStorage session from swallowing magic links

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/auth/magic-link/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/auth/magic-link/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { AlertCircle, Loader2 } from 'lucide-react';
 import { useAuthStore } from '@/stores/auth';
+import { shouldSkipMagicLinkConfirmation } from '@/lib/auth-session';
 
 function MagicLinkPageContent() {
   const router = useRouter();
@@ -33,10 +34,10 @@ function MagicLinkPageContent() {
   };
 
   useEffect(() => {
-    if (isAuthenticated) {
+    if (shouldSkipMagicLinkConfirmation(token, isAuthenticated)) {
       router.replace(redirect);
     }
-  }, [isAuthenticated, router, redirect]);
+  }, [token, isAuthenticated, router, redirect]);
 
   if (!token) {
     return (

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/auth-session.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/auth-session.test.ts
@@ -1,6 +1,26 @@
 import { describe, expect, it } from 'vitest';
 
-import { mergeAuthPersistedState } from './auth-session';
+import { mergeAuthPersistedState, shouldSkipMagicLinkConfirmation } from './auth-session';
+
+describe('shouldSkipMagicLinkConfirmation', () => {
+  it('confirms the token even when a stale session says the user is signed in', () => {
+    // The regression: persisted isAuthenticated outlives its access token, so
+    // redirecting here would discard the link the user just clicked.
+    expect(shouldSkipMagicLinkConfirmation('fresh-token', true)).toBe(false);
+  });
+
+  it('confirms the token for a signed-out visitor', () => {
+    expect(shouldSkipMagicLinkConfirmation('fresh-token', false)).toBe(false);
+  });
+
+  it('sends a signed-in visitor onward when the link carries no token', () => {
+    expect(shouldSkipMagicLinkConfirmation(null, true)).toBe(true);
+  });
+
+  it('stays put for a signed-out visitor with no token so the error renders', () => {
+    expect(shouldSkipMagicLinkConfirmation(null, false)).toBe(false);
+  });
+});
 
 describe('mergeAuthPersistedState', () => {
   it('keeps live session when persisted storage is empty', () => {

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/auth-session.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/auth-session.ts
@@ -22,6 +22,24 @@ export function clearAuthFlagCookie(): void {
 }
 
 /**
+ * Whether a visitor landing on the magic-link page should be sent straight to
+ * their destination instead of being asked to confirm.
+ *
+ * A token in the URL always wins. `isAuthenticated` is rehydrated from
+ * localStorage and routinely outlives the access token it was stored with, so
+ * trusting it here would redirect the user away before the freshly-emailed
+ * token is exchanged — the link silently does nothing and they bounce back to
+ * the login page, which reads to users as a caching bug.
+ */
+export function shouldSkipMagicLinkConfirmation(
+  token: string | null | undefined,
+  isAuthenticated: boolean,
+): boolean {
+  if (token) return false;
+  return isAuthenticated;
+}
+
+/**
  * Zustand persist merge: keep an active in-memory session when storage failed
  * to persist tokens (blocked localStorage, hydration race after magic-link).
  */

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/middleware.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/middleware.test.ts
@@ -29,6 +29,15 @@ describe('middleware auth redirects', () => {
     expect(response.headers.get('location')).toBeNull();
   });
 
+  it('marks the magic-link page as uncacheable', () => {
+    process.env.NODE_ENV = 'production';
+
+    const response = middleware(
+      requestFor('/auth/magic-link?token=abc', { 'nexus-auth-flag': 'true' }),
+    );
+    expect(response.headers.get('cache-control')).toContain('no-store');
+  });
+
   it('redirects other auth routes when auth cookie is present', () => {
     process.env.NODE_ENV = 'production';
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/middleware.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/middleware.ts
@@ -108,8 +108,16 @@ export function middleware(request: NextRequest) {
   }
 
   // Let users finish magic-link confirmation even when a stale auth cookie exists.
+  // no-store also keeps the confirmation page out of shared and back/forward
+  // caches, so a resurrected copy can never replay an already-spent token.
   const isMagicLinkRoute = pathname === '/auth/magic-link' || pathname.startsWith('/auth/magic-link/');
-  if (isAuthRoute && hasAuthCookie && !isMagicLinkRoute) {
+  if (isMagicLinkRoute) {
+    const res = NextResponse.next();
+    res.headers.set('Cache-Control', 'no-store, must-revalidate');
+    return res;
+  }
+
+  if (isAuthRoute && hasAuthCookie) {
     return NextResponse.redirect(new URL(`/workspace/${resolveDefaultWorkspace(request)}/chat`, request.url));
   }
 


### PR DESCRIPTION
## What users see

"Clicking the magic link does nothing / sends me back to login — feels like something is cached."

## Root cause

It is not an HTTP cache. It is a **stale persisted session in localStorage**.

`app/auth/magic-link/page.tsx` redirected on `isAuthenticated`:

```ts
useEffect(() => {
  if (isAuthenticated) router.replace(redirect);
}, [isAuthenticated, router, redirect]);
```

`isAuthenticated` is rehydrated by zustand `persist` from the `nexus-auth` localStorage key. That flag routinely **outlives the access token it was stored with** — it is only reset by an explicit `logout()`, or once a workspace page has mounted and run `checkAuth()`.

So for a user whose session expired server-side but who has not since loaded a workspace page:

1. They request a magic link and click it.
2. The page mounts, `persist` rehydrates `isAuthenticated: true`.
3. The effect fires and `router.replace(redirect)` runs **before they can confirm**.
4. The freshly emailed token is never exchanged; they land on `/` and get bounced to `/auth/login`.

The link is consumed from the user's point of view while the token is still unused — and because the trigger is old browser state, it presents exactly as "a cache problem".

## Fix

- A token in the URL now always wins over the persisted session. The redirect only applies to a **tokenless** visit to `/auth/magic-link`.
- The decision is extracted to `shouldSkipMagicLinkConfirmation()` in `lib/auth-session.ts` so it is directly unit-testable (the page itself is not covered — vitest here is `environment: 'node'` with `include: src/**/*.test.ts`, so there is no component-test path).
- `/auth/magic-link` now responds with `Cache-Control: no-store, must-revalidate`, keeping the confirmation page out of shared and back/forward caches so a resurrected copy cannot replay an already-spent token. This also restructures the existing magic-link branch in the middleware into its own early return; the redirect behaviour for every other auth route is unchanged.

## Relation to prior work

This is the same family as #1076 (`stop magic-link login loop when localStorage is blocked`) and the existing middleware exemption that lets `/auth/magic-link` through despite the `nexus-auth-flag` cookie. Those covered *blocked* storage and the *cookie* side; this covers *stale* storage, which was still live on `main`.

## Testing

- `src/lib/auth-session.test.ts` — 4 new cases over `shouldSkipMagicLinkConfirmation`, including the regression (token present + stale `isAuthenticated: true` must still confirm).
- `src/middleware.test.ts` — new case asserting `no-store` on the magic-link route; existing cases still pass.
- `vitest run src/middleware.test.ts src/lib/auth-session.test.ts` → **9 passed**.
- `tsc --noEmit` → no errors in the touched files.

Note: the full suite has **3 pre-existing failures** on `main` (`graph-query/explore-state`, `triples-export`, `feature-access`). They are untouched by this branch and unrelated to auth.