### PR TITLE
Enable Nexus email login

### DIFF
--- a/config.local.yaml
+++ b/config.local.yaml
@@ -69,8 +69,8 @@ modules:
           workspace_overrides: {}
 
         # Q: How do users sign in?
-        # A: Password login is on. Magic link is on but restricted to pre-seeded users only.
-        auth_password_enabled: true
+        # A: Magic link login is on and restricted to pre-seeded users. Password login is off.
+        auth_password_enabled: false
         magic_link_allow_signup: false
 
         # Q: What do the passwordless sign-in emails say?

--- a/config.local.yaml
+++ b/config.local.yaml
@@ -75,6 +75,8 @@ modules:
 
         # Q: What do the passwordless sign-in emails say?
         # A: Set the app name and templates -- {app_name}, {magic_link_url}, {expire_minutes} are auto-filled.
+        email_from_address: "no-reply@axi-ai-test.org"
+        email_from_name: "AXI AI"
         magic_link_email_app_name: "ABI Platform"
         magic_link_email_subject_template: "Your {app_name} sign-in link"
         magic_link_email_text_template: "Use this link to sign in to {app_name}:\n\n{magic_link_url}\n\nThis link expires in {expire_minutes} minutes."


### PR DESCRIPTION
## What changed

- Disabled Nexus password authentication in `config.local.yaml`.
- Kept magic-link signup restricted to pre-seeded users.
- Configured magic-link emails to use `no-reply@axi-ai-test.org` with the sender name `AXI AI`.
- Updated the adjacent configuration comment to describe the active login behavior.

## Why

The local Nexus stack should use passwordless email magic links instead of password login, with the AXI-branded sender already established for the local/test environment.

## Impact

The Nexus login form now requests an email address and sends a magic sign-in link from `AXI AI <no-reply@axi-ai-test.org>`. Password login, password registration, password reset, and password change endpoints are disabled by the existing authentication flag.

## Validation

- `uv run --frozen abi config validate --configuration-file .abi/config.local.yaml --modules`
- All enabled modules validated successfully.
- `git diff --check`