### PR TITLE
fix(onto2py): surface ruff failures and re-lint pre-existing class files

### DIFF
--- a/libs/naas-abi-core/naas_abi_core/utils/onto2py/onto2py.py
+++ b/libs/naas-abi-core/naas_abi_core/utils/onto2py/onto2py.py
@@ -1945,6 +1945,7 @@ def create_class_files(
     created_count = 0
     skipped_count = 0
     created_files: list[str] = []
+    skipped_files: list[str] = []
 
     for class_uri, class_info in classes.items():
         # External classes already live in another module's class-files
@@ -1981,9 +1982,13 @@ def create_class_files(
         # File name is the class name in Python
         class_file = class_dir / f"{class_info.name}.py"
 
-        # Skip if file exists and overwrite is False
+        # Skip if file exists and overwrite is False. Still lint it: an existing
+        # file was linted by whatever ruff was current when it was first
+        # written, so without this it stays frozen at those rules forever and
+        # drifts out of step with the repo's linter.
         if class_file.exists() and not overwrite:
             skipped_count += 1
+            skipped_files.append(str(class_file))
             continue
 
         # Calculate import path using absolute import starting from folder that begins with "naas_abi"
@@ -2080,8 +2085,8 @@ class {class_info.name}(_{class_info.name}):
         except Exception as e:  # noqa: BLE001
             print(f"⚠️  Warning: Failed to create class file {class_file}: {e}")
 
-    # Lint all created class files in one batch
-    _run_ruff(created_files)
+    # Lint created and pre-existing class files in one batch
+    _run_ruff(created_files + skipped_files)
 
     if created_count > 0 or skipped_count > 0:
         print(
@@ -2120,32 +2125,48 @@ def _run_ruff(paths: list[str]) -> None:
       source.fixAll        -> ruff check --fix
       source.organizeImports -> ruff check --fix --extend-select I
       editor.formatOnSave  -> ruff format
+
+    Failures are reported but never fatal: generation still produced valid
+    code, it just may not satisfy the consuming repo's lint config. Staying
+    silent here is what lets generated output drift until a downstream
+    `ruff check` fails on files nobody touched.
     """
     if not paths:
         return
     ruff = _find_ruff()
     if ruff is None:
+        print(
+            "⚠️  onto2py: ruff not found; generated files were left unlinted. "
+            "Install ruff (or make it importable via uvx) to lint generated output."
+        )
         return
     ruff_parts = ruff.split()
-    try:
-        subprocess.run(
-            [*ruff_parts, "check", "--fix", "--extend-select", "I", *paths],
-            capture_output=True,
-            text=True,
-            timeout=30,
-            check=False,
-        )
-        subprocess.run(
-            [*ruff_parts, "format", *paths],
-            capture_output=True,
-            text=True,
-            timeout=30,
-            check=False,
-        )
-    except (subprocess.TimeoutExpired, FileNotFoundError, subprocess.SubprocessError):
-        pass
-    except Exception:  # noqa: BLE001,S110
-        pass
+    for args in (
+        ["check", "--fix", "--extend-select", "I"],
+        ["format"],
+    ):
+        try:
+            result = subprocess.run(
+                [*ruff_parts, *args, *paths],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            print(f"⚠️  onto2py: ruff {args[0]} timed out on {len(paths)} file(s).")
+            continue
+        except (FileNotFoundError, subprocess.SubprocessError, OSError) as exc:
+            print(f"⚠️  onto2py: ruff {args[0]} could not run: {exc}")
+            continue
+        # `ruff check --fix` exits non-zero when violations remain unfixed,
+        # which means the generator emitted code the linter rejects.
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout or "").strip()
+            print(
+                f"⚠️  onto2py: ruff {args[0]} reported unresolved issues "
+                f"(exit {result.returncode}) in generated output:\n{detail}"
+            )
 
 
 def apply_linting(code: str) -> str:

--- a/libs/naas-abi-core/naas_abi_core/utils/onto2py/tests/lint_test.py
+++ b/libs/naas-abi-core/naas_abi_core/utils/onto2py/tests/lint_test.py
@@ -1,0 +1,113 @@
+"""Tests for onto2py's linting of generated output.
+
+The generator lints what it writes so downstream repos can run `ruff check`
+over generated files. These cover the two ways that used to fail invisibly:
+a ruff that is missing or erroring, and pre-existing class files that were
+never re-linted after the linter's rules moved on.
+"""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from naas_abi_core.utils.onto2py.onto2py import (
+    ClassInfo,
+    _run_ruff,
+    create_class_files,
+)
+
+
+def _class_info(name: str) -> ClassInfo:
+    return ClassInfo(
+        name=name,
+        uri=f"http://example.org/onto#{name}",
+        parent_classes=[],
+        properties=[],
+    )
+
+
+def test_run_ruff_warns_when_ruff_is_missing(capsys):
+    """A missing ruff must be reported, not silently skipped."""
+    with patch("naas_abi_core.utils.onto2py.onto2py._find_ruff", return_value=None):
+        _run_ruff(["some_file.py"])
+
+    out = capsys.readouterr().out
+    assert "ruff not found" in out
+    assert "unlinted" in out
+
+
+def test_run_ruff_reports_unresolved_violations(capsys):
+    """Non-zero exit means the generator emitted code the linter rejects."""
+    completed = subprocess.CompletedProcess(
+        args=[], returncode=1, stdout="E501 line too long", stderr=""
+    )
+    with (
+        patch("naas_abi_core.utils.onto2py.onto2py._find_ruff", return_value="ruff"),
+        patch(
+            "naas_abi_core.utils.onto2py.onto2py.subprocess.run",
+            return_value=completed,
+        ),
+    ):
+        _run_ruff(["some_file.py"])
+
+    out = capsys.readouterr().out
+    assert "unresolved issues" in out
+    assert "exit 1" in out
+    assert "E501 line too long" in out
+
+
+def test_run_ruff_is_silent_on_success(capsys):
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+    with (
+        patch("naas_abi_core.utils.onto2py.onto2py._find_ruff", return_value="ruff"),
+        patch(
+            "naas_abi_core.utils.onto2py.onto2py.subprocess.run",
+            return_value=completed,
+        ),
+    ):
+        _run_ruff(["some_file.py"])
+
+    assert capsys.readouterr().out == ""
+
+
+def test_run_ruff_skips_empty_path_list(capsys):
+    """No paths means nothing to lint - and nothing to warn about."""
+    with patch(
+        "naas_abi_core.utils.onto2py.onto2py._find_ruff", return_value=None
+    ) as find_ruff:
+        _run_ruff([])
+
+    assert capsys.readouterr().out == ""
+    find_ruff.assert_not_called()
+
+
+def test_create_class_files_lints_preexisting_files(tmp_path: Path):
+    """Existing class files are re-linted, not frozen at the rules that made them.
+
+    Without this, a class file keeps whatever formatting the ruff of the day
+    produced and drifts out of step with the repo's linter forever.
+    """
+    ontologies = tmp_path / "domain" / "ontologies"
+    ontologies.mkdir(parents=True)
+    ttl_file = ontologies / "modules" / "DomainOntology.ttl"
+    ttl_file.parent.mkdir(parents=True)
+    ttl_file.write_text("# ttl stub\n")
+    py_file = ttl_file.with_suffix(".py")
+    py_file.write_text("# generated stub\n")
+
+    classes = {"http://example.org/onto#Alpha": _class_info("Alpha")}
+
+    # First pass creates the class file.
+    with patch("naas_abi_core.utils.onto2py.onto2py._run_ruff") as run_ruff:
+        create_class_files(str(ttl_file), classes, py_file)
+        created = run_ruff.call_args.args[0]
+
+    assert len(created) == 1, "first pass should create and lint one class file"
+    assert created[0].endswith("Alpha.py")
+
+    # Second pass skips the now-existing file, but must still lint it.
+    with patch("naas_abi_core.utils.onto2py.onto2py._run_ruff") as run_ruff:
+        create_class_files(str(ttl_file), classes, py_file)
+        linted = run_ruff.call_args.args[0]
+
+    assert linted == created, "pre-existing class files must still be linted"


### PR DESCRIPTION
## Problem

onto2py lints the code it generates so consuming repos can run `ruff check` over the output. Two gaps let that silently stop working:

1. **`_run_ruff` swallowed everything.** It captured stdout/stderr, never inspected the return code, and ended in `except Exception: pass`. A ruff that was missing, timed out, or reported violations it could not auto-fix all looked identical to success.
2. **Only newly created class files were linted.** `create_class_files` passed `created_files` to `_run_ruff` and dropped the `skipped_count` ones. An existing class file stayed frozen at whatever ruff was current when it was first written.

This surfaced downstream in `axi-ai`: `make check` failed with 506 ruff errors across `src/**/ontologies/` on files nobody had touched. The generated output had been linted by ruff 0.15.x, and ruff 0.16 expanded its default rule set (UP/PIE) beyond what that ruff enforced. Same file, both versions:

```
src/report/ontologies/processes/ReportGeneration.py
  ruff 0.15.1 -> 0 errors
  ruff 0.16.0 -> 190 errors
```

Nothing in the generator reported that its linting had gone stale.

## Changes

- `_run_ruff` reports a missing ruff, a timeout, a spawn failure, and any non-zero exit (with ruff's own output). Linting stays **non-fatal** — generation still produced valid code, it just may not satisfy the consuming repo's lint config — but it is no longer invisible.
- `create_class_files` collects skipped (pre-existing) class files and lints them alongside newly created ones, so they track the repo's current linter instead of the one that first wrote them.

## Tests

New `naas_abi_core/utils/onto2py/tests/lint_test.py` (5 tests). The 3 covering new behavior fail on `main` and pass with this change; the other 2 pin the silent-on-success and empty-path-list paths.

Verified `ruff check` and `mypy` clean on both changed files. The pre-existing `ttl2py_test.py` suite is unchanged by this PR (8 failed / 1 passed both before and after — network-dependent fetches plus assertions written against pre-0.16 `Optional[...]` output).

## Note for maintainers

`_find_ruff` still resolves an unpinned `uvx ruff` as its last fallback, so the generator's effective rule set remains whatever ruff shipped that day. Consumers can close this by pinning ruff in their own venv (`_find_ruff` prefers it over `uvx`) and matching that pin in their lint gate. Pinning it inside onto2py itself felt like a call for this repo's maintainers rather than something to slip into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KggUriTu7Evj1Aqu2jY8dL