### PR TITLE
feat: Enhance Nexus Files Service with Pagination

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/files/adapters/primary/files__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/files/adapters/primary/files__primary_adapter__FastAPI.py
@@ -75,6 +75,7 @@ def _to_file_list_response_schema(value: FileListResponseData) -> FileListRespon
     return FileListResponse(
         files=[_to_file_info_schema(file) for file in value.files],
         path=value.path,
+        total=value.total,
     )
 
 
@@ -247,11 +248,25 @@ async def list_files(
     path: str = Query("", description="Directory path to list"),
     workspace_id: str | None = Query(default=None, max_length=100),
     scope: str = Query(default="workspace", pattern=SCOPE_PATTERN),
+    limit: int | None = Query(
+        default=None,
+        ge=1,
+        le=1000,
+        description="Max entries to return. Omit to return the full listing.",
+    ),
+    offset: int = Query(default=0, ge=0, description="Number of entries to skip"),
+    search: str | None = Query(
+        default=None,
+        max_length=255,
+        description="Case-insensitive substring filter on entry name (this folder only)",
+    ),
     current_user: User = Depends(get_current_user_required),
     files_service: FilesService = Depends(get_files_service),
 ):
     scoped_path = await _authorize_path(current_user, path, workspace_id, scope, files_service=files_service)
-    return _to_file_list_response_schema(files_service.list_files(path=scoped_path))
+    return _to_file_list_response_schema(
+        files_service.list_files(path=scoped_path, limit=limit, offset=offset, search=search)
+    )
 
 
 @router.post("/", response_model=FileInfo)

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/files/adapters/primary/files__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/files/adapters/primary/files__primary_adapter__FastAPI.py
@@ -260,12 +260,29 @@ async def list_files(
         max_length=255,
         description="Case-insensitive substring filter on entry name (this folder only)",
     ),
+    sort_by: str = Query(
+        default="name",
+        pattern="^(name|size|modified)$",
+        description="Column to sort the full listing by before paging",
+    ),
+    sort_dir: str = Query(
+        default="asc",
+        pattern="^(asc|desc)$",
+        description="Sort direction",
+    ),
     current_user: User = Depends(get_current_user_required),
     files_service: FilesService = Depends(get_files_service),
 ):
     scoped_path = await _authorize_path(current_user, path, workspace_id, scope, files_service=files_service)
     return _to_file_list_response_schema(
-        files_service.list_files(path=scoped_path, limit=limit, offset=offset, search=search)
+        files_service.list_files(
+            path=scoped_path,
+            limit=limit,
+            offset=offset,
+            search=search,
+            sort_by=sort_by,
+            sort_dir=sort_dir,
+        )
     )
 
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/files/adapters/primary/files__primary_adapter__schemas.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/files/adapters/primary/files__primary_adapter__schemas.py
@@ -47,3 +47,5 @@ class RenameRequest(BaseModel):
 class FileListResponse(BaseModel):
     files: list[FileInfo]
     path: str
+    # Total entries in the directory before limit/offset paging.
+    total: int = 0

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/files/files__schema.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/files/files__schema.py
@@ -76,6 +76,9 @@ class FileContentData:
 class FileListResponseData:
     files: list[FileInfoData]
     path: str
+    # Total number of entries in the directory (before limit/offset paging).
+    # Defaults to len(files) when the caller does not paginate.
+    total: int = 0
 
 
 @dataclass(frozen=True)

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/files/service.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/files/service.py
@@ -86,26 +86,35 @@ class FilesService:
             raise InvalidPathError("Path is required")
         return normalized
 
+    _SORT_KEYS = frozenset({"name", "size", "modified"})
+
     def list_files(
         self,
         path: str = "",
         limit: int | None = None,
         offset: int = 0,
         search: str | None = None,
+        sort_by: str = "name",
+        sort_dir: str = "asc",
     ) -> FileListResponseData:
         """List a directory's entries.
 
         ``_list_directory`` returns a stable, alphabetically sorted listing, so
         we can slice it with ``offset``/``limit`` *before* categorizing entries
-        or reading file bytes. This is what keeps large folders (e.g. 200+ files)
-        responsive: only the requested page pays the per-entry storage cost of a
-        directory check and, for files, a size read. ``limit=None`` returns every
-        entry (unchanged legacy behavior).
+        or reading metadata. This is what keeps large folders (e.g. 200+ files)
+        responsive: only the requested page pays the per-entry storage cost.
+        ``limit=None`` returns every entry (unchanged legacy behavior).
 
         ``search`` filters entries by a case-insensitive substring of their name
         (the final path segment) before paging, so ``total`` reflects the number
         of matches and pagination walks the filtered set — the same folder-scoped
         match the UI used to do client-side.
+
+        ``sort_by`` (``name`` | ``size`` | ``modified``) and ``sort_dir``
+        (``asc`` | ``desc``) order the full filtered listing before paging, so
+        the sort spans every page rather than just the current one. Sorting by
+        name needs no per-entry metadata, so only the returned page is stat-ed;
+        sorting by size or modified must stat every entry to compare them.
         """
         normalized_path = self.normalize_relative_path(path, allow_empty=True)
         entries = self._list_directory(normalized_path)
@@ -115,43 +124,60 @@ class FilesService:
             entries = [entry for entry in entries if needle in entry.split("/")[-1].lower()]
 
         total = len(entries)
-
+        sort_key = sort_by if sort_by in self._SORT_KEYS else "name"
+        reverse = sort_dir == "desc"
         start = max(offset, 0)
-        page = entries[start : start + limit] if limit is not None else entries[start:]
 
