### PR TITLE
fix(agent): coerce non-object tool call args to {} before Bedrock Converse re-send history

### DIFF
--- a/libs/naas-abi-cli/uv.lock
+++ b/libs/naas-abi-cli/uv.lock
@@ -2384,7 +2384,7 @@ wheels = [
 
 [[package]]
 name = "naas-abi"
-version = "2.44.0"
+version = "2.45.0"
 source = { editable = "../naas-abi" }
 dependencies = [
     { name = "aiosqlite" },
@@ -2499,7 +2499,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-core"
-version = "2.19.1"
+version = "2.19.2"
 source = { editable = "../naas-abi-core" }
 dependencies = [
     { name = "click" },
@@ -2615,7 +2615,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-marketplace"
-version = "3.22.3"
+version = "3.23.0"
 source = { editable = "../naas-abi-marketplace" }
 dependencies = [
     { name = "ijson" },
@@ -4550,8 +4550,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [

--- a/libs/naas-abi-core/CHANGELOG.md
+++ b/libs/naas-abi-core/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 <!-- version list -->
 
+## Unreleased
+
+### Bug Fixes
+
+- **agent**: Coerce non-object tool call args to `{}` before Bedrock Converse
+  re-sends history (fixes ValidationException on `toolUse.input` for models
+  like `gpt-oss-120b` that emit `[]`/`""` for zero-arg tools)
+
+
 ## v2.19.2 (2026-07-21)
 
 ### Bug Fixes

--- a/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 # Standard library imports for type hints
 import atexit
+import json
 import os
 import re
 import threading
@@ -1042,6 +1043,174 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
             )
             return response
 
+    @staticmethod
+    def _coerce_tool_args_to_object(args: Any) -> dict[str, Any]:
+        """Ensure tool-call args are a JSON object (``dict``).
+
+        Providers such as Amazon Bedrock Converse reject ``toolUse.input`` unless
+        it is a JSON object. Some models (notably OpenAI OSS models on Bedrock)
+        emit empty lists, empty strings, ``None``, or JSON-encoded strings for
+        zero-argument tools. Coerce those shapes so any default chat model can
+        safely continue a tool-calling turn.
+        """
+        if args is None:
+            return {}
+        if isinstance(args, dict):
+            return args
+        if isinstance(args, str):
+            text = args.strip()
+            if not text:
+                return {}
+            try:
+                parsed = json.loads(text)
+            except json.JSONDecodeError:
+                return {}
+            return parsed if isinstance(parsed, dict) else {}
+        if isinstance(args, (list, tuple)):
+            # boto3 Document decoding historically turns ``{}`` into ``[]``.
+            if len(args) == 0:
+                return {}
+            if len(args) == 1 and isinstance(args[0], dict):
+                return args[0]
+            return {}
+        return {}
+
+    @classmethod
+    def _normalize_ai_message_tool_inputs(cls, message: AIMessage) -> AIMessage:
+        """Rewrite an AIMessage so every tool input is a dict object."""
+        tool_calls = list(getattr(message, "tool_calls", None) or [])
+        normalized_calls: list[ToolCall] = []
+        calls_changed = False
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                normalized_calls.append(call)
+                continue
+            coerced = cls._coerce_tool_args_to_object(call.get("args"))
+            if coerced is not call.get("args"):
+                calls_changed = True
+                normalized_calls.append({**call, "args": coerced})
+            else:
+                normalized_calls.append(call)
+
+        content = message.content
+        content_changed = False
+        if isinstance(content, list):
+            new_blocks: list[Any] = []
+            for block in content:
+                if not isinstance(block, dict):
+                    new_blocks.append(block)
+                    continue
+                # LangChain uses type=tool_use; Bedrock wire form uses toolUse.
+                if block.get("type") == "tool_use":
+                    coerced_input = cls._coerce_tool_args_to_object(block.get("input"))
+                    if coerced_input is not block.get("input"):
+                        content_changed = True
+                        new_blocks.append({**block, "input": coerced_input})
+                    else:
+                        new_blocks.append(block)
+                elif "toolUse" in block:
+                    tool_use = block.get("toolUse") or {}
+                    coerced_input = cls._coerce_tool_args_to_object(
+                        tool_use.get("input")
+                    )
+                    if coerced_input is not tool_use.get("input"):
+                        content_changed = True
+                        new_blocks.append(
+                            {
+                                **block,
+                                "toolUse": {**tool_use, "input": coerced_input},
+                            }
+                        )
+                    else:
+                        new_blocks.append(block)
+                else:
+                    new_blocks.append(block)
+            if content_changed:
+                content = new_blocks
+
+        additional_kwargs = dict(getattr(message, "additional_kwargs", None) or {})
+        kwargs_changed = False
+        raw_tool_calls = additional_kwargs.get("tool_calls")
+        if isinstance(raw_tool_calls, list):
+            new_raw: list[Any] = []
+            for call in raw_tool_calls:
+                if not isinstance(call, dict):
+                    new_raw.append(call)
+                    continue
+                # OpenAI-style nested function.arguments may be a JSON string.
+                function = call.get("function")
+                if isinstance(function, dict) and "arguments" in function:
+                    arguments = function.get("arguments")
+                    if isinstance(arguments, str):
+                        coerced = cls._coerce_tool_args_to_object(arguments)
+                        encoded = json.dumps(coerced)
+                        if encoded != arguments:
+                            kwargs_changed = True
+                            new_raw.append(
+                                {
+                                    **call,
+                                    "function": {**function, "arguments": encoded},
+                                }
+                            )
+                        else:
+                            new_raw.append(call)
+                    elif not isinstance(arguments, dict):
+                        kwargs_changed = True
+                        new_raw.append(
+                            {
+                                **call,
+                                "function": {
+                                    **function,
+                                    "arguments": json.dumps(
+                                        cls._coerce_tool_args_to_object(arguments)
+                                    ),
+                                },
+                            }
+                        )
+                    else:
+                        new_raw.append(call)
+                elif "args" in call:
+                    coerced = cls._coerce_tool_args_to_object(call.get("args"))
+                    if coerced is not call.get("args"):
+                        kwargs_changed = True
+                        new_raw.append({**call, "args": coerced})
+                    else:
+                        new_raw.append(call)
+                else:
+                    new_raw.append(call)
+            if kwargs_changed:
+                additional_kwargs["tool_calls"] = new_raw
+
+        if not (calls_changed or content_changed or kwargs_changed):
+            return message
+
+        return AIMessage(
+            content=content,
+            tool_calls=normalized_calls,
+            id=message.id,
+            additional_kwargs=additional_kwargs,
+            response_metadata=dict(getattr(message, "response_metadata", None) or {}),
+            usage_metadata=getattr(message, "usage_metadata", None),
+            name=getattr(message, "name", None),
+        )
+
+    @classmethod
+    def _normalize_tool_inputs_in_messages(
+        cls, messages: list[AnyMessage]
+    ) -> list[AnyMessage]:
+        """Normalize tool inputs across a message history before model invoke."""
+        normalized: list[AnyMessage] = []
+        changed = False
+        for message in messages:
+            if isinstance(message, AIMessage):
+                new_message = cls._normalize_ai_message_tool_inputs(message)
+                if new_message is not message:
+                    changed = True
+                normalized.append(new_message)
+            else:
+                normalized.append(message)
+        return normalized if changed else messages
+
     def _strip_inbound_handoff_artifacts(
         self, messages: list[AnyMessage]
     ) -> list[AnyMessage]:
@@ -1189,6 +1358,9 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
             messages = [
                 SystemMessage(content=state["system_prompt"]),
             ] + messages
+        # Bedrock (and some other providers) require toolUse.input to be a JSON
+        # object. Normalize any prior assistant tool calls before re-sending.
+        messages = self._normalize_tool_inputs_in_messages(messages)
         logger.debug(f"Messages before calling model: {messages}")
 
         # Calling model. Only expose workspace-gated tools when a coding
@@ -1215,6 +1387,11 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
                 },
             )
         logger.debug(f"Model response: {response}")
+
+        # Normalize freshly returned tool inputs so the next turn (and Bedrock
+        # re-serialization) always sees a JSON object for toolUse.input.
+        if isinstance(response, AIMessage):
+            response = self._normalize_ai_message_tool_inputs(response)
 
         # Handle tool calls if present
         if (

--- a/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
@@ -652,9 +652,7 @@ class Agent(Expose):
             # Test if the chat model can bind tools by trying with a default tool first
             if can_bind_tools(base_chat_model):
                 self._chat_model_with_tools = base_chat_model.bind_tools(tools_to_bind)
-                gated = [
-                    t for t in tools_to_bind if not Agent._requires_workspace(t)
-                ]
+                gated = [t for t in tools_to_bind if not Agent._requires_workspace(t)]
                 self._chat_model_without_workspace_tools = (
                     base_chat_model.bind_tools(gated)
                     if len(gated) != len(tools_to_bind)
@@ -1064,16 +1062,46 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
             try:
                 parsed = json.loads(text)
             except json.JSONDecodeError:
+                logger.warning(
+                    "Discarding non-JSON tool-call args string; coercing to {}"
+                )
                 return {}
-            return parsed if isinstance(parsed, dict) else {}
+            if isinstance(parsed, dict):
+                return parsed
+            logger.warning(
+                "Tool-call args JSON is not an object (%s); coercing to {}",
+                type(parsed).__name__,
+            )
+            return {}
         if isinstance(args, (list, tuple)):
             # boto3 Document decoding historically turns ``{}`` into ``[]``.
             if len(args) == 0:
                 return {}
             if len(args) == 1 and isinstance(args[0], dict):
                 return args[0]
+            # A multi-element list (or a single non-dict element) cannot be a JSON
+            # object; there is no lossless coercion, so surface the drop.
+            logger.warning(
+                "Discarding non-object tool-call args list of length %d; coercing to {}",
+                len(args),
+            )
             return {}
+        logger.warning(
+            "Discarding unsupported tool-call args of type %s; coercing to {}",
+            type(args).__name__,
+        )
         return {}
+
+    @staticmethod
+    def _is_json_object_string(text: str) -> bool:
+        """Return True when ``text`` already encodes a JSON object (``dict``)."""
+        stripped = text.strip()
+        if not stripped:
+            return False
+        try:
+            return isinstance(json.loads(stripped), dict)
+        except json.JSONDecodeError:
+            return False
 
     @classmethod
     def _normalize_ai_message_tool_inputs(cls, message: AIMessage) -> AIMessage:
@@ -1085,8 +1113,9 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
             if not isinstance(call, dict):
                 normalized_calls.append(cast(ToolCall, call))
                 continue
-            coerced = cls._coerce_tool_args_to_object(call.get("args"))
-            if coerced is not call.get("args"):
+            current_args = call.get("args")
+            coerced = cls._coerce_tool_args_to_object(current_args)
+            if coerced is not current_args:
                 calls_changed = True
                 normalized_calls.append(cast(ToolCall, {**call, "args": coerced}))
             else:
@@ -1142,18 +1171,25 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
                 if isinstance(function, dict) and "arguments" in function:
                     arguments = function.get("arguments")
                     if isinstance(arguments, str):
-                        coerced = cls._coerce_tool_args_to_object(arguments)
-                        encoded = json.dumps(coerced)
-                        if encoded != arguments:
+                        # Only rewrite when the string is not already a valid JSON
+                        # object. Re-encoding a valid object would only reformat it
+                        # (spacing / unicode escaping), which would spuriously flag
+                        # the message as changed on every turn.
+                        if cls._is_json_object_string(arguments):
+                            new_raw.append(call)
+                        else:
                             kwargs_changed = True
                             new_raw.append(
                                 {
                                     **call,
-                                    "function": {**function, "arguments": encoded},
+                                    "function": {
+                                        **function,
+                                        "arguments": json.dumps(
+                                            cls._coerce_tool_args_to_object(arguments)
+                                        ),
+                                    },
                                 }
                             )
-                        else:
-                            new_raw.append(call)
                     elif not isinstance(arguments, dict):
                         kwargs_changed = True
                         new_raw.append(
@@ -1187,11 +1223,13 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
         return AIMessage(
             content=content,
             tool_calls=normalized_calls,
+            invalid_tool_calls=list(getattr(message, "invalid_tool_calls", None) or []),
             id=message.id,
             additional_kwargs=additional_kwargs,
             response_metadata=dict(getattr(message, "response_metadata", None) or {}),
             usage_metadata=getattr(message, "usage_metadata", None),
             name=getattr(message, "name", None),
+            example=getattr(message, "example", False),
         )
 
     @classmethod

--- a/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
@@ -1104,6 +1104,26 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
             return False
 
     @classmethod
+    def _coerce_object_at_key(
+        cls, container: dict[str, Any], key: str
+    ) -> tuple[dict[str, Any], bool]:
+        """Coerce ``container[key]`` to a JSON object, returning ``(new, changed)``.
+
+        Shared primitive for every tool-input shape (LangChain ``tool_calls``,
+        ``tool_use``/``toolUse`` content blocks, and raw ``args``). When ``key`` is
+        absent the container is returned unchanged — we never inject a key the
+        provider omitted. When present but already an object the same object is
+        returned so callers can detect "no change" by identity.
+        """
+        if key not in container:
+            return container, False
+        current = container[key]
+        coerced = cls._coerce_tool_args_to_object(current)
+        if coerced is current:
+            return container, False
+        return {**container, key: coerced}, True
+
+    @classmethod
     def _normalize_ai_message_tool_inputs(cls, message: AIMessage) -> AIMessage:
         """Rewrite an AIMessage so every tool input is a dict object."""
         tool_calls = list(getattr(message, "tool_calls", None) or [])
@@ -1113,13 +1133,9 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
             if not isinstance(call, dict):
                 normalized_calls.append(cast(ToolCall, call))
                 continue
-            current_args = call.get("args")
-            coerced = cls._coerce_tool_args_to_object(current_args)
-            if coerced is not current_args:
-                calls_changed = True
-                normalized_calls.append(cast(ToolCall, {**call, "args": coerced}))
-            else:
-                normalized_calls.append(cast(ToolCall, call))
+            new_call, changed = cls._coerce_object_at_key(call, "args")
+            calls_changed = calls_changed or changed
+            normalized_calls.append(cast(ToolCall, new_call))
 
         content = message.content
         content_changed = False
@@ -1131,25 +1147,16 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
                     continue
                 # LangChain uses type=tool_use; Bedrock wire form uses toolUse.
                 if block.get("type") == "tool_use":
-                    coerced_input = cls._coerce_tool_args_to_object(block.get("input"))
-                    if coerced_input is not block.get("input"):
-                        content_changed = True
-                        new_blocks.append({**block, "input": coerced_input})
-                    else:
-                        new_blocks.append(block)
-                elif "toolUse" in block:
-                    tool_use = block.get("toolUse") or {}
-                    coerced_input = cls._coerce_tool_args_to_object(
-                        tool_use.get("input")
+                    new_block, changed = cls._coerce_object_at_key(block, "input")
+                    content_changed = content_changed or changed
+                    new_blocks.append(new_block)
+                elif isinstance(block.get("toolUse"), dict):
+                    new_tool_use, changed = cls._coerce_object_at_key(
+                        block["toolUse"], "input"
                     )
-                    if coerced_input is not tool_use.get("input"):
+                    if changed:
                         content_changed = True
-                        new_blocks.append(
-                            {
-                                **block,
-                                "toolUse": {**tool_use, "input": coerced_input},
-                            }
-                        )
+                        new_blocks.append({**block, "toolUse": new_tool_use})
                     else:
                         new_blocks.append(block)
                 else:
@@ -1166,31 +1173,21 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
                 if not isinstance(call, dict):
                     new_raw.append(call)
                     continue
-                # OpenAI-style nested function.arguments may be a JSON string.
+                # OpenAI-style nested function.arguments is a JSON *string*, so it
+                # needs string (re)serialization rather than the dict-valued path.
                 function = call.get("function")
                 if isinstance(function, dict) and "arguments" in function:
-                    arguments = function.get("arguments")
-                    if isinstance(arguments, str):
-                        # Only rewrite when the string is not already a valid JSON
-                        # object. Re-encoding a valid object would only reformat it
-                        # (spacing / unicode escaping), which would spuriously flag
-                        # the message as changed on every turn.
-                        if cls._is_json_object_string(arguments):
-                            new_raw.append(call)
-                        else:
-                            kwargs_changed = True
-                            new_raw.append(
-                                {
-                                    **call,
-                                    "function": {
-                                        **function,
-                                        "arguments": json.dumps(
-                                            cls._coerce_tool_args_to_object(arguments)
-                                        ),
-                                    },
-                                }
-                            )
-                    elif not isinstance(arguments, dict):
+                    arguments = function["arguments"]
+                    # Leave anything that already represents an object untouched: a
+                    # dict, or a string encoding one. Re-encoding a valid object
+                    # would only reformat it and spuriously flag the message as
+                    # changed on every turn.
+                    if isinstance(arguments, dict) or (
+                        isinstance(arguments, str)
+                        and cls._is_json_object_string(arguments)
+                    ):
+                        new_raw.append(call)
+                    else:
                         kwargs_changed = True
                         new_raw.append(
                             {
@@ -1203,15 +1200,10 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
                                 },
                             }
                         )
-                    else:
-                        new_raw.append(call)
                 elif "args" in call:
-                    coerced = cls._coerce_tool_args_to_object(call.get("args"))
-                    if coerced is not call.get("args"):
-                        kwargs_changed = True
-                        new_raw.append({**call, "args": coerced})
-                    else:
-                        new_raw.append(call)
+                    new_call, changed = cls._coerce_object_at_key(call, "args")
+                    kwargs_changed = kwargs_changed or changed
+                    new_raw.append(new_call)
                 else:
                     new_raw.append(call)
             if kwargs_changed:

--- a/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
@@ -1083,14 +1083,14 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
         calls_changed = False
         for call in tool_calls:
             if not isinstance(call, dict):
-                normalized_calls.append(call)
+                normalized_calls.append(cast(ToolCall, call))
                 continue
             coerced = cls._coerce_tool_args_to_object(call.get("args"))
             if coerced is not call.get("args"):
                 calls_changed = True
-                normalized_calls.append({**call, "args": coerced})
+                normalized_calls.append(cast(ToolCall, {**call, "args": coerced}))
             else:
-                normalized_calls.append(call)
+                normalized_calls.append(cast(ToolCall, call))
 
         content = message.content
         content_changed = False

--- a/libs/naas-abi-core/naas_abi_core/services/agent/Agent_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/Agent_test.py
@@ -120,10 +120,11 @@ def test_agent_stream_invoke(model):
     for event in agent.stream_invoke("My name is ABI"):
         events.append(event)
 
-    assert len(events) == 3, events
-    assert events[0]["event"] == "ai_message", events[0]
-    assert events[1]["event"] == "message", events[1]
-    assert events[2]["event"] == "done", events[2]
+    assert len(events) == 4, events
+    assert events[0]["event"] == "call_model", events[0]
+    assert events[1]["event"] == "ai_message", events[1]
+    assert events[2]["event"] == "message", events[2]
+    assert events[3]["event"] == "done", events[3]
 
 
 def test_agent_stream_invoke_isolation(model):
@@ -552,3 +553,44 @@ def test_normalize_preserves_invalid_tool_calls_when_reconstructing():
     assert normalized.content[0]["input"] == {}
     assert len(normalized.invalid_tool_calls) == 1
     assert normalized.invalid_tool_calls[0]["id"] == "call-2"
+
+
+def test_normalize_does_not_inject_input_when_key_absent():
+    """A content block that omits ``input`` entirely must be left untouched — we
+    never fabricate a key the provider did not send."""
+    from langchain_core.messages import AIMessage
+
+    from naas_abi_core.services.agent.Agent import Agent
+
+    message = AIMessage(
+        content=[
+            {"type": "tool_use", "id": "call-1", "name": "no_args"},
+            {"toolUse": {"toolUseId": "call-2", "name": "no_args"}},
+        ],
+        id="ai1",
+    )
+
+    normalized = Agent._normalize_ai_message_tool_inputs(message)
+
+    # Nothing to coerce -> same object, no injected ``input`` keys.
+    assert normalized is message
+    assert "input" not in normalized.content[0]
+    assert "input" not in normalized.content[1]["toolUse"]
+
+
+def test_normalize_coerces_present_but_invalid_input_in_tooluse_block():
+    """Regression guard: a present-but-invalid ``input`` under ``toolUse`` is still
+    coerced (only *absent* keys are left alone)."""
+    from langchain_core.messages import AIMessage
+
+    from naas_abi_core.services.agent.Agent import Agent
+
+    message = AIMessage(
+        content=[{"toolUse": {"toolUseId": "call-1", "name": "do", "input": []}}],
+        id="ai1",
+    )
+
+    normalized = Agent._normalize_ai_message_tool_inputs(message)
+
+    assert normalized is not message
+    assert normalized.content[0]["toolUse"]["input"] == {}

--- a/libs/naas-abi-core/naas_abi_core/services/agent/Agent_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/Agent_test.py
@@ -251,9 +251,21 @@ def test_strip_removes_orphan_tool_use_block_in_list_content():
         AIMessage(
             content=[
                 {"type": "thinking", "thinking": "", "signature": "sig"},
-                {"type": "tool_use", "id": tid, "name": f"transfer_to_{sub}", "input": {}},
+                {
+                    "type": "tool_use",
+                    "id": tid,
+                    "name": f"transfer_to_{sub}",
+                    "input": {},
+                },
             ],
-            tool_calls=[{"name": f"transfer_to_{sub}", "args": {}, "id": tid, "type": "tool_call"}],
+            tool_calls=[
+                {
+                    "name": f"transfer_to_{sub}",
+                    "args": {},
+                    "id": tid,
+                    "type": "tool_call",
+                }
+            ],
             id="ai1",
         ),
         ToolMessage(
@@ -290,12 +302,29 @@ def test_strip_keeps_visible_text_but_drops_tool_use_block():
         AIMessage(
             content=[
                 {"type": "text", "text": "Sure, one moment."},
-                {"type": "tool_use", "id": tid, "name": f"transfer_to_{sub}", "input": {}},
+                {
+                    "type": "tool_use",
+                    "id": tid,
+                    "name": f"transfer_to_{sub}",
+                    "input": {},
+                },
             ],
-            tool_calls=[{"name": f"transfer_to_{sub}", "args": {}, "id": tid, "type": "tool_call"}],
+            tool_calls=[
+                {
+                    "name": f"transfer_to_{sub}",
+                    "args": {},
+                    "id": tid,
+                    "type": "tool_call",
+                }
+            ],
             id="ai1",
         ),
-        ToolMessage(content=f"__handoff__:{sub}", name=f"transfer_to_{sub}", tool_call_id=tid, id="tm1"),
+        ToolMessage(
+            content=f"__handoff__:{sub}",
+            name=f"transfer_to_{sub}",
+            tool_call_id=tid,
+            id="tm1",
+        ),
     ]
 
     cleaned = _strip(sub, messages)
@@ -306,9 +335,7 @@ def test_strip_keeps_visible_text_but_drops_tool_use_block():
     assert all(
         not (isinstance(b, dict) and b.get("type") == "tool_use") for b in ai.content
     )
-    assert any(
-        isinstance(b, dict) and b.get("type") == "text" for b in ai.content
-    )
+    assert any(isinstance(b, dict) and b.get("type") == "text" for b in ai.content)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -427,3 +454,101 @@ def test_normalize_tool_inputs_in_messages_only_rewrites_ai_messages():
     assert normalized[0] is messages[0]
     assert normalized[2] is messages[2]
     assert normalized[1].content[0]["input"] == {}
+
+
+def test_normalize_leaves_valid_openai_arguments_string_untouched():
+    """A valid compact JSON-object arguments string must not be reformatted,
+    otherwise the message would be flagged changed (and reconstructed) on every
+    turn purely due to json.dumps spacing/escaping differences."""
+    from langchain_core.messages import AIMessage
+
+    from naas_abi_core.services.agent.Agent import Agent
+
+    compact = '{"a":1,"b":"caf\\u00e9"}'
+    message = AIMessage(
+        content="",
+        additional_kwargs={
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "do", "arguments": compact},
+                }
+            ]
+        },
+        id="ai1",
+    )
+
+    normalized = Agent._normalize_ai_message_tool_inputs(message)
+
+    # No coercion needed -> same object returned, arguments string preserved.
+    assert normalized is message
+    assert (
+        normalized.additional_kwargs["tool_calls"][0]["function"]["arguments"]
+        == compact
+    )
+
+
+def test_normalize_rewrites_invalid_openai_arguments_string():
+    from langchain_core.messages import AIMessage
+
+    from naas_abi_core.services.agent.Agent import Agent
+
+    message = AIMessage(
+        content="",
+        additional_kwargs={
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "do", "arguments": ""},
+                }
+            ]
+        },
+        id="ai1",
+    )
+
+    normalized = Agent._normalize_ai_message_tool_inputs(message)
+
+    assert normalized is not message
+    assert (
+        normalized.additional_kwargs["tool_calls"][0]["function"]["arguments"] == "{}"
+    )
+
+
+def test_normalize_preserves_invalid_tool_calls_when_reconstructing():
+    """Reconstruction triggered by coercion must not drop invalid_tool_calls."""
+    from langchain_core.messages import AIMessage
+
+    from naas_abi_core.services.agent.Agent import Agent
+
+    message = AIMessage(
+        content=[
+            {
+                "type": "tool_use",
+                "id": "call-1",
+                "name": "git_push",
+                "input": [],
+            }
+        ],
+        tool_calls=[
+            {"name": "git_push", "args": {}, "id": "call-1", "type": "tool_call"}
+        ],
+        invalid_tool_calls=[
+            {
+                "name": "broken",
+                "args": "{not json",
+                "id": "call-2",
+                "error": "parse error",
+                "type": "invalid_tool_call",
+            }
+        ],
+        id="ai1",
+    )
+
+    normalized = Agent._normalize_ai_message_tool_inputs(message)
+
+    assert normalized is not message
+    assert normalized.content[0]["input"] == {}
+    assert len(normalized.invalid_tool_calls) == 1
+    assert normalized.invalid_tool_calls[0]["id"] == "call-2"

