### PR TITLE
feat(cli): workspace and user admin commands

### DIFF
--- a/libs/naas-abi-cli/README.md
+++ b/libs/naas-abi-cli/README.md
@@ -208,6 +208,45 @@ rejects a partial one.
 > Note: the same `.env` (Postgres/MinIO/Fuseki credentials) must be present on the
 > destination host — those credentials are baked into the data being restored.
 
+### Nexus admin (workspace / user / org)
+
+Authenticated admin surface against the Nexus HTTP API. Auth via
+`NEXUS_ACCESS_TOKEN`, or `NEXUS_EMAIL` + `NEXUS_PASSWORD`. Base URL:
+`NEXUS_API_URL` (default `http://localhost:9879`).
+
+```bash
+abi workspace create --name "Research preview" --slug research-preview --org org-...
+abi workspace list --org org-...
+abi workspace members list --workspace ws-...
+abi workspace members add --workspace ws-... --email someone@naas.ai --role member
+
+abi user create --email someone@naas.ai --name "Someone"
+abi user invite --email someone@naas.ai --workspace ws-... --role member
+abi user list --org org-...   # or --workspace ws-...
+
+abi org list
+abi org members list --org org-...
+abi org workspaces --org org-...
+```
+
+All of these accept `--dry-run` (prints the intended API call) and
+`--api-url` / `--token` / `--auth-email` / `--auth-password`.
+
+**Credentials:** `abi user create` never prints the password by default. It
+writes `secrets/NEXUS_USER_<EMAIL>.env` (mode 600). Pass `--show-password` only
+when you intentionally need stdout.
+
+**Break-glass Postgres** (Zen VM ops only, when password registration / browser
+auth is unavailable):
+
+```bash
+export NEXUS_POSTGRES_COMPOSE_DIR=/opt/zen/zen
+abi user create --via postgres --email someone@naas.ai --name "Someone" --org org-...
+abi workspace create --via postgres --name "..." --slug ... --org org-... --owner-id user-...
+```
+
+See issue [#1118](https://github.com/jupyter-naas/abi/issues/1118).
+
 ### Secret Management
 
 #### `abi secrets naas list`

--- a/libs/naas-abi-cli/naas_abi_cli/cli/__init__.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/__init__.py
@@ -12,11 +12,14 @@ from .docs import docs
 from .init import init
 from .module import module
 from .new import new
+from .org import org
 from .run import run
 from .secret import secrets
 from .setup import setup
 from .snapshot import snapshot
 from .stack import logs, stack, start, stop
+from .user import user
+from .workspace import workspace
 
 
 @click.group("abi")
@@ -41,6 +44,9 @@ _main.add_command(logs)
 stack.add_command(snapshot)
 _main.add_command(stack)
 _main.add_command(dev)
+_main.add_command(workspace)
+_main.add_command(user)
+_main.add_command(org)
 ran = False
 
 

--- a/libs/naas-abi-cli/naas_abi_cli/cli/nexus_admin_test.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/nexus_admin_test.py
@@ -1,0 +1,249 @@
+"""Tests for Nexus workspace/user/org admin CLI (parsing + dry-run)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from naas_abi_cli.cli import _main
+from naas_abi_cli.cli import nexus_client
+from naas_abi_cli.cli.nexus_postgres import create_user_sql, create_workspace_sql, esc
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_workspace_create_dry_run(runner: CliRunner) -> None:
+    result = runner.invoke(
+        _main,
+        [
+            "workspace",
+            "create",
+            "--name",
+            "Research preview",
+            "--slug",
+            "research-preview",
+            "--org",
+            "org-960fbfdd82bc",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["method"] == "POST"
+    assert payload["path"] == "/api/workspaces"
+    assert payload["body"]["slug"] == "research-preview"
+    assert payload["body"]["organization_id"] == "org-960fbfdd82bc"
+
+
+def test_workspace_list_org_dry_run(runner: CliRunner) -> None:
+    result = runner.invoke(
+        _main,
+        ["workspace", "list", "--org", "org-960fbfdd82bc", "--dry-run"],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["path"] == "/api/organizations/org-960fbfdd82bc/workspaces"
+
+
+def test_user_create_dry_run_redacts_password(runner: CliRunner) -> None:
+    result = runner.invoke(
+        _main,
+        [
+            "user",
+            "create",
+            "--email",
+            "tester@naas.ai",
+            "--name",
+            "Tester",
+            "--password",
+            "supersecret1",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["path"] == "/api/auth/register"
+    assert payload["body"]["email"] == "tester@naas.ai"
+    assert payload["body"]["password"] == "***"
+
+
+def test_user_invite_dry_run(runner: CliRunner) -> None:
+    result = runner.invoke(
+        _main,
+        [
+            "user",
+            "invite",
+            "--email",
+            "tester@naas.ai",
+            "--workspace",
+            "ws-abc",
+            "--role",
+            "member",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["path"] == "/api/workspaces/ws-abc/members/invite"
+    assert payload["body"] == {"email": "tester@naas.ai", "role": "member"}
+
+
+def test_user_list_requires_scope(runner: CliRunner) -> None:
+    result = runner.invoke(_main, ["user", "list", "--dry-run"])
+    assert result.exit_code != 0
+    assert "exactly one of --org or --workspace" in result.output
+
+
+def test_org_list_dry_run(runner: CliRunner) -> None:
+    result = runner.invoke(_main, ["org", "list", "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["path"] == "/api/organizations"
+
+
+def test_workspace_members_add_dry_run(runner: CliRunner) -> None:
+    result = runner.invoke(
+        _main,
+        [
+            "workspace",
+            "members",
+            "add",
+            "--workspace",
+            "ws-1",
+            "--email",
+            "a@b.co",
+            "--role",
+            "viewer",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["body"]["role"] == "viewer"
+
+
+def test_workspace_create_postgres_dry_run_requires_owner(runner: CliRunner) -> None:
+    result = runner.invoke(
+        _main,
+        [
+            "workspace",
+            "create",
+            "--name",
+            "X",
+            "--slug",
+            "x-workspace",
+            "--org",
+            "org-1",
+            "--via",
+            "postgres",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "--owner-id is required" in result.output
+
+
+def test_workspace_create_postgres_dry_run_prints_sql(runner: CliRunner) -> None:
+    result = runner.invoke(
+        _main,
+        [
+            "workspace",
+            "create",
+            "--name",
+            "Jeremy Ravenel",
+            "--slug",
+            "jeremy-ravenel",
+            "--org",
+            "org-960fbfdd82bc",
+            "--owner-id",
+            "user-0d9665ad586d",
+            "--via",
+            "postgres",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "INSERT INTO workspaces" in result.output
+    assert "jeremy-ravenel" in result.output
+    assert "user-0d9665ad586d" in result.output
+
+
+def test_create_user_sql_contains_memberships(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Bcrypt:
+        @staticmethod
+        def gensalt() -> bytes:
+            return b"$2b$12$abcdefghijklmnopqrstuv"
+
+        @staticmethod
+        def hashpw(password: bytes, salt: bytes) -> bytes:
+            return b"$2b$12$hashed"
+
+    monkeypatch.setitem(__import__("sys").modules, "bcrypt", _Bcrypt)
+    # Force re-import path: create_user_sql imports bcrypt inside the function.
+    sql, user_id = create_user_sql(
+        email="a@naas.ai",
+        name="A",
+        password="password12",
+        organization_id="org-1",
+        workspace_id="ws-1",
+    )
+    assert user_id.startswith("user-")
+    assert "INSERT INTO users" in sql
+    assert "organization_members" in sql
+    assert "workspace_members" in sql
+    assert "a@naas.ai" in sql
+
+
+def test_create_workspace_sql_escapes_quotes() -> None:
+    sql, ws_id = create_workspace_sql(
+        name="O'Brien Lab",
+        slug="obrien-lab",
+        owner_id="user-1",
+        organization_id="org-1",
+    )
+    assert ws_id.startswith("ws-")
+    assert "O''Brien Lab" in sql
+    assert esc("a'b") == "a''b"
+
+
+def test_client_get_sends_bearer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class _Resp:
+        def read(self) -> bytes:
+            return b'[{"id":"ws-1"}]'
+
+        def __enter__(self) -> "_Resp":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    def fake_urlopen(req: Any, timeout: float = 0) -> _Resp:
+        captured["url"] = req.full_url
+        captured["headers"] = dict(req.headers)
+        captured["method"] = req.get_method()
+        return _Resp()
+
+    monkeypatch.setattr(nexus_client.urllib.request, "urlopen", fake_urlopen)
+    client = nexus_client.NexusClient(api_url="http://nexus.test", access_token="tok")
+    rows = client.get("/api/workspaces")
+    assert rows == [{"id": "ws-1"}]
+    assert captured["url"] == "http://nexus.test/api/workspaces"
+    assert captured["headers"]["Authorization"] == "Bearer tok"
+    assert captured["method"] == "GET"
+
+
+def test_help_lists_new_groups(runner: CliRunner) -> None:
+    result = runner.invoke(_main, ["--help"])
+    assert result.exit_code == 0
+    assert "workspace" in result.output
+    assert "user" in result.output
+    assert "org" in result.output

--- a/libs/naas-abi-cli/naas_abi_cli/cli/nexus_admin_test.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/nexus_admin_test.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import Any, Self
 
 import pytest
 from click.testing import CliRunner
 
-from naas_abi_cli.cli import _main
-from naas_abi_cli.cli import nexus_client
+from naas_abi_cli.cli import _main, nexus_client
 from naas_abi_cli.cli.nexus_postgres import create_user_sql, create_workspace_sql, esc
 
 
@@ -220,7 +219,7 @@ def test_client_get_sends_bearer(
         def read(self) -> bytes:
             return b'[{"id":"ws-1"}]'
 
-        def __enter__(self) -> "_Resp":
+        def __enter__(self) -> Self:
             return self
 
         def __exit__(self, *args: object) -> None:

--- a/libs/naas-abi-cli/naas_abi_cli/cli/nexus_client.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/nexus_client.py
@@ -17,7 +17,6 @@ import urllib.request
 from dataclasses import dataclass
 from typing import Any
 
-
 DEFAULT_NEXUS_API_URL = "http://localhost:9879"
 
 
@@ -43,7 +42,7 @@ class NexusClient:
         token: str | None = None,
         email: str | None = None,
         password: str | None = None,
-    ) -> "NexusClient":
+    ) -> NexusClient:
         base = (api_url or os.getenv("NEXUS_API_URL") or DEFAULT_NEXUS_API_URL).rstrip(
             "/"
         )
@@ -131,7 +130,7 @@ def click_auth_error() -> RuntimeError:
 def _read_error_detail(exc: urllib.error.HTTPError) -> str:
     try:
         raw = exc.read().decode("utf-8")
-    except Exception:
+    except (OSError, ValueError, AttributeError):
         return exc.reason or str(exc)
     try:
         payload = json.loads(raw)

--- a/libs/naas-abi-cli/naas_abi_cli/cli/nexus_client.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/nexus_client.py
@@ -1,0 +1,215 @@
+"""Thin authenticated client for Nexus HTTP admin APIs.
+
+Auth resolution order:
+1. Explicit access token (`--token` / `NEXUS_ACCESS_TOKEN`)
+2. Email + password login (`--email`/`--password` or `NEXUS_EMAIL`/`NEXUS_PASSWORD`)
+
+Base URL: `--api-url` / `NEXUS_API_URL` (default `http://localhost:9879`).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Any
+
+
+DEFAULT_NEXUS_API_URL = "http://localhost:9879"
+
+
+class NexusApiError(RuntimeError):
+    def __init__(self, status: int, detail: str, path: str) -> None:
+        self.status = status
+        self.detail = detail
+        self.path = path
+        super().__init__(f"Nexus API {status} on {path}: {detail}")
+
+
+@dataclass
+class NexusClient:
+    api_url: str
+    access_token: str
+    timeout_s: float = 30.0
+
+    @classmethod
+    def from_env(
+        cls,
+        *,
+        api_url: str | None = None,
+        token: str | None = None,
+        email: str | None = None,
+        password: str | None = None,
+    ) -> "NexusClient":
+        base = (api_url or os.getenv("NEXUS_API_URL") or DEFAULT_NEXUS_API_URL).rstrip(
+            "/"
+        )
+        access = token or os.getenv("NEXUS_ACCESS_TOKEN")
+        if not access:
+            login_email = email or os.getenv("NEXUS_EMAIL")
+            login_password = password or os.getenv("NEXUS_PASSWORD")
+            if not login_email or not login_password:
+                raise click_auth_error()
+            access = cls._login(base, login_email, login_password)
+        return cls(api_url=base, access_token=access)
+
+    @staticmethod
+    def _login(api_url: str, email: str, password: str) -> str:
+        body = json.dumps({"email": email, "password": password}).encode("utf-8")
+        req = urllib.request.Request(
+            f"{api_url}/api/auth/login",
+            data=body,
+            method="POST",
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=30.0) as resp:
+                payload = json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            detail = _read_error_detail(exc)
+            raise NexusApiError(exc.code, detail, "/api/auth/login") from exc
+        token = payload.get("access_token")
+        if not token:
+            raise NexusApiError(500, "login response missing access_token", "/api/auth/login")
+        return str(token)
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_body: dict[str, Any] | None = None,
+        form_body: dict[str, str] | None = None,
+    ) -> Any:
+        url = f"{self.api_url}{path}"
+        headers = {
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.access_token}",
+        }
+        data: bytes | None = None
+        if json_body is not None:
+            data = json.dumps(json_body).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        elif form_body is not None:
+            data = urllib.parse.urlencode(form_body).encode("utf-8")
+            headers["Content-Type"] = "application/x-www-form-urlencoded"
+
+        req = urllib.request.Request(url, data=data, method=method.upper(), headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout_s) as resp:
+                raw = resp.read()
+                if not raw:
+                    return None
+                return json.loads(raw.decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            raise NexusApiError(exc.code, _read_error_detail(exc), path) from exc
+
+    def get(self, path: str) -> Any:
+        return self.request("GET", path)
+
+    def post(self, path: str, json_body: dict[str, Any] | None = None) -> Any:
+        return self.request("POST", path, json_body=json_body or {})
+
+    def patch(self, path: str, json_body: dict[str, Any]) -> Any:
+        return self.request("PATCH", path, json_body=json_body)
+
+    def delete(self, path: str) -> Any:
+        return self.request("DELETE", path)
+
+
+def click_auth_error() -> RuntimeError:
+    return RuntimeError(
+        "Nexus auth required. Set NEXUS_ACCESS_TOKEN, or NEXUS_EMAIL + NEXUS_PASSWORD "
+        "(or pass --token / --email --password). Base URL via NEXUS_API_URL "
+        f"(default {DEFAULT_NEXUS_API_URL})."
+    )
+
+
+def _read_error_detail(exc: urllib.error.HTTPError) -> str:
+    try:
+        raw = exc.read().decode("utf-8")
+    except Exception:
+        return exc.reason or str(exc)
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return raw or (exc.reason or str(exc))
+    detail = payload.get("detail", payload)
+    if isinstance(detail, (dict, list)):
+        return json.dumps(detail)
+    return str(detail)
+
+
+def common_api_options(fn):  # type: ignore[no-untyped-def]
+    """Decorator stacking shared Nexus API connection options onto a click command."""
+    import click
+
+    opts = [
+        click.option(
+            "--api-url",
+            envvar="NEXUS_API_URL",
+            default=DEFAULT_NEXUS_API_URL,
+            show_default=True,
+            help="Nexus API base URL (no trailing slash).",
+        ),
+        click.option(
+            "--token",
+            envvar="NEXUS_ACCESS_TOKEN",
+            default=None,
+            help="Bearer access token (preferred over email/password).",
+        ),
+        click.option(
+            "--auth-email",
+            "email",
+            envvar="NEXUS_EMAIL",
+            default=None,
+            help="Login email when no token is set (env: NEXUS_EMAIL).",
+        ),
+        click.option(
+            "--auth-password",
+            "password",
+            envvar="NEXUS_PASSWORD",
+            default=None,
+            help="Login password when no token is set (env: NEXUS_PASSWORD).",
+        ),
+        click.option(
+            "--dry-run",
+            is_flag=True,
+            default=False,
+            help="Print the intended API call without executing it.",
+        ),
+    ]
+    for opt in reversed(opts):
+        fn = opt(fn)
+    return fn
+
+
+def build_client(
+    *,
+    api_url: str,
+    token: str | None,
+    email: str | None,
+    password: str | None,
+) -> NexusClient:
+    return NexusClient.from_env(
+        api_url=api_url, token=token, email=email, password=password
+    )
+
+
+def print_json(payload: Any) -> None:
+    print(json.dumps(payload, indent=2, default=str, sort_keys=True))
+
+
+def print_table(rows: list[dict[str, Any]], columns: list[str], title: str) -> None:
+    from rich.console import Console
+    from rich.table import Table
+
+    table = Table(title=title, show_header=True, header_style="bold magenta")
+    for col in columns:
+        table.add_column(col, overflow="fold")
+    for row in rows:
+        table.add_row(*[str(row.get(col, "") or "") for col in columns])
+    Console().print(table)

--- a/libs/naas-abi-cli/naas_abi_cli/cli/nexus_postgres.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/nexus_postgres.py
@@ -1,0 +1,138 @@
+"""Break-glass Postgres helpers for Nexus user/workspace ops (Zen VM SOP).
+
+Preferred path is the authenticated Nexus HTTP API. Use this only when browser
+auth / password registration is unavailable, typically on `abi-naas-app` via:
+
+  NEXUS_POSTGRES_COMPOSE_DIR=/opt/zen/zen
+  abi user create --via postgres --email ... --name ...
+
+Requires `bcrypt` at runtime for password hashing.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import subprocess
+import uuid
+from pathlib import Path
+
+
+def esc(value: str) -> str:
+    return value.replace("'", "''")
+
+
+def create_user_sql(
+    *,
+    email: str,
+    name: str,
+    password: str,
+    organization_id: str | None = None,
+    org_role: str = "member",
+    workspace_id: str | None = None,
+    workspace_role: str = "member",
+) -> tuple[str, str]:
+    try:
+        import bcrypt
+    except ImportError as exc:  # pragma: no cover - env dependent
+        raise RuntimeError(
+            "bcrypt is required for --via postgres. Install it in the runtime env."
+        ) from exc
+
+    user_id = f"user-{secrets.token_hex(6)}"
+    hashed = bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+    statements = [
+        "BEGIN;",
+        (
+            "INSERT INTO users (id, email, name, hashed_password, is_superadmin, "
+            "created_at, updated_at) VALUES ("
+            f"'{esc(user_id)}', '{esc(email)}', '{esc(name)}', '{esc(hashed)}', "
+            "false, NOW(), NOW());"
+        ),
+    ]
+    if organization_id:
+        statements.append(
+            "INSERT INTO organization_members (id, organization_id, user_id, role, created_at) "
+            f"VALUES ('{esc(str(uuid.uuid4()))}', '{esc(organization_id)}', "
+            f"'{esc(user_id)}', '{esc(org_role)}', NOW());"
+        )
+    if workspace_id:
+        statements.append(
+            "INSERT INTO workspace_members (id, workspace_id, user_id, role, created_at) "
+            f"VALUES ('{esc(str(uuid.uuid4()))}', '{esc(workspace_id)}', "
+            f"'{esc(user_id)}', '{esc(workspace_role)}', NOW());"
+        )
+    statements.append("COMMIT;")
+    statements.append(
+        f"SELECT id, email, name FROM users WHERE id='{esc(user_id)}';"
+    )
+    return "\n".join(statements) + "\n", user_id
+
+
+def create_workspace_sql(
+    *,
+    name: str,
+    slug: str,
+    owner_id: str,
+    organization_id: str,
+) -> tuple[str, str]:
+    ws_id = f"ws-{secrets.token_hex(6)}"
+    member_id = str(uuid.uuid4())
+    sql = f"""
+BEGIN;
+INSERT INTO workspaces (id, name, slug, owner_id, organization_id, primary_color, created_at, updated_at)
+VALUES ('{esc(ws_id)}', '{esc(name)}', '{esc(slug)}', '{esc(owner_id)}', '{esc(organization_id)}', '#22c55e', NOW(), NOW());
+INSERT INTO workspace_members (id, workspace_id, user_id, role, created_at)
+VALUES ('{esc(member_id)}', '{esc(ws_id)}', '{esc(owner_id)}', 'owner', NOW());
+COMMIT;
+SELECT id, name, slug, organization_id, owner_id FROM workspaces WHERE id='{esc(ws_id)}';
+"""
+    return sql, ws_id
+
+
+def run_postgres_sql(sql: str) -> str:
+    """Execute SQL against Nexus Postgres via docker compose on the ops VM."""
+    compose_dir = os.getenv("NEXUS_POSTGRES_COMPOSE_DIR")
+    if not compose_dir:
+        raise RuntimeError(
+            "Set NEXUS_POSTGRES_COMPOSE_DIR to the Zen compose directory "
+            "(e.g. /opt/zen/zen) before using --via postgres."
+        )
+    root = Path(compose_dir)
+    gcp = root / "docker-compose.gcp.yml"
+    cmd = [
+        "sudo",
+        "docker",
+        "compose",
+        "-f",
+        "docker-compose.yml",
+    ]
+    if gcp.exists():
+        cmd.extend(["-f", "docker-compose.gcp.yml"])
+    cmd.extend(
+        [
+            "exec",
+            "-T",
+            "postgres",
+            "psql",
+            "-U",
+            os.getenv("NEXUS_POSTGRES_USER", "abi"),
+            "-d",
+            os.getenv("NEXUS_POSTGRES_DB", "nexus"),
+            "-v",
+            "ON_ERROR_STOP=1",
+        ]
+    )
+    proc = subprocess.run(
+        cmd,
+        input=sql,
+        text=True,
+        cwd=str(root),
+        capture_output=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"postgres exec failed ({proc.returncode}): {proc.stderr or proc.stdout}"
+        )
+    return proc.stdout

--- a/libs/naas-abi-cli/naas_abi_cli/cli/org.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/org.py
@@ -1,0 +1,188 @@
+"""Nexus organization admin commands."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import click
+
+from .nexus_client import (
+    NexusApiError,
+    build_client,
+    common_api_options,
+    print_json,
+    print_table,
+)
+
+
+@click.group("org")
+def org() -> None:
+    """Manage Nexus organizations via the authenticated API."""
+
+
+@org.command("list")
+@common_api_options
+def org_list(
+    api_url: str,
+    token: str | None,
+    email: str | None,
+    password: str | None,
+    dry_run: bool,
+) -> None:
+    """List organizations for the authenticated user."""
+    if dry_run:
+        print_json({"method": "GET", "path": "/api/organizations"})
+        return
+    client = build_client(api_url=api_url, token=token, email=email, password=password)
+    try:
+        rows = client.get("/api/organizations")
+    except NexusApiError as exc:
+        raise click.ClickException(str(exc)) from exc
+    if not isinstance(rows, list):
+        print_json(rows)
+        return
+    print_table(rows, ["id", "name", "slug"], title="Organizations")
+
+
+@org.command("create")
+@click.option("--name", required=True, help="Organization display name.")
+@click.option("--slug", required=True, help="URL-safe slug.")
+@common_api_options
+def org_create(
+    name: str,
+    slug: str,
+    api_url: str,
+    token: str | None,
+    email: str | None,
+    password: str | None,
+    dry_run: bool,
+) -> None:
+    """Create an organization (caller becomes owner)."""
+    body = {"name": name, "slug": slug}
+    if dry_run:
+        print_json({"method": "POST", "path": "/api/organizations", "body": body})
+        return
+    client = build_client(api_url=api_url, token=token, email=email, password=password)
+    try:
+        print_json(client.post("/api/organizations", body))
+    except NexusApiError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@org.command("get")
+@click.option("--id", "org_id", required=True, help="Organization id (org-...).")
+@common_api_options
+def org_get(
+    org_id: str,
+    api_url: str,
+    token: str | None,
+    email: str | None,
+    password: str | None,
+    dry_run: bool,
+) -> None:
+    """Fetch an organization by id."""
+    path = f"/api/organizations/{org_id}"
+    if dry_run:
+        print_json({"method": "GET", "path": path})
+        return
+    client = build_client(api_url=api_url, token=token, email=email, password=password)
+    try:
+        print_json(client.get(path))
+    except NexusApiError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@org.group("members")
+def org_members() -> None:
+    """Organization membership operations."""
+
+
+@org_members.command("list")
+@click.option("--org", "org_id", required=True, help="Organization id (org-...).")
+@common_api_options
+def org_members_list(
+    org_id: str,
+    api_url: str,
+    token: str | None,
+    email: str | None,
+    password: str | None,
+    dry_run: bool,
+) -> None:
+    """List organization members."""
+    path = f"/api/organizations/{org_id}/members"
+    if dry_run:
+        print_json({"method": "GET", "path": path})
+        return
+    client = build_client(api_url=api_url, token=token, email=email, password=password)
+    try:
+        rows = client.get(path)
+    except NexusApiError as exc:
+        raise click.ClickException(str(exc)) from exc
+    if not isinstance(rows, list):
+        print_json(rows)
+        return
+    print_table(rows, ["user_id", "email", "name", "role"], title=f"Members of {org_id}")
+
+
+@org_members.command("invite")
+@click.option("--org", "org_id", required=True, help="Organization id (org-...).")
+@click.option("--email", "member_email", required=True, help="Existing user email.")
+@click.option(
+    "--role",
+    default="member",
+    show_default=True,
+    type=click.Choice(["owner", "admin", "member"], case_sensitive=False),
+)
+@common_api_options
+def org_members_invite(
+    org_id: str,
+    member_email: str,
+    role: str,
+    api_url: str,
+    token: str | None,
+    email: str | None,
+    password: str | None,
+    dry_run: bool,
+) -> None:
+    """Invite an existing user into an organization."""
+    path = f"/api/organizations/{org_id}/members/invite"
+    body: dict[str, Any] = {"email": member_email, "role": role.lower()}
+    if dry_run:
+        print_json({"method": "POST", "path": path, "body": body})
+        return
+    client = build_client(api_url=api_url, token=token, email=email, password=password)
+    try:
+        print_json(client.post(path, body))
+    except NexusApiError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@org.command("workspaces")
+@click.option("--org", "org_id", required=True, help="Organization id (org-...).")
+@common_api_options
+def org_workspaces(
+    org_id: str,
+    api_url: str,
+    token: str | None,
+    email: str | None,
+    password: str | None,
+    dry_run: bool,
+) -> None:
+    """List workspaces under an organization."""
+    path = f"/api/organizations/{org_id}/workspaces"
+    if dry_run:
+        print_json({"method": "GET", "path": path})
+        return
+    client = build_client(api_url=api_url, token=token, email=email, password=password)
+    try:
+        rows = client.get(path)
+    except NexusApiError as exc:
+        raise click.ClickException(str(exc)) from exc
+    if not isinstance(rows, list):
+        print_json(rows)
+        return
+    print_table(
+        rows,
+        ["id", "name", "slug", "owner_id"],
+        title=f"Workspaces in {org_id}",
+    )

--- a/libs/naas-abi-cli/naas_abi_cli/cli/user.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/user.py
@@ -1,0 +1,374 @@
+"""Nexus user admin commands."""
+
+from __future__ import annotations
+
+import os
+import secrets
+from pathlib import Path
+from typing import Any
+
+import click
+
+from .nexus_client import (
+    NexusApiError,
+    build_client,
+    common_api_options,
+    print_json,
+    print_table,
+)
+from .nexus_postgres import create_user_sql, run_postgres_sql
+
+
+def _register_user(*, api_url: str, body: dict[str, Any]) -> Any:
+    """Public register endpoint (no bearer token)."""
+    import json
+    import urllib.error
+    import urllib.request
+
+    raw = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        f"{api_url.rstrip('/')}/api/auth/register",
+        data=raw,
+        method="POST",
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30.0) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        from .nexus_client import _read_error_detail
+
+        raise NexusApiError(exc.code, _read_error_detail(exc), "/api/auth/register") from exc
+
+
+@click.group("user")
+def user() -> None:
+    """Manage Nexus users via the authenticated API (or break-glass Postgres)."""
+
+
+@user.command("create")
+@click.option("--email", "user_email", required=True, help="User email.")
+@click.option("--name", "user_name", required=True, help="Display name.")
+@click.option(
+    "--password",
+    "user_password",
+    default=None,
+    help="Initial password (generated if omitted). Never printed unless --show-password.",
+)
+@click.option(
+    "--workspace",
+    "workspace_id",
+    default=None,
+    help="Optional workspace id to invite the user into after create.",
+)
+@click.option(
+    "--role",
+    default="member",
+    show_default=True,
+    type=click.Choice(["admin", "member", "viewer"], case_sensitive=False),
+    help="Workspace role when --workspace is set.",
+)
+@click.option(
+    "--org",
+    "organization_id",
+    default=None,
+    help="Optional organization id to invite the user into after create.",
+)
+@click.option(
+    "--org-role",
+    default="member",
+    show_default=True,
+    type=click.Choice(["owner", "admin", "member"], case_sensitive=False),
+)
+@click.option(
+    "--secret-file",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Write credentials here (mode 600). Default: secrets/NEXUS_USER_<EMAIL>.env",
+)
+@click.option(
+    "--show-password",
+    is_flag=True,
+    default=False,
+    help="Echo the password to stdout (off by default).",
+)
+@click.option(
+    "--via",
+    "via",
+    type=click.Choice(["api", "postgres"], case_sensitive=False),
+    default="api",
+    show_default=True,
+    help="api: POST /api/auth/register. postgres: break-glass SQL (Zen ops only).",
+)
+@common_api_options
+def user_create(
+    user_email: str,
+    user_name: str,
+    user_password: str | None,
+    workspace_id: str | None,
+    role: str,
+    organization_id: str | None,
+    org_role: str,
+    secret_file: Path | None,
+    show_password: bool,
+    via: str,
+    api_url: str,
+    token: str | None,
+    email: str | None,
+    password: str | None,
+    dry_run: bool,
+) -> None:
+    """Create a user.
+
+    API path uses `/api/auth/register` (requires password auth enabled on the
+    Nexus instance). On production Zen where password auth is disabled, use
+    magic-link signup or `--via postgres` on the VM (documented break-glass).
+    """
+    password_value = user_password or secrets.token_urlsafe(18)
+    if via.lower() == "postgres":
+        _create_via_postgres(
+            user_email=user_email,
+            user_name=user_name,
+            password_value=password_value,
+            organization_id=organization_id,
+            workspace_id=workspace_id,
+            workspace_role=role.lower(),
+            org_role=org_role.lower(),
+            secret_file=secret_file,
+            show_password=show_password,
+            dry_run=dry_run,
+        )
+        return
+
+    body = {"email": user_email, "name": user_name, "password": password_value}
+    if dry_run:
+        redacted = {**body, "password": "***"}
+        print_json({"method": "POST", "path": "/api/auth/register", "body": redacted})
+        return
+
+    try:
+        result = _register_user(api_url=api_url, body=body)
+    except NexusApiError as exc:
+        if exc.status == 410:
+            raise click.ClickException(
+                "Password registration is disabled on this Nexus instance. "
+                "Use magic-link signup, config seed (settings.users), or "
+                "`abi user create --via postgres` on the VM (break-glass)."
+            ) from exc
+        raise click.ClickException(str(exc)) from exc
+
+    user_payload = result.get("user") if isinstance(result, dict) else None
+    user_id = (user_payload or {}).get("id")
+
+    invite_results: list[dict[str, Any]] = []
+    if workspace_id or organization_id:
+        client = build_client(
+            api_url=api_url, token=token, email=email, password=password
+        )
+        if workspace_id:
+            try:
+                invite_results.append(
+                    client.post(
+                        f"/api/workspaces/{workspace_id}/members/invite",
+                        {"email": user_email, "role": role.lower()},
+                    )
+                )
+            except NexusApiError as exc:
+                raise click.ClickException(
+                    f"User created ({user_id}) but workspace invite failed: {exc}"
+                ) from exc
+        if organization_id:
+            try:
+                invite_results.append(
+                    client.post(
+                        f"/api/organizations/{organization_id}/members/invite",
+                        {"email": user_email, "role": org_role.lower()},
+                    )
+                )
+            except NexusApiError as exc:
+                raise click.ClickException(
+                    f"User created ({user_id}) but org invite failed: {exc}"
+                ) from exc
+
+    secret_path = _write_secret_file(
+        secret_file=secret_file,
+        user_email=user_email,
+        user_id=str(user_id or ""),
+        password_value=password_value,
+        workspace_id=workspace_id,
+    )
+
+    out: dict[str, Any] = {
+        "user": user_payload,
+        "secret_file": str(secret_path) if secret_path else None,
+        "invites": invite_results,
+    }
+    if show_password:
+        out["password"] = password_value
+    print_json(out)
+
+
+@user.command("invite")
+@click.option("--email", "member_email", required=True, help="Existing user email.")
+@click.option("--workspace", "workspace_id", required=True, help="Workspace id (ws-...).")
+@click.option(
+    "--role",
+    default="member",
+    show_default=True,
+    type=click.Choice(["admin", "member", "viewer"], case_sensitive=False),
+)
+@common_api_options
+def user_invite(
+    member_email: str,
+    workspace_id: str,
+    role: str,
+    api_url: str,
+    token: str | None,
+    email: str | None,
+    password: str | None,
+    dry_run: bool,
+) -> None:
+    """Invite an existing user to a workspace (alias of workspace members add)."""
+    path = f"/api/workspaces/{workspace_id}/members/invite"
+    body = {"email": member_email, "role": role.lower()}
+    if dry_run:
+        print_json({"method": "POST", "path": path, "body": body})
+        return
+    client = build_client(api_url=api_url, token=token, email=email, password=password)
+    try:
+        print_json(client.post(path, body))
+    except NexusApiError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@user.command("list")
+@click.option("--org", "organization_id", default=None, help="List organization members.")
+@click.option(
+    "--workspace",
+    "workspace_id",
+    default=None,
+    help="List workspace members.",
+)
+@common_api_options
+def user_list(
+    organization_id: str | None,
+    workspace_id: str | None,
+    api_url: str,
+    token: str | None,
+    email: str | None,
+    password: str | None,
+    dry_run: bool,
+) -> None:
+    """List users in an org or workspace (no global admin user index API today)."""
+    if bool(organization_id) == bool(workspace_id):
+        raise click.ClickException("Provide exactly one of --org or --workspace.")
+    path = (
+        f"/api/organizations/{organization_id}/members"
+        if organization_id
+        else f"/api/workspaces/{workspace_id}/members"
+    )
+    if dry_run:
+        print_json({"method": "GET", "path": path})
+        return
+    client = build_client(api_url=api_url, token=token, email=email, password=password)
+    try:
+        rows = client.get(path)
+    except NexusApiError as exc:
+        raise click.ClickException(str(exc)) from exc
+    if not isinstance(rows, list):
+        print_json(rows)
+        return
+    print_table(
+        rows,
+        ["user_id", "email", "name", "role"],
+        title="Users",
+    )
+
+
+@user.command("me")
+@common_api_options
+def user_me(
+    api_url: str,
+    token: str | None,
+    email: str | None,
+    password: str | None,
+    dry_run: bool,
+) -> None:
+    """Show the authenticated Nexus user (`GET /api/auth/me`)."""
+    if dry_run:
+        print_json({"method": "GET", "path": "/api/auth/me"})
+        return
+    client = build_client(api_url=api_url, token=token, email=email, password=password)
+    try:
+        print_json(client.get("/api/auth/me"))
+    except NexusApiError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+def _write_secret_file(
+    *,
+    secret_file: Path | None,
+    user_email: str,
+    user_id: str,
+    password_value: str,
+    workspace_id: str | None,
+) -> Path | None:
+    if secret_file is None:
+        safe = user_email.upper().replace("@", "_").replace(".", "_").replace("-", "_")
+        secret_file = Path("secrets") / f"NEXUS_USER_{safe}.env"
+    secret_file.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        f"email={user_email}",
+        f"user_id={user_id}",
+        f"password={password_value}",
+    ]
+    if workspace_id:
+        lines.append(f"workspace_id={workspace_id}")
+    secret_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    os.chmod(secret_file, 0o600)
+    return secret_file
+
+
+def _create_via_postgres(
+    *,
+    user_email: str,
+    user_name: str,
+    password_value: str,
+    organization_id: str | None,
+    workspace_id: str | None,
+    workspace_role: str,
+    org_role: str,
+    secret_file: Path | None,
+    show_password: bool,
+    dry_run: bool,
+) -> None:
+    sql, user_id = create_user_sql(
+        email=user_email,
+        name=user_name,
+        password=password_value,
+        organization_id=organization_id,
+        org_role=org_role,
+        workspace_id=workspace_id,
+        workspace_role=workspace_role,
+    )
+    if dry_run:
+        print(sql)
+        return
+    run_postgres_sql(sql)
+    secret_path = _write_secret_file(
+        secret_file=secret_file,
+        user_email=user_email,
+        user_id=user_id,
+        password_value=password_value,
+        workspace_id=workspace_id,
+    )
+    out: dict[str, Any] = {
+        "via": "postgres",
+        "user_id": user_id,
+        "email": user_email,
+        "name": user_name,
+        "secret_file": str(secret_path) if secret_path else None,
+    }
+    if show_password:
+        out["password"] = password_value
+    print_json(out)

