### PR TITLE
perf(engine): do not run ontology codegen on every engine load

### DIFF
--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/linkedin/__init__.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/linkedin/__init__.py
@@ -43,36 +43,57 @@ class ABIModule(BaseModule[_Configuration]):
     def on_initialized(self):
         super().on_initialized()
 
-        import glob
-        import os
-
         from naas_abi_core import logger
-        from naas_abi_core.utils.onto2py import onto2py
         from naas_abi_marketplace.applications.linkedin.workflows.CreateClassEmbeddingsWorkflow import (
             CreateClassEmbeddingsWorkflow,
             CreateClassEmbeddingsWorkflowConfiguration,
             CreateClassEmbeddingsWorkflowParameters,
         )
 
-        ontologies_dir = os.path.join(os.path.dirname(__file__), "ontologies")
-        ttl_files = glob.glob(
-            os.path.join(ontologies_dir, "modules", "*.ttl"), recursive=True
-        )
-
-        if not ttl_files:
-            logger.warning(f"No TTL files found in {ontologies_dir}")
-            return
-
-        for ttl_file in ttl_files:
-            if "Queries.ttl" in ttl_file:
-                continue
-            try:
-                logger.debug(f"Converting {ttl_file} to Python")
-                onto2py(ttl_file)
-            except Exception as e:
-                logger.error(
-                    f"Failed to convert {ttl_file} to Python: {e}", exc_info=True
-                )
+        # Ontology -> Python codegen is deliberately not run at boot.
+        #
+        # `on_initialized` fires on every `Engine.load()`: every API start, every
+        # uvicorn reload after a file is saved, every `abi chat`, every dagster
+        # boot. `onto2py()` is expensive on all of them. It runs BFO static
+        # validation and resolves `owl:imports`, which walks every project root
+        # and rdflib-parses every `.ttl` beneath it — 439 files and ~7s on the
+        # checkout this was measured on — then fetches any IRI it could not
+        # resolve locally over HTTP, with a 10s timeout per import and no
+        # caching. Behind a proxy or a slow resolver that turns a ~30s engine
+        # load into minutes, and the reload child pays it again on every save.
+        #
+        # The generated modules are committed, so boot has nothing to
+        # regenerate. Run the generator when a .ttl actually changes:
+        #     python -m naas_abi_core.utils.onto2py <ttl_file>
+        #
+        # Note: the commented-out block below ended with an early `return` when
+        # no .ttl was found, which also skipped the embeddings workflow that
+        # follows. This module ships a .ttl, so that path never ran in practice.
+        #
+        # import glob
+        # import os
+        #
+        # from naas_abi_core.utils.onto2py import onto2py
+        #
+        # ontologies_dir = os.path.join(os.path.dirname(__file__), "ontologies")
+        # ttl_files = glob.glob(
+        #     os.path.join(ontologies_dir, "modules", "*.ttl"), recursive=True
+        # )
+        #
+        # if not ttl_files:
+        #     logger.warning(f"No TTL files found in {ontologies_dir}")
+        #     return
+        #
+        # for ttl_file in ttl_files:
+        #     if "Queries.ttl" in ttl_file:
+        #         continue
+        #     try:
+        #         logger.debug(f"Converting {ttl_file} to Python")
+        #         onto2py(ttl_file)
+        #     except Exception as e:
+        #         logger.error(
+        #             f"Failed to convert {ttl_file} to Python: {e}", exc_info=True
+        #         )
 
         # Initialize and execute workflow for creating embeddings
         try:

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/domains/document/__init__.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/domains/document/__init__.py
@@ -113,30 +113,46 @@ class ABIModule(BaseModule):
     def on_initialized(self) -> None:
         super().on_initialized()
 
