### PR TITLE
fix: prompt for new module CLI #1112

### DIFF
--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/module.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/module.py
@@ -89,8 +89,15 @@ def new_module(module_name: str, module_path: str = ".", quiet: bool = False):
     )
 
     if not quiet:
+        # Configuration file requires an importable module namespace rather than an
+        # actual file path on the filesystem (so we need to replace '/' with '.')
         print(f"\nModule '{module_name}' has been created at:\n  {module_path}\n")
         print("To enable this module, add the following to your config.yaml:\n")
         print("modules:")
-        print(f"  - module: {module_path}")
+        print(f"  - module: {module_path.replace("/", ".")})
         print("    enabled: true\n")
+        print(
+            "Note: please check the module import namespace root level that might need "
+            "to be updated depending on your actual project structure.\n"
+        )
+

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/module.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/module.py
@@ -92,5 +92,5 @@ def new_module(module_name: str, module_path: str = ".", quiet: bool = False):
         print(f"\nModule '{module_name}' has been created at:\n  {module_path}\n")
         print("To enable this module, add the following to your config.yaml:\n")
         print("modules:")
-        print(f"  - path: {module_path}")
+        print(f"  - module: {module_path}")
         print("    enabled: true\n")


### PR DESCRIPTION
Closes #1112

# Content

- Update the prompt display to match new configuration file syntax

# Caveats

The module name displayed wthin the help message depends on the current working directory and/or whether the user uses a relative or absoute path as module directory. I added a prompt message to ask the user to be careful about what would the be the expected namespace.