--- a/libs/naas-abi-cli/naas_abi_cli/cli/workspace.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/workspace.py
@@ -1,0 +1,276 @@
+"""Nexus workspace admin commands."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import click
+
+from .nexus_client import (
+    NexusApiError,
+    build_client,
+    common_api_options,
+    print_json,
+    print_table,
+)
+from .nexus_postgres import create_workspace_sql, run_postgres_sql
+
+
+@click.group("workspace")
+def workspace() -> None:
+    """Manage Nexus workspaces via the authenticated API."""
+
+
+@workspace.command("create")
+@click.option("--name", required=True, help="Workspace display name.")
+@click.option("--slug", required=True, help="URL-safe slug (lowercase, digits, hyphens).")
+@click.option(
+    "--org",
+    "organization_id",
+    required=True,
+    help="Organization id (e.g. org-960fbfdd82bc).",
+)
+@click.option(
+    "--owner-id",
+    default=None,
+    help="Owner user id (required for --via postgres; API path always uses the caller).",
+)
+@click.option(
+    "--via",
+    type=click.Choice(["api", "postgres"], case_sensitive=False),
+    default="api",
+    show_default=True,
+    help="api: POST /api/workspaces. postgres: break-glass SQL (Zen ops only).",
+)
+@common_api_options
+def workspace_create(
+    name: str,
+    slug: str,
+    organization_id: str,
+    owner_id: str | None,
+    via: str,
+    api_url: str,
+    token: str | None,
+    email: str | None,
+    password: str | None,
+    dry_run: bool,
+) -> None:
+    """Create a workspace under an organization (API caller becomes owner)."""
+    if via.lower() == "postgres":
+        if not owner_id:
+            raise click.ClickException("--owner-id is required with --via postgres.")
+        sql, ws_id = create_workspace_sql(
+            name=name,
+            slug=slug,
+            owner_id=owner_id,
+            organization_id=organization_id,
+        )
+        if dry_run:
+            print(sql)
+            return
+        out = run_postgres_sql(sql)
+        print_json({"via": "postgres", "id": ws_id, "slug": slug, "postgres_output": out})
+        return
+
+    body = {"name": name, "slug": slug, "organization_id": organization_id}
+    if dry_run:
+        print_json({"method": "POST", "path": "/api/workspaces", "body": body})
+        return
+    client = build_client(api_url=api_url, token=token, email=email, password=password)
+    try:
+        result = client.post("/api/workspaces", body)
+    except NexusApiError as exc:
+        raise click.ClickException(str(exc)) from exc
+    print_json(result)
+
+
+@workspace.command("list")
+@click.option(
+    "--org",
+    "organization_id",
+    default=None,
+    help="If set, list workspaces for this organization instead of the caller's memberships.",
+)
+@common_api_options
+def workspace_list(
+    organization_id: str | None,
+    api_url: str,
+    token: str | None,
+    email: str | None,
+    password: str | None,
+    dry_run: bool,
+) -> None:
+    """List workspaces visible to the authenticated user (or under --org)."""
+    path = (
+        f"/api/organizations/{organization_id}/workspaces"
+        if organization_id
+        else "/api/workspaces"
+    )
+    if dry_run:
+        print_json({"method": "GET", "path": path})
+        return
+    client = build_client(api_url=api_url, token=token, email=email, password=password)
+    try:
+        rows = client.get(path)
+    except NexusApiError as exc:
+        raise click.ClickException(str(exc)) from exc
+    if not isinstance(rows, list):
+        print_json(rows)
+        return
+    print_table(
+        rows,
+        ["id", "name", "slug", "organization_id", "owner_id"],
+        title="Workspaces",
+    )
+
+
+@workspace.command("get")
+@click.option("--id", "workspace_id", default=None, help="Workspace id (ws-...).")
+@click.option("--slug", default=None, help="Workspace slug.")
+@common_api_options
+def workspace_get(
+    workspace_id: str | None,
+    slug: str | None,
+    api_url: str,
+    token: str | None,
+    email: str | None,
+    password: str | None,
+    dry_run: bool,
+) -> None:
+    """Fetch a workspace by id or slug."""
+    if bool(workspace_id) == bool(slug):
+        raise click.ClickException("Provide exactly one of --id or --slug.")
+    path = f"/api/workspaces/{workspace_id}" if workspace_id else f"/api/workspaces/slug/{slug}"
+    if dry_run:
+        print_json({"method": "GET", "path": path})
+        return
+    client = build_client(api_url=api_url, token=token, email=email, password=password)
+    try:
+        print_json(client.get(path))
+    except NexusApiError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@workspace.command("delete")
+@click.option("--id", "workspace_id", required=True, help="Workspace id (ws-...).")
+@click.option("--yes", is_flag=True, default=False, help="Skip confirmation.")
+@common_api_options
+def workspace_delete(
+    workspace_id: str,
+    yes: bool,
+    api_url: str,
+    token: str | None,
+    email: str | None,
+    password: str | None,
+    dry_run: bool,
+) -> None:
+    """Delete a workspace (owner only)."""
+    path = f"/api/workspaces/{workspace_id}"
+    if dry_run:
+        print_json({"method": "DELETE", "path": path})
+        return
+    if not yes and not click.confirm(f"Delete workspace {workspace_id}?"):
+        raise click.Abort()
+    client = build_client(api_url=api_url, token=token, email=email, password=password)
+    try:
+        print_json(client.delete(path))
+    except NexusApiError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@workspace.group("members")
+def workspace_members() -> None:
+    """Workspace membership operations."""
+
+
+@workspace_members.command("list")
+@click.option("--workspace", "workspace_id", required=True, help="Workspace id (ws-...).")
+@common_api_options
+def workspace_members_list(
+    workspace_id: str,
+    api_url: str,
+    token: str | None,
+    email: str | None,
+    password: str | None,
+    dry_run: bool,
+) -> None:
+    """List members of a workspace."""
+    path = f"/api/workspaces/{workspace_id}/members"
+    if dry_run:
+        print_json({"method": "GET", "path": path})
+        return
+    client = build_client(api_url=api_url, token=token, email=email, password=password)
+    try:
+        rows = client.get(path)
+    except NexusApiError as exc:
+        raise click.ClickException(str(exc)) from exc
+    if not isinstance(rows, list):
+        print_json(rows)
+        return
+    print_table(
+        rows,
+        ["user_id", "email", "name", "role"],
+        title=f"Members of {workspace_id}",
+    )
+
+
+@workspace_members.command("add")
+@click.option("--workspace", "workspace_id", required=True, help="Workspace id (ws-...).")
+@click.option("--email", "member_email", required=True, help="Existing user email.")
+@click.option(
+    "--role",
+    default="member",
+    show_default=True,
+    type=click.Choice(["admin", "member", "viewer"], case_sensitive=False),
+)
+@common_api_options
+def workspace_members_add(
+    workspace_id: str,
+    member_email: str,
+    role: str,
+    api_url: str,
+    token: str | None,
+    email: str | None,
+    password: str | None,
+    dry_run: bool,
+) -> None:
+    """Invite an existing user into a workspace."""
+    path = f"/api/workspaces/{workspace_id}/members/invite"
+    body: dict[str, Any] = {"email": member_email, "role": role.lower()}
+    if dry_run:
+        print_json({"method": "POST", "path": path, "body": body})
+        return
+    client = build_client(api_url=api_url, token=token, email=email, password=password)
+    try:
+        print_json(client.post(path, body))
+    except NexusApiError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@workspace_members.command("remove")
+@click.option("--workspace", "workspace_id", required=True, help="Workspace id (ws-...).")
+@click.option("--user-id", required=True, help="User id to remove.")
+@click.option("--yes", is_flag=True, default=False, help="Skip confirmation.")
+@common_api_options
+def workspace_members_remove(
+    workspace_id: str,
+    user_id: str,
+    yes: bool,
+    api_url: str,
+    token: str | None,
+    email: str | None,
+    password: str | None,
+    dry_run: bool,
+) -> None:
+    """Remove a member from a workspace."""
+    path = f"/api/workspaces/{workspace_id}/members/{user_id}"
+    if dry_run:
+        print_json({"method": "DELETE", "path": path})
+        return
+    if not yes and not click.confirm(f"Remove {user_id} from {workspace_id}?"):
+        raise click.Abort()
+    client = build_client(api_url=api_url, token=token, email=email, password=password)
+    try:
+        print_json(client.delete(path))
+    except NexusApiError as exc:
+        raise click.ClickException(str(exc)) from exc


### PR DESCRIPTION
## Summary
- Add `abi workspace`, `abi user`, and `abi org` admin commands against the authenticated Nexus HTTP API (`NEXUS_API_URL` + token or email/password).
- Cover the issue must-haves (`workspace create`, `user create`, `user invite`) plus list/members/org ops, `--dry-run`, password secret-file handling (no echo by default), and documented `--via postgres` break-glass for Zen VM ops.
- Tests for command parsing, dry-run payloads, SQL helpers, and bearer client headers.
- Lint fix for ruff CI (imports / Self / narrow exception).

Partially addresses #1118 (solid first slice). Remaining:
- Dedicated admin user-create API (today: `/api/auth/register` when password auth is on, else magic-link / seed / postgres break-glass)
- Optional service-account / magic-link device flow for token acquisition
- Zen ops SOP lives in the Zen repo (`docs/sop/nexus-workspace-user-cli.md`); keep in sync after merge

## Stacking
- Wave 1 independent off `main`.
- **P7** (#1125 create-on-invite) extends CLI invite after this + #1124 + #1122.

## Test plan
- [x] `uv run pytest libs/naas-abi-cli/naas_abi_cli/cli/nexus_admin_test.py -v`
- [ ] `abi workspace create --dry-run --name Demo --slug demo-ws --org org-...`
- [ ] `abi user create --dry-run --email someone@naas.ai --name Someone`
- [ ] Against a local stack with password auth: create workspace + invite member end-to-end
- [ ] Confirm passwords land in `secrets/NEXUS_USER_*.env` and are not printed without `--show-password`