-        import glob
-        import os
-
-        # Convert ontologies to Python classes.
-        from naas_abi_core import logger
-        from naas_abi_core.utils.onto2py import onto2py
-
-        ontologies_dir = os.path.join(os.path.dirname(__file__), "ontologies")
-        ttl_files = glob.glob(
-            os.path.join(ontologies_dir, "modules", "*.ttl"), recursive=True
-        )
-
-        if not ttl_files:
-            logger.warning(f"No TTL files found in {ontologies_dir}")
-            return
-
-        for ttl_file in ttl_files:
-            try:
-                logger.debug(f"Converting {ttl_file} to Python")
-                onto2py(ttl_file)
-            except Exception as e:
-                logger.error(
-                    f"Failed to convert {ttl_file} to Python: {e}", exc_info=True
-                )
+        # Ontology -> Python codegen is deliberately not run at boot.
+        #
+        # `on_initialized` fires on every `Engine.load()`: every API start, every
+        # uvicorn reload after a file is saved, every `abi chat`, every dagster
+        # boot. `onto2py()` is expensive on all of them. It runs BFO static
+        # validation and resolves `owl:imports`, which walks every project root
+        # and rdflib-parses every `.ttl` beneath it — 439 files and ~7s on the
+        # checkout this was measured on — then fetches any IRI it could not
+        # resolve locally over HTTP, with a 10s timeout per import and no
+        # caching. Behind a proxy or a slow resolver that turns a ~30s engine
+        # load into minutes, and the reload child pays it again on every save.
+        #
+        # The generated modules are committed, so boot has nothing to
+        # regenerate. Run the generator when a .ttl actually changes:
+        #     python -m naas_abi_core.utils.onto2py <ttl_file>
+        #
+        # import glob
+        # import os
+        #
+        # # Convert ontologies to Python classes.
+        # from naas_abi_core import logger
+        # from naas_abi_core.utils.onto2py import onto2py
+        #
+        # ontologies_dir = os.path.join(os.path.dirname(__file__), "ontologies")
+        # ttl_files = glob.glob(
+        #     os.path.join(ontologies_dir, "modules", "*.ttl"), recursive=True
+        # )
+        #
+        # if not ttl_files:
+        #     logger.warning(f"No TTL files found in {ontologies_dir}")
+        #     return
+        #
+        # for ttl_file in ttl_files:
+        #     try:
+        #         logger.debug(f"Converting {ttl_file} to Python")
+        #         onto2py(ttl_file)
+        #     except Exception as e:
+        #         logger.error(
+        #             f"Failed to convert {ttl_file} to Python: {e}", exc_info=True
+        #         )
 
     # The on_load method is invoked during initial module loading by the engine.
     # At this point, avoid accessing services or other modules, as they have not been loaded yet.

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/domains/organizations/__init__.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/domains/organizations/__init__.py
@@ -41,30 +41,46 @@ class ABIModule(BaseModule):
     def on_initialized(self) -> None:
         super().on_initialized()
 
-        import glob
-        import os
-
-        # Convert ontologies to Python classes.
-        from naas_abi_core import logger
-        from naas_abi_core.utils.onto2py import onto2py
-
-        ontologies_dir = os.path.join(os.path.dirname(__file__), "ontologies")
-        ttl_files = glob.glob(
-            os.path.join(ontologies_dir, "modules", "*.ttl"), recursive=True
-        )
-
-        if not ttl_files:
-            logger.warning(f"No TTL files found in {ontologies_dir}")
-            return
-
-        for ttl_file in ttl_files:
-            try:
-                logger.debug(f"Converting {ttl_file} to Python")
-                onto2py(ttl_file)
-            except Exception as e:
-                logger.error(
-                    f"Failed to convert {ttl_file} to Python: {e}", exc_info=True
-                )
+        # Ontology -> Python codegen is deliberately not run at boot.
+        #
+        # `on_initialized` fires on every `Engine.load()`: every API start, every
+        # uvicorn reload after a file is saved, every `abi chat`, every dagster
+        # boot. `onto2py()` is expensive on all of them. It runs BFO static
+        # validation and resolves `owl:imports`, which walks every project root
+        # and rdflib-parses every `.ttl` beneath it — 439 files and ~7s on the
+        # checkout this was measured on — then fetches any IRI it could not
+        # resolve locally over HTTP, with a 10s timeout per import and no
+        # caching. Behind a proxy or a slow resolver that turns a ~30s engine
+        # load into minutes, and the reload child pays it again on every save.
+        #
+        # The generated modules are committed, so boot has nothing to
+        # regenerate. Run the generator when a .ttl actually changes:
+        #     python -m naas_abi_core.utils.onto2py <ttl_file>
+        #
+        # import glob
+        # import os
+        #
+        # # Convert ontologies to Python classes.
+        # from naas_abi_core import logger
+        # from naas_abi_core.utils.onto2py import onto2py
+        #
+        # ontologies_dir = os.path.join(os.path.dirname(__file__), "ontologies")
+        # ttl_files = glob.glob(
+        #     os.path.join(ontologies_dir, "modules", "*.ttl"), recursive=True
+        # )
+        #
+        # if not ttl_files:
+        #     logger.warning(f"No TTL files found in {ontologies_dir}")
+        #     return
+        #
+        # for ttl_file in ttl_files:
+        #     try:
+        #         logger.debug(f"Converting {ttl_file} to Python")
+        #         onto2py(ttl_file)
+        #     except Exception as e:
+        #         logger.error(
+        #             f"Failed to convert {ttl_file} to Python: {e}", exc_info=True
+        #         )
 
         # if not self.configuration.sync_sec_org_graph_on_startup:
         #     return

--- a/libs/naas-abi/naas_abi/__init__.py
+++ b/libs/naas-abi/naas_abi/__init__.py
@@ -549,30 +549,46 @@ class ABIModule(BaseModule):
 
         _initialize_nexus_service_registry()
 
