### PR TITLE
feat(nexus-web): mobile workspace shell and chat UX

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/agents/adapters/primary/agents__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/agents/adapters/primary/agents__primary_adapter__FastAPI.py
@@ -111,6 +111,22 @@ def request_context(current_user: User) -> RequestContext:
     )
 
 
+def _get_engine_default_agent_class_name() -> str | None:
+    """Resolve engine ``default_agent`` (e.g. ``my_module MyAgent``) to registry class_name."""
+    try:
+        from naas_abi import ABIModule
+
+        default_agent = ABIModule.get_instance().engine.configuration.default_agent
+        if not default_agent or " " not in default_agent.strip():
+            return None
+        module_name, agent_name = default_agent.strip().split(" ", 1)
+        if module_name and agent_name:
+            return f"{module_name}/{agent_name}"
+    except Exception:
+        logger.debug("Could not resolve engine default_agent", exc_info=True)
+    return None
+
+
 def _extract_agent_suggestions(agent_cls: type) -> list[dict] | None:
     suggestions = getattr(agent_cls, "suggestions", None)
     if not isinstance(suggestions, list):
@@ -413,6 +429,8 @@ async def _reconcile_workspace_agents(
         stale_ids = {agent.id for agent in stale_agents}
         agent_list = [agent for agent in agent_list if agent.id not in stale_ids]
 
+    default_class_name = _get_engine_default_agent_class_name()
+
     # Persist any newly discovered agent classes to the database.
     for class_name, agent_cls in class_name_to_agent_class.items():
         if class_name in existing_agents_by_class_name:
@@ -420,7 +438,11 @@ async def _reconcile_workspace_agents(
 
         name = _get_agent_class_name(agent_cls)
         description = _get_agent_class_description(agent_cls)
-        enabled = name == "Abi"
+        # Enable the engine default agent; fall back to Abi for generic ABI deployments.
+        enabled = (
+            (default_class_name is not None and class_name == default_class_name)
+            or (default_class_name is None and name == "Abi")
+        )
 
         logger.debug("Creating agent in nexus backend: %s", name)
         system_prompt = _get_agent_system_prompt(agent_cls)
@@ -437,6 +459,14 @@ async def _reconcile_workspace_agents(
                 system_prompt=system_prompt,
             ),
         )
+        if default_class_name and class_name == default_class_name:
+            updated = await agent_service.update_agent(
+                context=context,
+                agent_id=created_agent.id,
+                updates=AgentUpdateInput(is_default=True),
+            )
+            if updated is not None:
+                created_agent = updated
         agent_list.append(created_agent)
         existing_agents_by_class_name[class_name] = created_agent
 
@@ -456,6 +486,27 @@ async def _reconcile_workspace_agents(
                     reconciled.append(updated)
                     continue
         reconciled.append(agent)
+
+    # Ensure the engine default agent is enabled and marked as workspace default.
+    if default_class_name:
+        default_agent = next(
+            (agent for agent in reconciled if agent.class_name == default_class_name),
+            None,
+        )
+        if default_agent and (not default_agent.enabled or not default_agent.is_default):
+            updated = await agent_service.update_agent(
+                context=context,
+                agent_id=default_agent.id,
+                updates=AgentUpdateInput(
+                    enabled=True if not default_agent.enabled else None,
+                    is_default=True if not default_agent.is_default else None,
+                ),
+            )
+            if updated is not None:
+                reconciled = [
+                    updated if agent.id == updated.id else agent for agent in reconciled
+                ]
+
     return reconciled
 
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/auth/forgot-password/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/auth/forgot-password/page.tsx
@@ -255,12 +255,12 @@ export default function ForgotPasswordPage() {
         )}
       </div>
       {tenant.show_powered_by && (
-        <p className="mt-4 text-center text-xs" style={{ color: subtitleColor }}>
+        <p className="mt-4 text-center text-caption" style={{ color: subtitleColor }}>
           Powered by NEXUS
         </p>
       )}
       {tenant.login_footer_text && (
-        <p className="mt-4 text-center text-xs" style={{ color: subtitleColor }}>
+        <p className="mt-4 text-center text-caption" style={{ color: subtitleColor }}>
           {tenant.login_footer_text}
         </p>
       )}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/auth/login/login-form.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/auth/login/login-form.tsx
@@ -162,12 +162,13 @@ export default function LoginForm() {
               <img
                 src={tenant.logo_url}
                 alt={tenant.tab_title}
-                className="h-12 w-12 rounded-xl object-contain"
+                className="h-12 w-12 object-contain"
+                style={{ borderRadius: cardRadius }}
               />
             ) : (
               <div
-                className="flex h-12 w-12 items-center justify-center rounded-xl text-white font-bold text-xl"
-                style={{ backgroundColor: primaryColor }}
+                className="flex h-12 w-12 items-center justify-center text-white font-bold text-xl"
+                style={{ backgroundColor: primaryColor, borderRadius: cardRadius }}
               >
                 {tenant.logo_emoji || 'N'}
               </div>
@@ -179,7 +180,10 @@ export default function LoginForm() {
         </div>
 
         {error && (
-          <div className="mb-6 flex items-center gap-2 rounded-lg bg-destructive/10 p-3 text-sm text-destructive">
+          <div
+            className="mb-6 flex items-center gap-2 bg-destructive/10 p-3 text-sm text-destructive"
+            style={{ borderRadius: cardRadius }}
+          >
             <AlertCircle size={16} />
             <span>{error}</span>
           </div>
@@ -308,7 +312,7 @@ export default function LoginForm() {
         </form>
       </div>
       {tenant.show_terms_footer && (
-        <p className="mt-8 text-center text-sm" style={{ color: subtitleColor }}>
+        <p className="mt-8 text-center text-caption" style={{ color: subtitleColor }}>
           By signing in, you agree to our{' '}
           <Link href="/terms" className="hover:underline">
             Terms of Service
@@ -320,12 +324,12 @@ export default function LoginForm() {
         </p>
       )}
       {tenant.show_powered_by && (
-        <p className="mt-4 text-center text-xs" style={{ color: subtitleColor }}>
+        <p className="mt-4 text-center text-caption" style={{ color: subtitleColor }}>
           Powered by NEXUS
         </p>
       )}
       {tenant.login_footer_text && (
-        <p className="mt-4 text-center text-xs" style={{ color: subtitleColor }}>
+        <p className="mt-4 text-center text-caption" style={{ color: subtitleColor }}>
           {tenant.login_footer_text}
         </p>
       )}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/auth/magic-link/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/auth/magic-link/page.tsx
@@ -5,11 +5,19 @@ import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { AlertCircle, Loader2 } from 'lucide-react';
 import { useAuthStore } from '@/stores/auth';
+import { useTenant } from '@/contexts/tenant-context';
 import { shouldSkipMagicLinkConfirmation } from '@/lib/auth-session';
+
+/** Same corner radius the tenant configured for the login card. */
+function useTenantRadius(): string {
+  const tenant = useTenant();
+  return `${tenant.login_border_radius || '0'}px`;
+}
 
 function MagicLinkPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const radius = useTenantRadius();
   const { verifyMagicLink, isLoading, error, clearError, isAuthenticated } = useAuthStore();
 
   const token = searchParams.get('token');
@@ -42,7 +50,7 @@ function MagicLinkPageContent() {
   if (!token) {
     return (
       <div className="flex min-h-screen items-center justify-center px-4">
-        <div className="w-full max-w-md rounded-xl border p-6 text-center">
+        <div className="w-full max-w-md border p-6 text-center" style={{ borderRadius: radius }}>
           <div className="mb-4 flex justify-center text-destructive">
             <AlertCircle className="h-8 w-8" />
           </div>
@@ -60,7 +68,7 @@ function MagicLinkPageContent() {
 
   return (
     <div className="flex min-h-screen items-center justify-center px-4">
-      <div className="w-full max-w-md rounded-xl border p-6 text-center">
+      <div className="w-full max-w-md border p-6 text-center" style={{ borderRadius: radius }}>
         <div className="mb-4 flex justify-center">
           <AlertCircle className="h-8 w-8 text-primary" />
         </div>
@@ -72,7 +80,8 @@ function MagicLinkPageContent() {
           type="button"
           onClick={handleConfirmSignIn}
           disabled={isLoading}
-          className="mt-4 inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+          style={{ borderRadius: radius }}
+          className="mt-4 inline-flex w-full items-center justify-center bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
         >
           {isLoading ? (
             <>
@@ -95,9 +104,10 @@ function MagicLinkPageContent() {
 }
 
 function MagicLinkPageFallback() {
+  const radius = useTenantRadius();
   return (
     <div className="flex min-h-screen items-center justify-center px-4">
-      <div className="w-full max-w-md rounded-xl border p-6 text-center">
+      <div className="w-full max-w-md border p-6 text-center" style={{ borderRadius: radius }}>
         <div className="mb-4 flex justify-center">
           <Loader2 className="h-8 w-8 animate-spin text-primary" />
         </div>

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/auth/register/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/auth/register/page.tsx
@@ -348,7 +348,7 @@ export default function RegisterPage() {
         </p>
       </div>
       {tenant.show_terms_footer && (
-        <p className="mt-8 text-center text-sm" style={{ color: subtitleColor }}>
+        <p className="mt-8 text-center text-caption" style={{ color: subtitleColor }}>
           By creating an account, you agree to our{' '}
           <Link href="/terms" className="hover:underline">
             Terms of Service
@@ -360,12 +360,12 @@ export default function RegisterPage() {
         </p>
       )}
       {tenant.show_powered_by && (
-        <p className="mt-4 text-center text-xs" style={{ color: subtitleColor }}>
+        <p className="mt-4 text-center text-caption" style={{ color: subtitleColor }}>
           Powered by NEXUS
         </p>
       )}
       {tenant.login_footer_text && (
-        <p className="mt-4 text-center text-xs" style={{ color: subtitleColor }}>
+        <p className="mt-4 text-center text-caption" style={{ color: subtitleColor }}>
           {tenant.login_footer_text}
         </p>
       )}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/auth/reset-password/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/auth/reset-password/page.tsx
@@ -325,12 +325,12 @@ function ResetPasswordContent() {
         )}
       </div>
       {tenant.show_powered_by && (
-        <p className="mt-4 text-center text-xs" style={{ color: subtitleColor }}>
+        <p className="mt-4 text-center text-caption" style={{ color: subtitleColor }}>
           Powered by NEXUS
         </p>
       )}
       {tenant.login_footer_text && (
-        <p className="mt-4 text-center text-xs" style={{ color: subtitleColor }}>
+        <p className="mt-4 text-center text-caption" style={{ color: subtitleColor }}>
           {tenant.login_footer_text}
         </p>
       )}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/globals.css
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/globals.css
@@ -36,10 +36,64 @@
     --ring: 160 84% 39%;
     --radius: 0.5rem;
 
+    /* Design tokens (px/hex) for vanilla CSS pages */
+
+    /* Typography */
+    --font-size-xs: 12px;
+    --font-size-sm: 14px;
+    --font-size-md: 16px;
+    --font-size-lg: 18px;
+    --font-size-xl: 24px;
+    --line-height-xs: 16px;
+    --line-height-sm: 20px;
+    --line-height-md: 24px;
+    --line-height-lg: 28px;
+    --font-weight-normal: 400;
+    --font-weight-medium: 500;
+    --font-weight-semibold: 600;
+
+    /* Spacing */
+    --space-1: 4px;
+    --space-2: 8px;
+    --space-3: 12px;
+    --space-4: 16px;
+    --space-6: 24px;
+    --space-8: 32px;
+    --space-12: 48px;
+
+    /* Radius */
+    --radius-sm: 4px;
+    --radius-md: 8px;
+    --radius-lg: 12px;
+
+    /* Colors (hex) */
+    --background-hex: #FCFCFC;
+    --color-primary: #34D399;
+    --color-primary-hover: #1FA574;
+    --color-primary-focus: #34D3994D;
+    --color-primary-subtle: #34D3991A;
+    --color-primary-foreground: #FFFFFF;
+    --color-destructive-subtle: #EF44441A;
+    --color-destructive-muted: #EF444433;
+    --color-destructive-bg-subtle: #EF44440D;
+    --foreground-hex: #18181B;
+    --muted-foreground-hex: #71717A;
+    --card-hex: #FFFFFF;
+    --input-bg-hex: #FCFCFC;
+    --muted-bg-hex: #EBEBEE;
+    --destructive-hex: #EF4444;
+    --color-destructive-hover: #DC2626;
+    --color-destructive-focus: #EF44444D;
+    --surface-subtle-hex: #F4F4F54D;
+    --code-bg-hex: #18181B;
+    --code-foreground-hex: #F4F4F5;
+    --shadow-focus: 0 0 0 2px var(--color-primary-focus);
+
     /* Glass effects */
-    --glass-bg: rgba(255, 255, 255, 0.8);
-    --glass-border: rgba(0, 0, 0, 0.08);
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.08);
+    --glass-bg: #FFFFFFCC;
+    --glass-border: #00000014;
+    --glass-shadow: 0 8px 32px #00000014;
+    --border-hex: #E3E3E7;
 
     /* Gradients */
     --gradient-primary: linear-gradient(135deg, #34D399 0%, #1FA574 100%);
@@ -69,16 +123,43 @@
     --input: 240 5% 18%;
     --ring: 160 84% 45%;
 
+    /* Design tokens (px/hex) - dark mode colors */
+    --background-hex: #19191C;
+    --color-primary: #34D399;
+    --color-primary-hover: #1FA574;
+    --color-primary-focus: #34D3994D;
+    --color-primary-subtle: #34D3991A;
+    --color-primary-foreground: #FFFFFF;
+    --color-destructive-subtle: #CC33331A;
+    --color-destructive-muted: #CC333333;
+    --color-destructive-bg-subtle: #CC33330D;
+    --foreground-hex: #FAFAFA;
+    --muted-foreground-hex: #95959D;
+    --card-hex: #1E1E22;
+    --input-bg-hex: #18181B;
+    --muted-bg-hex: #2B2B30;
+    --destructive-hex: #CC3333;
+    --color-destructive-hover: #B32B2B;
+    --color-destructive-focus: #CC33334D;
+    --surface-subtle-hex: #27272A4D;
+    --code-bg-hex: #18181B;
+    --code-foreground-hex: #F4F4F5;
+
     /* Glass effects - dark mode */
-    --glass-bg: rgba(25, 25, 28, 0.85);
-    --glass-border: rgba(255, 255, 255, 0.08);
-    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+    --glass-bg: #19191CD9;
+    --glass-border: #FFFFFF14;
+    --glass-shadow: 0 8px 32px #00000066;
+    --border-hex: #2B2B30;
   }
 }
 
 @layer base {
   * {
     @apply border-border;
+  }
+  html {
+    font-optical-sizing: auto;
+    font-variation-settings: 'opsz' 14;
   }
   body {
     @apply bg-background text-foreground;
@@ -125,12 +206,12 @@
 
   /* Glow effects */
   .glow-primary {
-    box-shadow: 0 0 20px rgba(52, 211, 153, 0.3),
-                0 0 40px rgba(52, 211, 153, 0.1);
+    box-shadow: 0 0 20px #34D3994D,
+                0 0 40px #34D3991A;
   }
 
   .glow-primary-sm {
-    box-shadow: 0 0 10px rgba(52, 211, 153, 0.2);
+    box-shadow: 0 0 10px #34D39933;
   }
 
   /* Button variants */
@@ -142,7 +223,7 @@
   .btn-hero::before {
     content: '';
     @apply absolute inset-0 opacity-0 transition-opacity;
-    background: linear-gradient(135deg, rgba(255,255,255,0.2) 0%, transparent 100%);
+    background: linear-gradient(135deg, #FFFFFF33 0%, transparent 100%);
   }
 
   .btn-hero:hover::before {
@@ -186,7 +267,7 @@ html {
 
 /* Subtle focus for glass cards */
 .glass-card:focus-within {
-  border-color: hsl(var(--border));
+  border-color: var(--border-hex);
 }
 
 /* ============================================
@@ -299,6 +380,37 @@ html {
   to { transform: rotate(360deg); }
 }
 
+/* Chat message body: user/assistant parity at text-sm (14px). */
+.chat-message-body.text-sm {
+  @apply leading-relaxed;
+}
+
+.chat-message-body h1 {
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+}
+
+.chat-message-body h2,
+.chat-message-body h3,
+.chat-message-body h4 {
+  font-size: 1rem;
+  line-height: 1.625;
+}
+
+/* Mobile shell layout: bump dense chrome for touch targets and readability. */
+[data-mobile-shell='true'] .files-table-head {
+  @apply text-sm;
+}
+
+[data-mobile-shell='true'] .files-pagination {
+  @apply text-sm;
+}
+
+[data-mobile-shell='true'] .files-pagination select,
+[data-mobile-shell='true'] .files-pagination button {
+  @apply text-sm;
+}
+
 /* ============================================
  * SHELL TYPOGRAPHY TOKENS
  * Naming: {surface}-{region}-{element}[-{modifier}] in kebab-case.
@@ -321,3 +433,8 @@ html {
   color: #95959D;
 }
 
+.shell-mobile-more-sheet-grid-label {
+  font-size: 14px;
+  line-height: 19px;
+  font-weight: 500;
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/org/[orgSlug]/auth/forgot-password/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/org/[orgSlug]/auth/forgot-password/page.tsx
@@ -337,14 +337,14 @@ export default function OrgForgotPasswordPage() {
 
       {/* Powered by NEXUS */}
       {(branding?.showPoweredBy ?? true) && (
-        <p className="mt-4 text-center text-xs" style={{ color: subtitleColor || 'rgba(255,255,255,0.3)' }}>
+        <p className="mt-4 text-center text-caption" style={{ color: subtitleColor || 'rgba(255,255,255,0.3)' }}>
           Powered by NEXUS
         </p>
       )}
 
       {/* Custom footer text */}
       {branding?.loginFooterText && (
-        <p className="mt-4 text-center text-xs" style={{ color: subtitleColor || 'rgba(255,255,255,0.4)' }}>
+        <p className="mt-4 text-center text-caption" style={{ color: subtitleColor || 'rgba(255,255,255,0.4)' }}>
           {branding.loginFooterText}
         </p>
       )}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/org/[orgSlug]/auth/login/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/org/[orgSlug]/auth/login/page.tsx
@@ -371,7 +371,7 @@ export default function OrgLoginPage() {
 
       {/* Footer -- controlled by org config */}
       {(branding?.showTermsFooter ?? true) && (
-        <p className="mt-8 text-center text-sm" style={{ color: subtitleColor || 'var(--muted-foreground)' }}>
+        <p className="mt-8 text-center text-caption" style={{ color: subtitleColor || 'var(--muted-foreground)' }}>
           By signing in, you agree to our{' '}
           <Link href="/terms" className="hover:underline">
             Terms of Service
@@ -385,14 +385,14 @@ export default function OrgLoginPage() {
 
       {/* Powered by NEXUS */}
       {(branding?.showPoweredBy ?? true) && (
-        <p className="mt-4 text-center text-xs" style={{ color: subtitleColor || 'rgba(255,255,255,0.3)' }}>
+        <p className="mt-4 text-center text-caption" style={{ color: subtitleColor || 'rgba(255,255,255,0.3)' }}>
           Powered by NEXUS
         </p>
       )}
 
       {/* Custom footer text (e.g. © 2026 Acme Corp - Confidential) */}
       {branding?.loginFooterText && (
-        <p className="mt-4 text-center text-xs" style={{ color: subtitleColor || 'rgba(255,255,255,0.4)' }}>
+        <p className="mt-4 text-center text-caption" style={{ color: subtitleColor || 'rgba(255,255,255,0.4)' }}>
           {branding.loginFooterText}
         </p>
       )}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/org/[orgSlug]/auth/register/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/org/[orgSlug]/auth/register/page.tsx
@@ -423,7 +423,7 @@ export default function OrgRegisterPage() {
 
       {/* Footer */}
       {(branding?.showTermsFooter ?? true) && (
-        <p className="mt-8 text-center text-sm" style={{ color: subtitleColor || 'var(--muted-foreground)' }}>
+        <p className="mt-8 text-center text-caption" style={{ color: subtitleColor || 'var(--muted-foreground)' }}>
           By signing up, you agree to our{' '}
           <Link href="/terms" className="hover:underline">
             Terms of Service
@@ -437,14 +437,14 @@ export default function OrgRegisterPage() {
 
       {/* Powered by NEXUS */}
       {(branding?.showPoweredBy ?? true) && (
-        <p className="mt-4 text-center text-xs" style={{ color: subtitleColor || 'rgba(255,255,255,0.3)' }}>
+        <p className="mt-4 text-center text-caption" style={{ color: subtitleColor || 'rgba(255,255,255,0.3)' }}>
           Powered by NEXUS
         </p>
       )}
 
       {/* Custom footer text */}
       {branding?.loginFooterText && (
-        <p className="mt-4 text-center text-xs" style={{ color: subtitleColor || 'rgba(255,255,255,0.4)' }}>
+        <p className="mt-4 text-center text-caption" style={{ color: subtitleColor || 'rgba(255,255,255,0.4)' }}>
           {branding.loginFooterText}
         </p>
       )}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/chat/[[...slug]]/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/chat/[[...slug]]/page.tsx
@@ -1,4 +1,6 @@
 import { ChatInterface } from '@/components/chat/chat-interface';
+import { ChatExportButton } from '@/components/chat/chat-export-button';
+import { NEW_CHAT_SLUG } from '@/components/shell/chat-route';
 import { Header } from '@/components/shell/header';
 
 interface ChatWorkspacePageProps {
@@ -9,10 +11,11 @@ interface ChatWorkspacePageProps {
 }
 
 export default function ChatWorkspacePage({ params }: ChatWorkspacePageProps) {
-  const conversationId = params.slug?.[0] ?? null;
+  const slug = params.slug?.[0] ?? null;
+  const conversationId = slug === NEW_CHAT_SLUG ? null : slug;
   return (
     <div className="flex h-full flex-col">
-      <Header title="Chat" />
+      <Header title="Chat" actions={<ChatExportButton />} />
       <ChatInterface initialConversationId={conversationId} />
     </div>
   );

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/files/lib/files-route.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/files/lib/files-route.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { filesBrowsePath, parseFilesRoute } from './files-route';
+
+const WS = 'ws-1';
+const BASE = `/workspace/${WS}/files`;
+
+describe('parseFilesRoute', () => {
+  it('shows the drive list on the bare files route', () => {
+    expect(parseFilesRoute(BASE)).toEqual({
+      isFilesRoute: true,
+      isBrowse: false,
+    });
+  });
+
+  it('opens the file browser on /files/browse', () => {
+    expect(parseFilesRoute(`${BASE}/browse`)).toEqual({
+      isFilesRoute: true,
+      isBrowse: true,
+    });
+  });
+
+  it('ignores a trailing slash on the index', () => {
+    expect(parseFilesRoute(`${BASE}/`).isBrowse).toBe(false);
+    expect(parseFilesRoute(`${BASE}/browse/`).isBrowse).toBe(true);
+  });
+
+  it('stops at a query string or fragment', () => {
+    expect(parseFilesRoute(`${BASE}/browse?path=foo`).isBrowse).toBe(true);
+    expect(parseFilesRoute(`${BASE}/browse#top`).isBrowse).toBe(true);
+  });
+
+  it('does not claim routes that merely contain the word files', () => {
+    expect(parseFilesRoute(`/workspace/${WS}/chat`).isFilesRoute).toBe(false);
+    expect(parseFilesRoute(`/workspace/${WS}/fileshare`).isFilesRoute).toBe(false);
+  });
+
+  it('treats a missing pathname as no route at all', () => {
+    expect(parseFilesRoute(null).isFilesRoute).toBe(false);
+    expect(parseFilesRoute(undefined).isFilesRoute).toBe(false);
+  });
+});
+
+describe('filesBrowsePath', () => {
+  it('points at the browse detail inside the workspace', () => {
+    expect(filesBrowsePath(WS)).toBe(`${BASE}/browse`);
+  });
+
+  it('degrades to a workspace-less path before a workspace is known', () => {
+    expect(filesBrowsePath(null)).toBe('/files/browse');
+  });
+});

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/files/lib/files-route.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/files/lib/files-route.ts
@@ -1,0 +1,37 @@
+/**
+ * The files URL drives the mobile list-then-detail shell.
+ *
+ *   /workspace/{id}/files         → drive list (mobile) / browser (desktop)
+ *   /workspace/{id}/files/browse → file browser (mobile detail)
+ */
+
+export const FILES_BROWSE_SLUG = 'browse';
+
+export interface FilesRoute {
+  /** On a files route at all. */
+  isFilesRoute: boolean;
+  /** File browser is open (mobile detail). */
+  isBrowse: boolean;
+}
+
+// Lookahead, not a consumed terminator: same contract as parseChatRoute.
+const FILES_SEGMENT = /(?:^|\/)files(?:\/([^/?#]+))?(?=[/?#]|$)/;
+
+export function parseFilesRoute(pathname: string | null | undefined): FilesRoute {
+  const match = pathname ? FILES_SEGMENT.exec(pathname) : null;
+  if (!match) {
+    return { isFilesRoute: false, isBrowse: false };
+  }
+  const slug = match[1] ?? null;
+  return {
+    isFilesRoute: true,
+    isBrowse: slug === FILES_BROWSE_SLUG,
+  };
+}
+
+/** Path of the file browser for a workspace (mobile detail). */
+export function filesBrowsePath(workspaceId: string | null): string {
+  return workspaceId
+    ? `/workspace/${workspaceId}/files/${FILES_BROWSE_SLUG}`
+    : `/files/${FILES_BROWSE_SLUG}`;
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/graph/create-graph/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/graph/create-graph/page.tsx
@@ -390,7 +390,7 @@ export default function CreateGraphPage() {
 
   return (
     <div className="flex h-full flex-col">
-      <Header />
+      <Header title="New Graph" />
       <div className="flex flex-1 flex-col overflow-y-auto bg-card p-6">
         <div className="mx-auto w-full max-w-2xl">
           <div className="mb-6 flex items-center justify-between">

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/graph/create-individual/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/graph/create-individual/page.tsx
@@ -521,7 +521,7 @@ export default function CreateIndividualPage() {
 
   return (
     <div className="flex h-full flex-col">
-      <Header />
+      <Header title="New Individual" />
       <div className="flex flex-1 flex-col overflow-y-auto bg-card p-6">
         <div className="mx-auto w-full max-w-2xl">
           <div className="mb-6 flex items-center justify-between">

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/graph/explore-next/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/graph/explore-next/page.tsx
@@ -19,7 +19,7 @@ export default function ExploreNextPage() {
 
   return (
     <div className="flex h-full flex-col">
-      <Header />
+      <Header title="Explore Graph" />
       <div className="flex min-h-0 flex-1 overflow-hidden">
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
           <GraphDevBanner />

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/graph/explore/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/graph/explore/page.tsx
@@ -1223,7 +1223,7 @@ export default function DiscoveryPage() {
 
   return (
     <div className="flex h-full flex-col">
-      <Header />
+      <Header title="Explore Graph" />
 
       <div className="flex min-h-0 flex-1 overflow-hidden">
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden">

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/graph/export/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/graph/export/page.tsx
@@ -245,7 +245,7 @@ export default function ExportPage() {
 
   return (
     <div className="flex h-full flex-col">
-      <Header />
+      <Header title="Export Graph" />
       <div className="flex flex-1 overflow-hidden">
         <div className="flex flex-1 flex-col overflow-hidden">
           <GraphDevBanner />

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/graph/import/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/graph/import/page.tsx
@@ -391,7 +391,7 @@ export default function ImportPage() {
 
   return (
     <div className="flex h-full flex-col">
-      <Header />
+      <Header title="Import Graph" />
       <ToastStack toasts={toasts} onDismiss={dismissToast} />
       <div className="flex flex-1 overflow-hidden">
         <div className="flex flex-1 flex-col overflow-hidden">

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/graph/individuals/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/graph/individuals/page.tsx
@@ -2039,7 +2039,7 @@ export default function IndividualsPage() {
 
   return (
     <div className="flex h-full flex-col">
-      <Header />
+      <Header title="Individuals" />
       <div className="flex min-h-0 flex-1 overflow-hidden">
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
           <GraphDevBanner />

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/graph/network/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/graph/network/page.tsx
@@ -1345,7 +1345,7 @@ export default function NetworkPage() {
 
   return (
     <div className="flex h-full flex-col">
-      <Header />
+      <Header title="Knowledge Graph" />
       <div className="flex flex-1 overflow-hidden">
         <div className="flex flex-1 flex-col overflow-hidden">
           <GraphDevBanner />

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/layout.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/layout.tsx
@@ -4,6 +4,7 @@ import { Component, useEffect, useState } from 'react';
 import { useParams, usePathname, useRouter } from 'next/navigation';
 import { isWorkspacePathAllowed } from '@/lib/feature-access';
 import { WorkspaceLayout } from '@/components/shell/workspace-layout';
+import { ShellTitleProvider } from '@/components/shell/shell-title';
 import { GraphExportToastHost } from '@/components/graph/graph-export-toast-host';
 import { useWorkspaceStore } from '@/stores/workspace';
 import { clearAuthFlagCookie } from '@/lib/auth-session';
@@ -237,10 +238,10 @@ export default function WorkspaceIdLayout({
           {children}
         </>
       ) : (
-        <>
+        <ShellTitleProvider>
           <GraphExportToastHost workspaceId={workspaceId} />
           <WorkspaceLayout>{children}</WorkspaceLayout>
-        </>
+        </ShellTitleProvider>
       )}
     </WorkspaceErrorBoundary>
   );

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/ontology/export/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/ontology/export/page.tsx
@@ -177,7 +177,7 @@ export default function OntologyExportPage() {
 
   return (
     <div className="flex h-full flex-col">
-      <Header />
+      <Header title="Export Ontology" />
       <div className="flex flex-1 overflow-hidden">
         <div className="flex flex-1 flex-col overflow-hidden">
           <div className="flex-1 overflow-y-auto px-6 py-6">

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/ontology/import/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/ontology/import/page.tsx
@@ -212,7 +212,7 @@ export default function OntologyImportPage() {
 
   return (
     <div className="flex h-full flex-col">
-      <Header />
+      <Header title="Import Ontology" />
       <ToastStack toasts={toasts} onDismiss={dismissToast} />
       <div className="flex flex-1 overflow-hidden">
         <div className="flex flex-1 flex-col overflow-hidden">

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/ontology/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/ontology/page.tsx
@@ -328,7 +328,7 @@ export default function OntologyPage() {
 
   return (
     <div className="flex h-full flex-col">
-      <Header />
+      <Header title="Ontology" />
 
       <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
         {/* Toolbar */}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/agent-selector.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/agent-selector.tsx
@@ -57,9 +57,8 @@ export function AgentSelector({ compact = false }: { compact?: boolean }) {
   const { selectedAgent, setSelectedAgent } = useWorkspaceStore();
   const { defaultAgents, customAgents, filteredAgents, enabledAgents } = useAgentList(searchQuery);
 
-  // Prefer Abi as default, fallback to first enabled agent
-  const abiAgent = enabledAgents.find((a) => a.name === 'Abi');
-  const defaultAgent = abiAgent || enabledAgents[0];
+  const defaultAgent =
+    enabledAgents.find((a) => a.isDefault) ?? enabledAgents[0];
   const selected = enabledAgents.find((a) => a.id === selectedAgent) || defaultAgent;
 
   useEffect(() => {

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-export-button.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-export-button.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Download, Loader2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { authFetch } from '@/stores/auth';
+import { getApiUrl } from '@/lib/config';
+import { useWorkspaceStore } from '@/stores/workspace';
+
+interface ChatExportButtonProps {
+  className?: string;
+}
+
+/**
+ * Exports the open conversation. Lives in the shell chrome (desktop Header,
+ * mobile top bar) rather than above the composer, so it costs no vertical
+ * space in the thread and does not shift the composer when the first message
+ * arrives. Reads the store directly so any chrome can render it unwired.
+ */
+export function ChatExportButton({ className }: ChatExportButtonProps) {
+  const [mounted, setMounted] = useState(false);
+  const [exporting, setExporting] = useState(false);
+  const conversation = useWorkspaceStore(
+    (s) => s.conversations.find((c) => c.id === s.activeConversationId) ?? null
+  );
+
+  useEffect(() => setMounted(true), []);
+
+  const handleExport = async () => {
+    if (!conversation || exporting) return;
+    setExporting(true);
+    try {
+      // Built from local state rather than read back from the server: the PATCH
+      // that persists tool calls may still be in flight when the user exports.
+      const messagesMetadata = conversation.messages
+        .filter((m) => m.role === 'assistant' && (m.toolCalls?.length || m.executionTime !== undefined))
+        .map((m) => ({
+          message_id: m.id,
+          execution_time: m.executionTime ?? null,
+          steps: (m.toolCalls ?? []).map((t) => ({
+            tool_name: t.toolName,
+            prefix: t.prefix,
+            status: t.status,
+            input: t.input ?? null,
+            output: t.output ?? null,
+          })),
+          sources: m.sources ?? [],
+        }));
+
+      const response = await authFetch(
+        `${getApiUrl()}/api/chat/conversations/${conversation.id}/export`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ format: 'txt', messages_metadata: messagesMetadata }),
+        }
+      );
+
+      if (!response.ok) throw new Error('Failed to export conversation');
+
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `conversation-${conversation.id}-${Date.now()}.txt`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error('Export failed:', error);
+      alert('Failed to export conversation. Please try again.');
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  // Nothing to export until a thread has content, and the store only holds
+  // conversations after hydration, so stay absent on the server pass.
+  if (!mounted || !conversation || conversation.messages.length === 0) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={handleExport}
+      disabled={exporting}
+      className={cn(
+        'flex h-8 w-8 items-center justify-center rounded-md transition-colors',
+        'text-muted-foreground hover:bg-muted hover:text-foreground',
+        exporting && 'cursor-wait opacity-60',
+        className
+      )}
+      title="Export conversation"
+      aria-label="Export conversation"
+    >
+      {exporting ? <Loader2 size={16} className="animate-spin" /> : <Download size={16} />}
+    </button>
+  );
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
@@ -2,13 +2,14 @@
 
 import React, { useState, useRef, useEffect, useMemo, useCallback, useLayoutEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { Send, Plus, Bot, User, AlertCircle, Brain, ChevronDown, X, ArrowUp, Download, ExternalLink, HardDrive, RefreshCw, Mic, Check, Loader2, Wrench, Copy, FileText, ThumbsUp, ThumbsDown, Volume2, Square } from 'lucide-react';
+import { Send, Plus, Bot, User, AlertCircle, Brain, ChevronDown, X, ArrowUp, ExternalLink, HardDrive, RefreshCw, Mic, Check, Loader2, Wrench, Copy, FileText, ThumbsUp, ThumbsDown, Volume2, Square } from 'lucide-react';
 import Image from 'next/image';
 import { usePathname, useRouter } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { cn } from '@/lib/utils';
-import { getModelHistory, useWorkspaceStore, type AgentType, type Message, type MessageFeedback, type MessageFeedbackDetails, type SidebarSection, type ToolCall } from '@/stores/workspace';
+import { useWorkspaceStore, type AgentType, type Message, type MessageFeedback, type MessageFeedbackDetails, type SidebarSection, type ToolCall } from '@/stores/workspace';
+import { nextChatUrl } from '@/components/shell/chat-route';
 import { useIntegrationsStore } from '@/stores/integrations';
 import { useAgentsStore } from '@/stores/agents';
 import { useSkillsStore, type Skill, type SkillScope } from '@/stores/skills';
@@ -793,7 +794,7 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
   const { tab_title: tabTitle } = useTenant();
 
   const { providers, getProviderForAgent: getLegacyProviderForAgent } = useIntegrationsStore();
-  const { getAgent } = useAgentsStore();
+  const { getAgent, resolveAgent } = useAgentsStore();
   const { getSecretByKey } = useSecretsStore();
   
   // Get provider for current agent - check agents store first, then legacy mapping
@@ -839,7 +840,6 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
     const agents = useAgentsStore.getState().agents;
     const defaultAgent =
       agents.find((a) => a.isDefault && a.enabled) ??
-      agents.find((a) => a.id === 'abi' && a.enabled) ??
       agents.find((a) => a.enabled);
     if (defaultAgent) setSelectedAgent(defaultAgent.id);
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -847,19 +847,10 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
 
   const pathname = usePathname();
 
-  // Keep the URL in sync with the active conversation so each conversation has a shareable link.
-  // Guarded against firing mid-workspace-switch: only rewrite the URL when the
-  // pathname already points at the current workspace's chat route. Otherwise a
-  // pending navigation to a different workspace (router.push from the sidebar)
-  // would race with this effect and get reverted.
   useEffect(() => {
     if (!mounted) return;
-    if (!currentWorkspaceId) return;
-    const base = `/workspace/${currentWorkspaceId}/chat`;
-    if (!pathname || !pathname.startsWith(`${base}`)) return;
-    const target = activeConversationId ? `${base}/${activeConversationId}` : base;
-    if (pathname === target) return;
-    router.replace(target, { scroll: false });
+    const target = nextChatUrl(pathname, currentWorkspaceId, activeConversationId);
+    if (target) router.replace(target, { scroll: false });
   }, [activeConversationId, mounted, currentWorkspaceId, router, pathname]);
 
   // Narrow selector: only the active conversation's title — avoids re-renders on every streaming token.
@@ -1084,7 +1075,7 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
   const activeConversation = mounted
     ? workspaceConversations.find((c) => c.id === activeConversationId)
     : null;
-  const selectedAgentData = getAgent(selectedAgent);
+  const selectedAgentData = resolveAgent(selectedAgent);
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -1669,11 +1660,7 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
     e?: React.FormEvent,
     messageOverride?: string,
     agentOverride?: string,
-    conversationIdOverride?: string,
-    // Set when re-running a past answer: the id of the assistant message being
-    // refreshed. The prompt is replayed as a new turn on both sides; the old
-    // answer stays in the database and only leaves the visible thread.
-    regenerateOf?: string
+    conversationIdOverride?: string
   ) => {
     e?.preventDefault();
     if (isSubmittingRef.current) return;
@@ -1755,9 +1742,6 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
       content: sourceText.trim() || (attachedImages.length > 0 ? 'What is in this image?' : ''),
       images: currentImages.length > 0 ? currentImages : undefined,
       fileAttachments: currentFileAttachments.length > 0 ? currentFileAttachments : undefined,
-      // Flags the duplicate so later turns don't send the model the same
-      // question twice; it is still shown, stored and exported like any other.
-      ...(regenerateOf ? { replayedPrompt: true, regenerateOf } : {}),
     });
 
     const userMessage = sourceText.trim() || (currentImages.length > 0 ? 'What is in this image?' : '');
@@ -1810,10 +1794,8 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
       const currentConversation = freshConversations.find(c => c.id === conversationId);
       const allMessages = currentConversation?.messages || [];
       
-      // Build full message history for the API (including images and agent attribution for multimodal).
-      // Superseded answers and replayed prompts are left out so a refreshed turn
-      // doesn't feed the model the answer it is replacing.
-      const fullHistory = getModelHistory(allMessages).map(m => ({
+      // Build full message history for the API (including images and agent attribution for multimodal)
+      const fullHistory = allMessages.map(m => ({
         role: m.role,
         content: m.content,
         images: m.images || null,
@@ -1842,9 +1824,6 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
           agent: effectiveAgent,
           activityLine: 'Processing...',
           // activityLine: searchEnabled ? 'Web search in progress' : 'Processing...',
-          // Records which answer this one re-runs, so later turns leave the
-          // superseded answer out of the model's context.
-          ...(regenerateOf ? { regenerateOf } : {}),
         });
         // Capture placeholder message id for controls. We keep it in a local
         // variable AND in React state — the SSE handler runs inside the same
@@ -2077,7 +2056,6 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
             provider: providerPayload,
             system_prompt: systemPrompt,
             search_enabled: false,
-            regenerate_of: regenerateOf ?? null,
             // search_enabled: searchEnabled,
           }),
         });
@@ -2287,7 +2265,6 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
             agent: effectiveAgent,
             provider: providerPayload,
             system_prompt: systemPrompt,
-            regenerate_of: regenerateOf ?? null,
           }),
         });
 
@@ -2304,7 +2281,6 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
           agent: effectiveAgent,
           thinkingDuration,
           sources: data.context_used?.length > 0 ? data.context_used : undefined,
-          ...(regenerateOf ? { regenerateOf } : {}),
         });
       }
     } catch (error) {
@@ -2402,89 +2378,6 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
     }
   };
 
-  // Re-run the prompt that produced a given assistant message. The prompt is
-  // replayed as a new turn appended to the thread — the original question, the
-  // old answer and the replay all stay on screen, in the database and in
-  // exports. Only the model's context skips the answer being re-run, so it
-  // redoes the work instead of repeating itself (see getModelHistory).
-  const handleRegenerate = (assistantMessage: Message) => {
-    if (isLoading || isStreaming || isSubmittingRef.current) return;
-    const conversationId = activeConversation?.id;
-    const messages = activeConversation?.messages ?? [];
-    const index = messages.findIndex((m) => m.id === assistantMessage.id);
-    if (!conversationId || index === -1) return;
-
-    // Walk back to the question this answer replied to.
-    const prompt =
-      messages
-        .slice(0, index)
-        .reverse()
-        .find((m) => m.role === 'user')?.content ?? '';
-    if (!prompt.trim()) return;
-
-    void handleSubmit(
-      undefined,
-      prompt,
-      assistantMessage.agent ?? selectedAgent,
-      conversationId,
-      assistantMessage.id
-    );
-  };
-
-  const handleExportConversation = async () => {
-    if (!activeConversation || activeConversation.messages.length === 0) {
-      alert('No conversation to export');
-      return;
-    }
-
-    try {
-      const { authFetch } = await import('@/stores/auth');
-
-      // Build inline metadata from local Zustand state so it's always present
-      // regardless of whether the async PATCH has completed in the backend.
-      const messagesMetadata = activeConversation.messages
-        .filter((m) => m.role === 'assistant' && (m.toolCalls?.length || m.executionTime !== undefined))
-        .map((m) => ({
-          message_id: m.id,
-          execution_time: m.executionTime ?? null,
-          steps: (m.toolCalls ?? []).map((t) => ({
-            tool_name: t.toolName,
-            prefix: t.prefix,
-            status: t.status,
-            input: t.input ?? null,
-            output: t.output ?? null,
-          })),
-          sources: m.sources ?? [],
-        }));
-
-      const response = await authFetch(
-        `${getApiBase()}/api/chat/conversations/${activeConversation.id}/export`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ format: 'txt', messages_metadata: messagesMetadata }),
-        }
-      );
-
-      if (!response.ok) {
-        throw new Error('Failed to export conversation');
-      }
-
-      const blob = await response.blob();
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement('a');
-      link.href = url;
-      link.download = `conversation-${activeConversation.id}-${Date.now()}.txt`;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      URL.revokeObjectURL(url);
-    } catch (error) {
-      console.error('Export failed:', error);
-      alert('Failed to export conversation. Please try again.');
-    }
-  };
-
   return (
     <div className="flex flex-1 min-h-0 relative">
     {/* Chat column */}
@@ -2514,8 +2407,6 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
                 }}
                 onPreviewUrl={setPreviewUrl}
                 requestSentAt={requestSentAt}
-                onRegenerate={handleRegenerate}
-                regenerateDisabled={isLoading || isStreaming}
               />
             ))}
             {isLoading && !isStreaming && (
@@ -2546,18 +2437,6 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
       {/* Input area */}
       <div className="p-4">
         <div className="mx-auto max-w-3xl">
-          {/* Header with Export button (agent selector now lives in the chatbar) */}
-          {activeConversation && activeConversation.messages.length > 0 && (
-            <div className="mb-2 flex items-center justify-end gap-2">
-              <button
-                onClick={handleExportConversation}
-                className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
-                title="Export conversation"
-              >
-                <Download size={16} />
-              </button>
-            </div>
-          )}
           <form onSubmit={handleSubmit}>
             {/* Image previews */}
             {attachedImages.length > 0 && (
@@ -2998,7 +2877,9 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
                 onConfirm={() => void confirmVoiceRecording()}
               />
             )}
-            <p className="mt-2 text-center text-xs text-muted-foreground">
+            {/* micro, not caption: this sits above the mobile keyboard, and at
+                11px the sentence wraps to two lines below a 375px viewport. */}
+            <p className="mt-2 text-center text-micro text-muted-foreground">
               AI doesn’t replace your judgment. You’re accountable for its use.
             </p>
           </form>
@@ -3423,8 +3304,6 @@ const MessageBubble = React.memo(function MessageBubble({
   onStop,
   onPreviewUrl,
   requestSentAt,
-  onRegenerate,
-  regenerateDisabled,
 }: {
   message: Message;
   currentSelectedAgent: string;
@@ -3433,8 +3312,6 @@ const MessageBubble = React.memo(function MessageBubble({
   onStop: () => void;
   onPreviewUrl?: (url: string) => void;
   requestSentAt?: number | null;
-  onRegenerate?: (message: Message) => void;
-  regenerateDisabled?: boolean;
 }) {
   const isUser = message.role === 'user';
   const [showThinking, setShowThinking] = useState(false);
@@ -3453,8 +3330,8 @@ const MessageBubble = React.memo(function MessageBubble({
   
   // Get user name and agent info for display
   const user = useAuthStore(state => state.user);
-  const agents = useAgentsStore(state => state.agents);
-  const agent = agents.find(a => a.id === message.agent);
+  const resolveAgent = useAgentsStore(state => state.resolveAgent);
+  const agent = resolveAgent(message.agent);
   const isFromDifferentAgent = !isUser && Boolean(message.agent) && message.agent !== currentSelectedAgent;
   
   // Determine sender name
@@ -3915,7 +3792,7 @@ const MessageBubble = React.memo(function MessageBubble({
         {/* Main response bubble */}
         <div
           className={cn(
-            'rounded-2xl px-4 py-3 text-sm',
+            'chat-message-body rounded-2xl px-4 py-3 text-sm',
             isUser ? 'bg-workspace-accent text-white' : 'bg-muted max-w-none',
             !isUser &&
               '[&_p]:my-2 [&_ul]:my-3 [&_ul]:list-disc [&_ul]:pl-6 [&_ol]:my-3 [&_ol]:list-decimal [&_ol]:pl-6 [&_li]:my-1 [&_li]:pt-0.5 [&_li]:leading-relaxed [&_h1]:text-base [&_h1]:font-bold [&_h1]:mt-4 [&_h1]:mb-1 [&_h2]:text-sm [&_h2]:font-semibold [&_h2]:mt-3 [&_h2]:mb-1 [&_h3]:text-sm [&_h3]:font-semibold [&_h3]:mt-2 [&_h3]:mb-1 [&_h4]:text-sm [&_h4]:font-semibold [&_h4]:mt-2 [&_h4]:mb-0.5 [&_h5]:text-sm [&_h5]:font-medium [&_h5]:mt-1.5 [&_h6]:text-sm [&_h6]:font-medium [&_h6]:mt-1 [&_code]:bg-background/50 [&_code]:px-1 [&_code]:rounded [&_code]:font-mono [&_pre]:my-0 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:border [&_pre]:border-border/70 [&_pre]:bg-background/80 [&_pre]:p-3 [&_pre]:text-xs [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_code]:rounded-none [&_pre_code]:text-inherit'
@@ -4084,11 +3961,7 @@ const MessageBubble = React.memo(function MessageBubble({
 
         {/* Per-message actions */}
         {!isUser && !isStillProcessing && (
-          <AssistantMessageActions
-            message={message}
-            onRegenerate={onRegenerate}
-            regenerateDisabled={regenerateDisabled}
-          />
+          <AssistantMessageActions message={message} />
         )}
         {isUser && <UserMessageActions message={message} />}
       </div>
@@ -4416,15 +4289,7 @@ function FeedbackDislikeDialog({
   );
 }
 
-function AssistantMessageActions({
-  message,
-  onRegenerate,
-  regenerateDisabled,
-}: {
-  message: Message;
-  onRegenerate?: (message: Message) => void;
-  regenerateDisabled?: boolean;
-}) {
+function AssistantMessageActions({ message }: { message: Message }) {
   const updateMessageFeedback = useWorkspaceStore((s) => s.updateMessageFeedback);
   const activeConversationId = useWorkspaceStore((s) => s.activeConversationId);
   const [busy, setBusy] = useState<null | 'like' | 'dislike'>(null);
@@ -4530,17 +4395,6 @@ function AssistantMessageActions({
             />
           )}
         </button>
-        {onRegenerate && (
-          <button
-            onClick={() => onRegenerate(message)}
-            disabled={regenerateDisabled}
-            title="Run this request again"
-            aria-label="Run this request again"
-            className="flex h-6 w-6 items-center justify-center rounded border border-transparent transition-colors hover:border-border hover:bg-muted/40 disabled:cursor-not-allowed disabled:opacity-40"
-          >
-            <RefreshCw size={12} />
-          </button>
-        )}
       </div>
       <FeedbackDislikeDialog
         open={dialogOpen}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/chat-route.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/chat-route.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+
+import { newChatPath, nextChatUrl, parseChatRoute } from './chat-route';
+
+const WS = 'ws-1';
+const BASE = `/workspace/${WS}/chat`;
+
+describe('parseChatRoute', () => {
+  it('shows the conversation list on the bare chat route', () => {
+    // The cold-start regression: a conversation id restored from localStorage
+    // used to force the thread open here, so reopening the app dropped the user
+    // into their last conversation instead of the list.
+    expect(parseChatRoute(BASE)).toEqual({
+      isChatRoute: true,
+      conversationId: null,
+      isThread: false,
+    });
+  });
+
+  it('opens a thread for a conversation id', () => {
+    expect(parseChatRoute(`${BASE}/conv-42`)).toEqual({
+      isChatRoute: true,
+      conversationId: 'conv-42',
+      isThread: true,
+    });
+  });
+
+  it('opens a blank thread on /chat/new without inventing a conversation id', () => {
+    expect(parseChatRoute(`${BASE}/new`)).toEqual({
+      isChatRoute: true,
+      conversationId: null,
+      isThread: true,
+    });
+  });
+
+  it('ignores a trailing slash', () => {
+    expect(parseChatRoute(`${BASE}/`).isThread).toBe(false);
+    expect(parseChatRoute(`${BASE}/conv-42/`).conversationId).toBe('conv-42');
+  });
+
+  it('stops at a query string or fragment', () => {
+    expect(parseChatRoute(`${BASE}/conv-42?ref=email`).conversationId).toBe('conv-42');
+    expect(parseChatRoute(`${BASE}/conv-42#top`).conversationId).toBe('conv-42');
+  });
+
+  it('does not claim routes that merely start with the word chat', () => {
+    // The old check was pathname.includes('/chat'), which would have swallowed these.
+    expect(parseChatRoute(`/workspace/${WS}/chatbots`).isChatRoute).toBe(false);
+    expect(parseChatRoute(`/workspace/${WS}/files`).isChatRoute).toBe(false);
+  });
+
+  it('treats a missing pathname as no route at all', () => {
+    expect(parseChatRoute(null).isChatRoute).toBe(false);
+    expect(parseChatRoute(undefined).isChatRoute).toBe(false);
+  });
+});
+
+describe('newChatPath', () => {
+  it('points at the blank thread inside the workspace', () => {
+    expect(newChatPath(WS)).toBe(`${BASE}/new`);
+  });
+
+  it('degrades to a workspace-less path before a workspace is known', () => {
+    expect(newChatPath(null)).toBe('/chat/new');
+  });
+});
+
+describe('nextChatUrl', () => {
+  it('leaves /chat/new alone while the thread is still blank', () => {
+    // The regression this whole route contract exists for: rewriting to /chat
+    // here sends the mobile shell straight back to the conversation list, so
+    // the composer the user just opened disappears under them.
+    expect(nextChatUrl(`${BASE}/new`, WS, null)).toBeNull();
+  });
+
+  it('promotes /chat/new to the real conversation once the first message lands', () => {
+    expect(nextChatUrl(`${BASE}/new`, WS, 'conv-42')).toBe(`${BASE}/conv-42`);
+  });
+
+  it('adds the conversation id so the thread is shareable', () => {
+    expect(nextChatUrl(BASE, WS, 'conv-42')).toBe(`${BASE}/conv-42`);
+  });
+
+  it('drops a stale conversation id when the chat is cleared', () => {
+    expect(nextChatUrl(`${BASE}/conv-42`, WS, null)).toBe(BASE);
+  });
+
+  it('stays quiet when the URL already matches', () => {
+    expect(nextChatUrl(`${BASE}/conv-42`, WS, 'conv-42')).toBeNull();
+    expect(nextChatUrl(BASE, WS, null)).toBeNull();
+  });
+
+  it('keeps out of the way mid-workspace-switch', () => {
+    // A router.push to another workspace is in flight; rewriting the URL to this
+    // workspace's chat route would revert that navigation.
+    expect(nextChatUrl('/workspace/ws-2/chat/conv-9', WS, 'conv-42')).toBeNull();
+    expect(nextChatUrl(`/workspace/${WS}/files`, WS, 'conv-42')).toBeNull();
+  });
+
+  it('waits for a workspace and a pathname before rewriting anything', () => {
+    expect(nextChatUrl(BASE, null, 'conv-42')).toBeNull();
+    expect(nextChatUrl(null, WS, 'conv-42')).toBeNull();
+  });
+});

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/chat-route.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/chat-route.ts
@@ -1,0 +1,64 @@
+/**
+ * The chat URL is the single source of truth for which chat view is showing.
+ *
+ *   /workspace/{id}/chat        → conversation list (mobile) / launcher (desktop)
+ *   /workspace/{id}/chat/new    → blank thread, default agent preselected
+ *   /workspace/{id}/chat/{cid}  → existing thread
+ */
+
+export const NEW_CHAT_SLUG = 'new';
+
+export interface ChatRoute {
+  /** On a chat route at all. */
+  isChatRoute: boolean;
+  /** Existing conversation id, or null for the list and for a blank new chat. */
+  conversationId: string | null;
+  /** A thread is open: either an existing conversation or a blank new one. */
+  isThread: boolean;
+}
+
+// Lookahead, not a consumed terminator: consuming it lets the engine backtrack
+// into "no slug" on /chat/{id}?query and silently report the list instead.
+const CHAT_SEGMENT = /(?:^|\/)chat(?:\/([^/?#]+))?(?=[/?#]|$)/;
+
+export function parseChatRoute(pathname: string | null | undefined): ChatRoute {
+  const match = pathname ? CHAT_SEGMENT.exec(pathname) : null;
+  if (!match) {
+    return { isChatRoute: false, conversationId: null, isThread: false };
+  }
+  const slug = match[1] ?? null;
+  return {
+    isChatRoute: true,
+    conversationId: slug && slug !== NEW_CHAT_SLUG ? slug : null,
+    isThread: slug !== null,
+  };
+}
+
+/** Path of the blank-new-chat thread for a workspace. */
+export function newChatPath(workspaceId: string | null): string {
+  return workspaceId ? `/workspace/${workspaceId}/chat/${NEW_CHAT_SLUG}` : `/chat/${NEW_CHAT_SLUG}`;
+}
+
+/**
+ * Where the chat URL should point, so every conversation has a shareable link.
+ * Returns null when the URL is already right and must be left alone.
+ */
+export function nextChatUrl(
+  pathname: string | null | undefined,
+  workspaceId: string | null,
+  activeConversationId: string | null
+): string | null {
+  if (!pathname || !workspaceId) return null;
+
+  const base = `/workspace/${workspaceId}/chat`;
+  // Mid-workspace-switch: a pending navigation to another workspace would race
+  // with this rewrite and get reverted.
+  if (!pathname.startsWith(base)) return null;
+
+  // /chat/new is a real destination (blank thread), not a stale URL to clean up.
+  // Collapsing it to /chat would send the mobile shell back to the conversation list.
+  if (!activeConversationId && pathname === `${base}/${NEW_CHAT_SLUG}`) return null;
+
+  const target = activeConversationId ? `${base}/${activeConversationId}` : base;
+  return pathname === target ? null : target;
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/header.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/header.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, type ReactNode } from 'react';
 import Link from 'next/link';
 import {
   PanelLeft,
@@ -18,14 +18,22 @@ import { cn } from '@/lib/utils';
 import { useWorkspaceStore, type WorkspaceBranch, type Workspace } from '@/stores/workspace';
 import { useAuthStore } from '@/stores/auth';
 import { useFeature } from '@/hooks/use-feature';
+import { useIsMobile } from '@/hooks/use-is-mobile';
+import { useRegisterShellTitle } from './shell-title';
 import { ApiStatusIndicator } from './api-status-indicator';
 
 interface HeaderProps {
   title?: string;
   subtitle?: string;
+  /** Page-level actions, rendered ahead of the global chrome on the right. */
+  actions?: ReactNode;
 }
 
-export function Header({ title, subtitle }: HeaderProps = {}) {
+export function Header({ title, subtitle, actions }: HeaderProps = {}) {
+  const isMobile = useIsMobile();
+  // Desktop chrome does not paint the title, but it is the page's declaration
+  // of where the user is, so publish it for the mobile top bar.
+  useRegisterShellTitle(title, subtitle);
   const [mounted, setMounted] = useState(false);
   const [userMenuOpen, setUserMenuOpen] = useState(false);
   const [branchMenuOpen, setBranchMenuOpen] = useState(false);
@@ -98,6 +106,9 @@ export function Header({ title, subtitle }: HeaderProps = {}) {
     return 'text-muted-foreground';
   };
 
+  // Mobile shell owns chrome (back header + bottom nav). Desktop Header
+  // (sidebar toggle, branch, AI pane) is dead weight there.
+  if (isMobile) return null;
 
   return (
     <header className="glass-nav relative z-[200] flex h-14 items-center justify-between border-b border-border/50 pl-2 pr-4">
@@ -134,6 +145,8 @@ export function Header({ title, subtitle }: HeaderProps = {}) {
 
       {/* Right side */}
       <div className="flex items-center gap-1">
+        {actions}
+
         {/* API connection status */}
         <ApiStatusIndicator />
 
@@ -186,7 +199,7 @@ export function Header({ title, subtitle }: HeaderProps = {}) {
           title="Toggle AI Assistant (⌘K)"
         >
           <Sparkles size={16} />
-          <kbd className="hidden rounded border bg-muted px-1 text-[10px] text-muted-foreground sm:inline">
+          <kbd className="hidden rounded border bg-muted px-1 text-micro text-muted-foreground sm:inline">
             ⌘K
           </kbd>
         </button>
@@ -228,7 +241,7 @@ export function Header({ title, subtitle }: HeaderProps = {}) {
               {/* Menu items */}
               <div className="py-2">
                 <Link
-                  href="/account"
+                  href="/account/profile"
                   onClick={() => setUserMenuOpen(false)}
                   className="flex items-center gap-3 rounded-md px-4 py-2.5 text-sm transition-colors hover:bg-muted"
                 >

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/mobile/mobile-bottom-nav.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/mobile/mobile-bottom-nav.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { Map, MessageSquare, Folder, LayoutGrid, MoreHorizontal } from 'lucide-react';
+import { usePathname, useRouter } from 'next/navigation';
+import { cn } from '@/lib/utils';
+import { useFeature } from '@/hooks/use-feature';
+import { useWorkspaceStore } from '@/stores/workspace';
+import { getWorkspacePath } from '../sidebar/utils';
+
+type MobileTab = 'maps' | 'chat' | 'files' | 'apps' | 'more';
+
+type TabDef = {
+  id: MobileTab;
+  label: string;
+  icon: React.ReactNode;
+  href?: string;
+  feature?: 'maps' | 'chat' | 'files' | 'apps';
+};
+
+const TABS: TabDef[] = [
+  { id: 'maps', label: 'Maps', icon: <Map size={20} />, href: '/maps', feature: 'maps' },
+  { id: 'chat', label: 'Chat', icon: <MessageSquare size={20} />, href: '/chat', feature: 'chat' },
+  { id: 'files', label: 'Files', icon: <Folder size={20} />, href: '/files', feature: 'files' },
+  { id: 'apps', label: 'Apps', icon: <LayoutGrid size={20} />, href: '/apps', feature: 'apps' },
+  { id: 'more', label: 'More', icon: <MoreHorizontal size={20} /> },
+];
+
+interface MobileBottomNavProps {
+  moreOpen: boolean;
+  onMoreToggle: () => void;
+}
+
+export function MobileBottomNav({ moreOpen, onMoreToggle }: MobileBottomNavProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const currentWorkspaceId = useWorkspaceStore((s) => s.currentWorkspaceId);
+  const setActivePanelSection = useWorkspaceStore((s) => s.setActivePanelSection);
+  const setActiveConversation = useWorkspaceStore((s) => s.setActiveConversation);
+  const setMobilePendingChatSlug = useWorkspaceStore((s) => s.setMobilePendingChatSlug);
+
+  const canMaps = useFeature('maps');
+  const canChat = useFeature('chat');
+  const canFiles = useFeature('files');
+  const canApps = useFeature('apps');
+
+  const enabled = (feature?: TabDef['feature']) => {
+    if (!feature) return true;
+    if (feature === 'maps') return !!canMaps;
+    if (feature === 'chat') return !!canChat;
+    if (feature === 'files') return !!canFiles;
+    if (feature === 'apps') return !!canApps;
+    return true;
+  };
+
+  const isTabActive = (tab: TabDef) => {
+    if (tab.id === 'more') return moreOpen;
+    if (tab.id === 'maps') return pathname.includes('/maps');
+    if (tab.id === 'chat') return pathname.includes('/chat');
+    if (tab.id === 'files') return pathname.includes('/files');
+    if (tab.id === 'apps') return pathname.includes('/apps');
+    return false;
+  };
+
+  const handleTab = (tab: TabDef) => {
+    if (tab.id === 'more') {
+      onMoreToggle();
+      return;
+    }
+    if (moreOpen) onMoreToggle();
+
+    if (tab.id === 'maps') {
+      setActivePanelSection('maps');
+      router.push(getWorkspacePath(currentWorkspaceId, '/maps'));
+      return;
+    }
+
+    if (tab.id === 'chat') {
+      // Teams-style: Chat tab always returns to the conversation list.
+      setActiveConversation(null);
+      setMobilePendingChatSlug(null);
+      setActivePanelSection('chat');
+      router.push(getWorkspacePath(currentWorkspaceId, '/chat'));
+      return;
+    }
+
+    if (tab.id === 'files') {
+      setActivePanelSection('files');
+      router.push(getWorkspacePath(currentWorkspaceId, '/files'));
+      return;
+    }
+    if (tab.id === 'apps') {
+      setActivePanelSection('apps');
+      router.push(getWorkspacePath(currentWorkspaceId, '/apps'));
+    }
+  };
+
+  return (
+    <nav
+      className="flex flex-shrink-0 items-stretch border-t border-border/60 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80"
+      style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
+      aria-label="Primary"
+    >
+      {TABS.filter((t) => enabled(t.feature)).map((tab) => {
+        const active = isTabActive(tab);
+        return (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => handleTab(tab)}
+            className={cn(
+              'mobile-bottom-nav-tab flex min-h-[52px] flex-1 flex-col items-center justify-center gap-1 py-2 text-sm font-medium transition-colors',
+              active ? 'text-workspace-accent' : 'text-muted-foreground'
+            )}
+          >
+            <span className={cn(active && 'text-workspace-accent')}>{tab.icon}</span>
+            <span>{tab.label}</span>
+          </button>
+        );
+      })}
+    </nav>
+  );
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/mobile/mobile-more-sheet.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/mobile/mobile-more-sheet.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { createPortal } from 'react-dom';
+import {
+  Search, BrainCircuit, Waypoints, FlaskConical, Code, Store, Settings, Activity, Boxes, X,
+} from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { cn } from '@/lib/utils';
+import { useAuthStore } from '@/stores/auth';
+import { useFeature } from '@/hooks/use-feature';
+import { useWorkspaceStore, type SidebarSection } from '@/stores/workspace';
+import { getWorkspacePath } from '../sidebar/utils';
+import { shellTokens } from '../tokens';
+
+type MoreItem = {
+  id: string;
+  label: string;
+  icon: React.ReactNode;
+  href: string;
+  section?: SidebarSection | null;
+  feature?: 'search' | 'ontology' | 'graph' | 'agents' | 'code' | 'marketplace' | 'settings.workspace';
+  superadmin?: boolean;
+};
+
+const MORE_ITEMS: MoreItem[] = [
+  { id: 'search', label: 'Search', icon: <Search size={18} />, href: '/search', section: 'search', feature: 'search' },
+  { id: 'ontology', label: 'Ontology', icon: <BrainCircuit size={18} />, href: '/ontology', section: 'ontology', feature: 'ontology' },
+  { id: 'graph', label: 'Knowledge Graph', icon: <Waypoints size={18} />, href: '/graph/network', section: 'graph', feature: 'graph' },
+  { id: 'lab', label: 'Lab', icon: <FlaskConical size={18} />, href: '/lab', section: 'lab', feature: 'agents' },
+  { id: 'code', label: 'Code', icon: <Code size={18} />, href: '/code/workspaces', section: 'code', feature: 'code' },
+  { id: 'marketplace', label: 'Marketplace', icon: <Store size={18} />, href: '/marketplace', section: 'marketplace', feature: 'marketplace' },
+  { id: 'settings', label: 'Settings', icon: <Settings size={18} />, href: '/settings', section: 'settings', feature: 'settings.workspace' },
+  { id: 'admin-events', label: 'Platform events', icon: <Activity size={18} />, href: '/admin/events', section: null, superadmin: true },
+  { id: 'admin-services', label: 'Services', icon: <Boxes size={18} />, href: '/admin/services', section: null, superadmin: true },
+];
+
+interface MobileMoreSheetProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function MobileMoreSheet({ open, onClose }: MobileMoreSheetProps) {
+  const [mounted, setMounted] = useState(false);
+  const router = useRouter();
+  const currentWorkspaceId = useWorkspaceStore((s) => s.currentWorkspaceId);
+  const setActivePanelSection = useWorkspaceStore((s) => s.setActivePanelSection);
+  const isSuperadmin = useAuthStore((s) => !!s.user?.is_superadmin);
+
+  const canSearch = useFeature('search');
+  const canOntology = useFeature('ontology');
+  const canGraph = useFeature('graph');
+  const canAgents = useFeature('agents');
+  const canCode = useFeature('code');
+  const canMarketplace = useFeature('marketplace');
+  const canSettings = useFeature('settings.workspace');
+
+  useEffect(() => setMounted(true), []);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  if (!mounted || !open) return null;
+
+  const enabled = (item: MoreItem) => {
+    if (item.superadmin) return isSuperadmin;
+    if (!item.feature) return true;
+    if (item.feature === 'search') return !!canSearch;
+    if (item.feature === 'ontology') return !!canOntology;
+    if (item.feature === 'graph') return !!canGraph;
+    if (item.feature === 'agents') return !!canAgents;
+    if (item.feature === 'code') return !!canCode;
+    if (item.feature === 'marketplace') return !!canMarketplace;
+    if (item.feature === 'settings.workspace') return !!canSettings;
+    return true;
+  };
+
+  const handleItem = (item: MoreItem) => {
+    setActivePanelSection(item.section ?? null);
+    router.push(getWorkspacePath(currentWorkspaceId, item.href));
+    onClose();
+  };
+
+  return createPortal(
+    // data-org-branded: the portal escapes the shell, where the radius token lives.
+    <div
+      className="fixed inset-0 z-[300]"
+      role="dialog"
+      aria-modal="true"
+      aria-label="More"
+      data-org-branded="true"
+    >
+      <button
+        type="button"
+        className="absolute inset-0 bg-black/40"
+        aria-label="Close"
+        onClick={onClose}
+      />
+      <div
+        className={cn(
+          'absolute inset-x-0 bottom-0 border border-border/60 bg-background shadow-xl',
+          'animate-in slide-in-from-bottom duration-200'
+        )}
+        style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
+      >
+        <div className="flex items-center justify-between px-4 pt-3 pb-2">
+          <span className="text-sm font-semibold">More</span>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label="Close more menu"
+          >
+            <X size={18} />
+          </button>
+        </div>
+        <div className="grid grid-cols-3 gap-1 px-3 pb-4">
+          {MORE_ITEMS.filter(enabled).map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => handleItem(item)}
+              className="flex flex-col items-center gap-1.5 px-2 py-3 text-muted-foreground transition-colors hover:text-workspace-accent"
+            >
+              <span className="flex h-10 w-10 items-center justify-center">
+                {item.icon}
+              </span>
+              <span className={shellTokens.mobile.moreSheet.gridLabel}>{item.label}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/mobile/mobile-top-bar-title.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/mobile/mobile-top-bar-title.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveMobileTopBarTitle } from './mobile-top-bar-title';
+
+describe('resolveMobileTopBarTitle', () => {
+  it('uses shell override on list tabs', () => {
+    expect(
+      resolveMobileTopBarTitle({
+        variant: 'top',
+        titleOverride: 'Files',
+        pageTitle: 'Workspace Drive',
+        workspaceName: 'Acme',
+      })
+    ).toBe('Files');
+  });
+
+  it('uses the conversation title on chat thread detail', () => {
+    expect(
+      resolveMobileTopBarTitle({
+        variant: 'detail',
+        pageTitle: 'Chat',
+        threadTitle: 'Quarterly plan',
+        isChatThread: true,
+      })
+    ).toBe('Quarterly plan');
+  });
+
+  it('uses the page-registered drive name on files browse detail', () => {
+    expect(
+      resolveMobileTopBarTitle({
+        variant: 'detail',
+        pageTitle: 'Workspace Drive',
+        threadTitle: 'New chat',
+        isChatThread: false,
+      })
+    ).toBe('Workspace Drive');
+  });
+
+  it('does not fall back to stale chat titles on files browse detail', () => {
+    expect(
+      resolveMobileTopBarTitle({
+        variant: 'detail',
+        threadTitle: 'New chat',
+        isChatThread: false,
+      })
+    ).toBe('');
+  });
+});

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/mobile/mobile-top-bar-title.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/mobile/mobile-top-bar-title.ts
@@ -1,0 +1,35 @@
+/**
+ * Mobile top bar title resolution, kept separate from the React component so
+ * vitest can cover it without parsing JSX.
+ */
+
+export type MobileTopBarTitleInput = {
+  variant: 'top' | 'detail';
+  titleOverride?: string;
+  pageTitle?: string;
+  threadTitle?: string;
+  workspaceName?: string;
+  /** Chat thread detail (not the conversation list). */
+  isChatThread?: boolean;
+};
+
+export function resolveMobileTopBarTitle({
+  variant,
+  titleOverride,
+  pageTitle,
+  threadTitle,
+  workspaceName,
+  isChatThread = false,
+}: MobileTopBarTitleInput): string {
+  if (variant === 'detail') {
+    return (
+      titleOverride ??
+      (isChatThread ? threadTitle : undefined) ??
+      pageTitle ??
+      workspaceName ??
+      ''
+    );
+  }
+
+  return titleOverride ?? pageTitle ?? workspaceName ?? '';
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/mobile/mobile-top-bar.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/mobile/mobile-top-bar.tsx
@@ -1,0 +1,287 @@
+'use client';
+
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import Link from 'next/link';
+import {
+  ArrowLeft, Check, User, LogOut, HelpCircle, Building2,
+} from 'lucide-react';
+import { useRouter, usePathname } from 'next/navigation';
+import { cn } from '@/lib/utils';
+import { useAuthStore } from '@/stores/auth';
+import { useFeature } from '@/hooks/use-feature';
+import { useWorkspaceStore } from '@/stores/workspace';
+import { isMobileChatThreadOpen, parseChatRoute } from '../chat-route';
+import { getWorkspacePath } from '../sidebar/utils';
+import { useShellTitle } from '../shell-title';
+import { resolveMobileTopBarTitle } from './mobile-top-bar-title';
+
+type MobileTopBarProps = {
+  /** Top-level tab chrome, or an immersive detail view (chat thread, file browser). */
+  variant: 'top' | 'detail';
+  /** Title for shell-owned views that mount no page Header (chat/files lists). */
+  title?: string;
+  /** Page-level actions for the current route, rendered on the right. */
+  actions?: ReactNode;
+  /** Override the default chat-list back target on detail views. */
+  onDetailBack?: () => void;
+  detailBackLabel?: string;
+};
+
+export function MobileTopBar({
+  variant,
+  title: titleOverride,
+  actions,
+  onDetailBack,
+  detailBackLabel,
+}: MobileTopBarProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const [mounted, setMounted] = useState(false);
+  const [workspaceOpen, setWorkspaceOpen] = useState(false);
+  const [profileOpen, setProfileOpen] = useState(false);
+  const [workspacePos, setWorkspacePos] = useState({ top: 0, left: 0 });
+  const [profilePos, setProfilePos] = useState({ top: 0, right: 0 });
+  const workspaceBtnRef = useRef<HTMLButtonElement>(null);
+  const profileBtnRef = useRef<HTMLButtonElement>(null);
+
+  const workspaces = useWorkspaceStore((s) => s.workspaces);
+  const currentWorkspaceId = useWorkspaceStore((s) => s.currentWorkspaceId);
+  const activeConversationId = useWorkspaceStore((s) => s.activeConversationId);
+  const mobilePendingChatSlug = useWorkspaceStore((s) => s.mobilePendingChatSlug);
+  const conversations = useWorkspaceStore((s) => s.conversations);
+  const setActiveConversation = useWorkspaceStore((s) => s.setActiveConversation);
+  const setMobilePendingChatSlug = useWorkspaceStore((s) => s.setMobilePendingChatSlug);
+
+  const { logout, user } = useAuthStore();
+  const canOrganizationSettings = useFeature('settings.organization');
+  const { title: pageTitle } = useShellTitle();
+
+  useEffect(() => setMounted(true), []);
+
+  const currentWorkspace = mounted
+    ? workspaces.find((w) => w.id === currentWorkspaceId) || null
+    : null;
+
+  const chatRoute = parseChatRoute(pathname);
+  const isChatThread = isMobileChatThreadOpen(chatRoute, mobilePendingChatSlug);
+
+  const threadTitle =
+    conversations.find((c) => c.id === activeConversationId)?.title || 'New chat';
+
+  const title = resolveMobileTopBarTitle({
+    variant,
+    titleOverride,
+    pageTitle,
+    threadTitle,
+    workspaceName: currentWorkspace?.name,
+    isChatThread,
+  });
+
+  // Replace rather than push: the list is where we came from, so stacking a
+  // second entry would make hardware back bounce through the detail again.
+  const handleBack = onDetailBack ?? (() => {
+    setActiveConversation(null);
+    setMobilePendingChatSlug(null);
+    router.replace(getWorkspacePath(currentWorkspaceId, '/chat'));
+  });
+
+  const openWorkspaceMenu = () => {
+    if (!workspaceBtnRef.current) return;
+    const rect = workspaceBtnRef.current.getBoundingClientRect();
+    setWorkspacePos({ top: rect.bottom + 6, left: Math.max(8, rect.left) });
+    setProfileOpen(false);
+    setWorkspaceOpen(true);
+  };
+
+  const openProfileMenu = () => {
+    if (!profileBtnRef.current) return;
+    const rect = profileBtnRef.current.getBoundingClientRect();
+    setProfilePos({ top: rect.bottom + 6, right: Math.max(8, window.innerWidth - rect.right) });
+    setWorkspaceOpen(false);
+    setProfileOpen(true);
+  };
+
+  return (
+    <>
+      {/* min-h, not h: the safe-area inset is padding inside the box, so a fixed
+          height would swallow the row on notched devices in standalone mode. */}
+      <header
+        className="flex min-h-12 flex-shrink-0 items-center gap-2 border-b border-border/60 px-2"
+        style={{ paddingTop: 'env(safe-area-inset-top, 0px)' }}
+      >
+        {variant === 'detail' ? (
+          <button
+            type="button"
+            onClick={handleBack}
+            className="flex h-9 w-9 flex-shrink-0 items-center justify-center text-foreground hover:bg-muted"
+            aria-label={detailBackLabel ?? 'Back to chats'}
+          >
+            <ArrowLeft size={20} />
+          </button>
+        ) : (
+          <button
+            ref={workspaceBtnRef}
+            type="button"
+            onClick={openWorkspaceMenu}
+            className="flex h-9 w-9 flex-shrink-0 items-center justify-center overflow-hidden transition-all hover:ring-2 hover:ring-workspace-accent/50"
+            style={{ backgroundColor: currentWorkspace?.theme?.primaryColor || '#22c55e' }}
+            title={currentWorkspace?.name || 'Workspace'}
+            aria-label="Switch workspace"
+          >
+            {currentWorkspace?.theme?.logoUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={currentWorkspace.theme.logoUrl}
+                alt={currentWorkspace.name}
+                className="h-full w-full object-cover"
+              />
+            ) : (
+              <span className="text-sm font-bold text-white">
+                {currentWorkspace?.theme?.logoEmoji
+                  || currentWorkspace?.icon
+                  || currentWorkspace?.name?.charAt(0)
+                  || 'Z'}
+              </span>
+            )}
+          </button>
+        )}
+
+        <h1 className="min-w-0 flex-1 truncate text-base font-semibold">{title}</h1>
+
+        {actions}
+
+        {/* Profile only on list / top-level tabs. Detail views stay immersive. */}
+        {variant === 'top' && (
+          <button
+            ref={profileBtnRef}
+            type="button"
+            onClick={openProfileMenu}
+            className={cn(
+              // Profile stays circular (same as desktop). Other mobile chrome stays sharp.
+              'flex h-8 w-8 flex-shrink-0 items-center justify-center overflow-hidden rounded-full',
+              user?.avatar ? 'bg-transparent' : 'bg-primary text-primary-foreground'
+            )}
+            aria-label="Account menu"
+          >
+            {user?.avatar ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={user.avatar} alt={user.name || 'User'} className="h-full w-full object-cover" />
+            ) : (
+              <span className="text-xs font-medium">{user?.name?.charAt(0) || 'U'}</span>
+            )}
+          </button>
+        )}
+      </header>
+
+      {workspaceOpen && mounted && createPortal(
+        // Portals land outside the shell, so re-declare org branding to keep
+        // the radius token applying to menu chrome.
+        <div data-org-branded="true">
+          <div className="fixed inset-0 z-[299]" onClick={() => setWorkspaceOpen(false)} />
+          <div
+            className="glass-card fixed z-[300] w-64 py-1 shadow-lg"
+            style={{ top: workspacePos.top, left: workspacePos.left }}
+          >
+            <p className="px-3 py-1.5 text-micro font-semibold uppercase tracking-wider text-muted-foreground">
+              Workspaces
+            </p>
+            {workspaces.map((workspace) => (
+              <button
+                key={workspace.id}
+                type="button"
+                onClick={() => {
+                  setWorkspaceOpen(false);
+                  setActiveConversation(null);
+                  router.push(`/workspace/${workspace.id}/maps/presence`);
+                }}
+                className={cn(
+                  'flex w-full items-center gap-2 px-3 py-2 text-sm transition-colors',
+                  'hover:bg-workspace-accent-10',
+                  currentWorkspaceId === workspace.id && 'bg-workspace-accent-5'
+                )}
+              >
+                <div
+                  className="flex h-6 w-6 flex-shrink-0 items-center justify-center overflow-hidden"
+                  style={{ backgroundColor: workspace.theme?.primaryColor || '#22c55e' }}
+                >
+                  {workspace.theme?.logoUrl ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img src={workspace.theme.logoUrl} alt={workspace.name} className="h-full w-full object-cover" />
+                  ) : (
+                    <span className="text-xs text-white">
+                      {workspace.theme?.logoEmoji || workspace.icon || workspace.name.charAt(0)}
+                    </span>
+                  )}
+                </div>
+                <span className="flex-1 text-left font-medium">{workspace.name}</span>
+                {currentWorkspaceId === workspace.id && (
+                  <Check size={14} className="text-workspace-accent" />
+                )}
+              </button>
+            ))}
+          </div>
+        </div>,
+        document.body
+      )}
+
+      {profileOpen && mounted && createPortal(
+        <div data-org-branded="true">
+          <div className="fixed inset-0 z-[299]" onClick={() => setProfileOpen(false)} />
+          <div
+            className="fixed z-[300] w-64 border bg-card p-2 shadow-lg"
+            style={{ top: profilePos.top, right: profilePos.right }}
+          >
+            <div className="border-b border-border/50 px-4 py-3">
+              <p className="truncate font-medium">{user?.name || 'User'}</p>
+              <p className="truncate text-xs text-muted-foreground">{user?.email || ''}</p>
+            </div>
+            <div className="py-2">
+              <Link
+                href="/account/profile"
+                onClick={() => setProfileOpen(false)}
+                className="flex items-center gap-3 px-4 py-2.5 text-sm hover:bg-muted"
+              >
+                <User size={16} className="shrink-0 text-muted-foreground" />
+                Account Settings
+              </Link>
+              {canOrganizationSettings && (
+                <Link
+                  href="/organizations"
+                  onClick={() => setProfileOpen(false)}
+                  className="flex items-center gap-3 px-4 py-2.5 text-sm hover:bg-muted"
+                >
+                  <Building2 size={16} className="shrink-0 text-muted-foreground" />
+                  Organization Settings
+                </Link>
+              )}
+              <Link
+                href={getWorkspacePath(currentWorkspaceId, '/help')}
+                onClick={() => setProfileOpen(false)}
+                className="flex items-center gap-3 px-4 py-2.5 text-sm hover:bg-muted"
+              >
+                <HelpCircle size={16} className="shrink-0 text-muted-foreground" />
+                Help
+              </Link>
+            </div>
+            <div className="border-t border-border/50 py-2">
+              <button
+                type="button"
+                onClick={() => {
+                  setProfileOpen(false);
+                  logout();
+                  router.push('/auth/login');
+                }}
+                className="flex w-full items-center gap-3 px-4 py-2.5 text-sm text-destructive hover:bg-destructive/10"
+              >
+                <LogOut size={16} className="shrink-0" />
+                Log Out
+              </button>
+            </div>
+          </div>
+        </div>,
+        document.body
+      )}
+    </>
+  );
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/shell-title-entry.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/shell-title-entry.ts
@@ -1,0 +1,25 @@
+/**
+ * Which page title applies right now. Kept apart from the React plumbing in
+ * shell-title.tsx so it stays testable: the test runner cannot parse JSX while
+ * tsconfig keeps jsx: "preserve" for Next.
+ */
+
+export interface ShellTitleEntry {
+  title?: string;
+  subtitle?: string;
+  /** The route that registered this title. */
+  pathname: string;
+}
+
+/**
+ * A title only counts for the route that registered it. Routes without a
+ * Header (platform admin, for one) must fall through to the caller's fallback
+ * rather than inherit the previous page's name.
+ */
+export function resolveShellTitle(
+  entry: ShellTitleEntry | null,
+  pathname: string | null
+): { title?: string; subtitle?: string } {
+  if (!entry || !pathname || entry.pathname !== pathname) return {};
+  return { title: entry.title, subtitle: entry.subtitle };
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/shell-title.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/shell-title.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveShellTitle } from './shell-title-entry';
+
+describe('resolveShellTitle', () => {
+  it('uses the title the current page registered', () => {
+    expect(
+      resolveShellTitle({ title: 'Marketplace', pathname: '/workspace/ws-1/marketplace' }, '/workspace/ws-1/marketplace')
+    ).toEqual({ title: 'Marketplace', subtitle: undefined });
+  });
+
+  it('carries the subtitle through', () => {
+    expect(
+      resolveShellTitle(
+        { title: 'Files', subtitle: 'Synced from your machine', pathname: '/workspace/ws-1/files' },
+        '/workspace/ws-1/files'
+      )
+    ).toEqual({ title: 'Files', subtitle: 'Synced from your machine' });
+  });
+
+  it('drops a title belonging to the route we just left', () => {
+    // Pages that render no Header (platform admin) would otherwise keep showing
+    // the previous page's name in the mobile top bar.
+    expect(
+      resolveShellTitle({ title: 'Files', pathname: '/workspace/ws-1/files' }, '/workspace/ws-1/admin/events')
+    ).toEqual({});
+  });
+
+  it('has nothing to say before any page has registered', () => {
+    expect(resolveShellTitle(null, '/workspace/ws-1/chat')).toEqual({});
+  });
+
+  it('holds back until the pathname is known', () => {
+    expect(
+      resolveShellTitle({ title: 'Chat', pathname: '/workspace/ws-1/chat' }, null)
+    ).toEqual({});
+  });
+});

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/shell-title.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/shell-title.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { createContext, useContext, useEffect, useLayoutEffect, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import { resolveShellTitle, type ShellTitleEntry } from './shell-title-entry';
+
+/**
+ * Pages already declare their title by rendering `<Header title=... />`.
+ * The desktop header does not paint it, but the mobile top bar needs it, and
+ * only the page knows things like "Local Folder / Invoices" vs plain "Files".
+ * So Header registers here and the mobile chrome reads it, instead of a second
+ * pathname-to-label table that drifts every time a route is added.
+ */
+type RegisterShellTitle = (entry: ShellTitleEntry) => void;
+
+const ShellTitleStateContext = createContext<ShellTitleEntry | null>(null);
+const ShellTitleRegisterContext = createContext<RegisterShellTitle>(() => {});
+
+export function ShellTitleProvider({ children }: { children: React.ReactNode }) {
+  const [entry, setEntry] = useState<ShellTitleEntry | null>(null);
+
+  return (
+    <ShellTitleRegisterContext.Provider value={setEntry}>
+      <ShellTitleStateContext.Provider value={entry}>{children}</ShellTitleStateContext.Provider>
+    </ShellTitleRegisterContext.Provider>
+  );
+}
+
+// Register before paint so a route change swaps the title in the same frame as
+// the page, instead of flashing the fallback. useEffect on the server, where
+// layout effects do not run.
+const useRegisterEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect;
+
+export function useRegisterShellTitle(title?: string, subtitle?: string): void {
+  const register = useContext(ShellTitleRegisterContext);
+  const pathname = usePathname();
+
+  useRegisterEffect(() => {
+    register({ title, subtitle, pathname });
+  }, [register, title, subtitle, pathname]);
+}
+
+export function useShellTitle(): { title?: string; subtitle?: string } {
+  const entry = useContext(ShellTitleStateContext);
+  const pathname = usePathname();
+
+  return resolveShellTitle(entry, pathname);
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/chat-section.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/chat-section.tsx
@@ -5,12 +5,14 @@ import Link from 'next/link';
 import { MessageSquare, ChevronRight, Plus, Pin, Folder, MoreVertical, Archive, Edit2, Trash2, Star, Zap } from 'lucide-react';
 import { useRouter, usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
+import { useIsMobile } from '@/hooks/use-is-mobile';
 import { useWorkspaceStore } from '@/stores/workspace';
 import { useAgentsStore } from '@/stores/agents';
 import { useSkillsStore } from '@/stores/skills';
 import { useAuthStore } from '@/stores/auth';
 import { CollapsibleSection } from './collapsible-section';
 import { getWorkspacePath } from './utils';
+import { newChatPath } from '../chat-route';
 import { AgentAvatar } from '@/components/chat/agent-selector';
 import { useFeature } from '@/hooks/use-feature';
 
@@ -27,6 +29,7 @@ const ConversationItem = React.memo(function ConversationItem({
   isRenaming,
   onStartRename,
   onCancelRename,
+  mobilePanel = false,
 }: {
   id: string;
   title: string;
@@ -40,7 +43,11 @@ const ConversationItem = React.memo(function ConversationItem({
   isRenaming?: boolean;
   onStartRename: () => void;
   onCancelRename: () => void;
+  mobilePanel?: boolean;
 }) {
+  const iconSize = mobilePanel ? 14 : 12;
+  const rowTextClass = mobilePanel ? 'text-sm leading-snug' : 'text-xs';
+  const rowPadClass = mobilePanel ? 'px-2 py-2.5 min-h-11' : 'px-2 py-1.5';
   const [showMenu, setShowMenu] = useState(false);
   const [editValue, setEditValue] = useState(title);
 
@@ -54,7 +61,7 @@ const ConversationItem = React.memo(function ConversationItem({
   if (isRenaming) {
     return (
       <div className="flex items-center gap-2 rounded-md px-2 py-1.5">
-        <MessageSquare size={12} className="flex-shrink-0 text-muted-foreground" />
+        <MessageSquare size={iconSize} className="flex-shrink-0 text-muted-foreground" />
         <input
           type="text"
           value={editValue}
@@ -68,7 +75,7 @@ const ConversationItem = React.memo(function ConversationItem({
           }}
           onBlur={handleRenameSubmit}
           autoFocus
-          className="flex-1 bg-transparent text-xs outline-none border-b border-workspace-accent"
+          className={cn('flex-1 bg-transparent outline-none border-b border-workspace-accent', rowTextClass)}
         />
       </div>
     );
@@ -79,13 +86,15 @@ const ConversationItem = React.memo(function ConversationItem({
       <button
         onClick={onClick}
         className={cn(
-          'group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors',
+          'group flex w-full items-center gap-2 rounded-md text-left transition-colors',
+          rowPadClass,
+          rowTextClass,
           'hover:bg-workspace-accent-10',
           isActive && 'bg-workspace-accent-15 text-workspace-accent'
         )}
       >
-        {pinned && <Pin size={12} className="flex-shrink-0 text-workspace-accent" />}
-        <MessageSquare size={12} className="flex-shrink-0 text-muted-foreground" />
+        {pinned && <Pin size={iconSize} className="flex-shrink-0 text-workspace-accent" />}
+        <MessageSquare size={iconSize} className="flex-shrink-0 text-muted-foreground" />
         <span className="flex-1 truncate">{title}</span>
         <div
           className="flex-shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-muted group-hover:opacity-100 cursor-pointer"
@@ -170,6 +179,7 @@ const ProjectGroup = React.memo(function ProjectGroup({
   renamingId,
   onStartRename,
   onCancelRename,
+  mobilePanel = false,
 }: {
   name: string;
   conversations: { id: string; title: string; pinned?: boolean }[];
@@ -182,22 +192,31 @@ const ProjectGroup = React.memo(function ProjectGroup({
   renamingId: string | null;
   onStartRename: (id: string) => void;
   onCancelRename: () => void;
+  mobilePanel?: boolean;
 }) {
+  const rowTextClass = mobilePanel ? 'text-sm leading-snug' : 'text-xs';
+  const iconSize = mobilePanel ? 14 : 12;
   const [expanded, setExpanded] = useState(true);
 
   return (
     <div className="space-y-0.5">
       <button
         onClick={() => setExpanded(!expanded)}
-        className="flex w-full items-center gap-1 rounded-md px-1 py-1 text-xs font-medium text-muted-foreground hover:text-foreground"
+        className={cn(
+          'flex w-full items-center gap-1 rounded-md px-1 py-1 font-medium text-muted-foreground hover:text-foreground',
+          rowTextClass,
+          mobilePanel && 'min-h-11 py-2'
+        )}
       >
         <ChevronRight
-          size={12}
+          size={iconSize}
           className={cn('transition-transform', expanded && 'rotate-90')}
         />
-        <Folder size={12} />
+        <Folder size={iconSize} />
         <span className="flex-1 truncate text-left">{name}</span>
-        <span className="text-[10px]">{conversations.length}</span>
+        <span className={mobilePanel ? 'text-xs text-muted-foreground' : 'text-micro text-muted-foreground'}>
+          {conversations.length}
+        </span>
       </button>
       {expanded && (
         <div className="ml-3 space-y-0.5">
@@ -216,6 +235,7 @@ const ProjectGroup = React.memo(function ProjectGroup({
               onRename={(newTitle) => onRename(conv.id, newTitle)}
               onCancelRename={onCancelRename}
               onDelete={() => onDelete(conv.id)}
+              mobilePanel={mobilePanel}
             />
           ))}
         </div>
@@ -225,6 +245,16 @@ const ProjectGroup = React.memo(function ProjectGroup({
 });
 
 export function ChatSection({ collapsed, detailOnly }: { collapsed: boolean; detailOnly?: boolean }) {
+  const isMobile = useIsMobile();
+  const isMobilePanel = isMobile && !!detailOnly;
+  const rowTextClass = isMobilePanel ? 'text-sm leading-snug' : 'text-xs';
+  const rowPadClass = isMobilePanel ? 'px-2 py-2.5 min-h-11' : 'px-2 py-1.5';
+  const iconSize = isMobilePanel ? 14 : 12;
+  const sectionLabelClass = cn(
+    'px-2 py-1 font-semibold uppercase tracking-wider text-muted-foreground',
+    isMobilePanel ? 'text-xs' : 'text-micro'
+  );
+  const listItemProps = { mobilePanel: isMobilePanel };
   const router = useRouter();
   const pathname = usePathname();
   const [renamingId, setRenamingId] = useState<string | null>(null);
@@ -250,7 +280,7 @@ export function ChatSection({ collapsed, detailOnly }: { collapsed: boolean; det
     deleteConversation,
   } = useWorkspaceStore();
 
-  const { agents, setDefaultAgent } = useAgentsStore();
+  const { agents, setDefaultAgent, fetchAgents } = useAgentsStore();
   // "agents" feature flag gates agent administration (edit, settings access).
   const canManageAgents = useFeature('agents');
   const canUseSkills = useFeature('skills');
@@ -285,6 +315,11 @@ export function ChatSection({ collapsed, detailOnly }: { collapsed: boolean; det
   useEffect(() => {
     if (!isChatRoute) clearAgentExplicitSelection();
   }, [isChatRoute, clearAgentExplicitSelection]);
+
+  useEffect(() => {
+    if (!currentWorkspaceId) return;
+    void fetchAgents(currentWorkspaceId, true);
+  }, [currentWorkspaceId, fetchAgents]);
 
   // Default agent first, then by most recently used (latest conversation
   // touched with that agent), never-used agents last in alphabetical order.
@@ -332,7 +367,7 @@ export function ChatSection({ collapsed, detailOnly }: { collapsed: boolean; det
   const handleUseSkill = useCallback(
     (slug: string) => {
       setPendingComposerText(`/${slug} `);
-      router.push(getWorkspacePath(currentWorkspaceId, '/chat'));
+      router.push(newChatPath(currentWorkspaceId));
     },
     [setPendingComposerText, router, currentWorkspaceId]
   );
@@ -351,11 +386,10 @@ export function ChatSection({ collapsed, detailOnly }: { collapsed: boolean; det
   const handleNewChat = useCallback(() => {
     const defaultAgent =
       safeAgents.find((a) => a.isDefault && a.enabled) ??
-      safeAgents.find((a) => a.id === 'abi' && a.enabled) ??
       safeAgents.find((a) => a.enabled);
     if (defaultAgent) setSelectedAgent(defaultAgent.id);
     setActiveConversation(null);
-    router.push(getWorkspacePath(currentWorkspaceId, '/chat'));
+    router.push(newChatPath(currentWorkspaceId));
   }, [safeAgents, setSelectedAgent, setActiveConversation, router, currentWorkspaceId]);
 
   // Clicking the "Chat" section header resets to a blank new-chat state,
@@ -363,7 +397,6 @@ export function ChatSection({ collapsed, detailOnly }: { collapsed: boolean; det
   const handleChatHeaderNavigate = useCallback(() => {
     const defaultAgent =
       safeAgents.find((a) => a.isDefault && a.enabled) ??
-      safeAgents.find((a) => a.id === 'abi' && a.enabled) ??
       safeAgents.find((a) => a.enabled);
     if (defaultAgent) setSelectedAgent(defaultAgent.id);
     setActiveConversation(null);
@@ -371,7 +404,7 @@ export function ChatSection({ collapsed, detailOnly }: { collapsed: boolean; det
 
   const handleSelectConversation = useCallback((id: string) => {
     setActiveConversation(id);
-    router.push(getWorkspacePath(currentWorkspaceId, '/chat'));
+    router.push(getWorkspacePath(currentWorkspaceId, `/chat/${id}`));
   }, [setActiveConversation, router, currentWorkspaceId]);
 
   useEffect(() => {
@@ -403,13 +436,14 @@ export function ChatSection({ collapsed, detailOnly }: { collapsed: boolean; det
         onClick={handleNewChat}
         title="New chat (Ctrl+I)"
         className={cn(
-          'flex w-full items-center gap-1 rounded-md px-1 py-1 text-xs font-medium transition-colors',
+          'flex w-full items-center gap-1.5 rounded-md px-2 font-medium transition-colors',
+          isMobilePanel ? 'py-2.5 min-h-11 text-sm' : 'px-1 py-1 text-xs',
           isNewChatActive
             ? 'bg-workspace-accent-15 text-workspace-accent'
             : 'text-muted-foreground hover:text-foreground'
         )}
       >
-        <Plus size={12} />
+        <Plus size={iconSize} />
         <span>New Chat</span>
       </button>
 
@@ -418,13 +452,18 @@ export function ChatSection({ collapsed, detailOnly }: { collapsed: boolean; det
         {canManageAgents ? (
           <Link
             href={getWorkspacePath(currentWorkspaceId, '/settings/agents')}
-            className="block px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground hover:text-foreground"
+            className={cn('block hover:text-foreground', sectionLabelClass)}
           >
             Agents
           </Link>
         ) : (
-          <p className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          <p className={sectionLabelClass}>
             Agents
+          </p>
+        )}
+        {visibleAgents.length === 0 && (
+          <p className={cn('px-2 py-1 text-muted-foreground', rowTextClass)}>
+            No agents available yet
           </p>
         )}
         {visibleAgents.map((agent) => {
@@ -436,25 +475,31 @@ export function ChatSection({ collapsed, detailOnly }: { collapsed: boolean; det
                 onClick={() => {
                   setSelectedAgent(agent.id, true);
                   setActiveConversation(null);
-                  router.push(getWorkspacePath(currentWorkspaceId, '/chat'));
+                  router.push(newChatPath(currentWorkspaceId));
                 }}
                 className={cn(
-                  'group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors',
+                  'group flex w-full items-center gap-2 rounded-md text-left transition-colors',
+                  rowPadClass,
+                  rowTextClass,
                   'hover:bg-workspace-accent-10',
                   isSelected && 'bg-workspace-accent-15 font-medium text-workspace-accent'
                 )}
               >
                 <span
                   className={cn(
-                    'flex h-4 w-4 flex-shrink-0 items-center justify-center overflow-hidden rounded',
+                    'flex flex-shrink-0 items-center justify-center overflow-hidden rounded',
+                    isMobilePanel ? 'h-5 w-5' : 'h-4 w-4',
                     !agent.logoUrl && (isSelected ? 'text-workspace-accent' : 'text-muted-foreground')
                   )}
                 >
-                  <AgentAvatar agent={agent} size={12} />
+                  <AgentAvatar agent={agent} size={iconSize} />
                 </span>
                 <span className="flex-1 truncate">{agent.name}</span>
                 {agent.isDefault && (
-                  <span className="flex-shrink-0 text-[9px] font-medium uppercase tracking-wider text-muted-foreground">
+                  <span className={cn(
+                    'flex-shrink-0 font-medium uppercase tracking-wider text-muted-foreground',
+                    isMobilePanel ? 'text-[10px]' : 'text-[9px]'
+                  )}>
                     Default
                   </span>
                 )}
@@ -508,10 +553,14 @@ export function ChatSection({ collapsed, detailOnly }: { collapsed: boolean; det
           <button
             type="button"
             onClick={() => setShowAllAgents(!showAllAgents)}
-            className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:text-foreground"
+            className={cn(
+              'flex w-full items-center gap-2 rounded-md text-left text-muted-foreground transition-colors hover:text-foreground',
+              rowPadClass,
+              rowTextClass
+            )}
           >
             <ChevronRight
-              size={12}
+              size={iconSize}
               className={cn('flex-shrink-0 transition-transform', showAllAgents && 'rotate-90')}
             />
             <span>{showAllAgents ? 'Show less' : `Show ${hiddenAgentCount} more`}</span>
@@ -524,12 +573,12 @@ export function ChatSection({ collapsed, detailOnly }: { collapsed: boolean; det
         <div className="space-y-0.5">
           <Link
             href={getWorkspacePath(currentWorkspaceId, '/settings/skills')}
-            className="block px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground hover:text-foreground"
+            className={cn('block hover:text-foreground', sectionLabelClass)}
           >
             Skills
           </Link>
           {sortedSkills.length === 0 && (
-            <p className="px-2 py-1 text-xs text-muted-foreground">
+            <p className={cn('px-2 py-1 text-muted-foreground', rowTextClass)}>
               Type /create-skill in the chat to add one
             </p>
           )}
@@ -539,11 +588,13 @@ export function ChatSection({ collapsed, detailOnly }: { collapsed: boolean; det
                 onClick={() => handleUseSkill(skill.slug)}
                 title={skill.description || skill.name}
                 className={cn(
-                  'group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors',
+                  'group flex w-full items-center gap-2 rounded-md text-left transition-colors',
+                  rowPadClass,
+                  rowTextClass,
                   'hover:bg-workspace-accent-10'
                 )}
               >
-                <Zap size={12} className="flex-shrink-0 text-muted-foreground" />
+                <Zap size={iconSize} className="flex-shrink-0 text-muted-foreground" />
                 <span className="flex-1 truncate">
                   {skill.name}
                   <span className="ml-1 text-muted-foreground">/{skill.slug}</span>
@@ -600,10 +651,14 @@ export function ChatSection({ collapsed, detailOnly }: { collapsed: boolean; det
             <button
               type="button"
               onClick={() => setShowAllSkills(!showAllSkills)}
-              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:text-foreground"
+              className={cn(
+                'flex w-full items-center gap-2 rounded-md text-left text-muted-foreground transition-colors hover:text-foreground',
+                rowPadClass,
+                rowTextClass
+              )}
             >
               <ChevronRight
-                size={12}
+                size={iconSize}
                 className={cn('flex-shrink-0 transition-transform', showAllSkills && 'rotate-90')}
               />
               <span>{showAllSkills ? 'Show less' : `Show ${hiddenSkillCount} more`}</span>
@@ -615,7 +670,7 @@ export function ChatSection({ collapsed, detailOnly }: { collapsed: boolean; det
       {/* Pinned */}
       {pinnedConvs.length > 0 && (
         <div className="space-y-0.5">
-          <p className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          <p className={sectionLabelClass}>
             Pinned
           </p>
           {pinnedConvs.map((conv) => (
@@ -643,6 +698,7 @@ export function ChatSection({ collapsed, detailOnly }: { collapsed: boolean; det
                   deleteConversation(conv.id);
                 }
               }}
+              {...listItemProps}
             />
           ))}
         </div>
@@ -677,13 +733,14 @@ export function ChatSection({ collapsed, detailOnly }: { collapsed: boolean; det
               deleteConversation(id);
             }
           }}
+          {...listItemProps}
         />
       ))}
 
       {/* Recent */}
       {recentConvs.length > 0 && (
         <div className="space-y-0.5">
-          <p className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          <p className={sectionLabelClass}>
             Recent
           </p>
           {recentConvs.slice(0, 10).map((conv) => (
@@ -710,6 +767,7 @@ export function ChatSection({ collapsed, detailOnly }: { collapsed: boolean; det
                   deleteConversation(conv.id);
                 }
               }}
+              {...listItemProps}
             />
           ))}
         </div>

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/workspace-layout.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/workspace-layout.tsx
@@ -1,12 +1,30 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
 import { useTheme } from 'next-themes';
 import { Sidebar } from './sidebar';
 import { SectionPanel } from './sidebar/section-panel';
+import { ChatSection } from './sidebar/chat-section';
 import { AIPane } from './ai-pane';
+import { MobileBottomNav } from './mobile/mobile-bottom-nav';
+import { MobileMoreSheet } from './mobile/mobile-more-sheet';
+import { MobileTopBar } from './mobile/mobile-top-bar';
+import { ChatExportButton } from '@/components/chat/chat-export-button';
+import { ChatInterface } from '@/components/chat/chat-interface';
+import {
+  isMobileChatThreadOpen,
+  parseChatRoute,
+  resolveMobileThreadConversationId,
+} from './chat-route';
+import { parseFilesRoute } from '@/app/workspace/[workspaceId]/files/lib/files-route';
+import { parseMapsRoute } from '@/app/workspace/[workspaceId]/maps/lib/maps-route';
+import { FilesSection } from './sidebar/files-section';
+import { MapsSection } from './sidebar/maps-section';
+import { useIsMobile } from '@/hooks/use-is-mobile';
 import { useWorkspaceStore } from '@/stores/workspace';
 import { PresenceIndicator } from '@/components/presence-indicator';
+import { getWorkspacePath } from './sidebar/utils';
 
 interface WorkspaceLayoutProps {
   children: React.ReactNode;
@@ -45,8 +63,14 @@ export function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
   const currentWorkspaceId = useWorkspaceStore((state) => state.currentWorkspaceId);
   const toggleContextPanel = useWorkspaceStore((state) => state.toggleContextPanel);
   const fetchWorkspaces = useWorkspaceStore((state) => state.fetchWorkspaces);
+  const mobilePendingChatSlug = useWorkspaceStore((state) => state.mobilePendingChatSlug);
+  const setMobilePendingChatSlug = useWorkspaceStore((state) => state.setMobilePendingChatSlug);
   const { setTheme } = useTheme();
   const [orgBorderRadius, setOrgBorderRadius] = useState('0');
+  const [moreOpen, setMoreOpen] = useState(false);
+  const isMobile = useIsMobile();
+  const pathname = usePathname();
+  const router = useRouter();
 
   // Fetch workspaces on mount
   useEffect(() => {
@@ -58,10 +82,10 @@ export function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
     const fetchOrgBranding = async () => {
       const currentWorkspace = workspaces.find((w) => w.id === currentWorkspaceId);
       if (!currentWorkspace) return;
-      
+
       // Check if user has explicitly overridden theme
       const hasUserOverride = localStorage.getItem('nexus-theme-user-override') === 'true';
-      
+
       // Fetch workspace details to get organization_id
       try {
         const { authFetch } = await import('@/stores/auth');
@@ -77,7 +101,7 @@ export function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
               const radius = orgData.loginBorderRadius ?? orgData.login_border_radius ?? '0';
               console.log('[WorkspaceLayout] Org border radius:', radius, 'from org:', wsData.organization_id);
               setOrgBorderRadius(radius);
-              
+
               // Apply org theme ONLY if user hasn't explicitly overridden it
               if (!hasUserOverride) {
                 const orgTheme = orgData.defaultTheme || orgData.default_theme;
@@ -140,8 +164,9 @@ export function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
     loadSkills();
   }, [currentWorkspaceId]);
 
-  // Keyboard shortcut: Cmd+K to toggle AI pane
+  // Keyboard shortcut: Cmd+K to toggle AI pane (desktop only)
   useEffect(() => {
+    if (isMobile) return;
     const handleKeyDown = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
         e.preventDefault();
@@ -150,8 +175,8 @@ export function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [toggleContextPanel]);
-  
+  }, [toggleContextPanel, isMobile]);
+
   // Find current workspace from state
   const currentWorkspace = workspaces.find((w) => w.id === currentWorkspaceId);
   
@@ -178,10 +203,129 @@ export function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
     }
   }, [primaryColor, accentColor]);
   
+  // Also on the root element, not just the shell div: menus and sheets render
+  // through portals into document.body, outside any inline style we set here.
+  useEffect(() => {
+    document.documentElement.style.setProperty('--org-border-radius', `${orgBorderRadius}px`);
+  }, [orgBorderRadius]);
+
   // Create dynamic CSS variables for org branding
   const themeStyles = {
     '--org-border-radius': `${orgBorderRadius}px`,
   } as React.CSSProperties;
+
+  // The URL owns which chat view is showing: /chat is the list, /chat/{id} and
+  // /chat/new are threads. mobilePendingChatSlug lets the shell flip to the
+  // thread immediately on tap before router.push updates the pathname.
+  const chatRoute = parseChatRoute(pathname);
+  const { isChatRoute, isThread } = chatRoute;
+  const { isFilesRoute, isBrowse: isFilesBrowse } = parseFilesRoute(pathname);
+  const { isMapsRoute, isDataset: isMapsDataset } = parseMapsRoute(pathname);
+  const showMobileChatThread = isMobile && isMobileChatThreadOpen(chatRoute, mobilePendingChatSlug);
+  const showMobileChatList = isMobile && isChatRoute && !showMobileChatThread;
+  const mobileThreadConversationId = resolveMobileThreadConversationId(
+    chatRoute,
+    mobilePendingChatSlug,
+  );
+  const showMobileFilesList = isMobile && isFilesRoute && !isFilesBrowse;
+  const showMobileFilesDetail = isMobile && isFilesRoute && isFilesBrowse;
+  const showMobileMapsList = isMobile && isMapsRoute && !isMapsDataset;
+  const showMobileMapsDetail = isMobile && isMapsRoute && isMapsDataset;
+  const showMobileDetail = showMobileChatThread || showMobileFilesDetail || showMobileMapsDetail;
+
+  useEffect(() => {
+    if (mobilePendingChatSlug && isThread) {
+      setMobilePendingChatSlug(null);
+    }
+  }, [mobilePendingChatSlug, isThread, setMobilePendingChatSlug]);
+
+  const handleFilesListBack = () => {
+    router.replace(getWorkspacePath(currentWorkspaceId, '/files'));
+  };
+
+  const handleMapsListBack = () => {
+    router.replace(getWorkspacePath(currentWorkspaceId, '/maps'));
+  };
+
+  // Detail views are immersive: dismiss More if it was open.
+  useEffect(() => {
+    if (showMobileDetail) setMoreOpen(false);
+  }, [showMobileDetail]);
+
+  if (isMobile) {
+    return (
+      <div
+        className="flex h-[100dvh] w-screen flex-col overflow-hidden bg-background"
+        style={themeStyles}
+        data-org-branded="true"
+        data-mobile-shell="true"
+      >
+        <MobileTopBar
+          variant={showMobileDetail ? 'detail' : 'top'}
+          // List screens are shell-owned, so no page Header is mounted to name them.
+          title={
+            showMobileChatList ? 'Chat'
+              : showMobileFilesList ? 'Files'
+                : showMobileMapsList ? 'Maps'
+                  : undefined
+          }
+          // The page passes its actions to the desktop Header, but mobile chrome
+          // is shell-owned, so the route decides what the bar carries.
+          actions={showMobileChatThread ? <ChatExportButton /> : undefined}
+          onDetailBack={
+            showMobileFilesDetail
+              ? handleFilesListBack
+              : showMobileMapsDetail
+                ? handleMapsListBack
+                : undefined
+          }
+          detailBackLabel={
+            showMobileFilesDetail
+              ? 'Back to files'
+              : showMobileMapsDetail
+                ? 'Back to maps'
+                : undefined
+          }
+        />
+        <main className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          {currentWorkspaceId && <PresenceIndicator workspaceId={currentWorkspaceId} />}
+          {showMobileChatList ? (
+            <nav className="min-h-0 flex-1 overflow-y-auto p-2">
+              <ChatSection collapsed={false} detailOnly />
+            </nav>
+          ) : showMobileFilesList ? (
+            <nav className="min-h-0 flex-1 overflow-y-auto p-2">
+              <FilesSection collapsed={false} detailOnly />
+            </nav>
+          ) : showMobileMapsList ? (
+            <nav className="min-h-0 flex-1 overflow-y-auto p-2">
+              <MapsSection collapsed={false} detailOnly />
+            </nav>
+          ) : showMobileChatThread ? (
+            // Flex column so ChatInterface flex-1/h-full fills the shell and the
+            // composer pins to the bottom (empty + non-empty). A plain block
+            // wrapper leaves the chat column content-sized and mid-screen.
+            <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+              <ChatInterface initialConversationId={mobileThreadConversationId} />
+            </div>
+          ) : (
+            <div className="flex min-h-0 flex-1 flex-col overflow-hidden">{children}</div>
+          )}
+        </main>
+
+        {/* Teams-style: bottom nav on list tabs only. Detail views own the screen. */}
+        {!showMobileDetail && (
+          <>
+            <MobileBottomNav
+              moreOpen={moreOpen}
+              onMoreToggle={() => setMoreOpen((v) => !v)}
+            />
+            <MobileMoreSheet open={moreOpen} onClose={() => setMoreOpen(false)} />
+          </>
+        )}
+      </div>
+    );
+  }
 
   return (
     <div 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/agents.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/agents.ts
@@ -106,6 +106,7 @@ interface AgentsState {
   setDefaultAgent: (id: string) => Promise<void>; // Promote one agent as workspace default
   setAgentProvider: (agentId: string, providerId: string | null) => void;
   getAgent: (id: string) => Agent | undefined;
+  resolveAgent: (id: string | undefined | null) => Agent | undefined;
   fetchAgents: (workspaceId: string, force?: boolean) => Promise<void>;
   addCustomType: (name: string) => string | null;
   setAgentTypeOverride: (agentId: string, type: string | null) => void;
@@ -218,23 +219,25 @@ export const useAgentsStore = create<AgentsState>()(
             });
 
             // Pick the best agent to surface in the chat UI.
-            // Priority: workspace default → SupervisorAgent (id "abi") → first enabled.
+            // Priority: workspace default → first enabled.
             const pickPreferred = (): Agent | undefined => {
               const defaultAgent = formattedAgents.find(a => a.isDefault && a.enabled);
               if (defaultAgent) return defaultAgent;
-              const abiAgent = formattedAgents.find(a => a.id === 'abi' && a.enabled);
-              if (abiAgent) return abiAgent;
               return formattedAgents.find(a => a.enabled);
             };
 
             const { useWorkspaceStore } = await import('./workspace');
-            const currentSelected = useWorkspaceStore.getState().selectedAgent;
-            if (currentSelected && !formattedAgents.find(a => a.id === currentSelected)) {
-              const preferred = pickPreferred();
-              if (preferred) useWorkspaceStore.getState().setSelectedAgent(preferred.id);
-            } else if (!currentSelected && formattedAgents.length > 0) {
-              const preferred = pickPreferred();
-              if (preferred) useWorkspaceStore.getState().setSelectedAgent(preferred.id);
+            const ws = useWorkspaceStore.getState();
+            const currentSelected = ws.selectedAgent;
+            const preferred = pickPreferred();
+            if (!preferred) return;
+
+            if (!ws.agentExplicitlySelected) {
+              ws.setSelectedAgent(preferred.id);
+            } else if (currentSelected && !formattedAgents.find(a => a.id === currentSelected)) {
+              ws.setSelectedAgent(preferred.id);
+            } else if (!currentSelected) {
+              ws.setSelectedAgent(preferred.id);
             }
           }
         } catch (error) {
@@ -477,6 +480,17 @@ export const useAgentsStore = create<AgentsState>()(
 
       getAgent: (id) => {
         return get().agents.find((a) => a.id === id);
+      },
+
+      /** Resolve an agent id, falling back to workspace default when stale/missing. */
+      resolveAgent: (id: string | undefined | null) => {
+        if (!id) return undefined;
+        const agents = get().agents;
+        const direct = agents.find((a) => a.id === id);
+        if (direct) return direct;
+        const defaultAgent = agents.find((a) => a.isDefault && a.enabled);
+        if (defaultAgent) return defaultAgent;
+        return agents.find((a) => a.enabled);
       },
 
       syncAgentsFromProviders: (enabledProviderIds, providerNames) => {

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
@@ -81,11 +81,6 @@ export interface Message {
   sources?: string[]; // filenames of RAG documents used to answer
   feedback?: MessageFeedback | null; // Reviewer thumbs up/down, persisted on metadata_
   feedbackDetails?: MessageFeedbackDetails | null; // Extended dislike details (type/detail/severity)
-  // Chat "refresh" lineage. Every one of these messages is displayed; the flags
-  // only shape what the model is given on later turns — see getModelHistory().
-  regenerateOf?: string; // Assistant message id this turn re-ran
-  supersededBy?: string; // Newer answer that replaced this one (set server-side)
-  replayedPrompt?: boolean; // Prompt re-sent by a refresh (duplicate of an earlier one)
   // Author attribution (preserved across sessions and users)
   authorId?: string;
   authorName?: string;
@@ -241,6 +236,9 @@ interface WorkspaceState {
    *  sidebar). Consumed and cleared by ChatInterface. Not persisted. */
   pendingComposerText: string | null;
   setPendingComposerText: (text: string | null) => void;
+  /** Mobile list→thread navigation in flight (conversation id or "new"). Not persisted. */
+  mobilePendingChatSlug: string | null;
+  setMobilePendingChatSlug: (slug: string | null) => void;
   paneAgent: AgentType; // AI Pane agent selection
   setPaneAgent: (agent: AgentType) => void;
   createConversation: (projectId?: string) => string;
@@ -338,40 +336,8 @@ type ApiConversation = {
   messages?: ApiChatMessage[];
 };
 
-const isFailedAnswer = (message: Message): boolean => {
-  const body = message.content.replace('▌', '').trim();
-  return !body || body.startsWith('❌ Error:');
-};
-
-/**
- * The transcript as the model should see it. Every message is rendered in the
- * chat — this is only about context: a refresh must not hand the model the
- * answer it is re-running, or it repeats it instead of redoing the work.
- *
- * Superseded answers are derived from the turns themselves: a refresh tags its
- * answer with the one it re-ran, so a completed replacement drops the original.
- * A refresh that failed or is still empty drops nothing, and the rule re-derives
- * itself identically after a reload, whatever local state was lost.
- */
-export const getModelHistory = (messages: Message[]): Message[] => {
-  const replaced = new Set<string>();
-  for (const message of messages) {
-    if (message.role !== 'assistant' || !message.regenerateOf) continue;
-    if (isFailedAnswer(message)) continue;
-    replaced.add(message.regenerateOf);
-  }
-  return messages.filter(
-    (message) =>
-      !message.replayedPrompt &&
-      !replaced.has(message.id) &&
-      typeof message.supersededBy !== 'string',
-  );
-};
-
 const mapApiMessage = (message: ApiChatMessage): Message => {
   const meta = message.metadata ?? {};
-  const supersededBy = meta.superseded_by;
-  const regenerateOf = meta.regenerate_of;
   const fb = meta.feedback;
   const fbType = meta.feedback_type;
   const fbDetail = meta.feedback_detail;
@@ -380,15 +346,43 @@ const mapApiMessage = (message: ApiChatMessage): Message => {
     typeof fbType === 'string' ||
     typeof fbDetail === 'string' ||
     typeof fbSeverity === 'number';
+  const rawSteps = meta.steps;
+  const toolCalls = Array.isArray(rawSteps)
+    ? rawSteps
+        .map((step): ToolCall | null => {
+          if (!step || typeof step !== 'object') return null;
+          const record = step as Record<string, unknown>;
+          const toolName = typeof record.tool_name === 'string' ? record.tool_name : '';
+          const prefix = typeof record.prefix === 'string' ? record.prefix : 'Tool';
+          const status = record.status === 'running' ? 'running' : 'done';
+          if (!toolName) return null;
+          return {
+            id: `${message.id}-step-${toolName}`,
+            toolName,
+            rawName: toolName,
+            prefix: prefix as ToolCall['prefix'],
+            status,
+            input: typeof record.input === 'string' ? record.input : undefined,
+            output: typeof record.output === 'string' ? record.output : undefined,
+          };
+        })
+        .filter((step): step is ToolCall => step !== null)
+    : undefined;
+  const rawSources = meta.sources;
+  const sources = Array.isArray(rawSources)
+    ? rawSources.filter((src): src is string => typeof src === 'string' && src.length > 0)
+    : undefined;
+  const executionTime =
+    typeof meta.execution_time === 'number' ? meta.execution_time : undefined;
   return {
     id: message.id,
     role: message.role,
     content: message.content,
     timestamp: new Date(message.created_at || Date.now()),
     agent: message.agent || undefined,
-    ...(typeof regenerateOf === 'string' ? { regenerateOf } : {}),
-    ...(typeof supersededBy === 'string' ? { supersededBy } : {}),
-    ...(meta.regenerate_replay === true ? { replayedPrompt: true } : {}),
+    toolCalls: toolCalls && toolCalls.length > 0 ? toolCalls : undefined,
+    sources: sources && sources.length > 0 ? sources : undefined,
+    executionTime,
     feedback: fb === 'like' || fb === 'dislike' ? fb : null,
     feedbackDetails: hasDetails
       ? {
@@ -446,13 +440,15 @@ export const useWorkspaceStore = create<WorkspaceState>()(
   // Chat state
   conversations: [],
   activeConversationId: null,
-  selectedAgent: 'abi', // Default to SupervisorAgent - omniscient supervisor agent for Chat
+  selectedAgent: '',
   agentExplicitlySelected: false,
   setSelectedAgent: (agent, explicit = false) =>
     set({ selectedAgent: agent, agentExplicitlySelected: explicit }),
   clearAgentExplicitSelection: () => set({ agentExplicitlySelected: false }),
   pendingComposerText: null,
   setPendingComposerText: (text) => set({ pendingComposerText: text }),
+  mobilePendingChatSlug: null,
+  setMobilePendingChatSlug: (slug) => set({ mobilePendingChatSlug: slug }),
   paneAgent: 'abi', // Default to SupervisorAgent - omniscient supervisor agent for AI Pane
   setPaneAgent: (agent) => set({ paneAgent: agent }),
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/tailwind.config.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/tailwind.config.ts
@@ -68,6 +68,14 @@ const config: Config = {
         sans: ['var(--font-inter)', 'system-ui', 'sans-serif'],
         mono: ['var(--font-mono)', 'monospace'],
       },
+      // Two steps below text-xs, so sub-12px type is a decision made once here
+      // rather than re-invented as text-[10px]/text-[11px] at each call site.
+      // caption: page-level fine print (terms, attribution, footers).
+      // micro: dense chrome and any line that must survive a 360px viewport.
+      fontSize: {
+        caption: ['0.6875rem', { lineHeight: '0.9375rem' }],
+        micro: ['0.625rem', { lineHeight: '0.875rem' }],
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- Add mobile workspace shell: `MobileTopBar`, `MobileBottomNav`, `MobileMoreSheet`, `workspace-layout` list-detail for Chat/Files/Maps, and shell title registration.
- Add typography/spacing tokens in `globals.css` + Tailwind, auth/page title polish, and chat export/header chrome.
- Keep chat route parsing in `components/shell/chat-route` so this PR does not depend on the Chat UI module move.

## Base
- Targets `main` (Maps #1106 is merged).
- Supersedes draft #1098 (old voice-skill stack base; STT/TTS already on `main`).

## Left for follow-ups
- Chat UI module P1/P2 (move `chat-section` / `chat-route` into `chat/`, agent selector module, chat landing polish).
- Files UI module browse split and mobile files chrome.
- Later composer polish that imports Chat module paths.

## Test plan
- [ ] Mobile viewport: open Chat list, tap thread, back returns to list; bottom nav hides on thread
- [ ] Mobile Maps list/detail via shell (Maps on `main` via #1106)
- [ ] Desktop shell unchanged aside from sidebar typography tokens
- [ ] Auth pages render with updated caption/radius tokens