--- a/libs/naas-abi-core/naas_abi_core/services/agent/Agent_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/Agent_test.py
@@ -309,3 +309,121 @@ def test_strip_keeps_visible_text_but_drops_tool_use_block():
     assert any(
         isinstance(b, dict) and b.get("type") == "text" for b in ai.content
     )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tool-input normalization — Bedrock requires toolUse.input to be a JSON object
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_coerce_tool_args_to_object_handles_common_invalid_shapes():
+    from naas_abi_core.services.agent.Agent import Agent
+
+    assert Agent._coerce_tool_args_to_object(None) == {}
+    assert Agent._coerce_tool_args_to_object([]) == {}
+    assert Agent._coerce_tool_args_to_object("") == {}
+    assert Agent._coerce_tool_args_to_object("{}") == {}
+    assert Agent._coerce_tool_args_to_object('{"path": "a.py"}') == {"path": "a.py"}
+    assert Agent._coerce_tool_args_to_object([{"path": "a.py"}]) == {"path": "a.py"}
+    assert Agent._coerce_tool_args_to_object({"path": "a.py"}) == {"path": "a.py"}
+    assert Agent._coerce_tool_args_to_object("not-json") == {}
+    assert Agent._coerce_tool_args_to_object([1, 2]) == {}
+
+
+def test_normalize_ai_message_tool_inputs_fixes_empty_list_in_content_blocks():
+    """Bedrock/boto3 can decode empty tool input ``{}`` as ``[]`` inside content
+    blocks. LangChain's ``tool_calls.args`` is already typed as dict, so the
+    invalid shape usually survives only in ``content``."""
+    from langchain_core.messages import AIMessage
+
+    from naas_abi_core.services.agent.Agent import Agent
+
+    message = AIMessage(
+        content=[
+            {
+                "type": "tool_use",
+                "id": "call-1",
+                "name": "git_push",
+                "input": [],
+            }
+        ],
+        tool_calls=[
+            {"name": "git_push", "args": {}, "id": "call-1", "type": "tool_call"}
+        ],
+        id="ai1",
+    )
+
+    normalized = Agent._normalize_ai_message_tool_inputs(message)
+
+    assert normalized is not message
+    assert normalized.tool_calls[0]["args"] == {}
+    assert normalized.content[0]["input"] == {}
+
+
+def test_normalize_ai_message_tool_inputs_fixes_missing_or_string_content_input():
+    from langchain_core.messages import AIMessage
+
+    from naas_abi_core.services.agent.Agent import Agent
+
+    message = AIMessage(
+        content=[
+            {
+                "type": "tool_use",
+                "id": "call-1",
+                "name": "git_status",
+                "input": "",
+            },
+            {
+                "type": "tool_use",
+                "id": "call-2",
+                "name": "git_push",
+                "input": None,
+            },
+        ],
+        tool_calls=[
+            {"name": "git_status", "args": {}, "id": "call-1", "type": "tool_call"},
+            {"name": "git_push", "args": {}, "id": "call-2", "type": "tool_call"},
+        ],
+        id="ai1",
+    )
+
+    normalized = Agent._normalize_ai_message_tool_inputs(message)
+
+    assert normalized.content[0]["input"] == {}
+    assert normalized.content[1]["input"] == {}
+
+
+def test_normalize_tool_inputs_in_messages_only_rewrites_ai_messages():
+    from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+    from naas_abi_core.services.agent.Agent import Agent
+
+    messages = [
+        HumanMessage(content="push please", id="h1"),
+        AIMessage(
+            content=[
+                {
+                    "type": "tool_use",
+                    "id": "call-1",
+                    "name": "git_status",
+                    "input": [],
+                }
+            ],
+            tool_calls=[
+                {
+                    "name": "git_status",
+                    "args": {},
+                    "id": "call-1",
+                    "type": "tool_call",
+                }
+            ],
+            id="ai1",
+        ),
+        ToolMessage(content="ok", name="git_status", tool_call_id="call-1", id="tm1"),
+    ]
+
+    normalized = Agent._normalize_tool_inputs_in_messages(messages)
+
+    assert normalized[0] is messages[0]
+    assert normalized[2] is messages[2]
+    assert normalized[1].content[0]["input"] == {}

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/ai/anthropic/models/claude_haiku_4_5.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/ai/anthropic/models/claude_haiku_4_5.py
@@ -23,7 +23,8 @@ class ClaudeHaiku45Model(ModelDefinition):
             max_retries=2,
             # Explicit — otherwise langchain_anthropic defaults max_tokens to 1024,
             # which extended thinking can exhaust and truncate the visible answer.
