### PR TITLE
feat(nexus): OpenRouter read-aloud (TTS) for assistant messages

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/api/endpoints/speech.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/api/endpoints/speech.py
@@ -1,0 +1,171 @@
+"""Text-to-speech endpoint (OpenRouter or native OpenAI)."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import httpx
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse, Response
+from pydantic import BaseModel, Field
+
+OPENAI_SPEECH_URL = "https://api.openai.com/v1/audio/speech"
+OPENROUTER_SPEECH_URL = "https://openrouter.ai/api/v1/audio/speech"
+
+# Cheap, reliable default on OpenRouter. Override via OPENROUTER_TTS_MODEL / VOICE.
+OPENROUTER_TTS_MODEL = "hexgrad/kokoro-82m"
+OPENROUTER_TTS_VOICE = "af_heart"
+
+# Native OpenAI fallback.
+OPENAI_TTS_MODEL = "tts-1"
+OPENAI_TTS_VOICE = "alloy"
+
+MAX_INPUT_CHARS = 3500
+
+router = APIRouter()
+
+
+class SpeechRequest(BaseModel):
+    text: str = Field(..., min_length=1)
+    voice: str | None = None
+    model: str | None = None
+
+
+def _secret(name: str) -> str | None:
+    from naas_abi import ABIModule
+
+    value = ABIModule.get_instance().engine.services.secret.get(name)
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def resolve_speech_backend() -> tuple[str, str, str, str] | None:
+    """Return (url, api_key, model, voice) for the best available TTS backend.
+
+    Prefer OpenRouter when an OpenRouter key is present (this deployment's default).
+    Fall back to native OpenAI only when a non-OpenRouter key is available.
+    """
+    openrouter_key = _secret("OPENROUTER_API_KEY")
+    openai_key = _secret("OPENAI_API_KEY")
+    speech_key = _secret("OPENAI_SPEECH_API_KEY")
+
+    model_override = _secret("OPENROUTER_TTS_MODEL")
+    voice_override = _secret("OPENROUTER_TTS_VOICE")
+
+    if speech_key and not speech_key.startswith("sk-or-"):
+        return (
+            OPENAI_SPEECH_URL,
+            speech_key,
+            _secret("OPENAI_TTS_MODEL") or OPENAI_TTS_MODEL,
+            voice_override or _secret("OPENAI_TTS_VOICE") or OPENAI_TTS_VOICE,
+        )
+
+    for key in (openrouter_key, openai_key, speech_key):
+        if key and key.startswith("sk-or-"):
+            return (
+                OPENROUTER_SPEECH_URL,
+                key,
+                model_override or OPENROUTER_TTS_MODEL,
+                voice_override or OPENROUTER_TTS_VOICE,
+            )
+
+    if openai_key and not openai_key.startswith("sk-or-"):
+        return (
+            OPENAI_SPEECH_URL,
+            openai_key,
+            _secret("OPENAI_TTS_MODEL") or OPENAI_TTS_MODEL,
+            voice_override or _secret("OPENAI_TTS_VOICE") or OPENAI_TTS_VOICE,
+        )
+
+    return None
+
+
+def prepare_speech_text(raw: str) -> str:
+    """Strip common markdown so TTS does not read fencing and link syntax aloud."""
+    text = raw.strip()
+    if not text:
+        return ""
+
+    text = re.sub(r"```[\s\S]*?```", " ", text)
+    text = re.sub(r"`([^`]+)`", r"\1", text)
+    text = re.sub(r"!\[([^\]]*)\]\([^)]+\)", r"\1", text)
+    text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
+    text = re.sub(r"^#{1,6}\s*", "", text, flags=re.MULTILINE)
+    text = re.sub(r"[*_~|>]+", " ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+
+    if len(text) > MAX_INPUT_CHARS:
+        text = text[: MAX_INPUT_CHARS - 3].rstrip() + "..."
+    return text
+
+
+@router.post("", include_in_schema=True)
+@router.post("/", include_in_schema=False)
+async def synthesize_speech(body: SpeechRequest) -> Response:
+    prepared = prepare_speech_text(body.text)
+    if not prepared:
+        return JSONResponse({"error": "No speakable text provided"}, status_code=400)
+
+    backend = resolve_speech_backend()
+    if backend is None:
+        return JSONResponse(
+            {
+                "error": (
+                    "No speech API key configured. Set OPENROUTER_API_KEY "
+                    "(preferred) or a native OPENAI_SPEECH_API_KEY."
+                )
+            },
+            status_code=500,
+        )
+
+    url, api_key, default_model, default_voice = backend
+    model = (body.model or "").strip() or default_model
+    voice = (body.voice or "").strip() or default_voice
+
+    headers: dict[str, str] = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    if "openrouter.ai" in url:
+        headers["HTTP-Referer"] = "https://zen.naas.ai"
+        headers["X-Title"] = "Zen"
+
+    payload: dict[str, Any] = {
+        "model": model,
+        "input": prepared,
+        "voice": voice,
+        "response_format": "mp3",
+    }
+
+    timeout = httpx.Timeout(connect=10.0, read=180.0, write=60.0, pool=30.0)
+    try:
+        async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+            response = await client.post(url, headers=headers, json=payload)
+    except httpx.TimeoutException:
+        return JSONResponse({"error": "Speech request timed out"}, status_code=504)
+    except httpx.HTTPError as exc:
+        message = str(exc) if str(exc) else "Network error while calling speech API"
+        return JSONResponse({"error": message}, status_code=502)
+    except Exception as exc:
+        message = str(exc) if str(exc) else "Unknown error"
+        return JSONResponse({"error": message}, status_code=500)
+
+    if response.status_code >= 400:
+        detail = response.text if response.text else ""
+        return JSONResponse(
+            {
+                "error": f"Speech synthesis failed ({response.status_code})",
+                "detail": detail,
+            },
+            status_code=response.status_code,
+        )
+
+    content_type = response.headers.get("content-type") or "audio/mpeg"
+    return Response(
+        content=response.content,
+        media_type=content_type,
+        headers={"Cache-Control": "no-store"},
+    )

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/api/endpoints/speech.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/api/endpoints/speech.py
@@ -86,7 +86,6 @@ _FR_WORDS = frozenset(
         "cette",
         "tout",
         "tous",
-        "bonjour",
         "salut",
     }
 )

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/api/endpoints/speech.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/api/endpoints/speech.py
@@ -130,8 +130,11 @@ async def synthesize_speech(body: SpeechRequest) -> Response:
         "Content-Type": "application/json",
     }
     if "openrouter.ai" in url:
-        headers["HTTP-Referer"] = "https://zen.naas.ai"
-        headers["X-Title"] = "Zen"
+        from naas_abi.apps.nexus.apps.api.app.services.openrouter_attribution import (
+            openrouter_attribution_headers,
+        )
+
+        headers.update(openrouter_attribution_headers())
 
     payload: dict[str, Any] = {
         "model": model,

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/api/endpoints/speech.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/api/endpoints/speech.py
@@ -13,15 +13,23 @@ from pydantic import BaseModel, Field
 OPENAI_SPEECH_URL = "https://api.openai.com/v1/audio/speech"
 OPENROUTER_SPEECH_URL = "https://openrouter.ai/api/v1/audio/speech"
 
-# Cheap, reliable default on OpenRouter. Override via OPENROUTER_TTS_MODEL / VOICE.
+# Cheap default for short English chat. Override via OPENROUTER_TTS_MODEL / VOICE.
 OPENROUTER_TTS_MODEL = "hexgrad/kokoro-82m"
 OPENROUTER_TTS_VOICE = "af_heart"
+
+# Expressive model for French / long-form narration (Kokoro FR is too thin).
+OPENROUTER_NARRATION_MODEL = "microsoft/mai-voice-2"
+OPENROUTER_NARRATION_MODEL_FAST = "microsoft/mai-voice-2-flash"
 
 # Native OpenAI fallback.
 OPENAI_TTS_MODEL = "tts-1"
 OPENAI_TTS_VOICE = "alloy"
 
 MAX_INPUT_CHARS = 3500
+# Upgrade off Kokoro when the reply is long enough to feel like narration.
+NARRATION_MIN_CHARS = 220
+# Languages where Kokoro training data is thin (French has one voice, <11h).
+NARRATION_LANGS = frozenset({"fr", "es", "de"})
 
 # Default Kokoro voices by detected language (prefix-coded in the model).
 KOKORO_LANG_VOICES: dict[str, str] = {
@@ -157,7 +165,7 @@ def resolve_speech_backend() -> tuple[str, str, str, str] | None:
 
 
 def prepare_speech_text(raw: str) -> str:
-    """Strip common markdown so TTS does not read fencing and link syntax aloud."""
+    """Strip markdown and shape punctuation so TTS can breathe between clauses."""
     text = raw.strip()
     if not text:
         return ""
@@ -166,13 +174,47 @@ def prepare_speech_text(raw: str) -> str:
     text = re.sub(r"`([^`]+)`", r"\1", text)
     text = re.sub(r"!\[([^\]]*)\]\([^)]+\)", r"\1", text)
     text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
+    text = re.sub(r"https?://\S+", " ", text)
     text = re.sub(r"^#{1,6}\s*", "", text, flags=re.MULTILINE)
     text = re.sub(r"[*_~|>]+", " ", text)
+    # Turn markdown list markers into short spoken beats.
+    text = re.sub(r"(?m)^\s*[-•]\s+", "", text)
+    # Give the synthesizer pause cues (stories sound less rushed).
+    text = text.replace("…", ". ")
+    text = re.sub(r"\.\.\.+", ". ", text)
+    text = re.sub(r"\s*;\s*", ". ", text)
+    text = re.sub(r"\s*:\s*", ", ", text)
     text = re.sub(r"\s+", " ", text).strip()
+    # Ensure terminal punctuation so the last sentence is not clipped flat.
+    if text and text[-1] not in ".!?":
+        text += "."
 
     if len(text) > MAX_INPUT_CHARS:
         text = text[: MAX_INPUT_CHARS - 3].rstrip() + "..."
     return text
+
+
+def normalize_speech_language(lang: str | None, text: str) -> str:
+    raw = (lang or "").strip().lower() or detect_speech_language(text)
+    if raw.startswith("fr"):
+        return "fr"
+    if raw.startswith("es"):
+        return "es"
+    if raw.startswith("pt"):
+        return "pt"
+    if raw.startswith("it"):
+        return "it"
+    if raw.startswith("ja"):
+        return "ja"
+    if raw.startswith("zh") or raw.startswith("cn"):
+        return "zh"
+    if raw.startswith("hi"):
+        return "hi"
+    if raw.startswith("de"):
+        return "de"
+    if raw.startswith("en"):
+        return "en"
+    return raw or "en"
 
 
 def detect_speech_language(text: str) -> str:
@@ -220,42 +262,7 @@ def detect_speech_language(text: str) -> str:
     return lang
 
 
-def resolve_voice_for_text(
-    text: str,
-    model: str,
-    *,
-    explicit_voice: str | None,
-    explicit_language: str | None,
-    default_voice: str,
-) -> str:
-    """Pick a voice matching the text language unless the caller forced one."""
-    if explicit_voice:
-        return explicit_voice
-
-    auto_raw = (_secret("OPENROUTER_TTS_AUTO_LANGUAGE") or "1").strip().lower()
-    if auto_raw in {"0", "false", "no", "off"}:
-        return default_voice
-
-    lang = (explicit_language or "").strip().lower() or detect_speech_language(text)
-    if lang.startswith("fr"):
-        lang = "fr"
-    elif lang.startswith("es"):
-        lang = "es"
-    elif lang.startswith("pt"):
-        lang = "pt"
-    elif lang.startswith("it"):
-        lang = "it"
-    elif lang.startswith("ja"):
-        lang = "ja"
-    elif lang.startswith("zh") or lang.startswith("cn"):
-        lang = "zh"
-    elif lang.startswith("hi"):
-        lang = "hi"
-    elif lang.startswith("de"):
-        lang = "de"
-    elif lang.startswith("en"):
-        lang = "en"
-
+def resolve_voice_for_model(model: str, lang: str, default_voice: str) -> str:
     model_l = model.lower()
     if "kokoro" in model_l:
         return KOKORO_LANG_VOICES.get(lang, default_voice)
@@ -263,7 +270,54 @@ def resolve_voice_for_text(
         return MAI_LANG_VOICES.get(lang, default_voice)
     if "voxtral" in model_l:
         return VOXTRAL_LANG_VOICES.get(lang, default_voice)
+    if "aura-2" in model_l and lang == "fr":
+        return "aura-2-agathe-fr"
     return default_voice
+
+
+def resolve_model_and_voice_for_text(
+    text: str,
+    *,
+    default_model: str,
+    default_voice: str,
+    explicit_model: str | None,
+    explicit_voice: str | None,
+    explicit_language: str | None,
+) -> tuple[str, str, str]:
+    """Return (model, voice, lang).
+
+    Kokoro is fine for short English chat. French storytelling needs a
+    narration-grade model: Kokoro's only French voice is trained on <11h.
+    """
+    lang = normalize_speech_language(explicit_language, text)
+    auto_raw = (_secret("OPENROUTER_TTS_AUTO_LANGUAGE") or "1").strip().lower()
+    auto_language = auto_raw not in {"0", "false", "no", "off"}
+
+    if explicit_model:
+        model = explicit_model
+    elif not auto_language:
+        model = default_model
+    else:
+        narration_model = (
+            _secret("OPENROUTER_NARRATION_MODEL") or OPENROUTER_NARRATION_MODEL
+        ).strip()
+        narration_fast = (
+            _secret("OPENROUTER_NARRATION_MODEL_FAST") or OPENROUTER_NARRATION_MODEL_FAST
+        ).strip()
+        needs_narration = lang in NARRATION_LANGS or len(text) >= NARRATION_MIN_CHARS
+        if needs_narration:
+            # Long-form uses the fuller MAI model; short FR chat uses Flash.
+            model = narration_model if len(text) >= NARRATION_MIN_CHARS else narration_fast
+        else:
+            model = default_model
+
+    if explicit_voice:
+        voice = explicit_voice
+    elif not auto_language:
+        voice = default_voice
+    else:
+        voice = resolve_voice_for_model(model, lang, default_voice)
+    return model, voice, lang
 
 
 @router.post("", include_in_schema=True)
@@ -286,13 +340,13 @@ async def synthesize_speech(body: SpeechRequest) -> Response:
         )
 
     url, api_key, default_model, default_voice = backend
-    model = (body.model or "").strip() or default_model
-    voice = resolve_voice_for_text(
+    model, voice, lang = resolve_model_and_voice_for_text(
         prepared,
-        model,
+        default_model=default_model,
+        default_voice=default_voice,
+        explicit_model=(body.model or "").strip() or None,
         explicit_voice=(body.voice or "").strip() or None,
         explicit_language=(body.language or "").strip() or None,
-        default_voice=default_voice,
     )
 
     headers: dict[str, str] = {
@@ -312,6 +366,12 @@ async def synthesize_speech(body: SpeechRequest) -> Response:
         "voice": voice,
         "response_format": "mp3",
     }
+    # MAI-Voice supports expressive delivery via provider passthrough.
+    if "mai-voice" in model.lower() and (
+        lang in NARRATION_LANGS or len(prepared) >= NARRATION_MIN_CHARS
+    ):
+        payload["provider"] = {"style": "narration", "styledegree": 1.3}
+        payload["speed"] = 0.95
 
     timeout = httpx.Timeout(connect=10.0, read=180.0, write=60.0, pool=30.0)
     try:
@@ -340,5 +400,10 @@ async def synthesize_speech(body: SpeechRequest) -> Response:
     return Response(
         content=response.content,
         media_type=content_type,
-        headers={"Cache-Control": "no-store"},
+        headers={
+            "Cache-Control": "no-store",
+            "X-TTS-Model": model,
+            "X-TTS-Voice": voice,
+            "X-TTS-Language": lang,
+        },
     )

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/api/endpoints/speech.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/api/endpoints/speech.py
@@ -23,6 +23,78 @@ OPENAI_TTS_VOICE = "alloy"
 
 MAX_INPUT_CHARS = 3500
 
+# Default Kokoro voices by detected language (prefix-coded in the model).
+KOKORO_LANG_VOICES: dict[str, str] = {
+    "en": "af_heart",
+    "fr": "ff_siwis",
+    "es": "ef_dora",
+    "pt": "pf_dora",
+    "it": "if_sara",
+    "ja": "jf_alpha",
+    "zh": "zf_xiaoxiao",
+    "hi": "hf_alpha",
+}
+
+MAI_LANG_VOICES: dict[str, str] = {
+    "en": "en-US-Harper:MAI-Voice-2",
+    "fr": "fr-FR-Soleil:MAI-Voice-2",
+    "es": "es-MX-Valeria:MAI-Voice-2",
+    "de": "de-DE-Klaus:MAI-Voice-2",
+}
+
+VOXTRAL_LANG_VOICES: dict[str, str] = {
+    "en": "en_paul_neutral",
+    "fr": "fr_marie_neutral",
+}
+
+_FR_WORDS = frozenset(
+    {
+        "je",
+        "tu",
+        "nous",
+        "vous",
+        "bonjour",
+        "merci",
+        "oui",
+        "non",
+        "avec",
+        "pour",
+        "une",
+        "des",
+        "les",
+        "que",
+        "pas",
+        "très",
+        "bien",
+        "est",
+        "suis",
+        "vais",
+        "entends",
+        "parfaitement",
+        "aussi",
+        "mais",
+        "donc",
+        "comme",
+        "cette",
+        "tout",
+        "tous",
+        "bonjour",
+        "salut",
+    }
+)
+_ES_WORDS = frozenset(
+    {"hola", "gracias", "porque", "también", "está", "están", "qué", "más", "pero", "como"}
+)
+_PT_WORDS = frozenset(
+    {"olá", "obrigado", "obrigada", "você", "não", "também", "está", "são", "como", "muito"}
+)
+_IT_WORDS = frozenset(
+    {"ciao", "grazie", "perché", "anche", "sono", "come", "questo", "questa", "molto", "bene"}
+)
+_EN_WORDS = frozenset(
+    {"the", "and", "you", "are", "is", "hello", "thanks", "with", "that", "this", "have", "what"}
+)
+
 router = APIRouter()
 
 
@@ -30,6 +102,7 @@ class SpeechRequest(BaseModel):
     text: str = Field(..., min_length=1)
     voice: str | None = None
     model: str | None = None
+    language: str | None = None
 
 
 def _secret(name: str) -> str | None:
@@ -102,6 +175,97 @@ def prepare_speech_text(raw: str) -> str:
     return text
 
 
+def detect_speech_language(text: str) -> str:
+    """Lightweight language guess for TTS voice routing (no extra dependency)."""
+    sample = text.strip()
+    if not sample:
+        return "en"
+
+    if re.search(r"[\u3040-\u30ff]", sample):
+        return "ja"
+    if re.search(r"[\u4e00-\u9fff]", sample):
+        return "zh"
+    if re.search(r"[\u0900-\u097f]", sample):
+        return "hi"
+
+    lower = sample.lower()
+    tokens = re.findall(r"[a-zàâäáãåæçéèêëíìîïñóòôöõœúùûüýÿß']+", lower, flags=re.IGNORECASE)
+    scores: dict[str, float] = {"en": 0.0, "fr": 0.0, "es": 0.0, "pt": 0.0, "it": 0.0}
+
+    if re.search(r"[àâäéèêëïîôùûüçœæ]", lower):
+        scores["fr"] += 3.0
+    if re.search(r"[ñ¿¡]", lower):
+        scores["es"] += 3.0
+    if re.search(r"[ãõ]", lower):
+        scores["pt"] += 2.5
+    if "'" in lower or "’" in sample:
+        # Common in French contractions: t'entends, j'ai, c'est
+        scores["fr"] += 1.0
+
+    for token in tokens:
+        if token in _FR_WORDS:
+            scores["fr"] += 1.0
+        if token in _ES_WORDS:
+            scores["es"] += 1.0
+        if token in _PT_WORDS:
+            scores["pt"] += 1.0
+        if token in _IT_WORDS:
+            scores["it"] += 1.0
+        if token in _EN_WORDS:
+            scores["en"] += 0.6
+
+    lang, score = max(scores.items(), key=lambda item: item[1])
+    if score < 1.5:
+        return "en"
+    return lang
+
+
+def resolve_voice_for_text(
+    text: str,
+    model: str,
+    *,
+    explicit_voice: str | None,
+    explicit_language: str | None,
+    default_voice: str,
+) -> str:
+    """Pick a voice matching the text language unless the caller forced one."""
+    if explicit_voice:
+        return explicit_voice
+
+    auto_raw = (_secret("OPENROUTER_TTS_AUTO_LANGUAGE") or "1").strip().lower()
+    if auto_raw in {"0", "false", "no", "off"}:
+        return default_voice
+
+    lang = (explicit_language or "").strip().lower() or detect_speech_language(text)
+    if lang.startswith("fr"):
+        lang = "fr"
+    elif lang.startswith("es"):
+        lang = "es"
+    elif lang.startswith("pt"):
+        lang = "pt"
+    elif lang.startswith("it"):
+        lang = "it"
+    elif lang.startswith("ja"):
+        lang = "ja"
+    elif lang.startswith("zh") or lang.startswith("cn"):
+        lang = "zh"
+    elif lang.startswith("hi"):
+        lang = "hi"
+    elif lang.startswith("de"):
+        lang = "de"
+    elif lang.startswith("en"):
+        lang = "en"
+
+    model_l = model.lower()
+    if "kokoro" in model_l:
+        return KOKORO_LANG_VOICES.get(lang, default_voice)
+    if "mai-voice" in model_l:
+        return MAI_LANG_VOICES.get(lang, default_voice)
+    if "voxtral" in model_l:
+        return VOXTRAL_LANG_VOICES.get(lang, default_voice)
+    return default_voice
+
+
 @router.post("", include_in_schema=True)
 @router.post("/", include_in_schema=False)
 async def synthesize_speech(body: SpeechRequest) -> Response:
@@ -123,7 +287,13 @@ async def synthesize_speech(body: SpeechRequest) -> Response:
 
     url, api_key, default_model, default_voice = backend
     model = (body.model or "").strip() or default_model
-    voice = (body.voice or "").strip() or default_voice
+    voice = resolve_voice_for_text(
+        prepared,
+        model,
+        explicit_voice=(body.voice or "").strip() or None,
+        explicit_language=(body.language or "").strip() or None,
+        default_voice=default_voice,
+    )
 
     headers: dict[str, str] = {
         "Authorization": f"Bearer {api_key}",

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/api/endpoints/speech_test.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/api/endpoints/speech_test.py
@@ -9,7 +9,7 @@ from naas_abi.apps.nexus.apps.api.app.api.endpoints.speech import (
 
 def test_prepare_speech_text_strips_markdown() -> None:
     raw = "# Title\n\n**Hello** [Naas](https://naas.ai) and `code`\n\n```python\nprint(1)\n```"
-    assert prepare_speech_text(raw) == "Title Hello Naas and code"
+    assert prepare_speech_text(raw) == "Title Hello Naas and code."
 
 
 def test_prepare_speech_text_truncates() -> None:

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/api/endpoints/speech_test.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/api/endpoints/speech_test.py
@@ -1,0 +1,23 @@
+"""Unit tests for speech text preparation (no network / secrets)."""
+
+from naas_abi.apps.nexus.apps.api.app.api.endpoints.speech import (
+    MAX_INPUT_CHARS,
+    prepare_speech_text,
+)
+
+
+def test_prepare_speech_text_strips_markdown() -> None:
+    raw = "# Title\n\n**Hello** [Naas](https://naas.ai) and `code`\n\n```python\nprint(1)\n```"
+    assert prepare_speech_text(raw) == "Title Hello Naas and code"
+
+
+def test_prepare_speech_text_truncates() -> None:
+    raw = "a" * (MAX_INPUT_CHARS + 50)
+    out = prepare_speech_text(raw)
+    assert len(out) == MAX_INPUT_CHARS
+    assert out.endswith("...")
+
+
+def test_prepare_speech_text_empty() -> None:
+    assert prepare_speech_text("   ") == ""
+    assert prepare_speech_text("```\nonly code\n```") == ""

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/api/endpoints/speech_test.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/api/endpoints/speech_test.py
@@ -1,7 +1,8 @@
-"""Unit tests for speech text preparation (no network / secrets)."""
+"""Unit tests for speech text preparation and language routing (no network)."""
 
 from naas_abi.apps.nexus.apps.api.app.api.endpoints.speech import (
     MAX_INPUT_CHARS,
+    detect_speech_language,
     prepare_speech_text,
 )
 
@@ -21,3 +22,13 @@ def test_prepare_speech_text_truncates() -> None:
 def test_prepare_speech_text_empty() -> None:
     assert prepare_speech_text("   ") == ""
     assert prepare_speech_text("```\nonly code\n```") == ""
+
+
+def test_detect_speech_language_french() -> None:
+    text = "Bonjour Jeremy. Je t'entends parfaitement. Je vais très bien, merci."
+    assert detect_speech_language(text) == "fr"
+
+
+def test_detect_speech_language_english() -> None:
+    text = "Hello Jeremy. I hear you perfectly. I am doing very well, thank you."
+    assert detect_speech_language(text) == "en"

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/api/router.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/api/router.py
@@ -12,6 +12,7 @@ from naas_abi.apps.nexus.apps.api.app.api.endpoints import (
     organizations,
     search,
     secrets,
+    speech,
     tenant,
     transcribe,
     view,
@@ -72,5 +73,6 @@ api_router.include_router(websocket.router, prefix="/websocket", tags=["websocke
 api_router.include_router(abi.router, prefix="/abi", tags=["abi"])
 api_router.include_router(tenant.router, prefix="/tenant", tags=["tenant"])
 api_router.include_router(transcribe.router, prefix="/transcribe", tags=["transcribe"])
+api_router.include_router(speech.router, prefix="/speech", tags=["speech"])
 api_router.include_router(analytics.router, prefix="/analytics", tags=["analytics"])
 api_router.include_router(admin.router, prefix="/admin", tags=["admin"])

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/openrouter_attribution.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/openrouter_attribution.py
@@ -1,0 +1,23 @@
+"""OpenRouter attribution headers from Nexus settings (product-agnostic).
+
+OpenRouter uses HTTP-Referer / X-Title for app ranking and analytics.
+These must come from deployment config (config.yaml -> Nexus settings),
+never from a hard-coded product name.
+"""
+
+from __future__ import annotations
+
+from naas_abi.apps.nexus.apps.api.app.core.config import settings
+
+
+def openrouter_attribution_headers() -> dict[str, str]:
+    referer = (settings.frontend_url or "").strip().rstrip("/") or "http://localhost:3000"
+    title = (
+        (settings.magic_link_email_app_name or "").strip()
+        or (settings.app_name or "").strip()
+        or "Nexus"
+    )
+    return {
+        "HTTP-Referer": referer,
+        "X-Title": title,
+    }

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/api/speech/route.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/api/speech/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+const DEFAULT_API_URL = 'http://localhost:9879';
+const API_SPEECH_PATH = '/api/speech';
+
+/**
+ * Proxies a text-to-speech request to the Python API speech endpoint.
+ * Expects JSON: { text: string, voice?: string, model?: string }
+ * Returns audio/mpeg bytes on success.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json().catch(() => null);
+    if (!body || typeof body !== 'object' || typeof (body as { text?: unknown }).text !== 'string') {
+      return NextResponse.json({ error: 'Missing text' }, { status: 400 });
+    }
+
+    const apiBase =
+      process.env.NEXUS_API_URL ||
+      process.env.NEXT_PUBLIC_API_URL ||
+      DEFAULT_API_URL;
+
+    const speechRes = await fetch(`${apiBase}${API_SPEECH_PATH}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    if (!speechRes.ok) {
+      const detail = await speechRes.text().catch(() => '');
+      let payload: { error?: string; detail?: string } = {};
+      try {
+        payload = JSON.parse(detail) as { error?: string; detail?: string };
+      } catch {
+        payload = {};
+      }
+      return NextResponse.json(
+        {
+          error: payload.error || `Speech synthesis failed (${speechRes.status})`,
+          detail: payload.detail || detail,
+        },
+        { status: speechRes.status }
+      );
+    }
+
+    const audio = await speechRes.arrayBuffer();
+    const contentType = speechRes.headers.get('content-type') || 'audio/mpeg';
+    return new NextResponse(audio, {
+      status: 200,
+      headers: {
+        'Content-Type': contentType,
+        'Cache-Control': 'no-store',
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useRef, useEffect, useMemo, useCallback, useLayoutEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { Send, Plus, Bot, User, AlertCircle, Brain, ChevronDown, X, ArrowUp, Download, ExternalLink, HardDrive, RefreshCw, Mic, Check, Loader2, Wrench, Copy, FileText, ThumbsUp, ThumbsDown } from 'lucide-react';
+import { Send, Plus, Bot, User, AlertCircle, Brain, ChevronDown, X, ArrowUp, Download, ExternalLink, HardDrive, RefreshCw, Mic, Check, Loader2, Wrench, Copy, FileText, ThumbsUp, ThumbsDown, Volume2, Square } from 'lucide-react';
 import Image from 'next/image';
 import { usePathname, useRouter } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
@@ -4023,6 +4023,129 @@ function CopyMessageButton({ content }: { content: string }) {
   );
 }
 
+/** Shared so only one assistant message speaks at a time. */
+let activeReadAloud: {
+  stop: () => void;
+  messageId: string;
+} | null = null;
+
+function ReadAloudButton({ messageId, content }: { messageId: string; content: string }) {
+  const [state, setState] = useState<'idle' | 'loading' | 'playing' | 'error'>('idle');
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const objectUrlRef = useRef<string | null>(null);
+
+  const cleanup = useCallback(() => {
+    if (audioRef.current) {
+      audioRef.current.pause();
+      audioRef.current.src = '';
+      audioRef.current = null;
+    }
+    if (objectUrlRef.current) {
+      URL.revokeObjectURL(objectUrlRef.current);
+      objectUrlRef.current = null;
+    }
+    if (activeReadAloud?.messageId === messageId) {
+      activeReadAloud = null;
+    }
+  }, [messageId]);
+
+  useEffect(() => () => cleanup(), [cleanup]);
+
+  const stop = useCallback(() => {
+    cleanup();
+    setState('idle');
+  }, [cleanup]);
+
+  const handleClick = async () => {
+    if (state === 'loading') return;
+
+    if (state === 'playing') {
+      stop();
+      return;
+    }
+
+    const text = typeof content === 'string' ? content.trim() : '';
+    if (!text) return;
+
+    if (activeReadAloud && activeReadAloud.messageId !== messageId) {
+      activeReadAloud.stop();
+    }
+
+    setState('loading');
+    try {
+      const response = await fetch(`${getApiBase()}/api/speech`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text }),
+      });
+
+      if (!response.ok) {
+        const errData = await response.json().catch(() => ({}));
+        throw new Error(
+          (errData as { error?: string }).error || `Speech failed (${response.status})`
+        );
+      }
+
+      const blob = await response.blob();
+      const objectUrl = URL.createObjectURL(blob);
+      objectUrlRef.current = objectUrl;
+
+      const audio = new Audio(objectUrl);
+      audioRef.current = audio;
+      activeReadAloud = { stop, messageId };
+
+      audio.onended = () => {
+        cleanup();
+        setState('idle');
+      };
+      audio.onerror = () => {
+        cleanup();
+        setState('error');
+        setTimeout(() => setState('idle'), 2000);
+      };
+
+      await audio.play();
+      setState('playing');
+    } catch (error) {
+      console.error('Read aloud failed:', error);
+      cleanup();
+      setState('error');
+      setTimeout(() => setState('idle'), 2000);
+    }
+  };
+
+  const title =
+    state === 'playing'
+      ? 'Stop reading'
+      : state === 'loading'
+        ? 'Generating audio...'
+        : state === 'error'
+          ? 'Read aloud failed'
+          : 'Read aloud';
+
+  return (
+    <button
+      onClick={() => {
+        void handleClick();
+      }}
+      disabled={state === 'loading'}
+      title={title}
+      aria-label={title}
+      className={`flex h-6 w-6 items-center justify-center rounded border border-transparent transition-colors hover:border-border hover:bg-muted/40 disabled:opacity-60 ${
+        state === 'playing' ? 'text-emerald-600 border-emerald-600/40 bg-emerald-50/40' : ''
+      } ${state === 'error' ? 'text-red-600' : ''}`}
+    >
+      {state === 'loading' ? (
+        <Loader2 size={12} className="animate-spin" />
+      ) : state === 'playing' ? (
+        <Square size={11} fill="currentColor" />
+      ) : (
+        <Volume2 size={12} />
+      )}
+    </button>
+  );
+}
+
 function UserMessageActions({ message }: { message: Message }) {
   return (
     <div className="mt-1 flex items-center text-muted-foreground">
@@ -4255,6 +4378,7 @@ function AssistantMessageActions({ message }: { message: Message }) {
     <>
       <div className="mt-1 flex items-center text-muted-foreground">
         <CopyMessageButton content={message.content} />
+        <ReadAloudButton messageId={message.id} content={message.content} />
         <button
           onClick={handleLikeClick}
           disabled={busy !== null}


### PR DESCRIPTION
## Summary
- Adds `POST /api/speech` that synthesizes MP3 via OpenRouter (`/api/v1/audio/speech`) when an OpenRouter key is present, with optional native OpenAI TTS override.
- Adds a Read aloud / Stop control under each assistant message in Nexus chat.
- Detects language from text and selects a matching voice.
- Routes French / ES / DE and long-form replies to Microsoft MAI-Voice (Flash for short, full for narration) with narration style. Keeps Kokoro for short English chat.
- OpenRouter attribution headers come from Nexus settings / config.yaml, not a hard-coded product name.
- Overrides: `OPENROUTER_TTS_MODEL`, `OPENROUTER_TTS_VOICE`, `OPENROUTER_NARRATION_MODEL`, `OPENROUTER_TTS_AUTO_LANGUAGE`.

## Test plan
- [ ] With `OPENROUTER_API_KEY` set, click Read aloud on an assistant reply and confirm audio plays
- [ ] Click again while playing and confirm playback stops
- [ ] French reply uses MAI-Voice Soleil (check `X-TTS-Model` / `X-TTS-Voice` response headers)
- [ ] Long French story uses `microsoft/mai-voice-2`, short French chat can use `mai-voice-2-flash`
- [ ] Markdown-heavy replies are spoken without link/fence noise
- [ ] Clear error when no speech API key is configured

Closes #1091