-        import glob
-        import os
-
-        # Convert ontologies to Python classes.
-        from naas_abi_core import logger
-        from naas_abi_core.utils.onto2py import onto2py
-
-        ontologies_dir = os.path.join(os.path.dirname(__file__), "ontologies")
-        ttl_files = glob.glob(
-            os.path.join(ontologies_dir, "modules", "*.ttl"), recursive=True
-        )
-
-        if not ttl_files:
-            logger.warning(f"No TTL files found in {ontologies_dir}")
-            return
-
-        for ttl_file in ttl_files:
-            try:
-                logger.debug(f"Converting {ttl_file} to Python")
-                onto2py(ttl_file)
-            except Exception as e:
-                logger.error(
-                    f"Failed to convert {ttl_file} to Python: {e}", exc_info=True
-                )
+        # Ontology -> Python codegen is deliberately not run at boot.
+        #
+        # `on_initialized` fires on every `Engine.load()`: every API start, every
+        # uvicorn reload after a file is saved, every `abi chat`, every dagster
+        # boot. `onto2py()` is expensive on all of them. It runs BFO static
+        # validation and resolves `owl:imports`, which walks every project root
+        # and rdflib-parses every `.ttl` beneath it — 439 files and ~7s on the
+        # checkout this was measured on — then fetches any IRI it could not
+        # resolve locally over HTTP, with a 10s timeout per import and no
+        # caching. Behind a proxy or a slow resolver that turns a ~30s engine
+        # load into minutes, and the reload child pays it again on every save.
+        #
+        # The generated modules are committed, so boot has nothing to
+        # regenerate. Run the generator when a .ttl actually changes:
+        #     python -m naas_abi_core.utils.onto2py <ttl_file>
+        #
+        # import glob
+        # import os
+        #
+        # # Convert ontologies to Python classes.
+        # from naas_abi_core import logger
+        # from naas_abi_core.utils.onto2py import onto2py
+        #
+        # ontologies_dir = os.path.join(os.path.dirname(__file__), "ontologies")
+        # ttl_files = glob.glob(
+        #     os.path.join(ontologies_dir, "modules", "*.ttl"), recursive=True
+        # )
+        #
+        # if not ttl_files:
+        #     logger.warning(f"No TTL files found in {ontologies_dir}")
+        #     return
+        #
+        # for ttl_file in ttl_files:
+        #     try:
+        #         logger.debug(f"Converting {ttl_file} to Python")
+        #         onto2py(ttl_file)
+        #     except Exception as e:
+        #         logger.error(
+        #             f"Failed to convert {ttl_file} to Python: {e}", exc_info=True
+        #         )
 
     def on_load(self):
         super().on_load()


### PR DESCRIPTION
## Problem

Four modules call `onto2py()` from `on_initialized()`:

| module | call site |
|---|---|
| `naas_abi` | `libs/naas-abi/naas_abi/__init__.py:571` |
| `naas_abi_marketplace.domains.organizations` | `…/domains/organizations/__init__.py:63` |
| `naas_abi_marketplace.domains.document` | `…/domains/document/__init__.py:135` |
| `naas_abi_marketplace.applications.linkedin` | `…/applications/linkedin/__init__.py:71` |

`on_initialized()` runs on every `Engine.load()` — every API start, every `abi chat`, every dagster boot, and **every uvicorn reload after a file is saved** (reload rebuilds the app via the `get_app` factory, so the full engine load repeats).

`onto2py()` is expensive to call there. Per invocation it:

- **Runs BFO static validation**, which resolves `owl:imports` by walking every project root and rdflib-parsing every `.ttl` beneath it. On the checkout this was profiled against: **439 files, ~7s**. The walk is not scoped to the module or to `config.yaml` — it indexes whatever happens to be on disk.
- **Fetches unresolved import IRIs over HTTP**, uncached, 10s timeout each. `urlopen(timeout=…)` does not bound DNS resolution, so behind a proxy or a slow resolver these stalls dominate boot.

## Why this is safe to skip at boot

The generated modules are **committed**, so boot has nothing to regenerate — it re-derives an artifact already in the repo. A dedicated entry point already exists for the times a `.ttl` actually changes:

```
python -m naas_abi_core.utils.onto2py <ttl_file>
```

## Change

The calls are **commented out rather than deleted**, each with a comment at the call site recording why, so the reasoning is visible where someone would otherwise re-add it.

## Evidence

Over a full `Engine.load()`, `onto2py` invocations drop from **4 to 1** — and the remaining one belongs to the consuming project, not this repo:

```
baseline   LOAD  onto2py_calls=4
   BobOntology.ttl                  <- consuming project
   ABIOntology.ttl                  <- removed here
   NexusPlatformOntology.ttl        <- removed here
   BFO7BucketsProcessOntology.ttl   <- removed here

patched    LOAD  onto2py_calls=1
   BobOntology.ttl
```

**No wall-clock speedup is claimed.** Run-to-run variance on the test machine was 26s–459s for identical code, far too noisy to attribute a number to this diff honestly. The per-call costs quoted above are properties of `onto2py` itself and were measured separately.

## Note on `linkedin`

The removed block ended with an early `return` when no `.ttl` was found, which also skipped the embeddings workflow that follows it. That module ships a `.ttl`, so the path never ran in practice; the comment records it. Its `logger` and workflow imports are kept — the remaining code still uses them.

## Checks

`py_compile` and `ruff check` clean on all four files.