-            max_tokens=8192,
+            # Use the pydantic field alias; mypy rejects the `max_tokens` kwarg.
+            max_tokens_to_sample=8192,
             api_key=SecretStr(ABIModule.get_instance().configuration.anthropic_api_key),
             timeout=None,
             stop=None,

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/ai/anthropic/models/claude_opus_4_8.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/ai/anthropic/models/claude_opus_4_8.py
@@ -22,7 +22,8 @@ class ClaudeOpus48Model(ModelDefinition):
             max_retries=2,
             # Explicit — otherwise langchain_anthropic defaults max_tokens to 1024,
             # which adaptive thinking can exhaust and truncate the visible answer.
-            max_tokens=8192,
+            # Use the pydantic field alias; mypy rejects the `max_tokens` kwarg.
+            max_tokens_to_sample=8192,
             api_key=SecretStr(ABIModule.get_instance().configuration.anthropic_api_key),
             timeout=None,
             stop=None,

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/ai/anthropic/models/claude_sonnet_5.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/ai/anthropic/models/claude_sonnet_5.py
@@ -22,7 +22,8 @@ class ClaudeSonnet5Model(ModelDefinition):
             max_retries=2,
             # Explicit — otherwise langchain_anthropic defaults max_tokens to 1024,
             # which adaptive thinking can exhaust and truncate the visible answer.
