### PR TITLE
feat: add message regeneration feature to replay and refresh assistant answers

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__dependencies.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__dependencies.py
@@ -152,6 +152,7 @@ def to_complete_chat_input(request: ChatRequest) -> CompleteChatInput:
         system_prompt=request.system_prompt,
         context=request.context,
         search_enabled=request.search_enabled,
+        regenerate_of=request.regenerate_of,
     )
 
 
@@ -255,6 +256,28 @@ async def persist_stream_content(
                     message_id=assistant_msg_id,
                     content=full_response,
                 )
+        await db.commit()
+
+
+async def mark_message_superseded(
+    user_id: str,
+    conversation_id: str,
+    message_id: str,
+    superseded_by: str,
+) -> None:
+    """Point a refreshed assistant message at the answer that replaced it.
+
+    Called once the regenerated response is complete, so a failed refresh leaves
+    the original answer in place. The superseded row itself is never deleted.
+    """
+    async with AsyncSessionLocal() as db:
+        with bind_registry(db) as registry:
+            await registry.chat.mark_message_superseded(
+                context=system_request_context(user_id),
+                conversation_id=conversation_id,
+                message_id=message_id,
+                superseded_by=superseded_by,
+            )
         await db.commit()
 
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__export.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__export.py
@@ -9,17 +9,39 @@ from naas_abi.apps.nexus.apps.api.app.core.datetime_compat import UTC
 
 
 def _parse_metadata(msg: Any, override: dict | None = None) -> dict:
-    if override:
-        return override
+    """Stored metadata, with the caller's live values layered on top.
+
+    The frontend sends execution time / steps / sources it may not have PATCHed
+    yet, so those win; everything else the row carries (regenerate lineage,
+    reviewer feedback) still makes it into the export.
+    """
+    stored: dict = {}
     raw = getattr(msg, "metadata_", None) or getattr(msg, "metadata", None)
     if isinstance(raw, dict):
-        return raw
-    if isinstance(raw, str):
+        stored = raw
+    elif isinstance(raw, str):
         try:
-            return json.loads(raw)
+            parsed = json.loads(raw)
+            if isinstance(parsed, dict):
+                stored = parsed
         except Exception:
             pass
