### PR TITLE
Prevent action workflows to run from forked repositories #1114

### DIFF
--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.repository == 'jupyter-naas/abi'
     timeout-minutes: 30
     steps:
       - name: Checkout repository

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: github.repository == 'jupyter-naas/abi'
     permissions:
       contents: read
       deployments: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
+    if: github.repository == 'jupyter-naas/abi'
     concurrency:
       group: ${{ github.workflow }}-release-${{ github.ref_name }}
       cancel-in-progress: false


### PR DESCRIPTION
Closes #1114 

# Content

The following actions were targeted : 

- release
- docs deployment to Cloudflare
- API deployment