### PR TITLE
fix(nexus): remap reserved create-skill slugs in skill drafts

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/service.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/service.py
@@ -122,6 +122,10 @@ _CREATE_SKILL_INSTRUCTIONS = (
     "exactly these keys: name, slug, description, prompt. Briefly explain your choices outside "
     "the code block. Do not attempt to save it yourself — the user reviews and saves it from "
     "the UI with one click.\n"
+    "Critical: the slug is the chat command users will type later (e.g. `/weekly-report`). "
+    "Never use `skills` or `create-skill` as the slug — those are reserved builtin commands. "
+    "Derive the slug from the task itself (what the skill does), not from the `/create-skill` "
+    "invocation.\n"
 )
 
 _SKILLS_CATALOG_HEADER = (

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/skills/service.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/skills/service.py
@@ -29,6 +29,15 @@ def normalize_slug(value: str) -> str:
     return slug.strip("-")
 
 
+def suggest_skill_slug(slug: str | None, name: str) -> str:
+    """Pick a non-reserved slug, remapping drafts that echo `/create-skill`."""
+    for candidate in (slug or "", name, f"{name}-task", "custom-skill"):
+        normalized = normalize_slug(candidate)
+        if normalized and normalized not in RESERVED_SLUGS:
+            return normalized
+    return "custom-skill"
+
+
 class SkillValidationError(ValueError):
     pass
 
@@ -115,11 +124,17 @@ class SkillService:
         self._ensure_scope(context, "skill.create", "Skill access denied")
         await self._ensure_workspace_access(context, data.workspace_id)
         self._validate_scope(data.scope)
-        data.slug = await self._validate_slug(data.workspace_id, data.user_id, data.slug)
         if not data.name.strip():
             raise SkillValidationError("Name cannot be empty")
         if not data.prompt.strip():
             raise SkillValidationError("Prompt cannot be empty")
+        # Models often set slug to "create-skill" because that was the slash
+        # command that started the draft. Remap before validation.
+        data.slug = await self._validate_slug(
+            data.workspace_id,
+            data.user_id,
+            suggest_skill_slug(data.slug, data.name),
+        )
         return await self.adapter.create(data)
 
     async def update_skill(

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/skills/service_test.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/skills/service_test.py
@@ -18,6 +18,7 @@ from naas_abi.apps.nexus.apps.api.app.services.skills.service import (
     SkillService,
     SkillValidationError,
     normalize_slug,
+    suggest_skill_slug,
 )
 
 
@@ -61,6 +62,12 @@ def test_normalize_slug() -> None:
     assert normalize_slug("/slash") == "slash"
 
 
+def test_suggest_skill_slug_remaps_reserved_create_skill() -> None:
+    assert suggest_skill_slug("create-skill", "Skill Creator") == "skill-creator"
+    assert suggest_skill_slug("skills", "Weekly Report") == "weekly-report"
+    assert suggest_skill_slug("skills", "Skills") == "skills-task"
+
+
 @pytest.mark.asyncio
 async def test_create_skill_normalizes_slug_and_creates() -> None:
     adapter = AsyncMock()
@@ -84,22 +91,23 @@ async def test_create_skill_normalizes_slug_and_creates() -> None:
 
 
 @pytest.mark.asyncio
-async def test_create_skill_rejects_reserved_and_duplicate_slug() -> None:
+async def test_create_skill_remaps_reserved_slug_then_rejects_duplicate() -> None:
     adapter = AsyncMock()
     adapter.get_visible_by_slug = AsyncMock(return_value=None)
+    adapter.create = AsyncMock(side_effect=lambda data: _record(slug=data.slug))
     service = _service(adapter)
 
-    with pytest.raises(SkillValidationError):
-        await service.create_skill(
-            _context(),
-            SkillCreateInput(
-                workspace_id="ws-1",
-                user_id="user-1",
-                name="Skills",
-                slug="skills",
-                prompt="x",
-            ),
-        )
+    created = await service.create_skill(
+        _context(),
+        SkillCreateInput(
+            workspace_id="ws-1",
+            user_id="user-1",
+            name="Skill Creator",
+            slug="create-skill",
+            prompt="x",
+        ),
+    )
+    assert created.slug == "skill-creator"
 
     adapter.get_visible_by_slug = AsyncMock(return_value=_record(id="other"))
     with pytest.raises(SkillValidationError):

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
@@ -78,6 +78,29 @@ function formatSkillListing(skills: Skill[]): string {
   ].join('\n');
 }
 
+/** Builtin slash commands that can never be skill slugs. */
+const RESERVED_SKILL_SLUGS = new Set(['skills', 'create-skill']);
+
+function normalizeSkillSlug(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/_/g, '-')
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/** Prefer a task slug; never keep reserved builtins like create-skill. */
+function suggestSkillSlug(slug: string | undefined, name: string): string {
+  for (const candidate of [slug ?? '', name, `${name}-task`, 'custom-skill']) {
+    const normalized = normalizeSkillSlug(candidate);
+    if (normalized && !RESERVED_SKILL_SLUGS.has(normalized)) {
+      return normalized;
+    }
+  }
+  return 'custom-skill';
+}
+
 /** Card rendered for ```skill fenced blocks in assistant messages: shows the
  *  agent's skill draft with a scope picker and a one-click save. */
 function SkillDraftCard({ raw }: { raw: string }) {
@@ -87,14 +110,20 @@ function SkillDraftCard({ raw }: { raw: string }) {
   const [saveError, setSaveError] = useState<string | null>(null);
   const [scope, setScope] = useState<SkillScope>('user');
   const [showPrompt, setShowPrompt] = useState(false);
+  const [slugOverride, setSlugOverride] = useState<string | null>(null);
+  const [savedSlug, setSavedSlug] = useState<string | null>(null);
 
   const draft = useMemo(() => {
     try {
       const parsed = JSON.parse(raw);
       if (parsed && typeof parsed.name === 'string' && typeof parsed.prompt === 'string') {
+        const name = parsed.name as string;
+        const rawSlug = typeof parsed.slug === 'string' ? (parsed.slug as string) : undefined;
+        const suggested = suggestSkillSlug(rawSlug, name);
         return {
-          name: parsed.name as string,
-          slug: typeof parsed.slug === 'string' ? (parsed.slug as string) : undefined,
+          name,
+          slug: suggested,
+          originalSlug: rawSlug ? normalizeSkillSlug(rawSlug) : undefined,
           description:
             typeof parsed.description === 'string' ? (parsed.description as string) : undefined,
           prompt: parsed.prompt as string,
@@ -105,6 +134,12 @@ function SkillDraftCard({ raw }: { raw: string }) {
     }
     return null;
   }, [raw]);
+
+  const effectiveSlug = slugOverride ?? draft?.slug ?? '';
+  const remappedReserved =
+    !!draft?.originalSlug &&
+    RESERVED_SKILL_SLUGS.has(draft.originalSlug) &&
+    effectiveSlug !== draft.originalSlug;
 
   // Distinguish "still streaming" from "settled but unparseable". If the raw
   // content stops growing for a moment and still won't parse, the draft was
@@ -126,16 +161,18 @@ function SkillDraftCard({ raw }: { raw: string }) {
 
   const handleSave = async () => {
     if (!currentWorkspaceId || !draft) return;
+    const slug = suggestSkillSlug(effectiveSlug, draft.name);
     setSaveState('saving');
     setSaveError(null);
     try {
-      await createSkill(currentWorkspaceId, {
+      const skill = await createSkill(currentWorkspaceId, {
         name: draft.name,
-        slug: draft.slug,
+        slug,
         description: draft.description,
         prompt: draft.prompt,
         scope,
       });
+      setSavedSlug(skill.slug);
       setSaveState('saved');
     } catch (err) {
       setSaveError(err instanceof Error ? err.message : 'Failed to save skill');
@@ -163,10 +200,26 @@ function SkillDraftCard({ raw }: { raw: string }) {
   return (
     <div className="my-3 rounded-lg border border-border bg-muted/30 p-3">
       <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0">
+        <div className="min-w-0 flex-1">
           <p className="text-sm font-medium text-foreground">{draft.name}</p>
-          {draft.slug && (
-            <p className="font-mono text-xs text-workspace-accent">/{draft.slug}</p>
+          <div className="mt-1 flex items-center gap-1 font-mono text-xs text-workspace-accent">
+            <span>/</span>
+            <input
+              type="text"
+              value={effectiveSlug}
+              onChange={(e) => {
+                setSlugOverride(normalizeSkillSlug(e.target.value));
+                setSaveError(null);
+              }}
+              disabled={saveState === 'saved' || saveState === 'saving'}
+              className="min-w-0 flex-1 rounded border border-border bg-background px-1.5 py-0.5 font-mono text-xs text-workspace-accent outline-none focus-visible:ring-1 focus-visible:ring-workspace-accent disabled:opacity-60"
+              aria-label="Skill command slug"
+            />
+          </div>
+          {remappedReserved && (
+            <p className="mt-1 text-xs text-amber-700 dark:text-amber-400">
+              /{draft.originalSlug} is reserved. Using /{effectiveSlug} instead.
+            </p>
           )}
           {draft.description && (
             <p className="mt-1 text-xs text-muted-foreground">{draft.description}</p>
@@ -201,7 +254,7 @@ function SkillDraftCard({ raw }: { raw: string }) {
         <button
           type="button"
           onClick={handleSave}
-          disabled={saveState === 'saved' || saveState === 'saving'}
+          disabled={saveState === 'saved' || saveState === 'saving' || !effectiveSlug}
           className={cn(
             'flex items-center gap-1.5 rounded-md px-3 py-1 text-xs font-medium transition-colors',
             saveState === 'saved'
@@ -212,7 +265,7 @@ function SkillDraftCard({ raw }: { raw: string }) {
           {saveState === 'saving' && <Loader2 size={12} className="animate-spin" />}
           {saveState === 'saved' && <Check size={12} />}
           {saveState === 'saved'
-            ? `Saved — use /${draft.slug ?? ''}`
+            ? `Saved — use /${savedSlug ?? effectiveSlug}`
             : saveState === 'saving'
               ? 'Saving…'
               : 'Save skill'}


### PR DESCRIPTION
## Summary
- Remap reserved skill slugs (`create-skill`, `skills`) to a name-derived slug on create.
- Skill Creator card shows an editable slug and warns when a reserved value was remapped.
- Prompt instructs the model never to use reserved builtins as the skill slug.

Closes #1093

## Test plan
- [x] Run `/create-skill that summarizes meetings` and confirm the draft slug is not `create-skill`
- [x] If a draft still has `create-skill`, the card remaps it and Save skill succeeds
- [x] Duplicate non-reserved slugs still fail validation