-            max_tokens=8192,
+            # Use the pydantic field alias; mypy rejects the `max_tokens` kwarg.
+            max_tokens_to_sample=8192,
             api_key=SecretStr(ABIModule.get_instance().configuration.anthropic_api_key),
             timeout=None,
             stop=None,

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/__init__.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/__init__.py
@@ -161,7 +161,17 @@ class XSearchRecentTweetsEventConfiguration(BaseModel):
         ge=1,
         description=(
             "Max undelivered ObjectPut events drained from the durable consumer "
-            "cursor per sensor evaluation."
+            "cursor per sensor evaluation. Further capped by free concurrency "
+            "slots (``max_concurrent_runs`` minus in-flight runs for this job)."
+        ),
+    )
+    max_concurrent_runs: int = Field(
+        default=1,
+        ge=1,
+        description=(
+            "Max Dagster runs of this job allowed queued/running at once. The "
+            "sensor checks this *before* ``query_for_consumer`` so the durable "
+            "event cursor does not advance when every slot is already taken."
         ),
     )
     persist: bool = Field(
@@ -294,6 +304,7 @@ class ABIModule(BaseModule):
                 interval_seconds: 30     # minimum delay between evaluations
                 prefix: x/search_recent_tweets
                 events_per_tick: 100     # max ObjectPut events drained per tick
+                max_concurrent_runs: 1   # skip (no cursor advance) when full
                 persist: true
 
             # ----- Scheduled files-reprocessing sensors --------------------

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/XSearchRecentTweetsEventOrchestration.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/XSearchRecentTweetsEventOrchestration.py
@@ -41,6 +41,7 @@ from naas_abi_marketplace.applications.x import (
     XSearchRecentTweetsEventConfiguration,
 )
 from naas_abi_marketplace.applications.x.orchestrations.utils import (
+    count_in_progress_runs,
     launchpad_override,
     run_search_pipeline_for_file,
     safe_name,
@@ -119,17 +120,23 @@ def _build_search_recent_tweets_event_sensor(
     for *event_cfg*.
 
     Job-per-entry so each sensor (which binds to a single job) and its durable
-    event consumer are isolated. The sensor drains undelivered ``ObjectPut``
-    events via ``events.query_for_consumer`` (durable cursor keyed on the sensor
-    name — every put is seen exactly once), keeps only those landing under
-    ``event_cfg.prefix``, and emits one RunRequest per file. The job is a single
-    op that feeds that envelope's ``prefix/key`` path to
-    :class:`XSearchRecentTweetsPipeline` in ``file_path`` mode, mapping the full
-    SearchQuery / SearchResultSet / SearchRecentTweets / Tweet structure from the
-    same file the workflow wrote (label-based dedupe makes a redelivered or
-    re-put file a no-op). Same in-process executor argument as the other X jobs:
-    share the dagster code-server's warm engine instead of forking a subprocess
-    that re-bootstraps and races the api on oxigraph / nexus.db.
+    event consumer are isolated. The sensor first counts in-flight /
+    queued runs of this job against ``event_cfg.max_concurrent_runs`` and
+    skips **before** calling ``events.query_for_consumer`` when no slot is
+    free — that API advances the durable consumer cursor atomically, so
+    draining events when we would only skip would drop them permanently.
+    When slots remain, it drains up to
+    ``min(events_per_tick, free_slots)`` undelivered ``ObjectPut`` events
+    (cursor keyed on the sensor name — every put is seen exactly once), keeps
+    only those landing under ``event_cfg.prefix``, and emits one RunRequest per
+    file. The job is a single op that feeds that envelope's ``prefix/key`` path
+    to :class:`XSearchRecentTweetsPipeline` in ``file_path`` mode, mapping the
+    full SearchQuery / SearchResultSet / SearchRecentTweets / Tweet structure
+    from the same file the workflow wrote (label-based dedupe makes a
+    redelivered or re-put file a no-op). Same in-process executor argument as
+    the other X jobs: share the dagster code-server's warm engine instead of
+    forking a subprocess that re-bootstraps and races the api on oxigraph /
+    nexus.db.
     """
 
     safe = safe_name(event_cfg.name)
@@ -168,6 +175,22 @@ def _build_search_recent_tweets_event_sensor(
             ObjectPut,
         )
 
+        # Gate BEFORE query_for_consumer: that call advances the durable
+        # consumer cursor. Skipping after a drain would permanently drop events.
+        in_flight = count_in_progress_runs(
+            context,
+            job_name,
+            limit=event_cfg.max_concurrent_runs,
+        )
+        free_slots = event_cfg.max_concurrent_runs - in_flight
+        if free_slots <= 0:
+            return dg.SkipReason(
+                f"Job '{job_name}' already has {in_flight}/{event_cfg.max_concurrent_runs} "
+                f"run(s) queued or running; not draining ObjectPut events so "
+                f"the consumer cursor stays put"
+            )
+        drain_limit = min(event_cfg.events_per_tick, free_slots)
+
         module = ABIModule.get_instance()
         if not module.engine.services.events_available():
             return dg.SkipReason(
@@ -178,7 +201,7 @@ def _build_search_recent_tweets_event_sensor(
             new_events = module.engine.services.events.query_for_consumer(
                 consumer_id=sensor_name,
                 event_class=ObjectPut,
-                limit=event_cfg.events_per_tick,
+                limit=drain_limit,
                 # Push the watched-prefix filter into the query so the per-tick
                 # budget and the durable cursor only advance over puts under
                 # this entry's prefix. `_is_search_recent_tweets_put` below

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/utils/__init__.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/utils/__init__.py
@@ -7,6 +7,7 @@ safe_name, has_in_progress_run, run_search_pipeline_for_file)``.
 
 from naas_abi_marketplace.applications.x.orchestrations.utils._common import (
     IN_PROGRESS_RUN_STATUSES,
+    count_in_progress_runs,
     has_in_progress_run,
     launchpad_override,
     run_search_pipeline_for_file,
@@ -15,6 +16,7 @@ from naas_abi_marketplace.applications.x.orchestrations.utils._common import (
 
 __all__ = [
     "IN_PROGRESS_RUN_STATUSES",
+    "count_in_progress_runs",
     "has_in_progress_run",
     "launchpad_override",
     "run_search_pipeline_for_file",

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/utils/_common.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/utils/_common.py
@@ -41,14 +41,28 @@ def launchpad_override(op_cfg: dict, key: str, default_value):
 
 def has_in_progress_run(context: dg.SensorEvaluationContext, job_name: str) -> bool:
     """True iff a run for *job_name* is still queued/starting/running."""
+    return count_in_progress_runs(context, job_name, limit=1) > 0
+
+
+def count_in_progress_runs(
+    context: dg.SensorEvaluationContext,
+    job_name: str,
+    *,
+    limit: int | None = None,
+) -> int:
+    """How many runs for *job_name* are still queued/starting/running.
+
+    Pass *limit* to short-circuit once enough in-flight runs are found (e.g.
+    stop after ``max_concurrent_runs`` when only checking capacity).
+    """
     runs = context.instance.get_runs(
         filters=dg.RunsFilter(
             job_name=job_name,
             statuses=IN_PROGRESS_RUN_STATUSES,
         ),
-        limit=1,
+        limit=limit,
     )
-    return len(runs) > 0
+    return len(runs)
 
 
 def run_search_pipeline_for_file(

--- a/libs/naas-abi-marketplace/uv.lock
+++ b/libs/naas-abi-marketplace/uv.lock
@@ -782,7 +782,7 @@ name = "cuda-bindings"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/a9/3a8241c6e19483ac1f1dcf5c10238205dcb8a6e9d0d4d4709240dff28ff4/cuda_bindings-13.2.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:721104c603f059780d287969be3d194a18d0cc3b713ed9049065a1107706759d", size = 5730273, upload-time = "2026-03-11T00:12:37.18Z" },
@@ -815,37 +815,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
 ]
 cufft = [
-    { name = "nvidia-cufft" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
 ]
 cufile = [
-    { name = "nvidia-cufile" },
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
 ]
 curand = [
-    { name = "nvidia-curand" },
+    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx" },
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -3312,7 +3312,7 @@ wheels = [
 
 [[package]]
 name = "naas-abi-core"
-version = "2.19.1"
+version = "2.19.2"
 source = { editable = "../naas-abi-core" }
 dependencies = [
     { name = "click" },
@@ -3739,7 +3739,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
@@ -3751,7 +3751,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -3781,9 +3781,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cusparse", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -3795,7 +3795,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3955,7 +3955,7 @@ resolution-markers = [
     "(python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/17/06/68c27a523103dad5837dc5b87e71285280c4f098c60e4fe8a8db6486ab09/opencv-python-4.11.0.86.tar.gz", hash = "sha256:03d60ccae62304860d232272e4a4fda93c39d595780cb40b161b310244b736a4", size = 95171956, upload-time = "2025-01-16T13:52:24.737Z" }
 wheels = [
@@ -3983,7 +3983,7 @@ resolution-markers = [
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/6f/5a28fef4c4a382be06afe3938c64cc168223016fa520c5abaf37e8862aa5/opencv_python-4.13.0.92-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:caf60c071ec391ba51ed00a4a920f996d0b64e3e46068aac1f646b5de0326a19", size = 46247052, upload-time = "2026-02-05T07:01:25.046Z" },
@@ -5955,8 +5955,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "jeepney", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -3547,7 +3547,7 @@ wheels = [
 
 [[package]]
 name = "naas-abi"
-version = "2.44.0"
+version = "2.45.0"
 source = { editable = "libs/naas-abi" }
 dependencies = [
     { name = "aiosqlite" },
@@ -3655,7 +3655,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-core"
-version = "2.19.1"
+version = "2.19.2"
 source = { editable = "libs/naas-abi-core" }
 dependencies = [
     { name = "click" },
@@ -3786,7 +3786,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-marketplace"
-version = "3.22.4"
+version = "3.23.0"
 source = { editable = "libs/naas-abi-marketplace" }
 dependencies = [
     { name = "ijson" },


### PR DESCRIPTION
This pull request resolves #fix-agent

# Summary

This PR addresses a bug fix related to the agent's handling of tool call arguments in the Naas ABI Core library. It ensures that tool call arguments are coerced into JSON objects before being sent to Amazon Bedrock Converse, which requires `toolUse.input` to be a JSON object.

# Details

- Added a static method `_coerce_tool_args_to_object` in the `Agent` class to coerce various invalid or unexpected shapes of tool call arguments (such as `None`, empty lists, empty strings, JSON strings, etc.) into a valid JSON object (Python dict).
- Added normalization methods `_normalize_ai_message_tool_inputs` and `_normalize_tool_inputs_in_messages` to rewrite AI messages and message histories so that all tool inputs are JSON objects.
- Integrated normalization of tool inputs before sending messages to the model and after receiving model responses to ensure compatibility with Bedrock and similar providers.
- Updated the changelog to document this bug fix.

# Tests

- Added multiple tests in `Agent_test.py` to verify the coercion of invalid tool argument shapes to JSON objects.
- Tests cover scenarios such as empty lists, empty strings, JSON strings, and nested function argument strings.
- Tests also verify that only AI messages are normalized and that content blocks with invalid tool inputs are corrected.

# Impact

This fix prevents `ValidationException` errors on `toolUse.input` when using models like `gpt-oss-120b` on Bedrock that emit empty lists or strings for zero-argument tools. It improves robustness and compatibility of the agent's tool calling mechanism with Bedrock Converse and similar providers.

# Changelog

## Unreleased

### Bug Fixes

- **agent**: Coerce non-object tool call args to `{}` before Bedrock Converse re-sends history (fixes ValidationException on `toolUse.input` for models like `gpt-oss-120b` that emit `[]`/`""` for zero-arg tools)