### PR TITLE
feat(nexus): wire org Users UI to member invite API

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/AGENTS.md
+++ b/libs/naas-abi/naas_abi/apps/nexus/AGENTS.md
@@ -310,6 +310,26 @@ Desktop keeps sidebar nav + content. Index redirects to `/settings/general`. Saf
 
 Pilot (full semantic CSS): `general/`. Other sections use the three-file layout and shared header; branding/billing/workspaces may still carry Tailwind in the section body until a later pass.
 
+### Users admin capability (shared API)
+
+Org **Users** and workspace **Members** are UI channels over the same Nexus HTTP admin APIs used by `abi user invite` / `abi workspace members add` / `abi org members` (CLI). Do **not** reimplement invite business logic in React; call these endpoints via `authFetch` / `useOrganizationStore`.
+
+| Action | Endpoint | Who |
+|---|---|---|
+| List org users | `GET /api/organizations/{orgId}/members` | Org member |
+| Add org user (existing account) | `POST /api/organizations/{orgId}/members/invite` `{email, role}` | Org owner/admin |
+| Update / remove org user | `PATCH` / `DELETE` `/api/organizations/{orgId}/members/{userId}` | Org owner/admin |
+| List workspace members | `GET /api/workspaces/{id}/members` | Workspace member |
+| Invite workspace member | `POST /api/workspaces/{id}/members/invite` `{email, role}` | Workspace owner/admin |
+
+Notes:
+
+- Org invite adds an **existing** user by email (`404` if unknown). New user creation is signup / seed / CLI (`abi user create`), not this form.
+- UI must hide or disable Add / Invite for non-admins; API still returns `403`.
+- **Agents:** call the same HTTP endpoints with the acting user's bearer token. Prefer thin tool wrappers over a parallel permission model. Track dedicated ABI agent tools separately if not yet in-tree.
+
+Web entry points: `organizations/[orgId]/settings/users/`, workspace `organization/users/`, workspace `settings/members/`. Store: `stores/organization.ts`.
+
 ## Maps UI module
 
 Maps is a **dataset loader**, not the Knowledge Graph. Graph stays under `/graph` (ontology network). Maps sits first in the primary nav (before Search) and loads datasets onto a canvas.

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/organizations/[orgId]/settings/users/users.css
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/organizations/[orgId]/settings/users/users.css
@@ -91,9 +91,123 @@
   color: var(--muted-foreground-hex);
 }
 