-        files: list[FileInfoData] = []
-
-        for entry in page:
-            name = entry.split("/")[-1]
-            if self._is_directory(entry):
-                files.append(
-                    FileInfoData(
-                        name=name,
-                        path=entry,
-                        type="folder",
-                        modified=datetime.now(),
-                    )
+        if sort_key == "name":
+            entries.sort(key=lambda entry: entry.split("/")[-1].lower(), reverse=reverse)
+            page = entries[start : start + limit] if limit is not None else entries[start:]
+            files = [
+                info for entry in page if (info := self._build_file_info(entry)) is not None
+            ]
+        else:
+            infos = [
+                info for entry in entries if (info := self._build_file_info(entry)) is not None
+            ]
+            if sort_key == "size":
+                infos.sort(
+                    key=lambda info: info.size if info.size is not None else -1,
+                    reverse=reverse,
                 )
-                continue
-
-            try:
-                content = self._read_bytes(entry)
-            except Exceptions.ObjectNotFound:
-                continue
-
-            ext = PurePosixPath(entry).suffix.lower()
-            files.append(
-                FileInfoData(
-                    name=name,
-                    path=entry,
-                    type="file",
-                    size=len(content),
-                    modified=datetime.now(),
-                    content_type=self._content_types.get(ext, "application/octet-stream"),
-                )
-            )
+            else:  # modified
+                infos.sort(key=lambda info: info.modified or datetime.min, reverse=reverse)
+            files = infos[start : start + limit] if limit is not None else infos[start:]
 
         return FileListResponseData(files=files, path=normalized_path, total=total)
+
+    def _build_file_info(self, entry: str) -> FileInfoData | None:
+        """Resolve a single directory entry into a ``FileInfoData``.
+
+        Returns ``None`` when the entry vanished between listing and stat (a
+        concurrent delete). Files carry real size/modified metadata pulled via a
+        cheap ``stat`` — no full object read. Folders have no tracked timestamp,
+        so ``modified`` is left unset.
+        """
+        name = entry.split("/")[-1]
+        if self._is_directory(entry):
+            return FileInfoData(name=name, path=entry, type="folder")
+        try:
+            size, modified = self._stat_file(entry)
+        except Exceptions.ObjectNotFound:
+            return None
+        ext = PurePosixPath(entry).suffix.lower()
+        return FileInfoData(
+            name=name,
+            path=entry,
+            type="file",
+            size=size,
+            modified=modified,
+            content_type=self._content_types.get(ext, "application/octet-stream"),
+        )
+
+    def _stat_file(self, path: str) -> tuple[int, datetime | None]:
+        prefix, key = self._split_file_path(path)
+        meta = self.storage.get_object_metadata(prefix, key)
+        return meta.file_size_bytes, meta.modified_time
 
     def create_file(
         self, path: str, content: str = "", content_type: str = "text/plain"

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/files/service.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/files/service.py
@@ -86,12 +86,42 @@ class FilesService:
             raise InvalidPathError("Path is required")
         return normalized
 
-    def list_files(self, path: str = "") -> FileListResponseData:
+    def list_files(
+        self,
+        path: str = "",
+        limit: int | None = None,
+        offset: int = 0,
+        search: str | None = None,
+    ) -> FileListResponseData:
+        """List a directory's entries.
+
+        ``_list_directory`` returns a stable, alphabetically sorted listing, so
+        we can slice it with ``offset``/``limit`` *before* categorizing entries
+        or reading file bytes. This is what keeps large folders (e.g. 200+ files)
+        responsive: only the requested page pays the per-entry storage cost of a
+        directory check and, for files, a size read. ``limit=None`` returns every
+        entry (unchanged legacy behavior).
+
+        ``search`` filters entries by a case-insensitive substring of their name
+        (the final path segment) before paging, so ``total`` reflects the number
+        of matches and pagination walks the filtered set — the same folder-scoped
+        match the UI used to do client-side.
+        """
         normalized_path = self.normalize_relative_path(path, allow_empty=True)
         entries = self._list_directory(normalized_path)
+
+        needle = search.strip().lower() if search else ""
+        if needle:
+            entries = [entry for entry in entries if needle in entry.split("/")[-1].lower()]
+
+        total = len(entries)
+
+        start = max(offset, 0)
+        page = entries[start : start + limit] if limit is not None else entries[start:]
+
         files: list[FileInfoData] = []
 
-        for entry in entries:
+        for entry in page:
             name = entry.split("/")[-1]
             if self._is_directory(entry):
                 files.append(
@@ -121,7 +151,7 @@ class FilesService:
                 )
             )
 
-        return FileListResponseData(files=files, path=normalized_path)
+        return FileListResponseData(files=files, path=normalized_path, total=total)
 
     def create_file(
         self, path: str, content: str = "", content_type: str = "text/plain"

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/files/service.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/files/service.py
@@ -156,22 +156,30 @@ class FilesService:
         concurrent delete). Files carry real size/modified metadata pulled via a
         cheap ``stat`` — no full object read. Folders have no tracked timestamp,
         so ``modified`` is left unset.
+
+        If a storage adapter cannot produce metadata for an object, the listing
+        must still succeed: the file is returned without size/modified rather
+        than dropped or raised (size/modified sorts then treat it as unknown).
         """
         name = entry.split("/")[-1]
         if self._is_directory(entry):
             return FileInfoData(name=name, path=entry, type="folder")
+        ext = PurePosixPath(entry).suffix.lower()
+        content_type = self._content_types.get(ext, "application/octet-stream")
         try:
             size, modified = self._stat_file(entry)
         except Exceptions.ObjectNotFound:
             return None
-        ext = PurePosixPath(entry).suffix.lower()
+        except Exception:
+            # Never let a metadata hiccup on one object break the whole listing.
+            return FileInfoData(name=name, path=entry, type="file", content_type=content_type)
         return FileInfoData(
             name=name,
             path=entry,
             type="file",
             size=size,
             modified=modified,
-            content_type=self._content_types.get(ext, "application/octet-stream"),
+            content_type=content_type,
         )
 
     def _stat_file(self, path: str) -> tuple[int, datetime | None]:

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/files/service_pagination_test.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/files/service_pagination_test.py
@@ -116,3 +116,58 @@ def test_list_files_blank_search_is_ignored(tmp_path) -> None:
 
     assert result.total == 4
     assert len(result.files) == 4
+
+
+def test_list_files_sort_by_name_is_case_insensitive_and_directional(tmp_path) -> None:
+    files_service = _make_files_service(tmp_path)
+    for name in ("banana.txt", "Apple.txt", "cherry.txt"):
+        files_service.create_file(path=f"dir/{name}", content="x", content_type="text/plain")
+
+    asc = files_service.list_files(path="dir", sort_by="name", sort_dir="asc")
+    assert [f.name for f in asc.files] == ["Apple.txt", "banana.txt", "cherry.txt"]
+
+    desc = files_service.list_files(path="dir", sort_by="name", sort_dir="desc")
+    assert [f.name for f in desc.files] == ["cherry.txt", "banana.txt", "Apple.txt"]
+
+
+def test_list_files_sort_by_size(tmp_path) -> None:
+    files_service = _make_files_service(tmp_path)
+    files_service.create_file(path="dir/small.txt", content="a", content_type="text/plain")
+    files_service.create_file(path="dir/medium.txt", content="a" * 50, content_type="text/plain")
+    files_service.create_file(path="dir/large.txt", content="a" * 500, content_type="text/plain")
+
+    asc = files_service.list_files(path="dir", sort_by="size", sort_dir="asc")
+    assert [f.name for f in asc.files] == ["small.txt", "medium.txt", "large.txt"]
+    assert [f.size for f in asc.files] == [1, 50, 500]
+
+    desc = files_service.list_files(path="dir", sort_by="size", sort_dir="desc")
+    assert [f.name for f in desc.files] == ["large.txt", "medium.txt", "small.txt"]
+
+
+def test_list_files_sort_reports_real_size_without_reading_content(tmp_path) -> None:
+    files_service = _make_files_service(tmp_path)
+    files_service.create_file(path="dir/a.txt", content="hello world", content_type="text/plain")
+
+    result = files_service.list_files(path="dir")
+
+    assert result.files[0].size == len("hello world")
+    # Folders carry no tracked timestamp.
+    files_service.create_folder(path="dir/sub")
+    with_folder = files_service.list_files(path="dir", sort_by="name")
+    folder = next(f for f in with_folder.files if f.type == "folder")
+    assert folder.modified is None
+
+
+def test_list_files_sort_applies_across_pages(tmp_path) -> None:
+    files_service = _make_files_service(tmp_path)
+    # Sizes increase with index; name order is the reverse of size order.
+    for i in range(6):
+        files_service.create_file(
+            path=f"dir/file-{i}.txt", content="a" * (10 * (6 - i)), content_type="text/plain"
+        )
+
+    # Second page of a size-ascending sort must continue the global order,
+    # not re-sort just the page.
+    page2 = files_service.list_files(path="dir", sort_by="size", sort_dir="asc", limit=2, offset=2)
+    assert page2.total == 6
+    assert [f.size for f in page2.files] == [30, 40]

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/files/service_pagination_test.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/files/service_pagination_test.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from naas_abi.apps.nexus.apps.api.app.services.files.service import FilesService
+from naas_abi_core.services.object_storage.adapters.secondary.ObjectStorageSecondaryAdapterFS import (  # noqa: E501
+    ObjectStorageSecondaryAdapterFS,
+)
+from naas_abi_core.services.object_storage.ObjectStorageService import ObjectStorageService
+
+
+def _make_files_service(tmp_path) -> FilesService:
+    adapter = ObjectStorageSecondaryAdapterFS(base_path=str(tmp_path))
+    storage = ObjectStorageService(adapter=adapter)
+    return FilesService(storage=storage)
+
+
+def _seed(files_service: FilesService, count: int) -> None:
+    # Zero-padded names so the alphabetical listing order is deterministic.
+    for i in range(count):
+        files_service.create_file(
+            path=f"dir/file-{i:03d}.txt", content=str(i), content_type="text/plain"
+        )
+
+
+def test_list_files_without_limit_returns_all_entries(tmp_path) -> None:
+    files_service = _make_files_service(tmp_path)
+    _seed(files_service, 5)
+
+    result = files_service.list_files(path="dir")
+
+    assert result.total == 5
+    assert len(result.files) == 5
+
+
+def test_list_files_limit_returns_first_page_and_full_total(tmp_path) -> None:
+    files_service = _make_files_service(tmp_path)
+    _seed(files_service, 12)
+
+    result = files_service.list_files(path="dir", limit=5, offset=0)
+
+    assert result.total == 12
+    assert [f.name for f in result.files] == [
+        "file-000.txt",
+        "file-001.txt",
+        "file-002.txt",
+        "file-003.txt",
+        "file-004.txt",
+    ]
+
+
+def test_list_files_offset_returns_following_page(tmp_path) -> None:
+    files_service = _make_files_service(tmp_path)
+    _seed(files_service, 12)
+
+    result = files_service.list_files(path="dir", limit=5, offset=10)
+
+    assert result.total == 12
+    # Only the last two entries remain in the final page.
+    assert [f.name for f in result.files] == ["file-010.txt", "file-011.txt"]
+
+
+def test_list_files_offset_past_end_returns_empty_page_with_total(tmp_path) -> None:
+    files_service = _make_files_service(tmp_path)
+    _seed(files_service, 3)
+
+    result = files_service.list_files(path="dir", limit=5, offset=50)
+
+    assert result.total == 3
+    assert result.files == []
+
+
+def test_list_files_search_filters_by_name_case_insensitively(tmp_path) -> None:
+    files_service = _make_files_service(tmp_path)
+    files_service.create_file(path="dir/Report-Q1.txt", content="a", content_type="text/plain")
+    files_service.create_file(path="dir/report-q2.txt", content="b", content_type="text/plain")
+    files_service.create_file(path="dir/notes.md", content="c", content_type="text/markdown")
+
+    result = files_service.list_files(path="dir", search="REPORT")
+
+    assert result.total == 2
+    assert sorted(f.name for f in result.files) == ["Report-Q1.txt", "report-q2.txt"]
+
+
+def test_list_files_search_total_reflects_matches_and_pages_over_them(tmp_path) -> None:
+    files_service = _make_files_service(tmp_path)
+    _seed(files_service, 20)  # file-000.txt .. file-019.txt
+    for name in ("alpha.txt", "beta.txt"):
+        files_service.create_file(path=f"dir/{name}", content="x", content_type="text/plain")
+
+    # "file" matches only the 20 seeded files, not alpha/beta.
+    page = files_service.list_files(path="dir", search="file", limit=5, offset=0)
+    assert page.total == 20
+    assert [f.name for f in page.files] == [
+        "file-000.txt",
+        "file-001.txt",
+        "file-002.txt",
+        "file-003.txt",
+        "file-004.txt",
+    ]
+
+    last = files_service.list_files(path="dir", search="file", limit=5, offset=15)
+    assert last.total == 20
+    assert [f.name for f in last.files] == [
+        "file-015.txt",
+        "file-016.txt",
+        "file-017.txt",
+        "file-018.txt",
+        "file-019.txt",
+    ]
+
+
+def test_list_files_blank_search_is_ignored(tmp_path) -> None:
+    files_service = _make_files_service(tmp_path)
+    _seed(files_service, 4)
+
+    result = files_service.list_files(path="dir", search="   ")
+
+    assert result.total == 4
+    assert len(result.files) == 4

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/files/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/files/page.tsx
@@ -87,6 +87,7 @@ export default function FilesPage() {
     loading,
     error,
     currentPath,
+    filesTotal,
     fetchFiles,
     createFile,
     createFolder,
@@ -114,6 +115,27 @@ export default function FilesPage() {
 
   const [viewMode, setViewMode] = useState<'list' | 'grid'>('list');
   const [searchQuery, setSearchQuery] = useState('');
+  // Debounced search term used to drive the server-side search fetch, so we
+  // don't hit the API on every keystroke.
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(searchQuery.trim()), 300);
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
+  // Client-side pagination: cap how many rows render at once so large folders
+  // (e.g. 200+ files) don't freeze the page while the API returns everything.
+  const PAGE_SIZE_OPTIONS = [10, 20, 50] as const;
+  const [pageSize, setPageSize] = useState<number>(50);
+  const [currentPage, setCurrentPage] = useState(1);
+  // Latest page size, readable from effects without making them re-run/re-fetch.
+  const pageSizeRef = useRef(pageSize);
+  useEffect(() => {
+    pageSizeRef.current = pageSize;
+  }, [pageSize]);
+  // The search term of the last fetch we issued. Updated synchronously so the
+  // debounced-search effect can tell a user edit apart from a fetch that
+  // navigation/mount already performed, avoiding a duplicate round-trip.
+  const lastSearchRef = useRef('');
   const [selectedFiles, setSelectedFiles] = useState<string[]>([]);
   const [isDragging, setIsDragging] = useState(false);
   const [dropTargetPath, setDropTargetPath] = useState<string | null>(null);
@@ -193,7 +215,11 @@ export default function FilesPage() {
     if (!starredNavigation) return;
     skipRegularFetchRef.current = true;
     setActiveSource(starredNavigation.source);
-    fetchFiles(starredNavigation.path);
+    setSearchQuery('');
+    setDebouncedSearch('');
+    lastSearchRef.current = '';
+    setCurrentPage(1);
+    fetchFiles(starredNavigation.path, { limit: pageSizeRef.current, offset: 0, search: '' });
     if (starredNavigation.previewPath) {
       setLocalPendingPreview(starredNavigation.previewPath);
     }
@@ -284,11 +310,16 @@ export default function FilesPage() {
     // Clear any previous errors
     setError(null);
 
-    // Fetch files based on active source
+    // Fetch files based on active source. Remote drives fetch the first page;
+    // local synced folders load fully and paginate client-side.
     if (isLocalFolder && activeSyncedFolder) {
       fetchLocalFiles(activeSyncedFolder.id);
     } else {
-      fetchFiles();
+      setSearchQuery('');
+      setDebouncedSearch('');
+      lastSearchRef.current = '';
+      setCurrentPage(1);
+      fetchFiles('', { limit: pageSizeRef.current, offset: 0, search: '' });
     }
   }, [fetchFiles, fetchLocalFiles, isLocalFolder, activeSyncedFolder, activeSource, setError]);
 
@@ -514,9 +545,102 @@ export default function FilesPage() {
     setSelectedFiles([]);
   };
 
-  const filteredFiles = files.filter(file =>
-    file.name.toLowerCase().includes(searchQuery.toLowerCase())
+  // Remote drives paginate on the server (the store fetches one page at a time),
+  // so `files` already holds just the current page. Local synced folders are read
+  // entirely in the browser via the File System Access API, so they paginate
+  // client-side by slicing the loaded list.
+  const isServerPaginated = !isLocalFolder;
+
+  // Remote search is applied by the server, so `files` is already the filtered
+  // page — don't filter again. Local folders filter the loaded list in-browser.
+  const filteredFiles = isServerPaginated
+    ? files
+    : files.filter((file) =>
+        file.name.toLowerCase().includes(searchQuery.toLowerCase())
+      );
+  const pageCount = isServerPaginated ? filesTotal : filteredFiles.length;
+  const totalPages = Math.max(1, Math.ceil(pageCount / pageSize));
+  const safePage = Math.min(currentPage, totalPages);
+  const pageStart = (safePage - 1) * pageSize;
+  const pagedFiles = isServerPaginated
+    ? filteredFiles
+    : filteredFiles.slice(pageStart, pageStart + pageSize);
+  // Range shown in the pagination footer ("X–Y of N").
+  const rangeStart = pageCount === 0 ? 0 : pageStart + 1;
+  const rangeEnd = isServerPaginated
+    ? pageStart + pagedFiles.length
+    : Math.min(pageStart + pageSize, filteredFiles.length);
+
+  // Fetch a page from the server (remote drives only). Local folders just move
+  // the client-side window via setCurrentPage.
+  const goToPage = useCallback(
+    (page: number) => {
+      const clamped = Math.max(1, page);
+      setCurrentPage(clamped);
+      if (isServerPaginated) {
+        fetchFiles(currentPath, {
+          limit: pageSize,
+          offset: (clamped - 1) * pageSize,
+          search: debouncedSearch,
+        });
+      }
+    },
+    [isServerPaginated, fetchFiles, currentPath, pageSize, debouncedSearch],
   );
+
+  const changePageSize = (size: number) => {
+    setPageSize(size);
+    setCurrentPage(1);
+    if (isServerPaginated) {
+      fetchFiles(currentPath, { limit: size, offset: 0, search: debouncedSearch });
+    }
+  };
+
+  // Navigate into a folder / breadcrumb target: clear any search, reset to page 1
+  // and fetch the first server page. Used by the JSX click handlers below.
+  const navigateToPath = useCallback(
+    (path: string) => {
+      setSearchQuery('');
+      setDebouncedSearch('');
+      lastSearchRef.current = '';
+      setCurrentPage(1);
+      fetchFiles(path, { limit: pageSizeRef.current, offset: 0, search: '' });
+    },
+    [fetchFiles],
+  );
+
+  // Reset to the first page whenever the search box changes (both modes).
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [searchQuery]);
+
+  // Server-side search: refetch the first page when the debounced term changes.
+  // Guarded against the last-fetched term so navigation/mount fetches (which
+  // already carry the right search) don't trigger a redundant round-trip.
+  useEffect(() => {
+    if (!isServerPaginated) return;
+    if (debouncedSearch === lastSearchRef.current) return;
+    lastSearchRef.current = debouncedSearch;
+    setCurrentPage(1);
+    fetchFiles(currentPath, { limit: pageSizeRef.current, offset: 0, search: debouncedSearch });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedSearch]);
+
+  // After the total shrinks (e.g. deleting the last item on the last page), pull
+  // the current page back into range and reload it. Server-paginated only.
+  useEffect(() => {
+    if (!isServerPaginated) return;
+    const maxPage = Math.max(1, Math.ceil(filesTotal / pageSize));
+    if (currentPage > maxPage) {
+      setCurrentPage(maxPage);
+      fetchFiles(currentPath, {
+        limit: pageSize,
+        offset: (maxPage - 1) * pageSize,
+        search: lastSearchRef.current,
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filesTotal]);
 
   const toggleSelectFile = (path: string) => {
     setSelectedFiles((prev) =>
@@ -524,12 +648,19 @@ export default function FilesPage() {
     );
   };
 
+  // Select-all operates on the currently visible page so the header checkbox
+  // reflects what the user can actually see.
   const allSelected =
-    filteredFiles.length > 0 && filteredFiles.every((f) => selectedFiles.includes(f.path));
+    pagedFiles.length > 0 && pagedFiles.every((f) => selectedFiles.includes(f.path));
   const someSelected = selectedFiles.length > 0 && !allSelected;
 
   const toggleSelectAll = () => {
-    setSelectedFiles(allSelected ? [] : filteredFiles.map((f) => f.path));
+    const pagePaths = pagedFiles.map((f) => f.path);
+    setSelectedFiles((prev) =>
+      allSelected
+        ? prev.filter((p) => !pagePaths.includes(p))
+        : Array.from(new Set([...prev, ...pagePaths]))
+    );
   };
 
   const formatSize = (bytes?: number) => {
@@ -984,28 +1115,6 @@ export default function FilesPage() {
               <RefreshCw size={14} className={loading ? "animate-spin" : ""} />
               Refresh
             </button>
-            {/* Hidden file input */}
-            <input
-              ref={fileInputRef}
-              type="file"
-              multiple
-              onChange={handleFileInputChange}
-              className="hidden"
-            />
-          </div>
-
-          <div className="flex items-center gap-2">
-            {/* Search */}
-            <div className="relative">
-              <Search size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground" />
-              <input
-                type="text"
-                placeholder="Search files..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                className="h-8 w-48 rounded-md border bg-transparent pl-8 pr-3 text-sm outline-none focus:ring-1 focus:ring-primary"
-              />
-            </div>
 
             {/* View toggle */}
             <div className="flex items-center rounded-md border">
@@ -1028,6 +1137,28 @@ export default function FilesPage() {
                 <Grid size={14} />
               </button>
             </div>
+            {/* Hidden file input */}
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              onChange={handleFileInputChange}
+              className="hidden"
+            />
+          </div>
+
+          <div className="flex items-center gap-2">
+            {/* Search */}
+            <div className="relative">
+              <Search size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground" />
+              <input
+                type="text"
+                placeholder="Search files..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="h-8 w-48 rounded-md border bg-transparent pl-8 pr-3 text-sm outline-none focus:ring-1 focus:ring-primary"
+              />
+            </div>
           </div>
         </div>
 
@@ -1038,7 +1169,7 @@ export default function FilesPage() {
               if (isLocalFolder && activeSyncedFolder) {
                 fetchLocalFiles(activeSyncedFolder.id, '');
               } else {
-                fetchFiles('');
+                navigateToPath('');
               }
             }}
             className={cn(
@@ -1059,7 +1190,7 @@ export default function FilesPage() {
                     // Send the storage-relative path so the API resolver anchors it
                     // under the drive root (server normalizes a leading drive root).
                     const fullPath = driveRoot ? `${driveRoot}/${sub}` : sub;
-                    fetchFiles(fullPath);
+                    navigateToPath(fullPath);
                   }
                 }}
                 className={cn(
@@ -1232,7 +1363,7 @@ export default function FilesPage() {
                 </tr>
               </thead>
               <tbody>
-                {filteredFiles.map((file) => (
+                {pagedFiles.map((file) => (
                   <tr
                     key={file.path}
                     draggable={!isLocalFolder}
@@ -1264,7 +1395,7 @@ export default function FilesPage() {
                             if (isLocalFolder && activeSyncedFolder) {
                               fetchLocalFiles(activeSyncedFolder.id, file.path);
                             } else {
-                              fetchFiles(file.path);
+                              navigateToPath(file.path);
                             }
                           } else if (isOfficeFile(file)) {
                             openOfficePreview(file);
@@ -1471,7 +1602,7 @@ export default function FilesPage() {
           ) : (
             /* Grid view */
             <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
-              {filteredFiles.map((file) => (
+              {pagedFiles.map((file) => (
                 <div
                   key={file.path}
                   draggable={!isLocalFolder}
@@ -1490,7 +1621,7 @@ export default function FilesPage() {
                         if (isLocalFolder && activeSyncedFolder) {
                           fetchLocalFiles(activeSyncedFolder.id, file.path);
                         } else {
-                          fetchFiles(file.path);
+                          navigateToPath(file.path);
                         }
                       } else if (isOfficeFile(file)) {
                         openOfficePreview(file);
@@ -1560,6 +1691,50 @@ export default function FilesPage() {
             </div>
           )}
         </div>
+
+        {/* Pagination bar */}
+        {pageCount > 0 && (
+          <div className="flex flex-wrap items-center justify-between gap-2 border-t px-4 py-2 text-sm">
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <span>Rows per page</span>
+              <select
+                value={pageSize}
+                onChange={(e) => changePageSize(Number(e.target.value))}
+                className="h-8 rounded-md border bg-transparent px-2 outline-none focus:ring-1 focus:ring-primary"
+              >
+                {PAGE_SIZE_OPTIONS.map((size) => (
+                  <option key={size} value={size}>
+                    {size}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="flex items-center gap-4">
+              <span className="text-muted-foreground">
+                {`${rangeStart}–${rangeEnd} of ${pageCount}`}
+              </span>
+              <div className="flex items-center gap-1">
+                <button
+                  onClick={() => goToPage(safePage - 1)}
+                  disabled={loading || safePage <= 1}
+                  className="rounded-md border px-3 py-1.5 hover:bg-muted disabled:opacity-50 disabled:hover:bg-transparent"
+                >
+                  Previous
+                </button>
+                <span className="px-2 text-muted-foreground">
+                  {`Page ${safePage} of ${totalPages}`}
+                </span>
+                <button
+                  onClick={() => goToPage(safePage + 1)}
+                  disabled={loading || safePage >= totalPages}
+                  className="rounded-md border px-3 py-1.5 hover:bg-muted disabled:opacity-50 disabled:hover:bg-transparent"
+                >
+                  Next
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
 
     </div>

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/files/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/files/page.tsx
@@ -31,9 +31,16 @@ import {
   Code,
   Star,
   X,
+  ArrowUp,
+  ArrowDown,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { useFilesStore, type FileInfo } from '@/stores/files';
+import {
+  useFilesStore,
+  type FileInfo,
+  type FileSortKey,
+  type SortDirection,
+} from '@/stores/files';
 import { authFetch, useAuthStore } from '@/stores/auth';
 import { usePrompt, useConfirm } from '@/components/ui/dialogs';
 import { PdfViewer } from '@/components/files/pdf-viewer';
@@ -77,6 +84,34 @@ async function collectEntries(
   return out;
 }
 
+// Client-side sort for local synced folders (loaded whole in the browser).
+// Mirrors the server ordering: case-insensitive name, numeric size, timestamp
+// modified — with missing size/modified sorting first on ascending order.
+function sortFiles(
+  files: FileInfo[],
+  sortBy: FileSortKey,
+  sortDir: SortDirection,
+): FileInfo[] {
+  const dir = sortDir === 'desc' ? -1 : 1;
+  return [...files].sort((a, b) => {
+    let cmp: number;
+    if (sortBy === 'size') {
+      cmp = (a.size ?? -1) - (b.size ?? -1);
+    } else if (sortBy === 'modified') {
+      const am = a.modified ? Date.parse(a.modified) : Number.NEGATIVE_INFINITY;
+      const bm = b.modified ? Date.parse(b.modified) : Number.NEGATIVE_INFINITY;
+      cmp = am - bm;
+    } else {
+      cmp = a.name.toLowerCase().localeCompare(b.name.toLowerCase());
+    }
+    // Stable tiebreak by name so equal sizes/dates keep a predictable order.
+    if (cmp === 0 && sortBy !== 'name') {
+      cmp = a.name.toLowerCase().localeCompare(b.name.toLowerCase());
+    }
+    return cmp * dir;
+  });
+}
+
 export default function FilesPage() {
   const router = useRouter();
   const params = useParams();
@@ -88,6 +123,9 @@ export default function FilesPage() {
     error,
     currentPath,
     filesTotal,
+    filesSortBy,
+    filesSortDir,
+    setFilesSort,
     fetchFiles,
     createFile,
     createFolder,
@@ -551,12 +589,17 @@ export default function FilesPage() {
   // client-side by slicing the loaded list.
   const isServerPaginated = !isLocalFolder;
 
-  // Remote search is applied by the server, so `files` is already the filtered
-  // page — don't filter again. Local folders filter the loaded list in-browser.
+  // Remote search + sort are applied by the server, so `files` is already the
+  // filtered, sorted page — use it as-is. Local folders are loaded whole in the
+  // browser, so we filter and sort them client-side to match.
   const filteredFiles = isServerPaginated
     ? files
-    : files.filter((file) =>
-        file.name.toLowerCase().includes(searchQuery.toLowerCase())
+    : sortFiles(
+        files.filter((file) =>
+          file.name.toLowerCase().includes(searchQuery.toLowerCase())
+        ),
+        filesSortBy,
+        filesSortDir,
       );
   const pageCount = isServerPaginated ? filesTotal : filteredFiles.length;
   const totalPages = Math.max(1, Math.ceil(pageCount / pageSize));
@@ -594,6 +637,35 @@ export default function FilesPage() {
     if (isServerPaginated) {
       fetchFiles(currentPath, { limit: size, offset: 0, search: debouncedSearch });
     }
+  };
+
+  // Sort a column. setFilesSort updates the persisted preference synchronously,
+  // so the follow-up fetch (which reads sort from the store) uses the new order.
+  // Local folders re-sort on render, no fetch needed.
+  const handleSort = (column: FileSortKey) => {
+    setFilesSort(column);
+    setCurrentPage(1);
+    if (isServerPaginated) {
+      fetchFiles(currentPath, { limit: pageSize, offset: 0, search: debouncedSearch });
+    }
+  };
+
+  // Header cell that sorts its column, with an active-direction arrow.
+  const SortHeader = ({ column, label }: { column: FileSortKey; label: string }) => {
+    const active = filesSortBy === column;
+    return (
+      <button
+        onClick={() => handleSort(column)}
+        className={cn(
+          'flex items-center gap-1 font-medium hover:text-foreground',
+          active ? 'text-foreground' : 'text-muted-foreground',
+        )}
+      >
+        {label}
+        {active &&
+          (filesSortDir === 'asc' ? <ArrowUp size={12} /> : <ArrowDown size={12} />)}
+      </button>
+    );
   };
 
   // Navigate into a folder / breadcrumb target: clear any search, reset to page 1
@@ -1075,6 +1147,47 @@ export default function FilesPage() {
       )}
 
       <div className="flex flex-1 flex-col overflow-hidden">
+        {/* Breadcrumb (file path) — shown above the toolbar row */}
+        <div className="flex items-center gap-1 border-b px-4 py-2 text-sm">
+          <button
+            onClick={() => {
+              if (isLocalFolder && activeSyncedFolder) {
+                fetchLocalFiles(activeSyncedFolder.id, '');
+              } else {
+                navigateToPath('');
+              }
+            }}
+            className={cn(
+              relativePath ? 'text-muted-foreground hover:text-foreground' : 'text-foreground'
+            )}
+          >
+            {driveLabel}
+          </button>
+          {relativePath && relativePath.split('/').map((part, i, arr) => (
+            <span key={i} className="flex items-center gap-1">
+              <span className="text-muted-foreground">/</span>
+              <button
+                onClick={() => {
+                  const sub = arr.slice(0, i + 1).join('/');
+                  if (isLocalFolder && activeSyncedFolder) {
+                    fetchLocalFiles(activeSyncedFolder.id, sub);
+                  } else {
+                    // Send the storage-relative path so the API resolver anchors it
+                    // under the drive root (server normalizes a leading drive root).
+                    const fullPath = driveRoot ? `${driveRoot}/${sub}` : sub;
+                    navigateToPath(fullPath);
+                  }
+                }}
+                className={cn(
+                  i === arr.length - 1 ? 'text-foreground' : 'text-muted-foreground hover:text-foreground'
+                )}
+              >
+                {part}
+              </button>
+            </span>
+          ))}
+        </div>
+
         {/* Toolbar */}
         <div className="flex items-center justify-between border-b px-4 py-2">
           <div className="flex items-center gap-2">
@@ -1160,47 +1273,6 @@ export default function FilesPage() {
               />
             </div>
           </div>
-        </div>
-
-        {/* Breadcrumb */}
-        <div className="flex items-center gap-1 border-b px-4 py-2 text-sm">
-          <button
-            onClick={() => {
-              if (isLocalFolder && activeSyncedFolder) {
-                fetchLocalFiles(activeSyncedFolder.id, '');
-              } else {
-                navigateToPath('');
-              }
-            }}
-            className={cn(
-              relativePath ? 'text-muted-foreground hover:text-foreground' : 'text-foreground'
-            )}
-          >
-            {driveLabel}
-          </button>
-          {relativePath && relativePath.split('/').map((part, i, arr) => (
-            <span key={i} className="flex items-center gap-1">
-              <span className="text-muted-foreground">/</span>
-              <button
-                onClick={() => {
-                  const sub = arr.slice(0, i + 1).join('/');
-                  if (isLocalFolder && activeSyncedFolder) {
-                    fetchLocalFiles(activeSyncedFolder.id, sub);
-                  } else {
-                    // Send the storage-relative path so the API resolver anchors it
-                    // under the drive root (server normalizes a leading drive root).
-                    const fullPath = driveRoot ? `${driveRoot}/${sub}` : sub;
-                    navigateToPath(fullPath);
-                  }
-                }}
-                className={cn(
-                  i === arr.length - 1 ? 'text-foreground' : 'text-muted-foreground hover:text-foreground'
-                )}
-              >
-                {part}
-              </button>
-            </span>
-          ))}
         </div>
 
         {/* Selection action bar (list view) */}
@@ -1356,9 +1428,15 @@ export default function FilesPage() {
                       />
                     </th>
                   )}
-                  <th className="pb-2 font-medium">Name</th>
-                  <th className="pb-2 font-medium">Size</th>
-                  <th className="pb-2 font-medium">Modified</th>
+                  <th className="pb-2 font-medium">
+                    <SortHeader column="name" label="Name" />
+                  </th>
+                  <th className="pb-2 font-medium">
+                    <SortHeader column="size" label="Size" />
+                  </th>
+                  <th className="pb-2 font-medium">
+                    <SortHeader column="modified" label="Modified" />
+                  </th>
                   <th className="pb-2 font-medium w-16"></th>
                 </tr>
               </thead>

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/files.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/files.ts
@@ -120,6 +120,15 @@ interface FilesState {
   currentPath: string;
   loading: boolean;
   error: string | null;
+
+  // Server-side pagination + search for the Files page. `filesTotal` is the
+  // number of matching entries in the current directory; `filesLimit`/`filesOffset`
+  // remember the last page requested and `filesSearch` the last search term, so
+  // refreshFiles() can reload the same slice after a mutation.
+  filesTotal: number;
+  filesLimit: number | null;
+  filesOffset: number;
+  filesSearch: string;
   
   // Lab state (VS Code-like, always at workspace root)
   labFiles: FileInfo[];
@@ -185,7 +194,10 @@ interface FilesState {
   fetchLocalFiles: (folderId: string, subPath?: string) => Promise<void>;  // Reads files from synced folder
   
   // API actions
-  fetchFiles: (path?: string) => Promise<void>;
+  fetchFiles: (
+    path?: string,
+    options?: { limit?: number; offset?: number; search?: string }
+  ) => Promise<void>;
   fetchLabFiles: () => Promise<void>;  // Always fetches workspace root for Lab
   fetchLabFolderContents: (folderPath: string) => Promise<FileInfo[]>;  // Fetch subfolder contents for Lab tree
   createFile: (path: string, content?: string) => Promise<FileInfo | null>;
@@ -217,7 +229,12 @@ export const useFilesStore = create<FilesState>((set, get) => ({
   currentPath: '',
   loading: false,
   error: null,
-  
+
+  filesTotal: 0,
+  filesLimit: null,
+  filesOffset: 0,
+  filesSearch: '',
+
   // Lab state (VS Code-like, always workspace root)
   labFiles: [],
   labLoading: false,
@@ -476,51 +493,82 @@ export const useFilesStore = create<FilesState>((set, get) => ({
     });
   },
 
-  fetchFiles: async (path = '') => {
+  fetchFiles: async (path = '', options) => {
     // Files page should reflect the object storage tree as-is.
     // Do not force a workspace prefix here.
     const relativePath = path.replace(/^\/+|\/+$/g, '');
     const workspaceId = getCurrentWorkspaceId();
     const scope = getFilesScope(get().activeSource);
 
+    // Pagination: when a limit is provided the server only lists that slice,
+    // which is what keeps large folders (200+ files) from stalling the API.
+    const limit = options?.limit ?? null;
+    const offset = options?.offset ?? 0;
+    // Search: filtered on the server (current folder only) so paging walks the
+    // matches, not just whatever happened to load on the current page.
+    const search = (options?.search ?? '').trim();
+
     // The files API requires a workspace for workspace/platform-drive scopes.
     // During app bootstrap the workspace can still be null.
     if (scope !== 'my_drive' && !relativePath && !workspaceId) {
-      set({ files: [], currentPath: '', loading: false, error: null });
+      set({
+        files: [],
+        currentPath: '',
+        filesTotal: 0,
+        filesLimit: limit,
+        filesOffset: offset,
+        filesSearch: search,
+        loading: false,
+        error: null,
+      });
       return;
     }
-    
+
     set({ loading: true, error: null });
     try {
+      const pageParams = limit != null ? `&limit=${limit}&offset=${offset}` : '';
+      const searchParam = search ? `&search=${encodeURIComponent(search)}` : '';
       const fetchListing = async (targetPath: string) => {
         const workspaceParam = scope !== 'my_drive' && workspaceId
           ? `&workspace_id=${encodeURIComponent(workspaceId)}`
           : '';
         const scopeParam = `&scope=${scope}`;
         const response = await authFetch(
-          `${getApiBase()}/api/files/?path=${encodeURIComponent(targetPath)}${workspaceParam}${scopeParam}`
+          `${getApiBase()}/api/files/?path=${encodeURIComponent(targetPath)}${workspaceParam}${scopeParam}${pageParams}${searchParam}`
         );
         if (!response.ok) {
           throw new Error('Failed to fetch files');
         }
         const data = await response.json();
-        return Array.isArray(data.files) ? (data.files as FileInfo[]) : [];
+        const listed = Array.isArray(data.files) ? (data.files as FileInfo[]) : [];
+        const total = typeof data.total === 'number' ? data.total : listed.length;
+        return { files: listed, total };
       };
 
       let resolvedPath = relativePath;
-      let resolvedFiles = await fetchListing(relativePath);
+      let { files: resolvedFiles, total: resolvedTotal } = await fetchListing(relativePath);
 
-      // Fallback: if root appears empty, try workspace root.
+      // Fallback: if the root has no entries at all, try the workspace root.
       // This handles deployments where objects are scoped under workspace IDs.
-      if (scope === 'workspace' && !relativePath && resolvedFiles.length === 0 && workspaceId) {
-        const workspaceFiles = await fetchListing(workspaceId);
-        if (workspaceFiles.length > 0) {
+      // Keyed on total (not the page length) so an empty later page doesn't retry.
+      if (scope === 'workspace' && !relativePath && resolvedTotal === 0 && workspaceId) {
+        const workspaceListing = await fetchListing(workspaceId);
+        if (workspaceListing.total > 0) {
           resolvedPath = workspaceId;
-          resolvedFiles = workspaceFiles;
+          resolvedFiles = workspaceListing.files;
+          resolvedTotal = workspaceListing.total;
         }
       }
 
-      set({ files: resolvedFiles, currentPath: resolvedPath, loading: false });
+      set({
+        files: resolvedFiles,
+        currentPath: resolvedPath,
+        filesTotal: resolvedTotal,
+        filesLimit: limit,
+        filesOffset: offset,
+        filesSearch: search,
+        loading: false,
+      });
     } catch (error) {
       set({ error: (error as Error).message, loading: false });
     }
@@ -865,8 +913,13 @@ export const useFilesStore = create<FilesState>((set, get) => ({
   },
 
   refreshFiles: async () => {
-    const { currentPath } = get();
-    await get().fetchFiles(currentPath);
+    const { currentPath, filesLimit, filesOffset, filesSearch } = get();
+    await get().fetchFiles(
+      currentPath,
+      filesLimit != null
+        ? { limit: filesLimit, offset: filesOffset, search: filesSearch }
+        : { search: filesSearch }
+    );
   },
 
   refreshLabFiles: async () => {

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/files.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/files.ts
@@ -108,6 +108,38 @@ const saveStarredItems = (items: StarredItem[]): void => {
   }
 };
 
+// Sort preference for the Files page — persisted so it survives paging,
+// navigation and reloads.
+export type FileSortKey = 'name' | 'size' | 'modified';
+export type SortDirection = 'asc' | 'desc';
+
+const SORT_STORAGE_KEY = 'nexus-files-sort';
+
+const getInitialSort = (): { sortBy: FileSortKey; sortDir: SortDirection } => {
+  const fallback = { sortBy: 'name' as FileSortKey, sortDir: 'asc' as SortDirection };
+  if (typeof window === 'undefined') return fallback;
+  try {
+    const stored = localStorage.getItem(SORT_STORAGE_KEY);
+    if (!stored) return fallback;
+    const parsed = JSON.parse(stored) as { sortBy?: FileSortKey; sortDir?: SortDirection };
+    return {
+      sortBy: parsed.sortBy === 'size' || parsed.sortBy === 'modified' ? parsed.sortBy : 'name',
+      sortDir: parsed.sortDir === 'desc' ? 'desc' : 'asc',
+    };
+  } catch {
+    return fallback;
+  }
+};
+
+const saveSort = (sortBy: FileSortKey, sortDir: SortDirection): void => {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(SORT_STORAGE_KEY, JSON.stringify({ sortBy, sortDir }));
+  } catch {
+    // ignore storage errors
+  }
+};
+
 export interface FileContent {
   path: string;
   content: string;
@@ -129,6 +161,9 @@ interface FilesState {
   filesLimit: number | null;
   filesOffset: number;
   filesSearch: string;
+  // Persisted sort preference, applied server-side (remote) or client-side (local).
+  filesSortBy: FileSortKey;
+  filesSortDir: SortDirection;
   
   // Lab state (VS Code-like, always at workspace root)
   labFiles: FileInfo[];
@@ -169,6 +204,9 @@ interface FilesState {
   setCurrentPath: (path: string) => void;
   setLoading: (loading: boolean) => void;
   setError: (error: string | null) => void;
+  // Toggle/select the sort column. Same column flips direction; a new column
+  // starts ascending. Persists the choice; the caller refetches to apply it.
+  setFilesSort: (sortBy: FileSortKey) => void;
   openFile: (path: string) => void;
   closeFile: (path: string) => void;
   setActiveFile: (path: string | null) => void;
@@ -234,6 +272,8 @@ export const useFilesStore = create<FilesState>((set, get) => ({
   filesLimit: null,
   filesOffset: 0,
   filesSearch: '',
+  filesSortBy: getInitialSort().sortBy,
+  filesSortDir: getInitialSort().sortDir,
 
   // Lab state (VS Code-like, always workspace root)
   labFiles: [],
@@ -282,6 +322,14 @@ export const useFilesStore = create<FilesState>((set, get) => ({
   setCurrentPath: (currentPath) => set({ currentPath }),
   setLoading: (loading) => set({ loading }),
   setError: (error) => set({ error }),
+
+  setFilesSort: (sortBy) => set((state) => {
+    // Same column flips direction; switching columns starts ascending.
+    const sortDir: SortDirection =
+      state.filesSortBy === sortBy && state.filesSortDir === 'asc' ? 'desc' : 'asc';
+    saveSort(sortBy, sortDir);
+    return { filesSortBy: sortBy, filesSortDir: sortDir };
+  }),
   
   // Storage source actions
   toggleCategory: (category) => set((state) => ({
@@ -524,17 +572,22 @@ export const useFilesStore = create<FilesState>((set, get) => ({
       return;
     }
 
+    // Sort is a persisted preference, so read it from state — every fetch (page,
+    // search, refresh) stays consistently ordered.
+    const { filesSortBy, filesSortDir } = get();
+
     set({ loading: true, error: null });
     try {
       const pageParams = limit != null ? `&limit=${limit}&offset=${offset}` : '';
       const searchParam = search ? `&search=${encodeURIComponent(search)}` : '';
+      const sortParams = `&sort_by=${filesSortBy}&sort_dir=${filesSortDir}`;
       const fetchListing = async (targetPath: string) => {
         const workspaceParam = scope !== 'my_drive' && workspaceId
           ? `&workspace_id=${encodeURIComponent(workspaceId)}`
           : '';
         const scopeParam = `&scope=${scope}`;
         const response = await authFetch(
-          `${getApiBase()}/api/files/?path=${encodeURIComponent(targetPath)}${workspaceParam}${scopeParam}${pageParams}${searchParam}`
+          `${getApiBase()}/api/files/?path=${encodeURIComponent(targetPath)}${workspaceParam}${scopeParam}${pageParams}${searchParam}${sortParams}`
         );
         if (!response.ok) {
           throw new Error('Failed to fetch files');


### PR DESCRIPTION
This pull request resolves #nexus-files-improv

# Summary

This PR introduces several improvements and new features primarily focused on the Nexus files service, the XSearchRecentTweets workflow, and the Agent tool input normalization for Bedrock compatibility. It also includes dependency updates and minor fixes in other parts of the codebase.

# Details

## Nexus Files Service Enhancements

- Added pagination support to the files listing API and service:
  - Added `limit`, `offset`, `search`, `sort_by`, and `sort_dir` query parameters to the `list_files` API endpoint.
  - The `FilesService.list_files` method now supports pagination, filtering by case-insensitive substring search on file names, and sorting by name, size, or modified date.
  - Sorting by size and modified date requires stat calls on all entries to get metadata.
  - The API response now includes a `total` field indicating the total number of entries matching the query before pagination.
  - Added comprehensive tests for pagination, search, and sorting behavior.

- Frontend changes in the Nexus web app:
  - Client-side sorting and pagination for local synced folders.
  - Server-side pagination, search, and sorting for remote drives.
  - Added UI elements for pagination controls, page size selection, and sortable table headers.
  - Breadcrumb navigation updated to reset search and pagination state on navigation.
  - Persisted sort preferences in localStorage.