### PR TITLE
fix-backfill-x: Improve agent tool input normalization and XSearchRecentTweetsWorkflow enhancements

### DIFF
--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/__init__.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/__init__.py
@@ -61,6 +61,24 @@ class XTweetSearchWorkflowConfiguration(BaseModel):
             "caps the amount of work done per tick."
         ),
     )
+    save_every_pages: int | None = Field(
+        default=10,
+        ge=1,
+        description=(
+            "Workflow writes a new search envelope every N pages during a run "
+            "(whichever of save_every_pages / save_every_tweets hits first). "
+            "Null disables the pages threshold."
+        ),
+    )
+    save_every_tweets: int | None = Field(
+        default=1000,
+        ge=1,
+        description=(
+            "Workflow writes a new search envelope every N tweets during a run "
+            "(whichever of save_every_pages / save_every_tweets hits first). "
+            "Null disables the tweets threshold."
+        ),
+    )
     sort_order: str = Field(
         default="recency",
         description="Order results are returned in: 'recency' or 'relevancy'.",
@@ -281,6 +299,8 @@ class ABIModule(BaseModule):
                 max_results: 100
                 max_pages: 1
                 sort_order: recency      # 'recency' or 'relevancy'
+                save_every_pages: 10     # flush envelope every N pages
+                save_every_tweets: 1000  # …or every N tweets (whichever first)
                 persist: true
                 cost_per_tweet_usd: 0.005
                 daily_max_usd: 20        # ~4000 tweets/day at $0.005

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/integrations/XIntegration.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/integrations/XIntegration.py
@@ -270,6 +270,10 @@ class XIntegration(Integration):
 
             page += 1
             if max_pages is not None and page >= max_pages:
+                # Signal callers (e.g. the search workflow) that more pages exist
+                # beyond this capped fetch so they can continue with until_id.
+                if page_meta.get("next_token"):
+                    merged_meta["has_more"] = True
                 break
 
             next_token = page_meta.get("next_token")
@@ -566,7 +570,7 @@ class XIntegration(Integration):
     # ----------------------------------------------------------------- search
 
     @cache(
-        lambda self, query, start_time=None, end_time=None, since_id=None, until_id=None, max_results=100, sort_order=None, tweet_fields=None, expansions=None, media_fields=None, poll_fields=None, user_fields=None, place_fields=None, max_pages=1: (
+        lambda self, query, start_time=None, end_time=None, since_id=None, until_id=None, max_results=100, sort_order=None, tweet_fields=None, expansions=None, media_fields=None, poll_fields=None, user_fields=None, place_fields=None, max_pages=1, persist_envelope=True: (
             "search_recent_tweets_"
             + hashlib.md5(
                 json_module.dumps(
@@ -585,6 +589,7 @@ class XIntegration(Integration):
                         "user_fields": sorted(user_fields) if user_fields else None,
                         "place_fields": sorted(place_fields) if place_fields else None,
                         "max_pages": max_pages,
+                        "persist_envelope": persist_envelope,
                     },
                     sort_keys=True,
                     default=str,
@@ -610,6 +615,7 @@ class XIntegration(Integration):
         user_fields: Optional[List[str]] = None,
         place_fields: Optional[List[str]] = None,
         max_pages: Optional[int] = 1,
+        persist_envelope: bool = True,
     ) -> Dict:
         """Search tweets from the last 7 days.
 
@@ -640,12 +646,17 @@ class XIntegration(Integration):
                 (sent as `place.fields`).
             max_pages (int, optional): Pages of results to fetch (None to exhaust).
                 Defaults to 1.
+            persist_envelope (bool): When True (default), write the
+                ``{query, options, results, …}`` envelope to object storage.
+                Set False when the caller (e.g. XSearchRecentTweetsWorkflow)
+                owns envelope persistence / batching.
 
         Returns:
-            Dict: The persisted search envelope with keys ``query``, ``options``,
-            ``results`` (the merged X v2 response — ``data``, ``includes``,
-            ``errors``, ``meta``), ``started_at``, ``ended_at`` and ``file_path``
-            (object-storage path of the saved envelope JSON).
+            Dict: Search envelope with keys ``query``, ``options``, ``results``
+            (merged X v2 response — ``data``, ``includes``, ``errors``, ``meta``;
+            ``meta.has_more`` is set when ``max_pages`` stopped pagination early),
+            ``started_at``, ``ended_at`` and ``file_path`` (object-storage path
+            when persisted, else ``None``).
         """
         params: Dict = {"query": query, "max_results": max_results}
         if start_time is not None:
@@ -796,9 +807,6 @@ class XIntegration(Integration):
             max_pages=max_pages,
         )
         ended_at = datetime.now(timezone.utc).isoformat()
-        # params_hash = hashlib.md5(
-        #     json_module.dumps(params, sort_keys=True, default=str).encode()
-        # ).hexdigest()[:8]
         options = {
             k: v
             for k, v in {
@@ -826,6 +834,7 @@ class XIntegration(Integration):
         envelope_filename = (
             f"{datetime.now(timezone.utc).isoformat()}_{slugify_query(query)}.json"
         )
+        file_path = os.path.join(envelope_dir, envelope_filename) if persist_envelope else None
 
         # Return the exact object we persist — the {query, options, results,
         # started_at, ended_at, file_path} envelope — rather than just the raw
@@ -839,14 +848,15 @@ class XIntegration(Integration):
             "results": tweets,
             "started_at": started_at,
             "ended_at": ended_at,
-            "file_path": os.path.join(envelope_dir, envelope_filename),
+            "file_path": file_path,
         }
-        self.__storage_utils.save_json(
-            envelope,
-            envelope_dir,
-            envelope_filename,
-            copy=False,
-        )
+        if persist_envelope:
+            self.__storage_utils.save_json(
+                envelope,
+                envelope_dir,
+                envelope_filename,
+                copy=False,
+            )
         return envelope
 
     # ------------------------------------------------------------ tweet counts

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/XSearchWorkflowOrchestration.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/XSearchWorkflowOrchestration.py
@@ -58,6 +58,16 @@ _SEARCH_WORKFLOW_OP_CONFIG_SCHEMA = {
         is_required=False,
         description="Maximum pages to fetch per run (null = no limit).",
     ),
+    "save_every_pages": dg.Field(
+        int,
+        is_required=False,
+        description="Flush a new envelope every N pages during pagination.",
+    ),
+    "save_every_tweets": dg.Field(
+        int,
+        is_required=False,
+        description="Flush a new envelope every N tweets during pagination.",
+    ),
     "sort_order": dg.Field(
         str,
         is_required=False,
@@ -117,16 +127,26 @@ def _run_search_workflow(
     max_results = launchpad_override(op_cfg, "max_results", filter_config.max_results)
     max_pages = launchpad_override(op_cfg, "max_pages", filter_config.max_pages)
     sort_order = launchpad_override(op_cfg, "sort_order", filter_config.sort_order)
+    save_every_pages = launchpad_override(
+        op_cfg, "save_every_pages", filter_config.save_every_pages
+    )
+    save_every_tweets = launchpad_override(
+        op_cfg, "save_every_tweets", filter_config.save_every_tweets
+    )
 
     options: dict = {
         "max_results": max_results,
         "max_pages": max_pages,
         "sort_order": sort_order,
+        "save_every_pages": save_every_pages,
+        "save_every_tweets": save_every_tweets,
     }
 
     logger.info(
         f"XSearchWorkflowOrchestration[{filter_config.name}]: running "
-        f"XSearchRecentTweetsWorkflow(query={query!r}) — fetch + save only"
+        f"XSearchRecentTweetsWorkflow(query={query!r}) — fetch + save only "
+        f"(save_every_pages={save_every_pages}, "
+        f"save_every_tweets={save_every_tweets})"
     )
 
     # XIntegration and the workflow both default datastore_path to the
@@ -140,6 +160,8 @@ def _run_search_workflow(
             x_integration=x_integration,
             object_storage=module.engine.services.object_storage,
             budget_key=filter_config.name,
+            save_every_pages=save_every_pages,
+            save_every_tweets=save_every_tweets,
             cost_per_tweet_usd=launchpad_override(
                 op_cfg, "cost_per_tweet_usd", filter_config.cost_per_tweet_usd
             ),
@@ -164,11 +186,13 @@ def _run_search_workflow(
         )
     )
 
-    file_paths = [
-        item["file_path"]
-        for item in output.get("results", [])
-        if item.get("file_path")
-    ]
+    file_paths: list[str] = []
+    for item in output.get("results", []):
+        paths = item.get("file_paths") or []
+        if paths:
+            file_paths.extend(paths)
+        elif item.get("file_path"):
+            file_paths.append(item["file_path"])
     logger.info(
         f"XSearchWorkflowOrchestration[{filter_config.name}]: saved "
         f"{len(file_paths)} envelope(s); the ObjectPut sensor will map them."

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/workflows/XSearchRecentTweetsWorkflow.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/workflows/XSearchRecentTweetsWorkflow.py
@@ -498,6 +498,7 @@ class XSearchRecentTweetsWorkflow(Workflow[XSearchRecentTweetsWorkflowParameters
         """Persist one search envelope and return it (triggers ObjectPut)."""
         meta = self._as_dict(results.get("meta"))
         tweets = results.get("data") or []
+        tweet_count = len(tweets) if isinstance(tweets, list) else 0
         envelope_dir = self._query_prefix(query)
         envelope_filename = (
             f"{datetime.now(timezone.utc).isoformat()}_{slugify_query(query)}.json"
@@ -517,7 +518,7 @@ class XSearchRecentTweetsWorkflow(Workflow[XSearchRecentTweetsWorkflowParameters
             "file_path": file_path,
             "batch": {
                 "pages": pages,
-                "tweet_count": len(tweets) if isinstance(tweets, list) else 0,
+                "tweet_count": tweet_count,
                 "has_more": has_more,
                 "newest_id": meta.get("newest_id"),
                 "oldest_id": meta.get("oldest_id"),
@@ -530,7 +531,7 @@ class XSearchRecentTweetsWorkflow(Workflow[XSearchRecentTweetsWorkflowParameters
             "XSearchRecentTweetsWorkflow: saved envelope %s "
             "(%s tweets, %s pages, has_more=%s)",
             file_path,
-            envelope["batch"]["tweet_count"],
+            tweet_count,
             pages,
             has_more,
         )

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/workflows/XSearchRecentTweetsWorkflow.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/workflows/XSearchRecentTweetsWorkflow.py
@@ -42,6 +42,8 @@ _SEARCH_OPTION_KEYS = frozenset(
         "user_fields",
         "place_fields",
         "max_pages",
+        "save_every_pages",
+        "save_every_tweets",
     }
 )
 
@@ -88,6 +90,11 @@ class XSearchRecentTweetsWorkflowConfiguration(WorkflowConfiguration):
     daily_max_usd: Optional[float] = None
     monthly_max_tweets: Optional[int] = None
     monthly_max_usd: Optional[float] = None
+    # Flush a new envelope whenever either threshold is hit during pagination
+    # (whichever comes first). None disables that threshold; when both are None
+    # the integration writes a single envelope at the end (legacy behaviour).
+    save_every_pages: Optional[int] = 10
+    save_every_tweets: Optional[int] = 1000
 
 
 class XSearchRecentTweetsWorkflowParameters(WorkflowParameters):
@@ -118,10 +125,19 @@ class XSearchRecentTweetsWorkflowParameters(WorkflowParameters):
                 "XIntegration.search_recent_tweets for every query — any subset "
                 "of: start_time, end_time, until_id, max_results, sort_order, "
                 "tweet_fields, expansions, media_fields, poll_fields, "
-                "user_fields, place_fields, max_pages. 'since_id' is not "
-                "accepted here; it is derived per query from the datastore."
+                "user_fields, place_fields, max_pages, save_every_pages, "
+                "save_every_tweets. 'since_id' is not accepted here; it is "
+                "derived per query from the datastore."
             ),
-            examples=[{"max_results": 100, "sort_order": "recency", "max_pages": None}],
+            examples=[
+                {
+                    "max_results": 100,
+                    "sort_order": "recency",
+                    "max_pages": None,
+                    "save_every_pages": 10,
+                    "save_every_tweets": 1000,
+                }
+            ],
         ),
     ]
     persist: Annotated[
@@ -305,11 +321,11 @@ class XSearchRecentTweetsWorkflow(Workflow[XSearchRecentTweetsWorkflowParameters
 
     For every query the workflow recovers a ``since_id`` from the datastore (the
     highest tweet id seen on a previous run) and asks X only for newer tweets.
-    The integration persists each response, so the cursor advances on its own:
-    the first run fetches the last 7 days, and every subsequent run returns only
-    what appeared since. ``since_id`` is read by scanning the per-query folder
-    newest-to-oldest and taking the first ``results.meta.newest_id`` found, so a
-    run that returned zero new tweets (no ``newest_id``) does not reset it.
+    Results are fetched newest-first (recency). The workflow — not the
+    integration — writes envelope JSON files, flushing every
+    ``save_every_pages`` / ``save_every_tweets`` (whichever hits first). After
+    each saved batch, if more pages remain above ``since_id``, the next fetch
+    uses the same ``since_id`` and ``until_id=<oldest id of that batch>``.
 
     Queries are processed concurrently, one worker thread per query, so a batch
     of N queries runs its N fetch passes in parallel.
@@ -319,13 +335,16 @@ class XSearchRecentTweetsWorkflow(Workflow[XSearchRecentTweetsWorkflowParameters
     __storage_utils: StorageUtils
     __budget: _XApiBudget
 
+    # Keys owned by the workflow; not forwarded to XIntegration.
+    _WORKFLOW_ONLY_OPTION_KEYS = frozenset({"save_every_pages", "save_every_tweets"})
+
     def __init__(self, configuration: XSearchRecentTweetsWorkflowConfiguration):
         super().__init__(configuration)
         self.__configuration = configuration
         self.__storage_utils = StorageUtils(self.__configuration.object_storage)
         # Global spend ledger lives under <datastore_path>/_budget so it sits
         # next to (but never collides with) the per-query search_recent_tweets
-        # envelopes the integration writes.
+        # envelopes this workflow writes.
         self.__budget = _XApiBudget(
             self.__storage_utils,
             os.path.join(self.__configuration.datastore_path, "_budget"),
@@ -339,71 +358,404 @@ class XSearchRecentTweetsWorkflow(Workflow[XSearchRecentTweetsWorkflowParameters
             ),
         )
 
-    def get_since_id(self, query: str) -> Optional[str]:
-        """Return the highest tweet id already fetched for ``query``, or None.
-
-        Scans ``<datastore_path>/search_recent_tweets/<slug>/`` from the newest
-        file to the oldest and returns the first ``results.meta.newest_id`` it
-        finds. Returns None on the first run for a query (no folder yet).
-        """
-        prefix = os.path.join(
+    def _query_prefix(self, query: str) -> str:
+        return os.path.join(
             self.__configuration.datastore_path,
             "search_recent_tweets",
             slugify_query(query),
         )
+
+    def _iter_envelope_filenames(self, query: str) -> list[str]:
+        """Envelope basenames for *query*, newest filename first."""
+        prefix = self._query_prefix(query)
         try:
             objects = self.__configuration.object_storage.list_objects(prefix)
         except Exception:
-            return None
-
-        filenames = sorted(
+            return []
+        return sorted(
             (os.path.basename(o) for o in objects if o.endswith(".json")),
             reverse=True,
         )
-        for filename in filenames:
-            data = self.__storage_utils.get_json(prefix, filename)
-            results = data.get("results") if isinstance(data, dict) else None
-            meta = results.get("meta") if isinstance(results, dict) else None
-            newest_id = meta.get("newest_id") if isinstance(meta, dict) else None
-            if newest_id:
-                return newest_id
-        return None
+
+    def _load_envelope(self, query: str, filename: str) -> dict:
+        data = self.__storage_utils.get_json(self._query_prefix(query), filename)
+        return data if isinstance(data, dict) else {}
+
+    @staticmethod
+    def _as_dict(value: object) -> dict:
+        return value if isinstance(value, dict) else {}
+
+    @staticmethod
+    def _envelope_newest_id(data: dict) -> Optional[str]:
+        batch = XSearchRecentTweetsWorkflow._as_dict(data.get("batch"))
+        if batch.get("newest_id"):
+            return str(batch["newest_id"])
+        results = XSearchRecentTweetsWorkflow._as_dict(data.get("results"))
+        meta = XSearchRecentTweetsWorkflow._as_dict(results.get("meta"))
+        newest_id = meta.get("newest_id")
+        return str(newest_id) if newest_id else None
+
+    @staticmethod
+    def _envelope_oldest_id(data: dict) -> Optional[str]:
+        batch = XSearchRecentTweetsWorkflow._as_dict(data.get("batch"))
+        if batch.get("oldest_id"):
+            return str(batch["oldest_id"])
+        results = XSearchRecentTweetsWorkflow._as_dict(data.get("results"))
+        meta = XSearchRecentTweetsWorkflow._as_dict(results.get("meta"))
+        oldest_id = meta.get("oldest_id")
+        return str(oldest_id) if oldest_id else None
+
+    def get_since_id(self, query: str) -> Optional[str]:
+        """Return the highest tweet id already fetched for ``query``, or None.
+
+        Scans every envelope under
+        ``<datastore_path>/search_recent_tweets/<slug>/`` and returns the max
+        ``newest_id`` (tweet ids are snowflakes — lexicographic max works).
+        Taking the max — not the newest file — is required once a run can write
+        multiple batch files (later files may hold older pages).
+        """
+        best: Optional[str] = None
+        for filename in self._iter_envelope_filenames(query):
+            newest_id = self._envelope_newest_id(self._load_envelope(query, filename))
+            if not newest_id:
+                continue
+            if best is None or newest_id > best:
+                best = newest_id
+        return best
+
+    def get_resume_until_id(self, query: str) -> Optional[str]:
+        """Oldest id to continue from when the latest envelope has ``has_more``.
+
+        After a crash mid-pagination the newest file still reports
+        ``batch.has_more=True``. The next run resumes older pages with
+        ``until_id=<that oldest_id>`` so already-saved batches are kept.
+        """
+        filenames = self._iter_envelope_filenames(query)
+        if not filenames:
+            return None
+        latest = self._load_envelope(query, filenames[0])
+        batch = self._as_dict(latest.get("batch"))
+        if not batch.get("has_more"):
+            return None
+        return self._envelope_oldest_id(latest)
+
+    def get_resume_since_id(self, query: str) -> Optional[str]:
+        """``options.since_id`` from the latest incomplete envelope, if any."""
+        filenames = self._iter_envelope_filenames(query)
+        if not filenames:
+            return None
+        latest = self._load_envelope(query, filenames[0])
+        batch = self._as_dict(latest.get("batch"))
+        if not batch.get("has_more"):
+            return None
+        options = self._as_dict(latest.get("options"))
+        since_id = options.get("since_id")
+        return str(since_id) if since_id else None
+
+    def _resolve_save_thresholds(self, options: dict) -> tuple[Optional[int], Optional[int]]:
+        save_every_pages = (
+            options["save_every_pages"]
+            if "save_every_pages" in options
+            else self.__configuration.save_every_pages
+        )
+        save_every_tweets = (
+            options["save_every_tweets"]
+            if "save_every_tweets" in options
+            else self.__configuration.save_every_tweets
+        )
+        return save_every_pages, save_every_tweets
+
+    @staticmethod
+    def _batch_max_pages(
+        save_every_pages: Optional[int],
+        save_every_tweets: Optional[int],
+        max_results: int,
+    ) -> Optional[int]:
+        """Pages per integration call from the configured flush thresholds.
+
+        Returns ``None`` when both thresholds are unset (legacy: one call uses
+        the caller's ``max_pages`` as-is).
+        """
+        limits: list[int] = []
+        if save_every_pages is not None:
+            limits.append(int(save_every_pages))
+        if save_every_tweets is not None:
+            per_page = max(int(max_results), 1)
+            limits.append(max(1, (int(save_every_tweets) + per_page - 1) // per_page))
+        return min(limits) if limits else None
+
+    def _save_envelope(
+        self,
+        *,
+        query: str,
+        options: dict,
+        results: dict,
+        has_more: bool,
+        pages: int,
+        started_at: str,
+        ended_at: str,
+    ) -> dict:
+        """Persist one search envelope and return it (triggers ObjectPut)."""
+        meta = self._as_dict(results.get("meta"))
+        tweets = results.get("data") or []
+        envelope_dir = self._query_prefix(query)
+        envelope_filename = (
+            f"{datetime.now(timezone.utc).isoformat()}_{slugify_query(query)}.json"
+        )
+        file_path = os.path.join(envelope_dir, envelope_filename)
+        stored_options = {
+            k: v
+            for k, v in options.items()
+            if k not in self._WORKFLOW_ONLY_OPTION_KEYS and v is not None
+        }
+        envelope = {
+            "query": query,
+            "options": stored_options,
+            "results": results,
+            "started_at": started_at,
+            "ended_at": ended_at,
+            "file_path": file_path,
+            "batch": {
+                "pages": pages,
+                "tweet_count": len(tweets) if isinstance(tweets, list) else 0,
+                "has_more": has_more,
+                "newest_id": meta.get("newest_id"),
+                "oldest_id": meta.get("oldest_id"),
+            },
+        }
+        self.__storage_utils.save_json(
+            envelope, envelope_dir, envelope_filename, copy=False
+        )
+        logger.info(
+            "XSearchRecentTweetsWorkflow: saved envelope %s "
+            "(%s tweets, %s pages, has_more=%s)",
+            file_path,
+            envelope["batch"]["tweet_count"],
+            pages,
+            has_more,
+        )
+        return envelope
+
+    def _fetch_and_save_batches(
+        self,
+        query: str,
+        *,
+        base_options: dict,
+        since_id: Optional[str],
+        until_id: Optional[str],
+        start_time: Optional[str],
+        overall_max_pages: Optional[int],
+        save_every_pages: Optional[int],
+        save_every_tweets: Optional[int],
+    ) -> tuple[list[str], list, Optional[str]]:
+        """Walk newest→older in batches; return (file_paths, tweets, newest_id)."""
+        max_results = int(base_options.get("max_results") or 100)
+        batch_pages = self._batch_max_pages(
+            save_every_pages, save_every_tweets, max_results
+        )
+
+        file_paths: list[str] = []
+        tweets: list = []
+        newest_id: Optional[str] = None
+        pages_used = 0
+        current_until_id = until_id
+
+        while True:
+            if overall_max_pages is not None and pages_used >= overall_max_pages:
+                break
+
+            call_max_pages = batch_pages
+            if overall_max_pages is not None:
+                remaining = overall_max_pages - pages_used
+                call_max_pages = (
+                    remaining
+                    if call_max_pages is None
+                    else min(call_max_pages, remaining)
+                )
+            if call_max_pages is not None and call_max_pages <= 0:
+                break
+
+            call_opts = {
+                k: v
+                for k, v in base_options.items()
+                if k not in self._WORKFLOW_ONLY_OPTION_KEYS
+                and k not in {"since_id", "until_id", "start_time", "max_pages"}
+            }
+            if since_id is not None:
+                call_opts["since_id"] = since_id
+            if current_until_id is not None:
+                call_opts["until_id"] = current_until_id
+            elif start_time is not None and since_id is None:
+                call_opts["start_time"] = start_time
+            if call_max_pages is not None:
+                call_opts["max_pages"] = call_max_pages
+
+            logger.info(
+                "XSearchRecentTweetsWorkflow: query=%r since_id=%s until_id=%s "
+                "max_pages=%s",
+                query,
+                since_id,
+                current_until_id,
+                call_max_pages,
+            )
+            started_at = datetime.now(timezone.utc).isoformat()
+            raw = self.__configuration.x_integration.search_recent_tweets(
+                query,
+                persist_envelope=False,
+                **call_opts,
+            )
+            ended_at = datetime.now(timezone.utc).isoformat()
+            results = self._as_dict(raw.get("results"))
+            meta = self._as_dict(results.get("meta"))
+            batch_tweets = results.get("data") or []
+            if not isinstance(batch_tweets, list):
+                batch_tweets = []
+            has_more = bool(meta.get("has_more"))
+            pages_this = call_max_pages
+            if pages_this is None:
+                pages_this = max(1, (len(batch_tweets) + max_results - 1) // max_results) if batch_tweets else 0
+            elif batch_tweets:
+                pages_this = max(
+                    1, min(pages_this, (len(batch_tweets) + max_results - 1) // max_results)
+                )
+            else:
+                pages_this = 0
+
+            envelope = self._save_envelope(
+                query=query,
+                options={**call_opts, "since_id": since_id, "until_id": current_until_id},
+                results=results,
+                has_more=has_more,
+                pages=pages_this or 0,
+                started_at=started_at,
+                ended_at=ended_at,
+            )
+            if envelope.get("file_path"):
+                file_paths.append(envelope["file_path"])
+            tweets.extend(batch_tweets)
+            if meta.get("newest_id"):
+                # Keep the chronologically newest id seen in this walk (first batch).
+                if newest_id is None or str(meta["newest_id"]) > newest_id:
+                    newest_id = str(meta["newest_id"])
+
+            pages_used += pages_this or (call_max_pages or 0)
+
+            if not batch_tweets or not has_more:
+                break
+            oldest_id = meta.get("oldest_id")
+            if not oldest_id:
+                break
+            # Next batch: same since_id window, walk older via until_id.
+            current_until_id = str(oldest_id)
+
+        return file_paths, tweets, newest_id
 
     def _process_query(self, query: str, options: dict) -> dict:
-        """Fetch one query incrementally and persist its JSON envelope.
+        """Fetch one query incrementally; workflow persists batched envelopes.
 
-        Recovers the query's ``since_id`` and calls the X v2 search endpoint,
-        which writes the ``{query, options, results, …}`` envelope to object
-        storage. Runs in its own worker thread.
+        1. If the latest envelope still has ``batch.has_more``, resume older
+           pages with ``until_id`` + the incomplete envelope's ``since_id``.
+        2. Then fetch tweets newer than the max stored ``newest_id`` via
+           ``since_id``, flushing every ``save_every_pages`` / ``save_every_tweets``.
         """
+        save_every_pages, save_every_tweets = self._resolve_save_thresholds(options)
+        overall_max_pages = options.get("max_pages")
+        max_results = int(options.get("max_results") or 100)
+        base_options = dict(options)
+
+        file_paths: list[str] = []
+        tweets: list = []
+        newest_id: Optional[str] = None
+        since_id_used: Optional[str] = None
+
+        # --- Phase A: finish an interrupted older-pages walk ----------------
+        resume_until_id = self.get_resume_until_id(query)
+        if resume_until_id is not None:
+            resume_since = self.get_resume_since_id(query)
+            logger.info(
+                "XSearchRecentTweetsWorkflow: query=%r resuming older pages "
+                "until_id=%s since_id=%s",
+                query,
+                resume_until_id,
+                resume_since,
+            )
+            paths, batch_tweets, batch_newest = self._fetch_and_save_batches(
+                query,
+                base_options=base_options,
+                since_id=resume_since,
+                until_id=resume_until_id,
+                start_time=None,
+                overall_max_pages=overall_max_pages,
+                save_every_pages=save_every_pages,
+                save_every_tweets=save_every_tweets,
+            )
+            file_paths.extend(paths)
+            tweets.extend(batch_tweets)
+            if batch_newest:
+                newest_id = batch_newest
+            since_id_used = resume_since
+
+        # --- Phase B: incremental newer tweets via since_id -----------------
         since_id = self.get_since_id(query)
+        since_id_used = since_id if since_id_used is None else since_id_used
+        start_time = options.get("start_time")
+        if since_id is None and not start_time:
+            start_time = (datetime.now(timezone.utc) - timedelta(hours=1)).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            )
 
-        # On the first run for a query there is no since_id to anchor the window,
-        # so default start_time to 1 hour ago (unless the caller set it). With a
-        # since_id, X already returns only newer tweets, so no default is needed.
-        if since_id is None and not options.get("start_time"):
-            options = {
-                **options,
-                "start_time": (
-                    datetime.now(timezone.utc) - timedelta(hours=1)
-                ).strftime("%Y-%m-%dT%H:%M:%SZ"),
-            }
+        # Pages already consumed by resume still count against overall_max_pages.
+        pages_already = 0
+        if overall_max_pages is not None and file_paths:
+            # Approximate from tweet count; exact page accounting is best-effort.
+            pages_already = max(
+                1, (len(tweets) + max_results - 1) // max_results
+            ) if tweets else 0
+            remaining = overall_max_pages - pages_already
+            if remaining <= 0:
+                return {
+                    "query": query,
+                    "since_id": since_id_used,
+                    "new_count": len(tweets),
+                    "newest_id": newest_id,
+                    "file_path": file_paths[-1] if file_paths else None,
+                    "file_paths": file_paths,
+                    "tweets": tweets,
+                }
+            phase_b_max = remaining
+        else:
+            phase_b_max = overall_max_pages
 
-        logger.info(f"XSearchRecentTweetsWorkflow: query={query!r} since_id={since_id}")
-        envelope = self.__configuration.x_integration.search_recent_tweets(
-            query, since_id=since_id, **options
+        logger.info(
+            "XSearchRecentTweetsWorkflow: query=%r since_id=%s "
+            "save_every_pages=%s save_every_tweets=%s",
+            query,
+            since_id,
+            save_every_pages,
+            save_every_tweets,
         )
-        results = envelope.get("results") or {}
-        tweets = results.get("data") or []
-        newest_id = (results.get("meta") or {}).get("newest_id")
-        file_path = envelope.get("file_path")
+        paths, batch_tweets, batch_newest = self._fetch_and_save_batches(
+            query,
+            base_options=base_options,
+            since_id=since_id,
+            until_id=None,
+            start_time=start_time,
+            overall_max_pages=phase_b_max,
+            save_every_pages=save_every_pages,
+            save_every_tweets=save_every_tweets,
+        )
+        file_paths.extend(paths)
+        tweets.extend(batch_tweets)
+        if batch_newest and (newest_id is None or batch_newest > newest_id):
+            newest_id = batch_newest
 
         return {
             "query": query,
             "since_id": since_id,
             "new_count": len(tweets),
             "newest_id": newest_id,
-            "file_path": file_path,
+            "file_path": file_paths[-1] if file_paths else None,
+            "file_paths": file_paths,
             "tweets": tweets,
         }
 

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/workflows/XSearchRecentTweetsWorkflow_test.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/workflows/XSearchRecentTweetsWorkflow_test.py
@@ -122,11 +122,61 @@ def test_filters_track_separate_ledgers():
     assert b.usage() == (0, 0)
 
 
-def test_snapshot_reports_usage_and_usd():
-    budget = _budget(_BudgetLimits(0.005, 100, None, 1000, None))
-    budget.record(40)
-    snap = budget.snapshot()
-    assert snap["tweets_today"] == 40
-    assert snap["usd_today"] == 0.2  # 40 * 0.005
-    assert snap["daily_tweet_cap"] == 100
-    assert snap["monthly_tweet_cap"] == 1000
+def test_batch_max_pages_from_thresholds():
+    from naas_abi_marketplace.applications.x.workflows.XSearchRecentTweetsWorkflow import (
+        XSearchRecentTweetsWorkflow,
+    )
+
+    assert XSearchRecentTweetsWorkflow._batch_max_pages(10, 1000, 100) == 10
+    assert XSearchRecentTweetsWorkflow._batch_max_pages(20, 1000, 100) == 10
+    assert XSearchRecentTweetsWorkflow._batch_max_pages(5, 1000, 100) == 5
+    assert XSearchRecentTweetsWorkflow._batch_max_pages(None, 250, 100) == 3
+    assert XSearchRecentTweetsWorkflow._batch_max_pages(None, None, 100) is None
+
+
+def test_get_since_id_takes_max_across_batch_files():
+    """Later batch files can hold older pages — since_id must be the max id."""
+    from naas_abi_marketplace.applications.x.workflows.XSearchRecentTweetsWorkflow import (
+        XSearchRecentTweetsWorkflow,
+    )
+
+    class _Fake:
+        _envelope_newest_id = staticmethod(XSearchRecentTweetsWorkflow._envelope_newest_id)
+        _envelope_oldest_id = staticmethod(XSearchRecentTweetsWorkflow._envelope_oldest_id)
+        _as_dict = staticmethod(XSearchRecentTweetsWorkflow._as_dict)
+
+        def _iter_envelope_filenames(self, query: str):
+            return ["b_later.json", "a_earlier.json"]
+
+        def _load_envelope(self, query: str, filename: str):
+            return {
+                "a_earlier.json": {
+                    "batch": {"newest_id": "200", "oldest_id": "150", "has_more": True}
+                },
+                "b_later.json": {
+                    "batch": {"newest_id": "149", "oldest_id": "100", "has_more": False}
+                },
+            }[filename]
+
+    fake = _Fake()
+    assert XSearchRecentTweetsWorkflow.get_since_id(fake, "q") == "200"  # type: ignore[arg-type]
+    # Latest file has has_more=False → no until_id resume.
+    assert XSearchRecentTweetsWorkflow.get_resume_until_id(fake, "q") is None  # type: ignore[arg-type]
+
+    class _Incomplete:
+        _envelope_newest_id = staticmethod(XSearchRecentTweetsWorkflow._envelope_newest_id)
+        _envelope_oldest_id = staticmethod(XSearchRecentTweetsWorkflow._envelope_oldest_id)
+        _as_dict = staticmethod(XSearchRecentTweetsWorkflow._as_dict)
+
+        def _iter_envelope_filenames(self, query: str):
+            return ["latest.json"]
+
+        def _load_envelope(self, query: str, filename: str):
+            return {
+                "batch": {"newest_id": "200", "oldest_id": "150", "has_more": True},
+                "options": {"since_id": "50"},
+            }
+
+    inc = _Incomplete()
+    assert XSearchRecentTweetsWorkflow.get_resume_until_id(inc, "q") == "150"  # type: ignore[arg-type]
+    assert XSearchRecentTweetsWorkflow.get_resume_since_id(inc, "q") == "50"  # type: ignore[arg-type]


### PR DESCRIPTION
This pull request resolves #fix-backfill-x

# Summary

This PR includes multiple improvements and fixes across the `naas-abi-core` and `naas-abi-marketplace` libraries, as well as updates to dependency markers and enhancements to the XSearchRecentTweetsWorkflow.

# Changes

## Agent Tool Input Normalization (naas-abi-core)
- Added robust coercion of tool call arguments to ensure they are always JSON objects (`dict`). This addresses issues with providers like Amazon Bedrock Converse that reject non-object `toolUse.input` values.
- Implemented normalization of tool inputs in AI messages and message histories to convert empty lists, empty strings, or invalid JSON strings into empty JSON objects.
- Added detailed tests covering various edge cases for tool input normalization.
- Updated the agent's message handling to normalize tool inputs before and after model calls.

## XSearchRecentTweetsWorkflow Enhancements (naas-abi-marketplace)
- Added new configuration options `save_every_pages` and `save_every_tweets` to flush search envelopes periodically during pagination instead of only once at the end.
- Modified the XIntegration search method to optionally disable automatic envelope persistence, allowing the workflow to manage batching and persistence.
- Implemented logic in the workflow to resume interrupted pagination using `until_id` and `since_id` from incomplete envelopes.
- Added concurrency control in the event sensor to limit the number of concurrent runs and prevent cursor advancement when no slots are free.
- Improved envelope file handling to support multiple batch files per query and correctly determine the highest `since_id`.
- Added comprehensive tests for the new batching and resumption logic.

## Dependency and Packaging Updates
- Updated several package versions in `uv.lock` files.
- Added platform-specific markers to dependencies such as `cryptography`, `jeepney`, and various NVIDIA CUDA packages to restrict installation to supported platforms.
- Fixed pydantic field alias usage in Anthropic model definitions for `max_tokens_to_sample`.

# Impact

- These changes improve compatibility with Bedrock and other providers by ensuring tool call inputs are always valid JSON objects.
- The XSearchRecentTweetsWorkflow now supports incremental saving of search results, better crash recovery, and concurrency limits to avoid lost events.
- Dependency markers reduce installation issues on unsupported platforms.

# Testing

- Added and updated unit tests for agent tool input normalization.
- Added tests for XSearchRecentTweetsWorkflow batching, resumption, and concurrency control.
- Existing tests updated to reflect changes in event stream invocation.

# Notes

- The workflow now manages envelope persistence granularity, which may affect downstream consumers expecting a single envelope per run.
- Concurrency gating in the sensor prevents event cursor advancement when the job is fully occupied, avoiding event loss.

---

This PR is a significant step towards more robust and scalable tweet search workflows and agent tool call handling.