-    return {}
+    return {**stored, **override} if override else stored
+
+
+def _lineage_lines(meta: dict, label_format: str) -> str:
+    """Regenerate ("refresh") bookkeeping, so an export shows the full history.
+
+    Superseded answers and replayed prompts stay in the export even though the
+    chat UI hides them; these lines say how each one relates to the others.
+    """
+    entries = []
+    if meta.get("regenerate_of"):
+        prefix = "Replayed prompt of" if meta.get("regenerate_replay") else "Regenerated from"
+        entries.append((prefix, meta["regenerate_of"]))
+    if meta.get("superseded_by"):
+        entries.append(("Superseded by", meta["superseded_by"]))
+    return "".join(label_format.format(label=label, value=value) for label, value in entries)
 
 
 def export_conversation_as_response(
@@ -48,8 +70,10 @@ def export_conversation_as_response(
                 role = f"ASSISTANT ({msg.agent})"
 
             content += f"[{role}]\n"
+            content += f"ID: {msg.id}\n"
             content += f"Timestamp: {msg.created_at.isoformat()}\n"
             meta = _parse_metadata(msg, (messages_metadata or {}).get(msg.id))
+            content += _lineage_lines(meta, "{label}: {value}\n")
             if meta.get("execution_time") is not None:
                 content += f"Execution time: {meta['execution_time']:.1f}s\n"
             feedback = meta.get("feedback")
@@ -142,8 +166,9 @@ def export_conversation_as_response(
             agent_info = f" ({msg.agent})" if msg.agent else ""
             content += f"## 🤖 Assistant{agent_info}\n\n"
 
-        content += f"*{msg.created_at.isoformat()}*\n\n"
+        content += f"*{msg.created_at.isoformat()}* · `{msg.id}`\n\n"
         meta = _parse_metadata(msg, (messages_metadata or {}).get(msg.id))
+        content += _lineage_lines(meta, "**{label}:** `{value}`\n\n")
         if meta.get("execution_time") is not None:
             content += f"⏱ **Execution time:** {meta['execution_time']:.1f}s\n\n"
         feedback = meta.get("feedback")

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__schemas.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__schemas.py
@@ -110,6 +110,9 @@ class ChatRequest(BaseModel):
     context: dict[str, Any] | None = None
     system_prompt: str | None = Field(None, max_length=50_000)
     search_enabled: bool = False
+    # Assistant message id being re-run (chat "refresh" action). The prompt is
+    # replayed as a brand new turn; nothing is deleted.
+    regenerate_of: str | None = Field(None, max_length=100)
 
 
 class ChatResponse(BaseModel):

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__streaming.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__streaming.py
@@ -13,6 +13,7 @@ from naas_abi.apps.nexus.apps.api.app.services.chat.adapters.primary.chat__prima
     bind_registry,
     build_provider_messages_with_agents,
     get_or_create_conversation,
+    mark_message_superseded,
     persist_stream_content,
     persist_stream_metadata,
     request_context,
@@ -288,6 +289,7 @@ async def stream_chat_response(
                     user_content=request.message,
                     assistant_agent=request.agent,
                     created_at=datetime.now(UTC).replace(tzinfo=None),
+                    regenerate_of=request.regenerate_of,
                 )
             await pre_db.commit()
     except Exception:
@@ -439,6 +441,22 @@ async def stream_chat_response(
                 except Exception:
                     logger.error("Failed to finalize stream messages to DB", exc_info=True)
                 await persist_final_metadata()
+                if request.regenerate_of and full_response.strip():
+                    # Only once the refreshed answer actually exists — a failed
+                    # regeneration must leave the original answer on screen.
+                    try:
+                        await mark_message_superseded(
+                            user_id=current_user.id,
+                            conversation_id=conversation_id,
+                            message_id=request.regenerate_of,
+                            superseded_by=assistant_msg_id,
+                        )
+                    except Exception:
+                        logger.warning(
+                            "Failed to mark message %s as superseded",
+                            request.regenerate_of,
+                            exc_info=True,
+                        )
 
             yield "data: [DONE]\n\n"
         except Exception as exc:

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/secondary/postgres.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/secondary/postgres.py
@@ -261,6 +261,7 @@ class ChatSecondaryAdapterPostgres(ChatPersistencePort):
         content: str,
         created_at,
         agent: str | None = None,
+        metadata_: str | None = None,
     ) -> None:
         self.db.add(
             MessageModel(
@@ -270,6 +271,7 @@ class ChatSecondaryAdapterPostgres(ChatPersistencePort):
                 content=content,
                 agent=agent,
                 created_at=created_at,
+                metadata_=metadata_,
             )
         )
         await self.db.flush()

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/chat__schema.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/chat__schema.py
@@ -59,6 +59,10 @@ class CompleteChatInput:
     system_prompt: str | None = None
     context: dict | None = None
     search_enabled: bool = False
+    # Id of the assistant message this turn re-runs. Set when the user hits the
+    # refresh action on a past answer: the same prompt is replayed, the previous
+    # answer is marked superseded, and both turns stay in the database.
+    regenerate_of: str | None = None
 
 
 @dataclass(frozen=True)

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/port.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/port.py
@@ -157,6 +157,7 @@ class ChatPersistencePort(ABC):
         content: str,
         created_at: datetime,
         agent: str | None = None,
+        metadata_: str | None = None,
     ) -> None:
         pass
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/service.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/service.py
@@ -60,6 +60,27 @@ class ResolvedProvider:
     model: str
 
 
+# Metadata keys tracking "refresh" (regenerate) lineage on messages.
+# Nothing is ever deleted: the replayed prompt and the superseded answer stay in
+# the database — and therefore in exports and analytics — they are only left out
+# of the live thread and of the context handed to the model on later turns.
+REGENERATE_OF_KEY = "regenerate_of"
+SUPERSEDED_BY_KEY = "superseded_by"
+REGENERATE_REPLAY_KEY = "regenerate_replay"
+
+# Prepended to the replayed prompt on the way to the provider — never stored.
+# Dropping the previous answer from the transcript is not enough: agents run with
+# their own thread memory (the in-process ABI agent only ever receives the latest
+# user message), so an identical question gets answered from that memory without
+# re-running any tool. This says the point of the turn out loud.
+REGENERATION_DIRECTIVE = (
+    "[REFRESH REQUESTED] The user asked you to run this exact request again. "
+    "Any answer you previously gave for it is stale and must be ignored: call the "
+    "tools again, read the current data, and build your answer from those fresh "
+    "results. Never repeat or summarise a previous answer from memory, even if "
+    "the question is identical to one you have already handled.\n\n"
+)
+
 _FORMATTING_RULES = """
 
 Formatting rules you must always follow:
@@ -612,6 +633,25 @@ class ChatService:
         )
         return created.id
 
+    @staticmethod
+    def _parse_message_metadata(raw: str | None) -> dict:
+        if not raw:
+            return {}
+        try:
+            parsed = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+
+    async def get_message(
+        self,
+        context: RequestContext,
+        conversation_id: str,
+        message_id: str,
+    ) -> ChatMessageRecord | None:
+        messages = await self.list_messages(context=context, conversation_id=conversation_id)
+        return next((m for m in messages if m.id == message_id), None)
+
     async def update_message_metadata(
         self,
         context: RequestContext,
@@ -619,16 +659,48 @@ class ChatService:
         message_id: str,
         metadata: dict,
     ) -> bool:
-        import json
+        """Merge ``metadata`` into whatever the message already carries.
 
+        Merging (rather than replacing) keeps bookkeeping written elsewhere —
+        regenerate lineage, reviewer feedback — alive when the frontend PATCHes
+        its execution time / steps / sources payload at the end of a stream.
+        """
         await self._ensure_conversation_access(
             context,
             conversation_id,
             action="chat.message.update",
         )
+        existing = await self.get_message(
+            context=context,
+            conversation_id=conversation_id,
+            message_id=message_id,
+        )
+        merged = {
+            **self._parse_message_metadata(existing.metadata_ if existing else None),
+            **metadata,
+        }
         return await self.adapter.update_message_metadata(
             message_id=message_id,
-            metadata=json.dumps(metadata),
+            metadata=json.dumps(merged),
+        )
+
+    async def mark_message_superseded(
+        self,
+        context: RequestContext,
+        conversation_id: str,
+        message_id: str,
+        superseded_by: str,
+    ) -> bool:
+        """Flag an assistant message as replaced by a regenerated answer.
+
+        The row is kept as-is; only its metadata gains a pointer to the newer
+        message so the UI and the model context can skip it.
+        """
+        return await self.update_message_metadata(
+            context=context,
+            conversation_id=conversation_id,
+            message_id=message_id,
+            metadata={SUPERSEDED_BY_KEY: superseded_by},
         )
 
     async def create_message(
@@ -640,6 +712,7 @@ class ChatService:
         created_at: datetime,
         agent: str | None = None,
         message_id: str | None = None,
+        metadata: dict | None = None,
     ) -> str:
         await self._ensure_conversation_access(
             context,
@@ -654,6 +727,7 @@ class ChatService:
             content=content,
             agent=agent,
             created_at=created_at,
+            metadata_=json.dumps(metadata) if metadata else None,
         )
         return msg_id
 
@@ -664,13 +738,26 @@ class ChatService:
         user_content: str,
         assistant_agent: str | None,
         created_at: datetime,
+        regenerate_of: str | None = None,
     ) -> tuple[str, str]:
+        user_metadata: dict | None = None
+        assistant_metadata: dict | None = None
+        if regenerate_of:
+            # The replayed prompt is a duplicate of an earlier one: persisted for
+            # the audit trail, hidden from the thread the user and the model see.
+            user_metadata = {
+                REGENERATE_REPLAY_KEY: True,
+                REGENERATE_OF_KEY: regenerate_of,
+            }
+            assistant_metadata = {REGENERATE_OF_KEY: regenerate_of}
+
         user_msg_id = await self.create_message(
             context=context,
             conversation_id=conversation_id,
             role="user",
             content=user_content,
             created_at=created_at,
+            metadata=user_metadata,
         )
         assistant_msg_id = await self.create_message(
             context=context,
@@ -679,6 +766,7 @@ class ChatService:
             content="",
             created_at=created_at,
             agent=assistant_agent,
+            metadata=assistant_metadata,
         )
         return user_msg_id, assistant_msg_id
 
@@ -746,6 +834,14 @@ class ChatService:
             role="user",
             content=request.message,
             created_at=now,
+            metadata=(
+                {
+                    REGENERATE_REPLAY_KEY: True,
+                    REGENERATE_OF_KEY: request.regenerate_of,
+                }
+                if request.regenerate_of
+                else None
+            ),
         )
 
         has_images = bool(request.images) or any(m.images for m in request.messages if m.images)
@@ -833,7 +929,17 @@ class ChatService:
             content=response_content,
             agent=request.agent,
             created_at=now,
+            metadata=(
+                {REGENERATE_OF_KEY: request.regenerate_of} if request.regenerate_of else None
+            ),
         )
+        if request.regenerate_of:
+            await self.mark_message_superseded(
+                context=context,
+                conversation_id=conversation_id,
+                message_id=request.regenerate_of,
+                superseded_by=assistant_message_id,
+            )
         await self.touch_conversation(
             context,
             conversation_id,
@@ -1115,6 +1221,42 @@ class ChatService:
             )
         return None
 
+    @classmethod
+    def _is_regeneration_leftover(
+        cls,
+        message: ChatMessageRecord,
+        regenerate_of: str | None = None,
+    ) -> bool:
+        """True when a stored message must stay out of the model's context.
+
+        Covers the answer being refreshed right now (``regenerate_of``), answers
+        a previous refresh already replaced, and the duplicated prompts those
+        refreshes wrote. All of them remain in the database for the audit trail.
+        """
+        if regenerate_of and message.id == regenerate_of:
+            return True
+        metadata = cls._parse_message_metadata(message.metadata_)
+        return bool(metadata.get(SUPERSEDED_BY_KEY) or metadata.get(REGENERATE_REPLAY_KEY))
+
+    @staticmethod
+    def _apply_regeneration_directive(
+        messages: list[ProviderMessage],
+    ) -> list[ProviderMessage]:
+        """Mark the prompt being replayed so the agent recomputes it.
+
+        Targets the last user message — the one every provider treats as the
+        current turn, and the only one the in-process ABI agent receives.
+        """
+        for index in range(len(messages) - 1, -1, -1):
+            if messages[index].role == "user":
+                messages[index] = ProviderMessage(
+                    role="user",
+                    content=f"{REGENERATION_DIRECTIVE}{messages[index].content}",
+                    images=messages[index].images,
+                )
+                break
+        return messages
+
     async def build_provider_messages_with_agents(
         self,
         context: RequestContext,
@@ -1137,6 +1279,7 @@ class ChatService:
                 }
                 for m in rows
                 if m.role in {"user", "assistant", "system"}
+                and not self._is_regeneration_leftover(m, request.regenerate_of)
             ]
             if request.message:
                 if (
@@ -1162,7 +1305,12 @@ class ChatService:
             for m in request.messages
         ]
         if not source_messages:
-            return [ProviderMessage(role="user", content=request.message, images=request.images)]
+            messages = [
+                ProviderMessage(role="user", content=request.message, images=request.images)
+            ]
+            return (
+                self._apply_regeneration_directive(messages) if request.regenerate_of else messages
+            )
 
         agent_ids = {
             m["agent"] for m in source_messages if m["role"] == "assistant" and m.get("agent")
@@ -1204,6 +1352,8 @@ class ChatService:
                     images=None,
                 )
             )
+        if request.regenerate_of:
+            self._apply_regeneration_directive(messages)
         return messages
 
     # async def run_search_if_needed(self, message: str, search_enabled: bool) -> str | None:

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/service_test.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/service_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from datetime import datetime
 from types import SimpleNamespace
@@ -11,10 +12,14 @@ from naas_abi.apps.nexus.apps.api.app.services.chat.chat__schema import (
     ChatInputMessage,
     CompleteChatInput,
 )
-from naas_abi.apps.nexus.apps.api.app.services.chat.port import ChatConversationRecord
+from naas_abi.apps.nexus.apps.api.app.services.chat.port import (
+    ChatConversationRecord,
+    ChatMessageRecord,
+)
 from naas_abi.apps.nexus.apps.api.app.services.chat.service import (
     _CREATE_SKILL_INSTRUCTIONS,
     AGENT_SYSTEM_PROMPTS,
+    REGENERATION_DIRECTIVE,
     ChatService,
     ResolvedProvider,
 )
@@ -35,6 +40,24 @@ def _conversation(now: datetime) -> ChatConversationRecord:
         agent="aia",
         created_at=now,
         updated_at=now,
+    )
+
+
+def _message(
+    message_id: str,
+    role: str,
+    content: str = "",
+    agent: str | None = None,
+    metadata_: str | None = None,
+) -> ChatMessageRecord:
+    return ChatMessageRecord(
+        id=message_id,
+        conversation_id="conv-1",
+        role=role,
+        content=content,
+        agent=agent,
+        metadata_=metadata_,
+        created_at=datetime.now(),
     )
 
 
@@ -148,6 +171,7 @@ async def test_create_message_generates_message_id_and_delegates() -> None:
         content="Hi",
         agent=None,
         created_at=now,
+        metadata_=None,
     )
 
 
@@ -191,6 +215,139 @@ async def test_create_streaming_message_pair_creates_user_then_assistant() -> No
     assert user_msg_id.startswith("msg-")
     assert assistant_msg_id.startswith("msg-")
     assert adapter.create_message.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_create_streaming_message_pair_tags_regenerated_turn() -> None:
+    now = datetime.now()
+    adapter = SimpleNamespace(
+        get_conversation_by_id_for_user=AsyncMock(return_value=_conversation(now)),
+        create_message=AsyncMock(),
+    )
+    service = ChatService(adapter=adapter)
+
+    await service.create_streaming_message_pair(
+        context=_context(),
+        conversation_id="conv-1",
+        user_content="hello",
+        assistant_agent="aia",
+        created_at=now,
+        regenerate_of="msg-old",
+    )
+
+    user_call, assistant_call = adapter.create_message.await_args_list
+    assert json.loads(user_call.kwargs["metadata_"]) == {
+        "regenerate_replay": True,
+        "regenerate_of": "msg-old",
+    }
+    assert json.loads(assistant_call.kwargs["metadata_"]) == {"regenerate_of": "msg-old"}
+
+
+@pytest.mark.asyncio
+async def test_update_message_metadata_merges_into_existing_payload() -> None:
+    now = datetime.now()
+    adapter = SimpleNamespace(
+        get_conversation_by_id_for_user=AsyncMock(return_value=_conversation(now)),
+        list_messages_by_conversation=AsyncMock(
+            return_value=[_message("msg-1", "assistant", metadata_='{"superseded_by": "msg-2"}')]
+        ),
+        update_message_metadata=AsyncMock(return_value=True),
+    )
+    service = ChatService(adapter=adapter)
+
+    await service.update_message_metadata(
+        context=_context(),
+        conversation_id="conv-1",
+        message_id="msg-1",
+        metadata={"execution_time": 1.5, "steps": []},
+    )
+
+    written = json.loads(adapter.update_message_metadata.await_args.kwargs["metadata"])
+    assert written == {
+        "superseded_by": "msg-2",
+        "execution_time": 1.5,
+        "steps": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_build_provider_messages_skips_regenerated_turns() -> None:
+    now = datetime.now()
+    adapter = SimpleNamespace(
+        get_conversation_by_id_for_user=AsyncMock(return_value=_conversation(now)),
+        list_messages_by_conversation=AsyncMock(
+            return_value=[
+                _message("msg-1", "user", content="what is X?"),
+                _message(
+                    "msg-2",
+                    "assistant",
+                    content="stale answer",
+                    metadata_='{"superseded_by": "msg-4"}',
+                ),
+                _message(
+                    "msg-3",
+                    "user",
+                    content="what is X?",
+                    metadata_='{"regenerate_replay": true}',
+                ),
+                _message("msg-4", "assistant", content="fresh answer"),
+                _message("msg-5", "user", content="and Y?"),
+                _message("msg-6", "assistant", content="answer being refreshed now"),
+            ]
+        ),
+        list_agent_names_by_ids=AsyncMock(return_value={"aia": "AIA"}),
+    )
+    service = ChatService(adapter=adapter)
+
+    messages = await service.build_provider_messages_with_agents(
+        context=_context(),
+        request=CompleteChatInput(
+            message="and Y?",
+            agent="aia",
+            conversation_id="conv-1",
+            regenerate_of="msg-6",
+        ),
+        current_agent_id="aia",
+        conversation_id="conv-1",
+    )
+
+    contents = [m.content for m in messages]
+    assert "stale answer" not in contents
+    assert "answer being refreshed now" not in contents
+    assert contents.count("what is X?") == 1
+    assert "fresh answer" in contents
+
+    # The replayed prompt is the last user turn and carries the re-run directive:
+    # agents keep their own thread memory, so a bare repeat gets answered from it.
+    replayed = [c for c in contents if c.endswith("and Y?")]
+    assert len(replayed) == 1
+    assert replayed[0].startswith(REGENERATION_DIRECTIVE)
+
+
+@pytest.mark.asyncio
+async def test_build_provider_messages_leaves_normal_turn_untouched() -> None:
+    now = datetime.now()
+    adapter = SimpleNamespace(
+        get_conversation_by_id_for_user=AsyncMock(return_value=_conversation(now)),
+        list_messages_by_conversation=AsyncMock(
+            return_value=[_message("msg-1", "user", content="what is X?")]
+        ),
+        list_agent_names_by_ids=AsyncMock(return_value={"aia": "AIA"}),
+    )
+    service = ChatService(adapter=adapter)
+
+    messages = await service.build_provider_messages_with_agents(
+        context=_context(),
+        request=CompleteChatInput(
+            message="what is X?",
+            agent="aia",
+            conversation_id="conv-1",
+        ),
+        current_agent_id="aia",
+        conversation_id="conv-1",
+    )
+
+    assert [m.content for m in messages] == ["what is X?"]
 
 
 @pytest.mark.asyncio

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/app-html/[...path]/route.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/app-html/[...path]/route.ts
@@ -26,6 +26,14 @@ export async function GET(
     if (contentType) {
       headers.set('content-type', contentType);
     }
+    const contentDisposition = res.headers.get('content-disposition');
+    if (contentDisposition) {
+      headers.set('content-disposition', contentDisposition);
+    }
+    const cacheControl = res.headers.get('cache-control');
+    if (cacheControl) {
+      headers.set('cache-control', cacheControl);
+    }
     const etag = res.headers.get('etag');
     if (etag) {
       headers.set('etag', etag);

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
@@ -8,7 +8,7 @@ import { usePathname, useRouter } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { cn } from '@/lib/utils';
-import { useWorkspaceStore, type AgentType, type Message, type MessageFeedback, type MessageFeedbackDetails, type SidebarSection, type ToolCall } from '@/stores/workspace';
+import { getModelHistory, useWorkspaceStore, type AgentType, type Message, type MessageFeedback, type MessageFeedbackDetails, type SidebarSection, type ToolCall } from '@/stores/workspace';
 import { useIntegrationsStore } from '@/stores/integrations';
 import { useAgentsStore } from '@/stores/agents';
 import { useSkillsStore, type Skill, type SkillScope } from '@/stores/skills';
@@ -1669,7 +1669,11 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
     e?: React.FormEvent,
     messageOverride?: string,
     agentOverride?: string,
-    conversationIdOverride?: string
+    conversationIdOverride?: string,
+    // Set when re-running a past answer: the id of the assistant message being
+    // refreshed. The prompt is replayed as a new turn on both sides; the old
+    // answer stays in the database and only leaves the visible thread.
+    regenerateOf?: string
   ) => {
     e?.preventDefault();
     if (isSubmittingRef.current) return;
@@ -1751,6 +1755,9 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
       content: sourceText.trim() || (attachedImages.length > 0 ? 'What is in this image?' : ''),
       images: currentImages.length > 0 ? currentImages : undefined,
       fileAttachments: currentFileAttachments.length > 0 ? currentFileAttachments : undefined,
+      // Flags the duplicate so later turns don't send the model the same
+      // question twice; it is still shown, stored and exported like any other.
+      ...(regenerateOf ? { replayedPrompt: true, regenerateOf } : {}),
     });
 
     const userMessage = sourceText.trim() || (currentImages.length > 0 ? 'What is in this image?' : '');
@@ -1803,8 +1810,10 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
       const currentConversation = freshConversations.find(c => c.id === conversationId);
       const allMessages = currentConversation?.messages || [];
       
-      // Build full message history for the API (including images and agent attribution for multimodal)
-      const fullHistory = allMessages.map(m => ({
+      // Build full message history for the API (including images and agent attribution for multimodal).
+      // Superseded answers and replayed prompts are left out so a refreshed turn
+      // doesn't feed the model the answer it is replacing.
+      const fullHistory = getModelHistory(allMessages).map(m => ({
         role: m.role,
         content: m.content,
         images: m.images || null,
@@ -1833,6 +1842,9 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
           agent: effectiveAgent,
           activityLine: 'Processing...',
           // activityLine: searchEnabled ? 'Web search in progress' : 'Processing...',
+          // Records which answer this one re-runs, so later turns leave the
+          // superseded answer out of the model's context.
+          ...(regenerateOf ? { regenerateOf } : {}),
         });
         // Capture placeholder message id for controls. We keep it in a local
         // variable AND in React state — the SSE handler runs inside the same
@@ -2065,6 +2077,7 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
             provider: providerPayload,
             system_prompt: systemPrompt,
             search_enabled: false,
+            regenerate_of: regenerateOf ?? null,
             // search_enabled: searchEnabled,
           }),
         });
@@ -2274,6 +2287,7 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
             agent: effectiveAgent,
             provider: providerPayload,
             system_prompt: systemPrompt,
+            regenerate_of: regenerateOf ?? null,
           }),
         });
 
@@ -2290,6 +2304,7 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
           agent: effectiveAgent,
           thinkingDuration,
           sources: data.context_used?.length > 0 ? data.context_used : undefined,
+          ...(regenerateOf ? { regenerateOf } : {}),
         });
       }
     } catch (error) {
@@ -2387,6 +2402,35 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
     }
   };
 
+  // Re-run the prompt that produced a given assistant message. The prompt is
+  // replayed as a new turn appended to the thread — the original question, the
+  // old answer and the replay all stay on screen, in the database and in
+  // exports. Only the model's context skips the answer being re-run, so it
+  // redoes the work instead of repeating itself (see getModelHistory).
+  const handleRegenerate = (assistantMessage: Message) => {
+    if (isLoading || isStreaming || isSubmittingRef.current) return;
+    const conversationId = activeConversation?.id;
+    const messages = activeConversation?.messages ?? [];
+    const index = messages.findIndex((m) => m.id === assistantMessage.id);
+    if (!conversationId || index === -1) return;
+
+    // Walk back to the question this answer replied to.
+    const prompt =
+      messages
+        .slice(0, index)
+        .reverse()
+        .find((m) => m.role === 'user')?.content ?? '';
+    if (!prompt.trim()) return;
+
+    void handleSubmit(
+      undefined,
+      prompt,
+      assistantMessage.agent ?? selectedAgent,
+      conversationId,
+      assistantMessage.id
+    );
+  };
+
   const handleExportConversation = async () => {
     if (!activeConversation || activeConversation.messages.length === 0) {
       alert('No conversation to export');
@@ -2470,6 +2514,8 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
                 }}
                 onPreviewUrl={setPreviewUrl}
                 requestSentAt={requestSentAt}
+                onRegenerate={handleRegenerate}
+                regenerateDisabled={isLoading || isStreaming}
               />
             ))}
             {isLoading && !isStreaming && (
@@ -3377,6 +3423,8 @@ const MessageBubble = React.memo(function MessageBubble({
   onStop,
   onPreviewUrl,
   requestSentAt,
+  onRegenerate,
+  regenerateDisabled,
 }: {
   message: Message;
   currentSelectedAgent: string;
@@ -3385,6 +3433,8 @@ const MessageBubble = React.memo(function MessageBubble({
   onStop: () => void;
   onPreviewUrl?: (url: string) => void;
   requestSentAt?: number | null;
+  onRegenerate?: (message: Message) => void;
+  regenerateDisabled?: boolean;
 }) {
   const isUser = message.role === 'user';
   const [showThinking, setShowThinking] = useState(false);
@@ -4034,7 +4084,11 @@ const MessageBubble = React.memo(function MessageBubble({
 
         {/* Per-message actions */}
         {!isUser && !isStillProcessing && (
-          <AssistantMessageActions message={message} />
+          <AssistantMessageActions
+            message={message}
+            onRegenerate={onRegenerate}
+            regenerateDisabled={regenerateDisabled}
+          />
         )}
         {isUser && <UserMessageActions message={message} />}
       </div>
@@ -4239,7 +4293,15 @@ function FeedbackDislikeDialog({
   );
 }
 
-function AssistantMessageActions({ message }: { message: Message }) {
+function AssistantMessageActions({
+  message,
+  onRegenerate,
+  regenerateDisabled,
+}: {
+  message: Message;
+  onRegenerate?: (message: Message) => void;
+  regenerateDisabled?: boolean;
+}) {
   const updateMessageFeedback = useWorkspaceStore((s) => s.updateMessageFeedback);
   const activeConversationId = useWorkspaceStore((s) => s.activeConversationId);
   const [busy, setBusy] = useState<null | 'like' | 'dislike'>(null);
@@ -4344,6 +4406,17 @@ function AssistantMessageActions({ message }: { message: Message }) {
             />
           )}
         </button>
+        {onRegenerate && (
+          <button
+            onClick={() => onRegenerate(message)}
+            disabled={regenerateDisabled}
+            title="Run this request again"
+            aria-label="Run this request again"
+            className="flex h-6 w-6 items-center justify-center rounded border border-transparent transition-colors hover:border-border hover:bg-muted/40 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            <RefreshCw size={12} />
+          </button>
+        )}
       </div>
       <FeedbackDislikeDialog
         open={dialogOpen}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
@@ -80,6 +80,11 @@ export interface Message {
   sources?: string[]; // filenames of RAG documents used to answer
   feedback?: MessageFeedback | null; // Reviewer thumbs up/down, persisted on metadata_
   feedbackDetails?: MessageFeedbackDetails | null; // Extended dislike details (type/detail/severity)
+  // Chat "refresh" lineage. Every one of these messages is displayed; the flags
+  // only shape what the model is given on later turns — see getModelHistory().
+  regenerateOf?: string; // Assistant message id this turn re-ran
+  supersededBy?: string; // Newer answer that replaced this one (set server-side)
+  replayedPrompt?: boolean; // Prompt re-sent by a refresh (duplicate of an earlier one)
   // Author attribution (preserved across sessions and users)
   authorId?: string;
   authorName?: string;
@@ -332,8 +337,40 @@ type ApiConversation = {
   messages?: ApiChatMessage[];
 };
 
+const isFailedAnswer = (message: Message): boolean => {
+  const body = message.content.replace('▌', '').trim();
+  return !body || body.startsWith('❌ Error:');
+};
+
+/**
+ * The transcript as the model should see it. Every message is rendered in the
+ * chat — this is only about context: a refresh must not hand the model the
+ * answer it is re-running, or it repeats it instead of redoing the work.
+ *
+ * Superseded answers are derived from the turns themselves: a refresh tags its
+ * answer with the one it re-ran, so a completed replacement drops the original.
+ * A refresh that failed or is still empty drops nothing, and the rule re-derives
+ * itself identically after a reload, whatever local state was lost.
+ */
+export const getModelHistory = (messages: Message[]): Message[] => {
+  const replaced = new Set<string>();
+  for (const message of messages) {
+    if (message.role !== 'assistant' || !message.regenerateOf) continue;
+    if (isFailedAnswer(message)) continue;
+    replaced.add(message.regenerateOf);
+  }
+  return messages.filter(
+    (message) =>
+      !message.replayedPrompt &&
+      !replaced.has(message.id) &&
+      typeof message.supersededBy !== 'string',
+  );
+};
+
 const mapApiMessage = (message: ApiChatMessage): Message => {
   const meta = message.metadata ?? {};
+  const supersededBy = meta.superseded_by;
+  const regenerateOf = meta.regenerate_of;
   const fb = meta.feedback;
   const fbType = meta.feedback_type;
   const fbDetail = meta.feedback_detail;
@@ -348,6 +385,9 @@ const mapApiMessage = (message: ApiChatMessage): Message => {
     content: message.content,
     timestamp: new Date(message.created_at || Date.now()),
     agent: message.agent || undefined,
+    ...(typeof regenerateOf === 'string' ? { regenerateOf } : {}),
+    ...(typeof supersededBy === 'string' ? { supersededBy } : {}),
+    ...(meta.regenerate_replay === true ? { replayedPrompt: true } : {}),
     feedback: fb === 'like' || fb === 'dislike' ? fb : null,
     feedbackDetails: hasDetails
       ? {

--- a/uv.lock
+++ b/uv.lock
@@ -3786,7 +3786,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-marketplace"
-version = "3.26.0"
+version = "3.26.1"
 source = { editable = "libs/naas-abi-marketplace" }
 dependencies = [
     { name = "ijson" },

--- a/uv.lock
+++ b/uv.lock
@@ -3547,7 +3547,7 @@ wheels = [
 
 [[package]]
 name = "naas-abi"
-version = "2.46.2"
+version = "2.46.3"
 source = { editable = "libs/naas-abi" }
 dependencies = [
     { name = "aiosqlite" },
@@ -3786,7 +3786,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-marketplace"
-version = "3.26.1"
+version = "3.28.0"
 source = { editable = "libs/naas-abi-marketplace" }
 dependencies = [
     { name = "ijson" },


### PR DESCRIPTION
This pull request resolves #replay-last-message

# Summary

This PR introduces a feature to support "replaying" or "refreshing" a previously generated assistant message in the chat system. When a user requests to regenerate a past assistant message, the system re-runs the prompt as a new turn, keeps the original prompt and answer in the database and UI, but excludes the superseded answer from the model's context to avoid repetition.

# Key Changes

## Backend

- Added `regenerate_of` field to chat request and internal data models to track which assistant message is being re-run.
- Implemented `mark_message_superseded` to mark an old assistant message as replaced by a regenerated answer.
- Updated message creation to tag regenerated turns with metadata indicating replay and supersession.
- Modified message metadata update to merge new metadata with existing data, preserving lineage and feedback.
- Enhanced message export to include regeneration lineage information.
- Updated chat service to exclude superseded and replayed messages from the model context.
- Added regeneration directive prepended to replayed prompts to force the agent to recompute answers.
- Added tests covering regeneration metadata tagging, metadata merging, message filtering, and directive application.

## Frontend

- Added UI support for a "regenerate" button on assistant messages.
- When regenerating, the prompt that produced the original answer is replayed as a new user turn.
- The frontend marks regenerated messages with flags (`regenerateOf`, `replayedPrompt`) to control visibility and context.
- The message history sent to the model excludes superseded answers and replayed prompts to avoid repetition.
- Updated message export and display to show regeneration lineage.

# Behavior

- The original prompt and answer remain visible and stored for audit and export.
- The regenerated answer is treated as a new message linked to the original.
- The model context excludes superseded answers and replayed prompts to ensure fresh computation.
- Failed regenerations leave the original answer in place.

# Additional Notes

- The regeneration directive instructs the agent to ignore previous answers and re-run tools and data retrieval.
- The feature is fully covered by new unit tests.

This enhancement improves user experience by allowing seamless refreshing of assistant answers without losing conversation history or auditability.