+.org-settings-users-row-end {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+
+.org-settings-users-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-1);
+  border: none;
+  border-radius: var(--org-border-radius, 0px);
+  background: transparent;
+  color: var(--muted-foreground-hex);
+  cursor: pointer;
+}
+
+.org-settings-users-remove:hover {
+  color: var(--destructive-hex, #ef4444);
+}
+
+.org-settings-users-alert {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border-radius: var(--org-border-radius, 0px);
+  background-color: color-mix(in srgb, var(--destructive-hex, #ef4444) 12%, transparent);
+  color: var(--destructive-hex, #ef4444);
+  font-size: var(--font-size-sm);
+}
+
+.org-settings-users-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-4);
+  background-color: color-mix(in srgb, #000 50%, transparent);
+}
+
+.org-settings-users-modal {
+  width: 100%;
+  max-width: 28rem;
+  padding: var(--space-6);
+  border: 1px solid var(--border-hex);
+  border-radius: var(--org-border-radius, 0px);
+  background-color: var(--card-hex);
+  box-shadow: 0 16px 40px color-mix(in srgb, #000 18%, transparent);
+}
+
+.org-settings-users-modal-title {
+  margin: 0 0 var(--space-2);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--foreground-hex);
+}
+
+.org-settings-users-modal-hint {
+  margin: 0 0 var(--space-4);
+  font-size: var(--font-size-xs);
+  line-height: var(--line-height-xs, 1.4);
+  color: var(--muted-foreground-hex);
+}
+
+.org-settings-users-modal-fields {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.org-settings-users-modal-actions {
+  display: flex;
+  gap: var(--space-2);
+  margin-top: var(--space-6);
+}
+
+.org-settings-users-modal-actions > * {
+  flex: 1;
+  justify-content: center;
+}
+
+.org-settings-users-secondary-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: 10px 20px;
+  border: 1px solid var(--border-hex);
+  border-radius: var(--org-border-radius, 0px);
+  background-color: transparent;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--foreground-hex);
+  cursor: pointer;
+}
+
+.org-settings-users-secondary-button:hover {
+  background-color: var(--muted-bg-hex, transparent);
+}
+
+.org-settings-footnote code {
+  font-size: 0.95em;
+}
+
 @media (max-width: 767px) {
   .org-settings-users-row {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .org-settings-users-row-end {
+    width: 100%;
+    justify-content: space-between;
   }
 }

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/organizations/[orgId]/settings/users/users.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/organizations/[orgId]/settings/users/users.tsx
@@ -1,67 +1,285 @@
 'use client';
 
-import { Plus, Shield, Crown, UserCircle } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import { Plus, Shield, Crown, UserCircle, AlertCircle, Trash2 } from 'lucide-react';
+import { useAuthStore } from '@/stores/auth';
+import { useOrganizationStore } from '@/stores/organization';
 import { OrgSettingsPageHeader } from '../components/org-settings-page-header';
 import { OrgSettingsSectionCard } from '../components/org-settings-section-card';
 import '../components/org-settings-components.css';
 import './users.css';
 
-const DEMO_USERS = [
-  { name: 'Alice Johnson', email: 'alice@example.com', role: 'owner' as const },
-  { name: 'Bob Smith', email: 'bob@example.com', role: 'admin' as const },
-  { name: 'Carol Lee', email: 'carol@example.com', role: 'member' as const },
-];
+type InviteRole = 'admin' | 'member';
+
+function roleBadge(role: 'owner' | 'admin' | 'member') {
+  if (role === 'owner') {
+    return (
+      <span className="org-settings-users-badge org-settings-users-badge-owner">
+        <Crown size={12} />
+        Owner
+      </span>
+    );
+  }
+  if (role === 'admin') {
+    return (
+      <span className="org-settings-users-badge org-settings-users-badge-admin">
+        <Shield size={12} />
+        Admin
+      </span>
+    );
+  }
+  return (
+    <span className="org-settings-users-badge org-settings-users-badge-member">
+      <UserCircle size={12} />
+      Member
+    </span>
+  );
+}
 
 export default function OrgUsersPage() {
+  const params = useParams();
+  const orgId = params.orgId as string;
+  const authUser = useAuthStore((s) => s.user);
+  const {
+    fetchMembers,
+    inviteMember,
+    removeMember,
+    membersCache,
+    membersLoading,
+  } = useOrganizationStore();
+
+  const members = membersCache[orgId] || [];
+  const myMembership = members.find((m) => m.userId === authUser?.id);
+  const canManage =
+    myMembership?.role === 'owner' || myMembership?.role === 'admin';
+
+  const [showInviteModal, setShowInviteModal] = useState(false);
+  const [inviteEmail, setInviteEmail] = useState('');
+  const [inviteRole, setInviteRole] = useState<InviteRole>('member');
+  const [inviteError, setInviteError] = useState('');
+  const [inviteLoading, setInviteLoading] = useState(false);
+  const [actionError, setActionError] = useState('');
+
+  useEffect(() => {
+    if (orgId) {
+      void fetchMembers(orgId);
+    }
+  }, [orgId, fetchMembers]);
+
+  const closeInviteModal = () => {
+    setShowInviteModal(false);
+    setInviteEmail('');
+    setInviteRole('member');
+    setInviteError('');
+  };
+
+  const handleInvite = async () => {
+    if (!orgId || !inviteEmail.trim() || !canManage) return;
+
+    setInviteError('');
+    setInviteLoading(true);
+
+    try {
+      await inviteMember(orgId, inviteEmail.trim(), inviteRole);
+      closeInviteModal();
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to add user';
+      setInviteError(message);
+    } finally {
+      setInviteLoading(false);
+    }
+  };
+
+  const handleRemove = async (userId: string) => {
+    if (!orgId || !canManage) return;
+    if (!confirm('Remove this user from the organization?')) return;
+
+    setActionError('');
+    try {
+      await removeMember(orgId, userId);
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to remove user';
+      setActionError(message);
+    }
+  };
+
   return (
     <div className="org-settings-users-page">
       <OrgSettingsPageHeader
         title="Users"
         subtitle="Manage who has access to this organization"
         actions={
-          <button type="button" className="org-settings-primary-button">
-            <Plus size={16} />
-            Add User
-          </button>
+          canManage ? (
+            <button
+              type="button"
+              className="org-settings-primary-button"
+              onClick={() => setShowInviteModal(true)}
+            >
+              <Plus size={16} />
+              Add User
+            </button>
+          ) : (
+            <button
+              type="button"
+              className="org-settings-primary-button"
+              disabled
+              title="Only organization owners and admins can add users"
+            >
+              <Plus size={16} />
+              Add User
+            </button>
+          )
         }
       />
 
+      {actionError && (
+        <div className="org-settings-users-alert" role="alert">
+          <AlertCircle size={16} />
+          <span>{actionError}</span>
+        </div>
+      )}
+
       <OrgSettingsSectionCard flush overflowHidden>
-        <p className="org-settings-users-list-label">Organization Users</p>
-        <ul className="org-settings-users-list">
-          {DEMO_USERS.map((user) => (
-            <li key={user.email} className="org-settings-users-row">
-              <div className="org-settings-users-row-start">
-                <div className="org-settings-users-avatar">
-                  <UserCircle size={20} />
+        <p className="org-settings-users-list-label">
+          Organization Users{members.length > 0 ? ` (${members.length})` : ''}
+        </p>
+        {membersLoading && members.length === 0 ? (
+          <div className="org-settings-loading">Loading users...</div>
+        ) : members.length === 0 ? (
+          <div className="org-settings-empty">
+            <div className="org-settings-empty-icon">
+              <UserCircle size={24} />
+            </div>
+            <p className="org-settings-empty-title">No users yet</p>
+            <p className="org-settings-empty-body">
+              {canManage
+                ? 'Add an existing account by email to grant organization access.'
+                : 'Ask an organization owner or admin to add users.'}
+            </p>
+          </div>
+        ) : (
+          <ul className="org-settings-users-list">
+            {members.map((user) => (
+              <li key={user.id} className="org-settings-users-row">
+                <div className="org-settings-users-row-start">
+                  <div className="org-settings-users-avatar">
+                    <UserCircle size={20} />
+                  </div>
+                  <div>
+                    <p className="org-settings-users-name">
+                      {user.name || 'Unknown'}
+                    </p>
+                    <p className="org-settings-users-email">
+                      {user.email || user.userId}
+                    </p>
+                  </div>
                 </div>
-                <div>
-                  <p className="org-settings-users-name">{user.name}</p>
-                  <p className="org-settings-users-email">{user.email}</p>
+                <div className="org-settings-users-row-end">
+                  {roleBadge(user.role)}
+                  {canManage &&
+                    user.role !== 'owner' &&
+                    user.userId !== authUser?.id && (
+                      <button
+                        type="button"
+                        className="org-settings-users-remove"
+                        onClick={() => void handleRemove(user.userId)}
+                        title="Remove user"
+                      >
+                        <Trash2 size={16} />
+                      </button>
+                    )}
                 </div>
-              </div>
-              {user.role === 'owner' ? (
-                <span className="org-settings-users-badge org-settings-users-badge-owner">
-                  <Crown size={12} />
-                  Owner
-                </span>
-              ) : user.role === 'admin' ? (
-                <span className="org-settings-users-badge org-settings-users-badge-admin">
-                  <Shield size={12} />
-                  Admin
-                </span>
-              ) : (
-                <span className="org-settings-users-badge org-settings-users-badge-member">
-                  <UserCircle size={12} />
-                  Member
-                </span>
-              )}
-            </li>
-          ))}
-        </ul>
+              </li>
+            ))}
+          </ul>
+        )}
       </OrgSettingsSectionCard>
 
-      <p className="org-settings-footnote">User management coming soon</p>
+      <p className="org-settings-footnote">
+        Add User requires an existing account (same API as the abi CLI
+        invite commands). Organization owner or admin only.
+      </p>
+
+      {showInviteModal && (
+        <div
+          className="org-settings-users-modal-backdrop"
+          role="presentation"
+          onClick={(event) => {
+            if (event.target === event.currentTarget) closeInviteModal();
+          }}
+        >
+          <div
+            className="org-settings-users-modal"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="org-add-user-title"
+          >
+            <h3 id="org-add-user-title" className="org-settings-users-modal-title">
+              Add User
+            </h3>
+            <p className="org-settings-users-modal-hint">
+              The email must already belong to a registered user. New accounts
+              are created via signup or ops CLI, not this form.
+            </p>
+
+            {inviteError && (
+              <div className="org-settings-users-alert" role="alert">
+                <AlertCircle size={16} />
+                <span>{inviteError}</span>
+              </div>
+            )}
+
+            <div className="org-settings-users-modal-fields">
+              <label className="org-settings-field">
+                <span className="org-settings-field-label">Email</span>
+                <input
+                  type="email"
+                  value={inviteEmail}
+                  onChange={(e) => setInviteEmail(e.target.value)}
+                  placeholder="user@example.com"
+                  className="org-settings-input"
+                  autoFocus
+                />
+              </label>
+
+              <label className="org-settings-field">
+                <span className="org-settings-field-label">Role</span>
+                <select
+                  value={inviteRole}
+                  onChange={(e) =>
+                    setInviteRole(e.target.value as InviteRole)
+                  }
+                  className="org-settings-input"
+                >
+                  <option value="member">Member</option>
+                  <option value="admin">Admin</option>
+                </select>
+              </label>
+            </div>
+
+            <div className="org-settings-users-modal-actions">
+              <button
+                type="button"
+                className="org-settings-users-secondary-button"
+                onClick={closeInviteModal}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="org-settings-primary-button"
+                onClick={() => void handleInvite()}
+                disabled={!inviteEmail.trim() || inviteLoading}
+              >
+                {inviteLoading ? 'Adding...' : 'Add User'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/organization/users/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/organization/users/page.tsx
@@ -3,22 +3,26 @@
 import { useState, useEffect } from 'react';
 import { Plus, Shield, Crown, UserCircle, Trash2, AlertCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { useOrganizationStore, OrganizationMember } from '@/stores/organization';
+import { useAuthStore } from '@/stores/auth';
+import { useOrganizationStore } from '@/stores/organization';
 
 export default function OrgUsersPage() {
+  const authUser = useAuthStore((s) => s.user);
   const {
     organizations,
     fetchOrganizations,
     fetchMembers,
     inviteMember,
-    updateMemberRole,
     removeMember,
     membersCache,
     membersLoading,
   } = useOrganizationStore();
-  
-  const org = organizations[0]; // Primary org
-  const members = org ? (membersCache[org.id] || []) : [];
+
+  const org = organizations[0];
+  const members = org ? membersCache[org.id] || [] : [];
+  const myMembership = members.find((m) => m.userId === authUser?.id);
+  const canManage =
+    myMembership?.role === 'owner' || myMembership?.role === 'admin';
 
   const [showInviteModal, setShowInviteModal] = useState(false);
   const [inviteEmail, setInviteEmail] = useState('');
@@ -27,51 +31,45 @@ export default function OrgUsersPage() {
   const [inviteLoading, setInviteLoading] = useState(false);
 
   useEffect(() => {
-    fetchOrganizations();
+    void fetchOrganizations();
   }, [fetchOrganizations]);
 
   useEffect(() => {
     if (org) {
-      fetchMembers(org.id);
+      void fetchMembers(org.id);
     }
   }, [org, fetchMembers]);
 
   const handleInvite = async () => {
-    if (!org || !inviteEmail) return;
-    
+    if (!org || !inviteEmail.trim() || !canManage) return;
+
     setInviteError('');
     setInviteLoading(true);
-    
+
     try {
-      await inviteMember(org.id, inviteEmail, inviteRole);
+      await inviteMember(org.id, inviteEmail.trim(), inviteRole);
       setShowInviteModal(false);
       setInviteEmail('');
       setInviteRole('member');
-    } catch (error: any) {
-      setInviteError(error.message || 'Failed to invite member');
+    } catch (error: unknown) {
+      setInviteError(
+        error instanceof Error ? error.message : 'Failed to invite member'
+      );
     } finally {
       setInviteLoading(false);
     }
   };
 
   const handleRemove = async (userId: string) => {
-    if (!org) return;
+    if (!org || !canManage) return;
     if (!confirm('Are you sure you want to remove this member?')) return;
-    
+
     try {
       await removeMember(org.id, userId);
-    } catch (error: any) {
-      alert(error.message || 'Failed to remove member');
-    }
-  };
-
-  const handleRoleChange = async (userId: string, newRole: 'owner' | 'admin' | 'member') => {
-    if (!org) return;
-    
-    try {
-      await updateMemberRole(org.id, userId, newRole);
-    } catch (error: any) {
-      alert(error.message || 'Failed to update role');
+    } catch (error: unknown) {
+      alert(
+        error instanceof Error ? error.message : 'Failed to remove member'
+      );
     }
   };
 
@@ -94,7 +92,13 @@ export default function OrgUsersPage() {
         </div>
         <button
           onClick={() => setShowInviteModal(true)}
-          className="flex items-center gap-2 rounded-lg bg-blue-500 px-4 py-2 text-sm font-medium text-white hover:bg-blue-600 transition-colors"
+          disabled={!canManage}
+          title={
+            canManage
+              ? undefined
+              : 'Only organization owners and admins can add users'
+          }
+          className="flex items-center gap-2 rounded-lg bg-blue-500 px-4 py-2 text-sm font-medium text-white hover:bg-blue-600 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
         >
           <Plus size={16} />
           Add User
@@ -118,14 +122,21 @@ export default function OrgUsersPage() {
         ) : (
           <div className="divide-y">
             {members.map((member) => (
-              <div key={member.id} className="flex items-center justify-between px-4 py-3">
+              <div
+                key={member.id}
+                className="flex items-center justify-between px-4 py-3"
+              >
                 <div className="flex items-center gap-3">
                   <div className="flex h-9 w-9 items-center justify-center rounded-full bg-blue-500/10 text-blue-500">
                     <UserCircle size={20} />
                   </div>
                   <div>
-                    <p className="text-sm font-medium">{member.name || 'Unknown'}</p>
-                    <p className="text-xs text-muted-foreground">{member.email}</p>
+                    <p className="text-sm font-medium">
+                      {member.name || 'Unknown'}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {member.email}
+                    </p>
                   </div>
                 </div>
                 <div className="flex items-center gap-2">
@@ -147,15 +158,17 @@ export default function OrgUsersPage() {
                       Member
                     </span>
                   )}
-                  {member.role !== 'owner' && (
-                    <button
-                      onClick={() => handleRemove(member.userId)}
-                      className="text-red-500 hover:text-red-600 transition-colors"
-                      title="Remove member"
-                    >
-                      <Trash2 size={16} />
-                    </button>
-                  )}
+                  {canManage &&
+                    member.role !== 'owner' &&
+                    member.userId !== authUser?.id && (
+                      <button
+                        onClick={() => void handleRemove(member.userId)}
+                        className="text-red-500 hover:text-red-600 transition-colors"
+                        title="Remove member"
+                      >
+                        <Trash2 size={16} />
+                      </button>
+                    )}
                 </div>
               </div>
             ))}
@@ -163,12 +176,15 @@ export default function OrgUsersPage() {
         )}
       </div>
 
-      {/* Invite Modal */}
-      {showInviteModal && (
+      {showInviteModal && canManage && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
           <div className="w-full max-w-md rounded-xl border bg-card p-6 shadow-lg">
-            <h3 className="text-lg font-semibold mb-4">Invite Member</h3>
-            
+            <h3 className="text-lg font-semibold mb-2">Add User</h3>
+            <p className="mb-4 text-xs text-muted-foreground">
+              Existing account required. Same as org settings Users and{' '}
+              <code>POST /api/organizations/{'{id}'}/members/invite</code>.
+            </p>
+
             {inviteError && (
               <div className="mb-4 flex items-center gap-2 rounded-lg bg-destructive/10 p-3 text-sm text-destructive">
                 <AlertCircle size={16} />
@@ -192,7 +208,9 @@ export default function OrgUsersPage() {
                 <label className="block text-sm font-medium mb-2">Role</label>
                 <select
                   value={inviteRole}
-                  onChange={(e) => setInviteRole(e.target.value as 'admin' | 'member')}
+                  onChange={(e) =>
+                    setInviteRole(e.target.value as 'admin' | 'member')
+                  }
                   className="w-full rounded-lg border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-blue-500/30"
                 >
                   <option value="member">Member</option>
@@ -213,15 +231,15 @@ export default function OrgUsersPage() {
                 Cancel
               </button>
               <button
-                onClick={handleInvite}
-                disabled={!inviteEmail || inviteLoading}
+                onClick={() => void handleInvite()}
+                disabled={!inviteEmail.trim() || inviteLoading}
                 className={cn(
                   'flex-1 rounded-lg bg-blue-500 px-4 py-2 text-sm font-medium text-white transition-colors',
                   'hover:bg-blue-600',
                   'disabled:opacity-50 disabled:cursor-not-allowed'
                 )}
               >
-                {inviteLoading ? 'Inviting...' : 'Send Invite'}
+                {inviteLoading ? 'Adding...' : 'Add User'}
               </button>
             </div>
           </div>

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/members/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/members/page.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { Plus, Mail, MoreVertical, Shield, User, Crown, Trash2 } from 'lucide-react';
+import { Plus, Shield, User, Crown, Trash2, AlertCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useAuthStore } from '@/stores/auth';
+import { useWorkspaceStore } from '@/stores/workspace';
 import { useParams } from 'next/navigation';
 
 interface Member {
@@ -23,98 +24,166 @@ const roleConfig = {
   viewer: { label: 'Viewer', icon: User, color: 'text-muted-foreground' },
 };
 
+async function readApiError(response: Response, fallback: string): Promise<string> {
+  try {
+    const data = await response.json();
+    if (typeof data?.detail === 'string') return data.detail;
+    if (Array.isArray(data?.detail)) {
+      return data.detail.map((d: { msg?: string }) => d.msg || String(d)).join(', ');
+    }
+  } catch {
+    // ignore parse errors
+  }
+  return fallback;
+}
+
 export default function MembersPage() {
   const params = useParams();
   const workspaceId = params.workspaceId as string;
   const authUser = useAuthStore((s) => s.user);
+  const workspaces = useWorkspaceStore((s) => s.workspaces);
+  const workspace = workspaces.find((w) => w.id === workspaceId);
   const [members, setMembers] = useState<Member[]>([]);
   const [loading, setLoading] = useState(true);
   const [inviteEmail, setInviteEmail] = useState('');
   const [inviteRole, setInviteRole] = useState<'admin' | 'member' | 'viewer'>('member');
   const [showInvite, setShowInvite] = useState(false);
+  const [inviteLoading, setInviteLoading] = useState(false);
+  const [inviteError, setInviteError] = useState('');
+  const [actionError, setActionError] = useState('');
 
-  // Fetch members
+  const membershipRole =
+    workspace?.currentUserRole ||
+    members.find((m) => m.user_id === authUser?.id)?.role;
+  const canManage =
+    membershipRole === 'owner' || membershipRole === 'admin';
+
+  const refreshMembers = async () => {
+    const { authFetch } = await import('@/stores/auth');
+    const response = await authFetch(`/api/workspaces/${workspaceId}/members`);
+    if (!response.ok) {
+      throw new Error(await readApiError(response, 'Failed to load members'));
+    }
+    const data = await response.json();
+    setMembers(
+      data.map((m: Record<string, unknown>) => ({
+        ...m,
+        name: (m.name as string) || 'Unknown',
+        email: (m.email as string) || '',
+        joinedAt: new Date(m.created_at as string),
+      }))
+    );
+  };
+
   useEffect(() => {
     const fetchMembers = async () => {
       try {
-        const { authFetch } = await import('@/stores/auth');
-        const response = await authFetch(`/api/workspaces/${workspaceId}/members`);
-        const data = await response.json();
-        setMembers(data.map((m: any) => ({
-          ...m,
-          joinedAt: new Date(m.created_at),
-        })));
+        await refreshMembers();
       } catch (error) {
         console.error('Failed to fetch members:', error);
+        setActionError(
+          error instanceof Error ? error.message : 'Failed to load members'
+        );
       } finally {
         setLoading(false);
       }
     };
-    
+
     if (workspaceId) {
-      fetchMembers();
+      void fetchMembers();
     }
+    // refreshMembers closes over workspaceId; effect keyed on workspaceId only
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [workspaceId]);
 
   const handleInvite = async () => {
-    if (!inviteEmail.trim()) return;
-    
+    if (!inviteEmail.trim() || !canManage) return;
+
+    setInviteError('');
+    setInviteLoading(true);
+
     try {
       const { authFetch } = await import('@/stores/auth');
-      await authFetch(`/api/workspaces/${workspaceId}/members/invite`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: inviteEmail, role: inviteRole }),
-      });
-      
-      // Refresh members list
-      const response = await authFetch(`/api/workspaces/${workspaceId}/members`);
-      const data = await response.json();
-      setMembers(data.map((m: any) => ({
-        ...m,
-        joinedAt: new Date(m.created_at),
-      })));
-      
+      const response = await authFetch(
+        `/api/workspaces/${workspaceId}/members/invite`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email: inviteEmail.trim(), role: inviteRole }),
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error(await readApiError(response, 'Failed to send invite'));
+      }
+
+      await refreshMembers();
       setInviteEmail('');
+      setInviteRole('member');
       setShowInvite(false);
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Failed to invite member:', error);
-      alert(error.message || 'Failed to send invite');
+      setInviteError(
+        error instanceof Error ? error.message : 'Failed to send invite'
+      );
+    } finally {
+      setInviteLoading(false);
     }
   };
 
   const handleRemoveMember = async (userId: string) => {
+    if (!canManage) return;
     if (!confirm('Remove this member?')) return;
-    
+
+    setActionError('');
     try {
       const { authFetch } = await import('@/stores/auth');
-      await authFetch(`/api/workspaces/${workspaceId}/members/${userId}`, {
-        method: 'DELETE',
-      });
-      
-      setMembers(members.filter(m => m.user_id !== userId));
-    } catch (error: any) {
+      const response = await authFetch(
+        `/api/workspaces/${workspaceId}/members/${userId}`,
+        { method: 'DELETE' }
+      );
+      if (!response.ok) {
+        throw new Error(await readApiError(response, 'Failed to remove member'));
+      }
+      setMembers(members.filter((m) => m.user_id !== userId));
+    } catch (error: unknown) {
       console.error('Failed to remove member:', error);
-      alert(error.message || 'Failed to remove member');
+      setActionError(
+        error instanceof Error ? error.message : 'Failed to remove member'
+      );
     }
   };
 
-  const handleChangeRole = async (userId: string, newRole: 'admin' | 'member' | 'viewer') => {
+  const handleChangeRole = async (
+    userId: string,
+    newRole: 'admin' | 'member' | 'viewer'
+  ) => {
+    if (!canManage) return;
+    setActionError('');
     try {
       const { authFetch } = await import('@/stores/auth');
-      await authFetch(`/api/workspaces/${workspaceId}/members/${userId}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ role: newRole }),
-      });
-      
-      // Update local state
-      setMembers(members.map(m => 
-        m.user_id === userId ? { ...m, role: newRole } : m
-      ));
-    } catch (error: any) {
+      const response = await authFetch(
+        `/api/workspaces/${workspaceId}/members/${userId}`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ role: newRole }),
+        }
+      );
+      if (!response.ok) {
+        throw new Error(await readApiError(response, 'Failed to change role'));
+      }
+
+      setMembers(
+        members.map((m) =>
+          m.user_id === userId ? { ...m, role: newRole } : m
+        )
+      );
+    } catch (error: unknown) {
       console.error('Failed to change role:', error);
-      alert(error.message || 'Failed to change role');
+      setActionError(
+        error instanceof Error ? error.message : 'Failed to change role'
+      );
     }
   };
 
@@ -133,19 +202,50 @@ export default function MembersPage() {
           </p>
         </div>
         <button
-          onClick={() => setShowInvite(true)}
-          className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          onClick={() => {
+            setInviteError('');
+            setShowInvite(true);
+          }}
+          disabled={!canManage}
+          title={
+            canManage
+              ? undefined
+              : 'Only workspace owners and admins can invite members'
+          }
+          className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
         >
           <Plus size={16} />
           Invite Member
         </button>
       </div>
 
-      {/* Invite form */}
-      {showInvite && (
+      {actionError && (
+        <div className="flex items-center gap-2 rounded-lg bg-destructive/10 p-3 text-sm text-destructive">
+          <AlertCircle size={16} />
+          <span>{actionError}</span>
+        </div>
+      )}
+
+      {showInvite && canManage && (
         <div className="rounded-xl border bg-card p-4">
-          <h3 className="mb-4 font-medium">Invite New Member</h3>
-          <div className="flex gap-3">
+          <h3 className="mb-2 font-medium">Invite New Member</h3>
+          <p className="mb-4 text-xs text-muted-foreground">
+            Email must match an existing account. Same API as{' '}
+            <code className="text-[0.95em]">abi workspace members add</code> /{' '}
+            <code className="text-[0.95em]">
+              POST /api/workspaces/{'{id}'}/members/invite
+            </code>
+            .
+          </p>
+
+          {inviteError && (
+            <div className="mb-4 flex items-center gap-2 rounded-lg bg-destructive/10 p-3 text-sm text-destructive">
+              <AlertCircle size={16} />
+              <span>{inviteError}</span>
+            </div>
+          )}
+
+          <div className="flex flex-col gap-3 sm:flex-row">
             <div className="flex-1">
               <input
                 type="email"
@@ -157,7 +257,9 @@ export default function MembersPage() {
             </div>
             <select
               value={inviteRole}
-              onChange={(e) => setInviteRole(e.target.value as typeof inviteRole)}
+              onChange={(e) =>
+                setInviteRole(e.target.value as typeof inviteRole)
+              }
               className="rounded-lg border bg-background px-3 py-2 text-sm"
             >
               <option value="member">Member</option>
@@ -165,13 +267,17 @@ export default function MembersPage() {
               <option value="admin">Admin</option>
             </select>
             <button
-              onClick={handleInvite}
-              className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+              onClick={() => void handleInvite()}
+              disabled={!inviteEmail.trim() || inviteLoading}
+              className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
             >
-              Send Invite
+              {inviteLoading ? 'Sending...' : 'Send Invite'}
             </button>
             <button
-              onClick={() => setShowInvite(false)}
+              onClick={() => {
+                setShowInvite(false);
+                setInviteError('');
+              }}
               className="rounded-lg border px-4 py-2 text-sm text-muted-foreground hover:bg-secondary"
             >
               Cancel
@@ -180,79 +286,104 @@ export default function MembersPage() {
         </div>
       )}
 
-      {/* Members list */}
       <div className="rounded-xl border bg-card">
-        <table className="w-full">
-          <thead>
-            <tr className="border-b text-left text-sm text-muted-foreground">
-              <th className="p-4 font-medium">Member</th>
-              <th className="p-4 font-medium">Role</th>
-              <th className="p-4 font-medium">Joined</th>
-              <th className="p-4 font-medium text-right">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {members.map((member) => {
-              const role = roleConfig[member.role];
-              const RoleIcon = role.icon;
-              return (
-                <tr key={member.id} className="border-b last:border-0">
-                  <td className="p-4">
-                    <div className="flex items-center gap-3">
-                      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary text-primary-foreground">
-                        {member.name.charAt(0).toUpperCase()}
+        {loading ? (
+          <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+            Loading members...
+          </div>
+        ) : members.length === 0 ? (
+          <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+            No members yet.
+          </div>
+        ) : (
+          <table className="w-full">
+            <thead>
+              <tr className="border-b text-left text-sm text-muted-foreground">
+                <th className="p-4 font-medium">Member</th>
+                <th className="p-4 font-medium">Role</th>
+                <th className="p-4 font-medium">Joined</th>
+                <th className="p-4 font-medium text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {members.map((member) => {
+                const role = roleConfig[member.role] || roleConfig.member;
+                const RoleIcon = role.icon;
+                const initial = (member.name || member.email || '?')
+                  .charAt(0)
+                  .toUpperCase();
+                const roleLocked =
+                  member.role === 'owner' ||
+                  member.user_id === authUser?.id ||
+                  !canManage;
+                return (
+                  <tr key={member.id} className="border-b last:border-0">
+                    <td className="p-4">
+                      <div className="flex items-center gap-3">
+                        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary text-primary-foreground">
+                          {initial}
+                        </div>
+                        <div>
+                          <p className="font-medium">{member.name}</p>
+                          <p className="text-sm text-muted-foreground">
+                            {member.email}
+                          </p>
+                        </div>
                       </div>
-                      <div>
-                        <p className="font-medium">{member.name}</p>
-                        <p className="text-sm text-muted-foreground">{member.email}</p>
-                      </div>
-                    </div>
-                  </td>
-                  <td className="p-4">
-                    {member.role === 'owner' || member.user_id === authUser?.id ? (
-                      <div className={cn('flex items-center gap-2 text-sm', role.color)}>
-                        <RoleIcon size={14} />
-                        {role.label}
-                      </div>
-                    ) : (
-                      <select
-                        value={member.role}
-                        onChange={(e) => handleChangeRole(member.user_id, e.target.value as 'admin' | 'member' | 'viewer')}
-                        className="rounded border bg-background px-2 py-1 text-sm outline-none focus:ring-2 focus:ring-primary/30"
-                      >
-                        <option value="member">Member</option>
-                        <option value="viewer">Viewer</option>
-                        <option value="admin">Admin</option>
-                      </select>
-                    )}
-                  </td>
-                  <td className="p-4 text-sm text-muted-foreground">
-                    {member.joinedAt.toLocaleDateString()}
-                  </td>
-                  <td className="p-4 text-right">
-                    {member.role !== 'owner' && member.user_id !== authUser?.id && (
-                      <button 
-                        onClick={() => handleRemoveMember(member.user_id)}
-                        className="text-muted-foreground hover:text-destructive"
-                      >
-                        <Trash2 size={16} />
-                      </button>
-                    )}
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
+                    </td>
+                    <td className="p-4">
+                      {roleLocked ? (
+                        <div
+                          className={cn(
+                            'flex items-center gap-2 text-sm',
+                            role.color
+                          )}
+                        >
+                          <RoleIcon size={14} />
+                          {role.label}
+                        </div>
+                      ) : (
+                        <select
+                          value={member.role}
+                          onChange={(e) =>
+                            void handleChangeRole(
+                              member.user_id,
+                              e.target.value as 'admin' | 'member' | 'viewer'
+                            )
+                          }
+                          className="rounded border bg-background px-2 py-1 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+                        >
+                          <option value="member">Member</option>
+                          <option value="viewer">Viewer</option>
+                          <option value="admin">Admin</option>
+                        </select>
+                      )}
+                    </td>
+                    <td className="p-4 text-sm text-muted-foreground">
+                      {member.joinedAt.toLocaleDateString()}
+                    </td>
+                    <td className="p-4 text-right">
+                      {canManage &&
+                        member.role !== 'owner' &&
+                        member.user_id !== authUser?.id && (
+                          <button
+                            onClick={() =>
+                              void handleRemoveMember(member.user_id)
+                            }
+                            className="text-muted-foreground hover:text-destructive"
+                          >
+                            <Trash2 size={16} />
+                          </button>
+                        )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
       </div>
 
-      {/* Pending invites */}
-      <div className="rounded-xl border bg-card p-6">
-        <h3 className="mb-4 font-semibold">Pending Invites</h3>
-        <p className="text-sm text-muted-foreground">No pending invites</p>
-      </div>
-
-      {/* Roles explanation */}
       <div className="rounded-xl border bg-muted/30 p-4">
         <h3 className="mb-3 font-medium">Role Permissions</h3>
         <div className="grid gap-3 sm:grid-cols-3">

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/organization.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/organization.ts
@@ -341,8 +341,15 @@ export const useOrganizationStore = create<OrganizationState>()((set, get) => ({
         body: JSON.stringify({ email, role }),
       });
       if (!response.ok) {
-        const data = await response.json();
-        throw new Error(data.detail || 'Failed to invite member');
+        const data = await response.json().catch(() => ({}));
+        const detail = data?.detail;
+        const message =
+          typeof detail === 'string'
+            ? detail
+            : Array.isArray(detail)
+              ? detail.map((d: { msg?: string }) => d.msg || String(d)).join(', ')
+              : 'Failed to invite member';
+        throw new Error(message);
       }
       const data = await response.json();
 


### PR DESCRIPTION
## Summary
- Replace mock Alice/Bob/Carol + \"coming soon\" on org settings **Users** with live `GET/POST /api/organizations/{orgId}/members` (invite existing user by email + role), same APIs as CLI #1119.
- Enforce owner/admin in UI (disable Add User); API remains the ABAC source of truth (`403`).
- Align workspace **Members** invite UX (errors, loading, admin gate) and workspace org Users page.
- Document the shared UI/CLI/agent capability surface in Nexus `AGENTS.md`. Agent tool wrappers tracked in #1121.

## Stacking
- **Depends on:** #1117 (Users framing). Base branch is `fix/nexus-org-users-not-admins`.
- Merge #1117 first, then this PR.

## Test plan
- [ ] `/organizations/{orgId}/settings/users` lists real members (no demo names)
- [ ] Owner/admin: **Add User** invites existing email; list refreshes; unknown email shows API error
- [ ] Non-admin: Add User disabled; direct API invite returns 403
- [ ] Workspace Settings → Members: invite shows inline errors; Invite disabled for non-admins
- [ ] `pnpm exec tsc --noEmit` and org-settings route vitest pass
- [ ] Live-test on zen after ABI pin