### PR TITLE
feat(nexus-web): dual-chat compare pane + pane-send fixes

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/chat/components/chat-agent-selector.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/chat/components/chat-agent-selector.tsx
@@ -178,7 +178,13 @@ export function ChatAgentSelector({
     closePicker();
   };
 
-  const triggerLabel = autoMode ? 'Auto' : activeAgent?.name ?? 'Agent';
+  // Pane surface: always show the resolved agent name (Abi by default).
+  // Main chat keeps Cursor-style "Auto" until the user picks an agent.
+  const triggerLabel = isPane
+    ? activeAgent?.name ?? 'Abi'
+    : autoMode
+      ? 'Auto'
+      : activeAgent?.name ?? 'Agent';
 
   if (!mounted || !activeAgent) {
     return null;
@@ -285,7 +291,13 @@ export function ChatAgentSelector({
         type="button"
         className={cn('chat-agent-selector-trigger', open && 'is-open')}
         onClick={() => (open ? closePicker() : openPicker())}
-        title={autoMode ? 'Auto agent selection' : activeAgent.name}
+        title={
+          isPane
+            ? activeAgent.name
+            : autoMode
+              ? 'Auto agent selection'
+              : activeAgent.name
+        }
       >
         <span className="chat-agent-selector-trigger-label">{triggerLabel}</span>
         <ChevronDown

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/chat/components/chat-agent-selector.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/chat/components/chat-agent-selector.tsx
@@ -36,25 +36,40 @@ function AutoToggle({
   );
 }
 
+export type ChatAgentSelectorSource = 'chat' | 'pane';
+
 /**
  * Compact agent picker for the chat composer.
  * Panel = Search + Auto toggle + agents list (no dual-panel / model drill-down).
  * Mobile: bottom sheet. Desktop: compact popover above the trigger.
+ *
+ * `source="pane"` binds to the right AI / compare surface (paneAgent).
  */
-export function ChatAgentSelector() {
+export function ChatAgentSelector({
+  source = 'chat',
+}: {
+  source?: ChatAgentSelectorSource;
+} = {}) {
   const [mounted, setMounted] = useState(false);
   const [open, setOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const ref = useRef<HTMLDivElement>(null);
   const sheetRef = useRef<HTMLDivElement>(null);
   const isMobile = useIsMobile();
+  const isPane = source === 'pane';
 
-  const {
-    selectedAgent,
-    agentExplicitlySelected,
-    setSelectedAgent,
-    clearAgentExplicitSelection,
-  } = useWorkspaceStore();
+  const selectedAgent = useWorkspaceStore((s) =>
+    isPane ? s.paneAgent : s.selectedAgent
+  );
+  const agentExplicitlySelected = useWorkspaceStore((s) =>
+    isPane ? s.paneAgentExplicitlySelected : s.agentExplicitlySelected
+  );
+  const setSelectedAgent = useWorkspaceStore((s) =>
+    isPane ? s.setPaneAgent : s.setSelectedAgent
+  );
+  const clearAgentExplicitSelection = useWorkspaceStore((s) =>
+    isPane ? s.clearPaneAgentExplicitSelection : s.clearAgentExplicitSelection
+  );
   const { defaultAgents, customAgents, filteredAgents } = useAgentList(searchQuery);
 
   const enabledAgents = useMemo(
@@ -62,7 +77,22 @@ export function ChatAgentSelector() {
     [defaultAgents, customAgents]
   );
 
-  const defaultAgent = enabledAgents.find((a) => a.isDefault) ?? enabledAgents[0];
+  const defaultAgent = useMemo(() => {
+    if (isPane) {
+      return (
+        enabledAgents.find(
+          (a) =>
+            a.enabled &&
+            (a.name === 'Abi' ||
+              (typeof a.class_name === 'string' &&
+                a.class_name.toLowerCase().includes('abiagent')))
+        ) ??
+        enabledAgents.find((a) => a.isDefault) ??
+        enabledAgents[0]
+      );
+    }
+    return enabledAgents.find((a) => a.isDefault) ?? enabledAgents[0];
+  }, [enabledAgents, isPane]);
   const activeAgent =
     enabledAgents.find((a) => a.id === selectedAgent) || defaultAgent;
   const autoMode = !agentExplicitlySelected;

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useRef, useEffect, useMemo, useCallback, useLayoutEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { Send, Plus, Bot, User, AlertCircle, Brain, ChevronDown, X, ArrowUp, ExternalLink, HardDrive, RefreshCw, Mic, Check, Loader2, Wrench, Copy, FileText, ThumbsUp, ThumbsDown, Volume2, Square } from 'lucide-react';
+import { Send, Plus, Bot, User, AlertCircle, Brain, ChevronDown, X, ArrowUp, ExternalLink, HardDrive, RefreshCw, Mic, Check, Loader2, Wrench, Copy, FileText, ThumbsUp, ThumbsDown, Volume2, Square, Columns2 } from 'lucide-react';
 import Image from 'next/image';
 import { usePathname, useRouter } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
@@ -712,7 +712,19 @@ function LinkWithPreview({
   );
 }
 
-export function ChatInterface({ initialConversationId }: { initialConversationId?: string | null }) {
+export type ChatSurface = 'main' | 'pane';
+
+const COMPARE_SEND_EVENT = 'nexus-compare-send';
+
+export function ChatInterface({
+  initialConversationId,
+  surface = 'main',
+}: {
+  initialConversationId?: string | null;
+  /** `pane` = right AI / compare surface (independent conversation + agent). */
+  surface?: ChatSurface;
+} = {}) {
+  const isPane = surface === 'pane';
   const [mounted, setMounted] = useState(false);
   const [input, setInput] = useState('');
   const [isLoading, setIsLoading] = useState(false);
@@ -799,18 +811,39 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
 
   const router = useRouter();
 
-  const {
-    activeConversationId,
-    selectedAgent,
-    setSelectedAgent,
-    createConversation,
-    setActiveConversation,
-    addMessage,
-    updateLastMessage,
-    getWorkspaceConversations,
-    currentWorkspaceId,
-    loadConversationMessages,
-  } = useWorkspaceStore();
+  const storeActiveConversationId = useWorkspaceStore((s) => s.activeConversationId);
+  const paneConversationId = useWorkspaceStore((s) => s.paneConversationId);
+  const storeSelectedAgent = useWorkspaceStore((s) => s.selectedAgent);
+  const paneAgent = useWorkspaceStore((s) => s.paneAgent);
+  const contextPanelOpen = useWorkspaceStore((s) => s.contextPanelOpen);
+  const createConversation = useWorkspaceStore((s) => s.createConversation);
+  const setActiveConversation = useWorkspaceStore((s) => s.setActiveConversation);
+  const setPaneConversationId = useWorkspaceStore((s) => s.setPaneConversationId);
+  const setSelectedAgent = useWorkspaceStore((s) => s.setSelectedAgent);
+  const addMessage = useWorkspaceStore((s) => s.addMessage);
+  const updateLastMessage = useWorkspaceStore((s) => s.updateLastMessage);
+  const getWorkspaceConversations = useWorkspaceStore((s) => s.getWorkspaceConversations);
+  const currentWorkspaceId = useWorkspaceStore((s) => s.currentWorkspaceId);
+  const loadConversationMessages = useWorkspaceStore((s) => s.loadConversationMessages);
+
+  const activeConversationId = isPane ? paneConversationId : storeActiveConversationId;
+  const selectedAgent = isPane ? paneAgent : storeSelectedAgent;
+  const bindConversation = isPane ? setPaneConversationId : setActiveConversation;
+
+  const readSurfaceConversationId = useCallback(() => {
+    const s = useWorkspaceStore.getState();
+    return isPane ? s.paneConversationId : s.activeConversationId;
+  }, [isPane]);
+
+  const readSurfaceAgent = useCallback(() => {
+    const s = useWorkspaceStore.getState();
+    return isPane ? s.paneAgent : s.selectedAgent;
+  }, [isPane]);
+
+  const createSurfaceConversation = useCallback(
+    (projectId?: string) => createConversation(projectId, { surface }),
+    [createConversation, surface]
+  );
 
   const { socket, startTyping, stopTyping, onMessage } = useWebSocket();
   const { tab_title: tabTitle } = useTenant();
@@ -848,11 +881,11 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
     setMounted(true);
   }, []);
 
-  // Sync URL slug → active conversation. When there's no slug (/chat base route),
-  // reset to a blank new-chat state and pre-select the workspace default agent —
-  // unless the user just explicitly picked an agent (sidebar/composer), which
-  // must survive the navigation to the base chat route.
+  // Sync URL slug → active conversation (main surface only). When there's no
+  // slug (/chat base route), reset to a blank new-chat state and pre-select the
+  // workspace default agent — unless the user just explicitly picked an agent.
   useEffect(() => {
+    if (isPane) return;
     if (initialConversationId) {
       setActiveConversation(initialConversationId);
       return;
@@ -865,26 +898,27 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
       agents.find((a) => a.enabled);
     if (defaultAgent) setSelectedAgent(defaultAgent.id);
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialConversationId]);
+  }, [initialConversationId, isPane]);
 
   const pathname = usePathname();
 
   useEffect(() => {
-    if (!mounted) return;
+    if (!mounted || isPane) return;
     const target = nextChatUrl(pathname, currentWorkspaceId, activeConversationId);
     if (target) router.replace(target, { scroll: false });
-  }, [activeConversationId, mounted, currentWorkspaceId, router, pathname]);
+  }, [activeConversationId, mounted, currentWorkspaceId, router, pathname, isPane]);
 
   // Narrow selector: only the active conversation's title — avoids re-renders on every streaming token.
-  const activeConversationTitle = useWorkspaceStore((s) =>
-    s.conversations.find((c) => c.id === s.activeConversationId)?.title
-  );
+  const activeConversationTitle = useWorkspaceStore((s) => {
+    const id = isPane ? s.paneConversationId : s.activeConversationId;
+    return s.conversations.find((c) => c.id === id)?.title;
+  });
 
-  // Update the browser tab title with the active conversation name.
+  // Update the browser tab title with the active conversation name (main only).
   // The 700 ms delay ensures we run after tenant-context.tsx's 600 ms re-apply,
   // which resets the title after every pathname change.
   useEffect(() => {
-    if (!mounted) return;
+    if (!mounted || isPane) return;
     const t = setTimeout(() => {
       if (activeConversationTitle && activeConversationTitle !== 'New Conversation') {
         document.title = `${activeConversationTitle} | ${tabTitle}`;
@@ -893,7 +927,7 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
       }
     }, 700);
     return () => clearTimeout(t);
-  }, [activeConversationTitle, mounted, tabTitle]);
+  }, [activeConversationTitle, mounted, tabTitle, isPane]);
 
   // Keep the typing cursor in the chat bar whenever the active conversation changes
   // (including null = new chat state).
@@ -905,11 +939,11 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
   // Consume one-shot composer seeds (e.g. "/skill-slug " from the sidebar).
   const pendingComposerText = useWorkspaceStore((s) => s.pendingComposerText);
   useEffect(() => {
-    if (!mounted || !pendingComposerText) return;
+    if (!mounted || isPane || !pendingComposerText) return;
     setInput(pendingComposerText);
     useWorkspaceStore.getState().setPendingComposerText(null);
     focusChatInput();
-  }, [pendingComposerText, mounted, focusChatInput]);
+  }, [pendingComposerText, mounted, focusChatInput, isPane]);
 
   // ---------- Slash-command autocomplete ----------
   const [slashIndex, setSlashIndex] = useState(0);
@@ -1196,7 +1230,7 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
   const uploadDocumentToChat = async (file: File): Promise<void> => {
     let conversationId = activeConversationId;
     if (!conversationId) {
-      conversationId = createConversation();
+      conversationId = createSurfaceConversation();
     }
 
     const token = useAuthStore.getState().token;
@@ -1264,7 +1298,7 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
   const ingestFromMyDrive = async (sourcePath: string, filename: string): Promise<void> => {
     let conversationId = activeConversationId;
     if (!conversationId) {
-      conversationId = createConversation();
+      conversationId = createSurfaceConversation();
     }
     setShowMyDrivePicker(false);
 
@@ -1542,7 +1576,7 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
 
       const formData = new FormData();
       formData.append('audio', file);
-      const currentConversationId = useWorkspaceStore.getState().activeConversationId;
+      const currentConversationId = readSurfaceConversationId();
       if (currentConversationId) {
         formData.append('conversation_id', currentConversationId);
       }
@@ -1573,9 +1607,9 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
       const preservedConversationId = echoedConversationId ?? currentConversationId;
       if (
         preservedConversationId &&
-        useWorkspaceStore.getState().activeConversationId !== preservedConversationId
+        readSurfaceConversationId() !== preservedConversationId
       ) {
-        useWorkspaceStore.getState().setActiveConversation(preservedConversationId);
+        bindConversation(preservedConversationId);
       }
 
       // On validate: send the transcript directly as a chat message.
@@ -1584,7 +1618,7 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
       const combined = existing.trim()
         ? `${existing.trim()} ${transcript}`
         : transcript;
-      const selectedAgentAtSend = useWorkspaceStore.getState().selectedAgent;
+      const selectedAgentAtSend = readSurfaceAgent();
 
       handleInputChange('');
       await handleSubmit(
@@ -1691,15 +1725,15 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
     isSubmittingRef.current = true;
     const effectiveAgent = agentOverride ?? selectedAgent;
 
-    const latestActiveConversationId = useWorkspaceStore.getState().activeConversationId;
+    const latestActiveConversationId = readSurfaceConversationId();
     let conversationId = conversationIdOverride ?? latestActiveConversationId ?? activeConversationId;
     const existingConversationBeforeSend = conversationId
       ? useWorkspaceStore.getState().conversations.find((c) => c.id === conversationId)
       : null;
 
-    // Create new conversation if none active
+    // Create new conversation if none active (scoped to this surface)
     if (!conversationId) {
-      conversationId = createConversation();
+      conversationId = createSurfaceConversation();
     }
 
     // Keep the conversation's latest agent in sync locally — the backend does
@@ -2405,6 +2439,30 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
     }
   };
 
+  const handleSubmitRef = useRef(handleSubmit);
+  handleSubmitRef.current = handleSubmit;
+
+  // Compare mode: both surfaces listen and submit the shared prompt.
+  useEffect(() => {
+    const onCompareSend = (event: Event) => {
+      const detail = (event as CustomEvent<{ text?: string }>).detail;
+      const text = detail?.text?.trim();
+      if (!text) return;
+      void handleSubmitRef.current(undefined, text);
+    };
+    window.addEventListener(COMPARE_SEND_EVENT, onCompareSend);
+    return () => window.removeEventListener(COMPARE_SEND_EVENT, onCompareSend);
+  }, []);
+
+  const handleSendToBoth = useCallback(() => {
+    const text = input.trim();
+    if (!text || isLoading) return;
+    window.dispatchEvent(
+      new CustomEvent(COMPARE_SEND_EVENT, { detail: { text } })
+    );
+    setInput('');
+  }, [input, isLoading]);
+
   return (
     <div className="relative flex h-full min-h-0 flex-1">
     {/* Chat column */}
@@ -2735,7 +2793,7 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
               <div className="chat-composer-toolbar">
                 <div className="chat-composer-toolbar-row">
                   <div className="chat-composer-toolbar-start">
-                    <ChatAgentSelector />
+                    <ChatAgentSelector source={isPane ? 'pane' : 'chat'} />
 
                     {/* Attach (plus) */}
                     <button
@@ -2852,6 +2910,23 @@ export function ChatInterface({ initialConversationId }: { initialConversationId
                     >
                       <Mic size={18} />
                     </button>
+
+                    {/* Compare: same prompt → both surfaces (main composer only) */}
+                    {!isPane && contextPanelOpen && (
+                      <button
+                        type="button"
+                        onClick={handleSendToBoth}
+                        disabled={!input.trim() || isLoading}
+                        className={cn(
+                          'chat-composer-action',
+                          input.trim() && !isLoading && 'is-active'
+                        )}
+                        title="Send to both panes (compare)"
+                        aria-label="Send to both panes"
+                      >
+                        <Columns2 size={16} />
+                      </button>
+                    )}
 
                     {/* Send: org-radius filled square (not a circle) */}
                     <button

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
@@ -1229,7 +1229,10 @@ export function ChatInterface({
 
   const uploadDocumentToChat = async (file: File): Promise<void> => {
     let conversationId = activeConversationId;
-    if (!conversationId) {
+    const existing = conversationId
+      ? useWorkspaceStore.getState().conversations.find((c) => c.id === conversationId)
+      : null;
+    if (!conversationId || !existing) {
       conversationId = createSurfaceConversation();
     }
 
@@ -1297,7 +1300,10 @@ export function ChatInterface({
 
   const ingestFromMyDrive = async (sourcePath: string, filename: string): Promise<void> => {
     let conversationId = activeConversationId;
-    if (!conversationId) {
+    const existing = conversationId
+      ? useWorkspaceStore.getState().conversations.find((c) => c.id === conversationId)
+      : null;
+    if (!conversationId || !existing) {
       conversationId = createSurfaceConversation();
     }
     setShowMyDrivePicker(false);
@@ -1723,17 +1729,46 @@ export function ChatInterface({
     const sourceText = messageOverride !== undefined ? messageOverride : input;
     if ((!sourceText.trim() && attachedImages.length === 0 && pendingFileAttachments.length === 0) || isLoading) return;
     isSubmittingRef.current = true;
-    const effectiveAgent = agentOverride ?? selectedAgent;
+    let effectiveAgent = agentOverride ?? selectedAgent;
+    // Pane can hydrate with paneAgent="" before agents sync; resolve Abi/default
+    // so stream has a real agent id (selector label may already show Abi).
+    if (!effectiveAgent) {
+      const agents = useAgentsStore.getState().agents.filter((a) => a.enabled);
+      const resolved =
+        (isPane
+          ? agents.find(
+              (a) =>
+                a.name === 'Abi' ||
+                (typeof a.class_name === 'string' &&
+                  a.class_name.toLowerCase().includes('abiagent'))
+            )
+          : null) ??
+        agents.find((a) => a.isDefault) ??
+        agents[0];
+      if (resolved) {
+        effectiveAgent = resolved.id;
+        if (isPane) {
+          useWorkspaceStore.getState().setPaneAgent(resolved.id);
+        } else {
+          useWorkspaceStore.getState().setSelectedAgent(resolved.id);
+        }
+      }
+    }
 
     const latestActiveConversationId = readSurfaceConversationId();
     let conversationId = conversationIdOverride ?? latestActiveConversationId ?? activeConversationId;
-    const existingConversationBeforeSend = conversationId
+    let existingConversationBeforeSend = conversationId
       ? useWorkspaceStore.getState().conversations.find((c) => c.id === conversationId)
       : null;
 
-    // Create new conversation if none active (scoped to this surface)
-    if (!conversationId) {
+    // Create when none active, or when the surface id is orphaned (sync wiped a
+    // local draft / deleted thread while paneConversationId stayed set). Without
+    // this, addMessage no-ops and the composer still clears: send looks dead.
+    if (!conversationId || !existingConversationBeforeSend) {
       conversationId = createSurfaceConversation();
+      existingConversationBeforeSend = useWorkspaceStore
+        .getState()
+        .conversations.find((c) => c.id === conversationId) ?? null;
     }
 
     // Keep the conversation's latest agent in sync locally — the backend does

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
@@ -2911,7 +2911,7 @@ export function ChatInterface({
                       <Mic size={18} />
                     </button>
 
-                    {/* Compare: same prompt → both surfaces (main composer only) */}
+                    {/* Side-by-side: same prompt → both surfaces (main composer only) */}
                     {!isPane && contextPanelOpen && (
                       <button
                         type="button"
@@ -2921,8 +2921,8 @@ export function ChatInterface({
                           'chat-composer-action',
                           input.trim() && !isLoading && 'is-active'
                         )}
-                        title="Send to both panes (compare)"
-                        aria-label="Send to both panes"
+                        title="Send to both chats"
+                        aria-label="Send to both chats"
                       >
                         <Columns2 size={16} />
                       </button>

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
@@ -1757,24 +1757,55 @@ export function ChatInterface({
 
     const latestActiveConversationId = readSurfaceConversationId();
     let conversationId = conversationIdOverride ?? latestActiveConversationId ?? activeConversationId;
+    const workspaceIdForSend = useWorkspaceStore.getState().currentWorkspaceId;
+    // Only accept a thread that exists in the *current* workspace. Cross-workspace
+    // pane ids (left behind after workspace switch) must be treated as orphaned.
     let existingConversationBeforeSend = conversationId
-      ? useWorkspaceStore.getState().conversations.find((c) => c.id === conversationId)
+      ? useWorkspaceStore
+          .getState()
+          .conversations.find(
+            (c) =>
+              c.id === conversationId &&
+              (!workspaceIdForSend || c.workspaceId === workspaceIdForSend)
+          )
       : null;
 
     // Create when none active, or when the surface id is orphaned (sync wiped a
-    // local draft / deleted thread while paneConversationId stayed set). Without
-    // this, addMessage no-ops and the composer still clears: send looks dead.
+    // local draft / deleted thread while paneConversationId stayed set, or the
+    // id belongs to another workspace). Without this, addMessage updates a
+    // hidden row (or no-ops) and the composer still clears: send looks dead.
     if (!conversationId || !existingConversationBeforeSend) {
       conversationId = createSurfaceConversation();
       existingConversationBeforeSend = useWorkspaceStore
         .getState()
         .conversations.find((c) => c.id === conversationId) ?? null;
     }
+    if (!existingConversationBeforeSend || !conversationId) {
+      // createConversation returns an id without inserting when no workspace is
+      // selected. Abort before clearing the composer so send is not a silent no-op.
+      console.error('Cannot send: no conversation in the current workspace');
+      isSubmittingRef.current = false;
+      return;
+    }
 
     // Keep the conversation's latest agent in sync locally — the backend does
     // the same in get_or_create_conversation on every send.
-    if (existingConversationBeforeSend && existingConversationBeforeSend.agent !== effectiveAgent) {
+    if (existingConversationBeforeSend.agent !== effectiveAgent) {
       useWorkspaceStore.getState().setConversationAgent(conversationId, effectiveAgent);
+    }
+
+    // Load server history *before* adding the optimistic user message. Doing it
+    // after addMessage let loadConversationMessages replace the thread and wipe
+    // the just-sent message from the UI.
+    if (
+      !existingConversationBeforeSend.isDraft &&
+      conversationId.startsWith('conv-') &&
+      existingConversationBeforeSend.messages.length === 0
+    ) {
+      await loadConversationMessages(conversationId);
+      existingConversationBeforeSend =
+        useWorkspaceStore.getState().conversations.find((c) => c.id === conversationId) ??
+        existingConversationBeforeSend;
     }
 
     // ---- Slash commands: /skills, /create-skill <desc>, /<skill_slug> [args] ----
@@ -1869,17 +1900,7 @@ export function ChatInterface({
       // Get agent's system prompt
       const agentData = getAgent(effectiveAgent);
       const systemPrompt = agentData?.systemPrompt || null;
-      
-      // If this is an existing thread with no local history loaded yet, fetch it first.
-      // Skip for drafts — they don't exist on the backend until the first send.
-      if (
-        existingConversationBeforeSend &&
-        !existingConversationBeforeSend.isDraft &&
-        conversationId.startsWith('conv-') &&
-        existingConversationBeforeSend.messages.length === 0
-      ) {
-        await loadConversationMessages(conversationId);
-      }
+
       // Get current conversation with fresh state (including the just-added user message)
       const freshConversations = useWorkspaceStore.getState().conversations;
       const currentConversation = freshConversations.find(c => c.id === conversationId);

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/ai-pane.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/ai-pane.tsx
@@ -1,763 +1,141 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
-import { useRouter } from 'next/navigation';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import {
-  X,
-  Send,
-  Sparkles,
-  Bot,
-  Loader2,
-  ChevronDown,
-  Infinity,
-  ListTree,
-  Bug,
-  MessageSquare,
-  Check,
-  Plus,
-  History,
-  Download,
-  Trash2,
-} from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Columns2, Plus, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useWorkspaceStore } from '@/stores/workspace';
-import { useAgentsStore } from '@/stores/agents';
-import { useIntegrationsStore } from '@/stores/integrations';
-import { useSecretsStore } from '@/stores/secrets';
-import { useAuthStore } from '@/stores/auth';
+import { ChatInterface } from '@/components/chat/chat-interface';
 
-import { getApiUrl, getOllamaUrl } from '@/lib/config';
-
-const getApiBase = () => getApiUrl();
-
-type Mode = 'agent' | 'plan' | 'debug' | 'ask';
-
-const modes: { id: Mode; label: string; icon: React.ElementType; shortcut?: string; description: string }[] = [
-  { id: 'agent', label: 'Agent', icon: Infinity, shortcut: '⌘I', description: 'Can perform actions' },
-  { id: 'plan', label: 'Plan', icon: ListTree, description: 'Proposes plans' },
-  { id: 'debug', label: 'Debug', icon: Bug, description: 'Helps debug issues' },
-  { id: 'ask', label: 'Ask', icon: MessageSquare, description: 'Only answers questions' },
-];
-
-interface Message {
-  id: string;
-  role: 'user' | 'assistant';
-  content: string;
-  thinkingDuration?: number;
-}
-
-interface ChatSession {
-  id: string;
-  title: string;
-  messages: Message[];
-  createdAt: Date;
-}
-
+/**
+ * Right AI / compare surface.
+ *
+ * Renders the same ChatInterface as the central chat panel (bubbles, tool
+ * calls, uploads, composer, agent selector) with an independent conversation
+ * and agent (defaults to Abi). Open via header Sparkles or ⌘I.
+ */
 export function AIPane() {
-  const router = useRouter();
   const [mounted, setMounted] = useState(false);
-  const [input, setInput] = useState('');
-  const [messages, setMessages] = useState<Message[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const [mode, setMode] = useState<Mode>('agent');
-  const [showModeMenu, setShowModeMenu] = useState(false);
-  const [showAgentMenu, setShowAgentMenu] = useState(false);
-  const [showHistory, setShowHistory] = useState(false);
-  const [chatSessions, setChatSessions] = useState<ChatSession[]>([]);
-  const [currentSessionId, setCurrentSessionId] = useState<string | null>(null);
-  const messagesEndRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLTextAreaElement>(null);
-  const modeMenuRef = useRef<HTMLDivElement>(null);
-  const modelMenuRef = useRef<HTMLDivElement>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const dragStartX = useRef(0);
+  const dragStartWidth = useRef(0);
+  const isDraggingRef = useRef(false);
 
-  const { contextPanelOpen, toggleContextPanel, currentWorkspaceId, paneAgent, setPaneAgent } = useWorkspaceStore();
-  const { agents, getAgent } = useAgentsStore();
-  const { providers } = useIntegrationsStore();
-  const { getSecretByKey } = useSecretsStore();
-  
-  const currentAgent = mounted
-    ? agents.find((a) => a.id === paneAgent) ||
-      agents.find(
-        (a) =>
-          a.enabled &&
-          (a.name === 'Abi' ||
-            (typeof a.class_name === 'string' &&
-              a.class_name.toLowerCase().includes('abiagent')))
-      ) ||
-      agents.find((a) => a.isDefault && a.enabled) ||
-      agents.find((a) => a.enabled) ||
-      agents[0]
-    : null;
-  
-  // Get provider for agent with resolved secrets
-  const getProviderForAgent = (agentId: string) => {
-    const agent = getAgent(agentId);
-    if (agent?.providerId) {
-      const provider = providers.find(p => p.id === agent.providerId && p.enabled);
-      if (provider) {
-        // Resolve secrets to actual values
-        let resolvedApiKey = provider.apiKey; // Legacy fallback
-        let resolvedAccountId = provider.accountId; // Legacy fallback
-        
-        // Note: Secrets are server-side encrypted, we can't access actual values
-        // Just use the provider's configured keys
-        if (provider.apiKeySecretKey) {
-          resolvedApiKey = provider.apiKeySecretKey; // Reference to secret key
-        }
-        if (provider.accountIdSecretKey) {
-          resolvedAccountId = provider.accountIdSecretKey; // Reference to secret key
-        }
-        
-        return {
-          ...provider,
-          apiKey: resolvedApiKey,
-          accountId: resolvedAccountId,
-        };
-      }
-    }
-    return null;
-  };
+  const contextPanelOpen = useWorkspaceStore((s) => s.contextPanelOpen);
+  const toggleContextPanel = useWorkspaceStore((s) => s.toggleContextPanel);
+  const aiPaneWidth = useWorkspaceStore((s) => s.aiPaneWidth);
+  const setAiPaneWidth = useWorkspaceStore((s) => s.setAiPaneWidth);
+  const setPaneConversationId = useWorkspaceStore((s) => s.setPaneConversationId);
+  const paneAgent = useWorkspaceStore((s) => s.paneAgent);
 
   useEffect(() => {
     setMounted(true);
   }, []);
 
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages]);
-
-  // Focus input when pane opens
-  useEffect(() => {
-    if (contextPanelOpen && mounted) {
-      setTimeout(() => inputRef.current?.focus(), 100);
-    }
-  }, [contextPanelOpen, mounted]);
-
-  // Close menus on click outside
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (modeMenuRef.current && !modeMenuRef.current.contains(e.target as Node)) {
-        setShowModeMenu(false);
-      }
-      if (modelMenuRef.current && !modelMenuRef.current.contains(e.target as Node)) {
-        setShowAgentMenu(false);
-      }
+    const onMove = (e: MouseEvent) => {
+      if (!isDraggingRef.current) return;
+      const delta = dragStartX.current - e.clientX;
+      setAiPaneWidth(dragStartWidth.current + delta);
     };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
-
-  // Chat session management
-  const handleNewChat = () => {
-    // Save current session if it has messages
-    if (messages.length > 0) {
-      const newSession: ChatSession = {
-        id: currentSessionId || Date.now().toString(),
-        title: messages[0]?.content.slice(0, 30) + '...' || 'New chat',
-        messages: [...messages],
-        createdAt: new Date(),
-      };
-      setChatSessions((prev) => {
-        const existing = prev.find((s) => s.id === newSession.id);
-        if (existing) {
-          return prev.map((s) => (s.id === newSession.id ? newSession : s));
-        }
-        return [newSession, ...prev];
-      });
-    }
-    // Start fresh
-    setMessages([]);
-    setCurrentSessionId(Date.now().toString());
-    setShowHistory(false);
-    inputRef.current?.focus();
-  };
-
-  const handleLoadSession = (session: ChatSession) => {
-    // Save current first
-    if (messages.length > 0 && currentSessionId) {
-      setChatSessions((prev) =>
-        prev.map((s) =>
-          s.id === currentSessionId ? { ...s, messages: [...messages] } : s
-        )
-      );
-    }
-    setMessages(session.messages);
-    setCurrentSessionId(session.id);
-    setShowHistory(false);
-  };
-
-  const handleDeleteSession = (sessionId: string, e: React.MouseEvent) => {
-    e.stopPropagation();
-    setChatSessions((prev) => prev.filter((s) => s.id !== sessionId));
-    if (currentSessionId === sessionId) {
-      setMessages([]);
-      setCurrentSessionId(null);
-    }
-  };
-
-  const handleExportChat = () => {
-    if (messages.length === 0) return;
-    
-    const transcript = messages
-      .map((m) => `${m.role === 'user' ? 'You' : 'AI'}: ${m.content}`)
-      .join('\n\n');
-    
-    const blob = new Blob([transcript], { type: 'text/plain' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `chat-${new Date().toISOString().slice(0, 10)}.txt`;
-    a.click();
-    URL.revokeObjectURL(url);
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!input.trim() || isLoading) return;
-
-    const userContent = input.trim();
-    const userMessage: Message = {
-      id: Date.now().toString(),
-      role: 'user',
-      content: userContent,
+    const onUp = () => {
+      if (!isDraggingRef.current) return;
+      isDraggingRef.current = false;
+      setIsDragging(false);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
     };
-    setMessages((prev) => [...prev, userMessage]);
-    setInput('');
-    setIsLoading(true);
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+    return () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+  }, [setAiPaneWidth]);
 
-    try {
-      // Resolve the pane agent id (persisted paneAgent may be stale 'abi' string).
-      const agentData =
-        getAgent(paneAgent) ||
-        agents.find(
-          (a) =>
-            a.enabled &&
-            (a.name === 'Abi' ||
-              (typeof a.class_name === 'string' &&
-                a.class_name.toLowerCase().includes('abiagent')))
-        ) ||
-        null;
-      const resolvedAgentId = agentData?.id || paneAgent;
-
-      // For ABI-backed agents, omit the client provider so the API resolves
-      // in-process AbiAgent (with tools). Client integration mappings often
-      // point at Ollama and would bypass tool calling.
-      const usesAbiProvider = agentData?.provider === 'abi';
-      const provider = usesAbiProvider ? null : getProviderForAgent(resolvedAgentId);
-      const providerPayload = provider
-        ? {
-            id: provider.id,
-            name: provider.name,
-            type: provider.type,
-            enabled: provider.enabled,
-            endpoint: provider.endpoint || getOllamaUrl(),
-            api_key: provider.apiKey,
-            account_id: provider.accountId,
-            model: provider.model,
-          }
-        : null;
-
-      const systemPrompt = agentData?.systemPrompt || null;
-      
-      // Build message history for the API (must include the current user message)
-      // Note: React setState is async, so `messages` doesn't have userMessage yet.
-      // We manually append it, matching how chat-interface uses getState() for fresh data.
-      const fullHistory = [...messages, userMessage].map(m => ({ role: m.role, content: m.content }));
-
-      // Add placeholder for streaming response
-      const assistantId = (Date.now() + 1).toString();
-      const thinkingStartTime = Date.now();
-      setMessages((prev) => [...prev, { id: assistantId, role: 'assistant', content: '▌' }]);
-      setIsLoading(false); // Stop loading indicator, streaming will show the cursor
-
-      const token = useAuthStore.getState().token;
-      const response = await fetch(`${getApiBase()}/api/chat/stream`, {
-        method: 'POST',
-        headers: { 
-          'Content-Type': 'application/json',
-          ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
-        },
-        body: JSON.stringify({
-          workspace_id: currentWorkspaceId,
-          message: userContent,
-          messages: fullHistory,
-          agent: resolvedAgentId,
-          provider: providerPayload,
-          system_prompt: systemPrompt,
-        }),
-      });
-
-      if (!response.ok) {
-        throw new Error(`API error: ${response.status}`);
-      }
-
-      const reader = response.body?.getReader();
-      const decoder = new TextDecoder();
-      let thinkingContent = '';
-      let responseContent = '';
-      let isInThinking = false;
-
-      if (reader) {
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-
-          const chunk = decoder.decode(value);
-          const lines = chunk.split('\n');
-
-          for (const line of lines) {
-            if (line.startsWith('data: ')) {
-              const data = line.slice(6);
-              if (data === '[DONE]') continue;
-              
-              try {
-                const parsed = JSON.parse(data);
-                if (parsed.content) {
-                  const token = parsed.content as string;
-                  
-                  // Track <think> tags
-                  if (token.includes('<think>')) {
-                    isInThinking = true;
-                    const assembled = `<think>${thinkingContent}</think>`;
-                    setMessages((prev) => 
-                      prev.map((m) => m.id === assistantId ? { ...m, content: assembled } : m)
-                    );
-                    continue;
-                  }
-                  
-                  if (token.includes('</think>')) {
-                    isInThinking = false;
-                    const assembled = `<think>${thinkingContent}</think>\n\n▌`;
-                    setMessages((prev) => 
-                      prev.map((m) => m.id === assistantId ? { ...m, content: assembled } : m)
-                    );
-                    continue;
-                  }
-                  
-                  if (isInThinking) {
-                    thinkingContent += token;
-                    const assembled = `<think>${thinkingContent}</think>`;
-                    setMessages((prev) => 
-                      prev.map((m) => m.id === assistantId ? { ...m, content: assembled } : m)
-                    );
-                    continue;
-                  }
-                  
-                  // Regular response content
-                  responseContent += token;
-                  const assembled = thinkingContent
-                    ? `<think>${thinkingContent}</think>\n\n${responseContent}▌`
-                    : `${responseContent}▌`;
-                  setMessages((prev) => 
-                    prev.map((m) => m.id === assistantId ? { ...m, content: assembled } : m)
-                  );
-                }
-                if (parsed.error) {
-                  const errContent = `Error: ${parsed.error}`;
-                  setMessages((prev) => 
-                    prev.map((m) => m.id === assistantId ? { ...m, content: errContent } : m)
-                  );
-                  throw new Error(parsed.error);
-                }
-              } catch (parseError) {
-                // Only swallow JSON parsing failures for partial SSE chunks
-                if (!(parseError instanceof SyntaxError)) {
-                  throw parseError;
-                }
-              }
-            }
-          }
-        }
-        // Final: store full content with thinking duration
-        const thinkingDuration = (Date.now() - thinkingStartTime) / 1000;
-        const finalContent = thinkingContent
-          ? `<think>${thinkingContent}</think>\n\n${responseContent}`
-          : responseContent;
-        setMessages((prev) => 
-          prev.map((m) => m.id === assistantId ? { ...m, content: finalContent, thinkingDuration } : m)
-        );
-      }
-    } catch (error) {
-      console.error('AI Pane API error:', error);
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      setMessages((prev) => [...prev, {
-        id: (Date.now() + 1).toString(),
-        role: 'assistant',
-        content: `Error: ${errorMessage}\n\nMake sure the API server is running and the agent has a configured provider.`,
-      }]);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
+  const handleDragStart = useCallback(
+    (e: React.MouseEvent) => {
       e.preventDefault();
-      handleSubmit(e);
-    }
-  };
+      isDraggingRef.current = true;
+      setIsDragging(true);
+      dragStartX.current = e.clientX;
+      dragStartWidth.current = aiPaneWidth;
+      document.body.style.cursor = 'col-resize';
+      document.body.style.userSelect = 'none';
+    },
+    [aiPaneWidth]
+  );
 
-  const currentMode = modes.find((m) => m.id === mode) || modes[0];
-  const ModeIcon = currentMode.icon;
+  const handleNewChat = () => {
+    setPaneConversationId(null);
+  };
 
   if (!mounted || !contextPanelOpen) return null;
 
   return (
-    <aside className="flex h-full w-80 flex-col border-l border-border/50 bg-background">
-      {/* Header */}
-      <div className="flex h-14 items-center justify-between border-b px-3">
-        <div className="flex items-center gap-1">
-          <button
-            onClick={handleNewChat}
-            className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
-            title="New chat"
-          >
-            <Plus size={16} />
-          </button>
-          <button
-            onClick={() => setShowHistory(!showHistory)}
-            className={cn(
-              'rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground',
-              showHistory && 'bg-muted text-foreground'
-            )}
-            title="Chat history"
-          >
-            <History size={16} />
-          </button>
-          <button
-            onClick={handleExportChat}
-            disabled={messages.length === 0}
-            className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed"
-            title="Export conversation"
-          >
-            <Download size={16} />
-          </button>
+    <>
+      {isDragging && <div className="fixed inset-0 z-50 cursor-col-resize" />}
+      <div
+        className="group relative flex w-2 shrink-0 cursor-col-resize items-center justify-center"
+        onMouseDown={handleDragStart}
+        title="Drag to resize compare pane"
+        aria-label="Resize compare pane"
+        role="separator"
+        aria-orientation="vertical"
+      >
+        <div className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border transition-colors group-hover:bg-workspace-accent" />
+        <div className="relative z-10 flex flex-col gap-[5px]">
+          {[0, 1, 2, 3, 4].map((i) => (
+            <div
+              key={i}
+              className="h-[3px] w-[3px] rounded-full bg-muted-foreground/40 transition-colors group-hover:bg-workspace-accent"
+            />
+          ))}
         </div>
-        <button
-          onClick={toggleContextPanel}
-          className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
-          title="Close"
-        >
-          <X size={16} />
-        </button>
       </div>
-
-      {/* History Panel */}
-      {showHistory && (
-        <div className="border-b bg-muted/30 p-2 max-h-48 overflow-auto">
-          <div className="text-xs font-medium text-muted-foreground mb-2 px-1">Recent Chats</div>
-          {chatSessions.length === 0 ? (
-            <p className="text-xs text-muted-foreground px-1">No chat history</p>
-          ) : (
-            <div className="space-y-1">
-              {chatSessions.map((session) => (
-                <div
-                  key={session.id}
-                  onClick={() => handleLoadSession(session)}
-                  className={cn(
-                    'flex items-center justify-between rounded px-2 py-1.5 cursor-pointer text-xs hover:bg-muted',
-                    currentSessionId === session.id && 'bg-muted'
-                  )}
-                >
-                  <div className="flex items-center gap-2 truncate flex-1">
-                    <MessageSquare size={12} className="text-muted-foreground shrink-0" />
-                    <span className="truncate">{session.title}</span>
-                  </div>
-                  <button
-                    onClick={(e) => handleDeleteSession(session.id, e)}
-                    className="p-1 rounded text-muted-foreground hover:text-destructive hover:bg-destructive/10"
-                  >
-                    <Trash2 size={12} />
-                  </button>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-      )}
-
-      {/* Messages */}
-      <div className="flex-1 overflow-auto p-3">
-        {messages.length === 0 ? (
-          <div className="flex h-full flex-col items-center justify-center text-center">
-            <Bot size={40} className="mb-3 text-muted-foreground/20" />
-            <p className="text-sm text-muted-foreground">How can I help you?</p>
-          </div>
-        ) : (
-          <div className="space-y-3">
-            {messages.map((message) => (
-              <PaneMessage key={message.id} message={message} />
-            ))}
-            {isLoading && messages[messages.length - 1]?.role !== 'assistant' && (
-              <div className="mr-6 flex items-center gap-2 rounded-lg bg-muted px-3 py-2 text-sm">
-                <Loader2 size={14} className="animate-spin" />
-                <span className="text-muted-foreground">Processing...</span>
-              </div>
-            )}
-            <div ref={messagesEndRef} />
-          </div>
-        )}
-      </div>
-
-      {/* Input area */}
-      <div className="border-t p-3">
-        <form onSubmit={handleSubmit}>
-          <textarea
-            ref={inputRef}
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder="Ask anything..."
-            rows={3}
-            className={cn(
-              'w-full resize-none rounded-lg border bg-background px-3 py-2 text-sm outline-none',
-              'placeholder:text-muted-foreground/50',
-              'focus:ring-1 focus:ring-primary/30'
-            )}
-            disabled={isLoading}
-          />
-          
-          {/* Bottom bar with mode and model selectors */}
-          <div className="mt-2 flex items-center justify-between">
-            <div className="flex items-center gap-1">
-              {/* Mode selector */}
-              <div ref={modeMenuRef} className="relative">
-                <button
-                  type="button"
-                  onClick={() => setShowModeMenu(!showModeMenu)}
-                  className={cn(
-                    'flex items-center gap-1.5 rounded px-2 py-1 text-xs',
-                    'hover:bg-muted',
-                    showModeMenu && 'bg-muted'
-                  )}
-                >
-                  <ModeIcon size={14} />
-                  <span>{currentMode.label}</span>
-                  {currentMode.shortcut && (
-                    <kbd className="ml-1 rounded border bg-background px-1 text-[10px] text-muted-foreground">
-                      {currentMode.shortcut}
-                    </kbd>
-                  )}
-                </button>
-                
-                {showModeMenu && (
-                  <div className="absolute bottom-full left-0 mb-1 w-36 rounded-lg border bg-background py-1 shadow-lg">
-                    {modes.map((m) => {
-                      const Icon = m.icon;
-                      return (
-                        <button
-                          key={m.id}
-                          type="button"
-                          onClick={() => {
-                            setMode(m.id);
-                            setShowModeMenu(false);
-                          }}
-                          className={cn(
-                            'flex w-full items-center gap-2 px-3 py-1.5 text-sm',
-                            'hover:bg-muted',
-                            mode === m.id && 'bg-muted'
-                          )}
-                        >
-                          <Icon size={14} />
-                          <span className="flex-1 text-left">{m.label}</span>
-                          {m.shortcut && (
-                            <kbd className="rounded border bg-background px-1 text-[10px] text-muted-foreground">
-                              {m.shortcut}
-                            </kbd>
-                          )}
-                          {mode === m.id && <Check size={12} />}
-                        </button>
-                      );
-                    })}
-                  </div>
-                )}
-              </div>
-
-              {/* Agent selector (AI Pane defaults to Abi) */}
-              <div ref={modelMenuRef} className="relative">
-                <button
-                  type="button"
-                  onClick={() => setShowAgentMenu(!showAgentMenu)}
-                  className={cn(
-                    'flex items-center gap-1.5 rounded px-2 py-1 text-xs',
-                    'hover:bg-muted',
-                    showAgentMenu && 'bg-muted'
-                  )}
-                >
-                  <span>{currentAgent?.name || 'Abi'}</span>
-                  <ChevronDown size={12} className="text-muted-foreground" />
-                </button>
-                
-                {showAgentMenu && (
-                  <div className="absolute bottom-full left-0 mb-1 w-48 rounded-lg border bg-background py-1 shadow-lg">
-                    <div className="px-3 py-1.5 text-xs text-muted-foreground">
-                      Select agent
-                    </div>
-                    {agents.filter(agent => agent.enabled).sort((a, b) => a.name.localeCompare(b.name)).map((agent) => (
-                      <button
-                        key={agent.id}
-                        type="button"
-                        onClick={() => {
-                          setPaneAgent(agent.id, true);
-                          setShowAgentMenu(false);
-                        }}
-                        className={cn(
-                          'flex w-full items-center gap-2 px-3 py-1.5 text-sm',
-                          'hover:bg-muted',
-                          (paneAgent === agent.id || currentAgent?.id === agent.id) && 'bg-muted'
-                        )}
-                      >
-                        <span className="flex-1 text-left">{agent.name}</span>
-                        {(paneAgent === agent.id || currentAgent?.id === agent.id) && <Check size={12} />}
-                      </button>
-                    ))}
-                  </div>
-                )}
+      <aside
+        className="flex h-full shrink-0 flex-col border-l border-border/50 bg-background"
+        style={{ width: aiPaneWidth }}
+        data-ai-pane="true"
+      >
+        <div className="flex h-14 shrink-0 items-center justify-between border-b border-border/50 px-3">
+          <div className="flex min-w-0 items-center gap-2">
+            <Columns2 size={16} className="shrink-0 text-muted-foreground" />
+            <div className="min-w-0">
+              <div className="truncate text-sm font-semibold">Compare</div>
+              <div className="truncate text-[11px] text-muted-foreground">
+                Independent thread{paneAgent ? ' · own agent' : ''}
               </div>
             </div>
-
-            {/* Send button */}
+          </div>
+          <div className="flex items-center gap-0.5">
             <button
-              type="submit"
-              disabled={!input.trim() || isLoading}
+              type="button"
+              onClick={handleNewChat}
               className={cn(
-                'flex h-7 w-7 items-center justify-center rounded-full bg-primary text-primary-foreground',
-                'hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50'
+                'rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground'
               )}
+              style={{ borderRadius: 'var(--org-border-radius, 0px)' }}
+              title="New compare chat"
             >
-              <Send size={14} />
+              <Plus size={16} />
+            </button>
+            <button
+              type="button"
+              onClick={toggleContextPanel}
+              className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+              style={{ borderRadius: 'var(--org-border-radius, 0px)' }}
+              title="Close compare pane"
+            >
+              <X size={16} />
             </button>
           </div>
-        </form>
-      </div>
-    </aside>
-  );
-}
-
-function PaneMessage({ message }: { message: Message }) {
-  const isUser = message.role === 'user';
-  const [showThinking, setShowThinking] = useState(false);
-  const [autoCollapsed, setAutoCollapsed] = useState(false);
-  const [elapsedSeconds, setElapsedSeconds] = useState(0);
-  const wasProcessingRef = useRef(false);
-  const processingStartRef = useRef<number | null>(null);
-
-  // Parse <think> tags
-  const parseThinking = (content: string) => {
-    const match = content.match(/<think>([\s\S]*?)<\/think>/);
-    if (match) {
-      const thinking = match[1].trim();
-      const response = content.replace(/<think>[\s\S]*?<\/think>/, '').trim();
-      return { thinking, response };
-    }
-    return { thinking: null, response: content };
-  };
-
-  const { thinking, response } = isUser
-    ? { thinking: null, response: message.content }
-    : parseThinking(message.content);
-
-  const isStillProcessing = Boolean(
-    !isUser && thinking && (!response || response === '▌')
-  );
-
-  // Live elapsed timer while processing
-  useEffect(() => {
-    if (isStillProcessing) {
-      if (processingStartRef.current === null) {
-        processingStartRef.current = Date.now();
-        setElapsedSeconds(0);
-      }
-      const interval = setInterval(() => {
-        setElapsedSeconds(Math.floor((Date.now() - (processingStartRef.current ?? Date.now())) / 1000));
-      }, 1000);
-      return () => clearInterval(interval);
-    } else {
-      processingStartRef.current = null;
-    }
-  }, [isStillProcessing]);
-
-  // Auto-close thinking 3s after processing finishes
-  useEffect(() => {
-    if (isStillProcessing) {
-      wasProcessingRef.current = true;
-    } else if (wasProcessingRef.current && !autoCollapsed) {
-      const timer = setTimeout(() => {
-        setShowThinking(false);
-        setAutoCollapsed(true);
-      }, 3000);
-      return () => clearTimeout(timer);
-    }
-  }, [isStillProcessing, autoCollapsed]);
-
-  const formatDuration = (seconds: number) => {
-    if (seconds < 1) return '<1s';
-    if (seconds < 60) return `${Math.round(seconds)}s`;
-    const mins = Math.floor(seconds / 60);
-    const secs = Math.round(seconds % 60);
-    return `${mins}m ${secs}s`;
-  };
-
-  const hasThinkingSection = !isUser && (thinking || (message.thinkingDuration && message.thinkingDuration > 0));
-
-  if (isUser) {
-    return (
-      <div className="ml-6 rounded-lg bg-primary px-3 py-2 text-sm text-primary-foreground">
-        <p className="whitespace-pre-wrap">{message.content}</p>
-      </div>
-    );
-  }
-
-  return (
-    <div className="mr-6 space-y-1">
-      {/* Processing / Processed indicator */}
-      {hasThinkingSection && (
-        <div>
-          <button
-            onClick={() => thinking && setShowThinking(!showThinking)}
-            className={cn(
-              'flex items-center gap-1 text-[10px] text-muted-foreground transition-colors',
-              thinking && !isStillProcessing && 'hover:text-foreground cursor-pointer'
-            )}
-            disabled={!thinking || isStillProcessing}
-          >
-            {isStillProcessing ? (
-              <span className="font-medium tabular-nums">{formatDuration(elapsedSeconds)}</span>
-            ) : (
-              <span className="font-medium">
-                Processed in {formatDuration(message.thinkingDuration || 0)}
-              </span>
-            )}
-            {thinking && !isStillProcessing && (
-              <ChevronDown
-                size={10}
-                className={cn('transition-transform', showThinking && 'rotate-180')}
-              />
-            )}
-          </button>
-
-          {thinking && (showThinking || (isStillProcessing && !autoCollapsed)) && (
-            <div className="mt-1 max-h-32 overflow-y-auto rounded border border-border/50 bg-muted/50 px-2 py-1.5 text-[10px] text-muted-foreground">
-              <p className="whitespace-pre-wrap leading-relaxed">{thinking}</p>
-            </div>
-          )}
         </div>
-      )}
-
-      {/* Response bubble */}
-      <div className="rounded-lg bg-muted px-3 py-2 text-sm prose prose-sm dark:prose-invert max-w-none [&_p]:my-0.5 [&_ul]:my-1 [&_ol]:my-1 [&_li]:my-0 [&_code]:bg-background/50 [&_code]:px-1 [&_code]:rounded [&_code]:text-xs">
-        {isStillProcessing ? (
-          <span className="inline-flex items-center gap-0.5">
-            <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-muted-foreground/60" style={{ animationDelay: '0ms' }} />
-            <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-muted-foreground/60" style={{ animationDelay: '150ms' }} />
-            <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-muted-foreground/60" style={{ animationDelay: '300ms' }} />
-          </span>
-        ) : (
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>{response}</ReactMarkdown>
-        )}
-      </div>
-    </div>
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          <ChatInterface surface="pane" />
+        </div>
+      </aside>
+    </>
   );
 }

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/ai-pane.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/ai-pane.tsx
@@ -1,31 +1,36 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { Columns2, Plus, X } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { History, MessageSquare, Plus, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useWorkspaceStore } from '@/stores/workspace';
 import { ChatInterface } from '@/components/chat/chat-interface';
 
 /**
- * Right AI / compare surface.
- *
- * Renders the same ChatInterface as the central chat panel (bubbles, tool
- * calls, uploads, composer, agent selector) with an independent conversation
- * and agent (defaults to Abi). Open via header Sparkles or ⌘I.
+ * Right chat pane: same ChatInterface as the central panel, with Cursor-like
+ * open-chat tabs and a history clock. Side-by-side compare stays available by
+ * keeping this pane open next to the main thread (⌘K / Sparkles).
  */
 export function AIPane() {
   const [mounted, setMounted] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
+  const [showHistory, setShowHistory] = useState(false);
   const dragStartX = useRef(0);
   const dragStartWidth = useRef(0);
   const isDraggingRef = useRef(false);
+  const historyRef = useRef<HTMLDivElement>(null);
 
   const contextPanelOpen = useWorkspaceStore((s) => s.contextPanelOpen);
   const toggleContextPanel = useWorkspaceStore((s) => s.toggleContextPanel);
   const aiPaneWidth = useWorkspaceStore((s) => s.aiPaneWidth);
   const setAiPaneWidth = useWorkspaceStore((s) => s.setAiPaneWidth);
+  const paneConversationId = useWorkspaceStore((s) => s.paneConversationId);
   const setPaneConversationId = useWorkspaceStore((s) => s.setPaneConversationId);
-  const paneAgent = useWorkspaceStore((s) => s.paneAgent);
+  const paneOpenTabIds = useWorkspaceStore((s) => s.paneOpenTabIds);
+  const openPaneTab = useWorkspaceStore((s) => s.openPaneTab);
+  const closePaneTab = useWorkspaceStore((s) => s.closePaneTab);
+  const conversations = useWorkspaceStore((s) => s.conversations);
+  const currentWorkspaceId = useWorkspaceStore((s) => s.currentWorkspaceId);
 
   useEffect(() => {
     setMounted(true);
@@ -54,6 +59,17 @@ export function AIPane() {
     };
   }, [setAiPaneWidth]);
 
+  useEffect(() => {
+    if (!showHistory) return;
+    const onDown = (e: MouseEvent) => {
+      if (historyRef.current && !historyRef.current.contains(e.target as Node)) {
+        setShowHistory(false);
+      }
+    };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [showHistory]);
+
   const handleDragStart = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault();
@@ -69,7 +85,25 @@ export function AIPane() {
 
   const handleNewChat = () => {
     setPaneConversationId(null);
+    setShowHistory(false);
   };
+
+  const openTabs = useMemo(() => {
+    return paneOpenTabIds
+      .map((id) => conversations.find((c) => c.id === id))
+      .filter((c): c is NonNullable<typeof c> => Boolean(c));
+  }, [paneOpenTabIds, conversations]);
+
+  const recentConversations = useMemo(() => {
+    if (!currentWorkspaceId) return [];
+    return conversations
+      .filter((c) => c.workspaceId === currentWorkspaceId && !c.archived)
+      .slice()
+      .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
+      .slice(0, 30);
+  }, [conversations, currentWorkspaceId]);
+
+  const showNewChatTab = paneConversationId === null;
 
   if (!mounted || !contextPanelOpen) return null;
 
@@ -79,8 +113,8 @@ export function AIPane() {
       <div
         className="group relative flex w-2 shrink-0 cursor-col-resize items-center justify-center"
         onMouseDown={handleDragStart}
-        title="Drag to resize compare pane"
-        aria-label="Resize compare pane"
+        title="Drag to resize chat pane"
+        aria-label="Resize chat pane"
         role="separator"
         aria-orientation="vertical"
       >
@@ -99,37 +133,144 @@ export function AIPane() {
         style={{ width: aiPaneWidth }}
         data-ai-pane="true"
       >
-        <div className="flex h-14 shrink-0 items-center justify-between border-b border-border/50 px-3">
-          <div className="flex min-w-0 items-center gap-2">
-            <Columns2 size={16} className="shrink-0 text-muted-foreground" />
-            <div className="min-w-0">
-              <div className="truncate text-sm font-semibold">Compare</div>
-              <div className="truncate text-[11px] text-muted-foreground">
-                Independent thread{paneAgent ? ' · own agent' : ''}
-              </div>
-            </div>
+        <div className="flex h-10 shrink-0 items-stretch border-b border-border/50">
+          <div
+            className="flex min-w-0 flex-1 items-stretch overflow-x-auto"
+            role="tablist"
+            aria-label="Open chats"
+          >
+            {showNewChatTab && (
+              <button
+                type="button"
+                role="tab"
+                aria-selected
+                className={cn(
+                  'group/tab relative flex max-w-[160px] shrink-0 items-center gap-1.5 border-r border-border/50 px-3 text-xs',
+                  'bg-background text-foreground'
+                )}
+              >
+                <span className="truncate font-medium">New chat</span>
+              </button>
+            )}
+            {openTabs.map((tab) => {
+              const active = paneConversationId === tab.id;
+              return (
+                <div
+                  key={tab.id}
+                  role="tab"
+                  aria-selected={active}
+                  className={cn(
+                    'group/tab relative flex max-w-[160px] shrink-0 items-center gap-1 border-r border-border/50 pl-3 pr-1 text-xs',
+                    active
+                      ? 'bg-background text-foreground'
+                      : 'bg-muted/30 text-muted-foreground hover:bg-muted/50 hover:text-foreground'
+                  )}
+                >
+                  <button
+                    type="button"
+                    onClick={() => openPaneTab(tab.id)}
+                    className="min-w-0 flex-1 truncate py-2 text-left font-medium"
+                    title={tab.title}
+                  >
+                    {tab.title || 'Chat'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      closePaneTab(tab.id);
+                    }}
+                    className={cn(
+                      'rounded p-0.5 text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground',
+                      'group-hover/tab:opacity-100 focus-visible:opacity-100',
+                      active && 'opacity-70'
+                    )}
+                    style={{ borderRadius: 'var(--org-border-radius, 0px)' }}
+                    title="Close tab"
+                    aria-label={`Close ${tab.title || 'chat'}`}
+                  >
+                    <X size={12} />
+                  </button>
+                </div>
+              );
+            })}
           </div>
-          <div className="flex items-center gap-0.5">
+
+          <div className="relative flex shrink-0 items-center gap-0.5 px-1.5" ref={historyRef}>
             <button
               type="button"
               onClick={handleNewChat}
-              className={cn(
-                'rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground'
-              )}
+              className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
               style={{ borderRadius: 'var(--org-border-radius, 0px)' }}
-              title="New compare chat"
+              title="New chat"
+              aria-label="New chat"
             >
               <Plus size={16} />
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowHistory((v) => !v)}
+              className={cn(
+                'rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground',
+                showHistory && 'bg-muted text-foreground'
+              )}
+              style={{ borderRadius: 'var(--org-border-radius, 0px)' }}
+              title="Chat history"
+              aria-label="Chat history"
+              aria-expanded={showHistory}
+            >
+              <History size={16} />
             </button>
             <button
               type="button"
               onClick={toggleContextPanel}
               className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
               style={{ borderRadius: 'var(--org-border-radius, 0px)' }}
-              title="Close compare pane"
+              title="Close chat pane"
+              aria-label="Close chat pane"
             >
               <X size={16} />
             </button>
+
+            {showHistory && (
+              <div className="absolute right-1 top-full z-40 mt-1 w-72 max-h-80 overflow-auto rounded-md border border-border bg-popover py-1 shadow-lg">
+                <div className="px-3 py-1.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                  Recent
+                </div>
+                {recentConversations.length === 0 ? (
+                  <p className="px-3 py-2 text-xs text-muted-foreground">No chat history yet</p>
+                ) : (
+                  recentConversations.map((conv) => {
+                    const isActive = paneConversationId === conv.id;
+                    const isOpen = paneOpenTabIds.includes(conv.id);
+                    return (
+                      <button
+                        key={conv.id}
+                        type="button"
+                        onClick={() => {
+                          openPaneTab(conv.id);
+                          setShowHistory(false);
+                        }}
+                        className={cn(
+                          'flex w-full items-center gap-2 px-3 py-2 text-left text-xs transition-colors',
+                          'hover:bg-muted',
+                          isActive && 'bg-muted'
+                        )}
+                      >
+                        <MessageSquare
+                          size={12}
+                          className={cn(
+                            'shrink-0',
+                            isOpen ? 'text-workspace-accent' : 'text-muted-foreground'
+                          )}
+                        />
+                        <span className="min-w-0 flex-1 truncate">{conv.title || 'Chat'}</span>
+                      </button>
+                    );
+                  })
+                )}
+              </div>
+            )}
           </div>
         </div>
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden">

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/ai-pane.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/ai-pane.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { History, MessageSquare, Plus, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useWorkspaceStore } from '@/stores/workspace';
+import { useAgentsStore } from '@/stores/agents';
 import { ChatInterface } from '@/components/chat/chat-interface';
 
 /**
@@ -84,7 +85,24 @@ export function AIPane() {
   );
 
   const handleNewChat = () => {
+    const ws = useWorkspaceStore.getState();
     setPaneConversationId(null);
+    // New blank pane chat: restore Abi unless the user picked another agent
+    // in the selector (history tabs must not count as an explicit pick).
+    if (!ws.paneAgentExplicitlySelected) {
+      const agents = useAgentsStore.getState().agents;
+      const abi =
+        agents.find(
+          (a) =>
+            a.enabled &&
+            (a.name === 'Abi' ||
+              (typeof a.class_name === 'string' &&
+                a.class_name.toLowerCase().includes('abiagent')))
+        ) ??
+        agents.find((a) => a.isDefault && a.enabled) ??
+        agents.find((a) => a.enabled);
+      if (abi) ws.setPaneAgent(abi.id);
+    }
     setShowHistory(false);
   };
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/header.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/header.tsx
@@ -188,7 +188,7 @@ export function Header({ title, subtitle, actions }: HeaderProps = {}) {
           )}
         </div>
 
-        {/* Compare / AI pane toggle (side-by-side chat surface) */}
+        {/* Side chat pane toggle (side-by-side threads) */}
         <button
           onClick={toggleContextPanel}
           className={cn(
@@ -196,7 +196,7 @@ export function Header({ title, subtitle, actions }: HeaderProps = {}) {
             'hover:bg-muted',
             panelOpen ? 'bg-primary/10 text-primary' : 'text-muted-foreground hover:text-foreground'
           )}
-          title="Toggle compare pane (⌘K)"
+          title="Toggle chat pane (⌘K)"
         >
           <Sparkles size={16} />
           <kbd className="hidden rounded border bg-muted px-1 text-micro text-muted-foreground sm:inline">

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/header.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/header.tsx
@@ -188,7 +188,7 @@ export function Header({ title, subtitle, actions }: HeaderProps = {}) {
           )}
         </div>
 
-        {/* AI Pane toggle */}
+        {/* Compare / AI pane toggle (side-by-side chat surface) */}
         <button
           onClick={toggleContextPanel}
           className={cn(
@@ -196,7 +196,7 @@ export function Header({ title, subtitle, actions }: HeaderProps = {}) {
             'hover:bg-muted',
             panelOpen ? 'bg-primary/10 text-primary' : 'text-muted-foreground hover:text-foreground'
           )}
-          title="Toggle AI Assistant (⌘K)"
+          title="Toggle compare pane (⌘K)"
         >
           <Sparkles size={16} />
           <kbd className="hidden rounded border bg-muted px-1 text-micro text-muted-foreground sm:inline">

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/section-panel.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/section-panel.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { cn } from '@/lib/utils';
 import { useWorkspaceStore, type SidebarSection } from '@/stores/workspace';
 import { useFeature } from '@/hooks/use-feature';
@@ -56,27 +57,96 @@ function SectionContent({ section }: { section: SidebarSection }) {
 }
 
 export function SectionPanel() {
-  const { activePanelSection } = useWorkspaceStore();
+  const activePanelSection = useWorkspaceStore((s) => s.activePanelSection);
+  const sectionPanelWidth = useWorkspaceStore((s) => s.sectionPanelWidth);
+  const setSectionPanelWidth = useWorkspaceStore((s) => s.setSectionPanelWidth);
   const isOpen = activePanelSection !== null;
   const panelTitle = activePanelSection ? SECTION_LABELS[activePanelSection] : '';
 
+  const [isDragging, setIsDragging] = useState(false);
+  const dragStartX = useRef(0);
+  const dragStartWidth = useRef(0);
+  const isDraggingRef = useRef(false);
+
+  useEffect(() => {
+    const onMove = (e: MouseEvent) => {
+      if (!isDraggingRef.current) return;
+      const delta = e.clientX - dragStartX.current;
+      setSectionPanelWidth(dragStartWidth.current + delta);
+    };
+    const onUp = () => {
+      if (!isDraggingRef.current) return;
+      isDraggingRef.current = false;
+      setIsDragging(false);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+    return () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+  }, [setSectionPanelWidth]);
+
+  const handleDragStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      isDraggingRef.current = true;
+      setIsDragging(true);
+      dragStartX.current = e.clientX;
+      dragStartWidth.current = sectionPanelWidth;
+      document.body.style.cursor = 'col-resize';
+      document.body.style.userSelect = 'none';
+    },
+    [sectionPanelWidth]
+  );
+
   return (
-    <div
-      className={cn(
-        'glass flex flex-col border-r border-border/50 transition-all duration-300 overflow-hidden flex-shrink-0',
-        isOpen ? 'w-64' : 'w-0'
-      )}
-    >
-      {isOpen && activePanelSection && (
-        <>
-          <div className="flex h-14 flex-shrink-0 items-center border-b border-border/50 px-4">
-            <span className="text-sm font-semibold">{panelTitle}</span>
+    <>
+      {isDragging && <div className="fixed inset-0 z-50 cursor-col-resize" />}
+      <div
+        className={cn(
+          'glass flex flex-col border-r border-border/50 overflow-hidden flex-shrink-0',
+          // Disable width transition while dragging so resize stays 1:1 with the pointer
+          !isDragging && 'transition-[width] duration-300',
+          !isOpen && 'w-0 border-r-0'
+        )}
+        style={isOpen ? { width: sectionPanelWidth } : undefined}
+      >
+        {isOpen && activePanelSection && (
+          <>
+            <div className="flex h-14 flex-shrink-0 items-center border-b border-border/50 px-4">
+              <span className="text-sm font-semibold">{panelTitle}</span>
+            </div>
+            <nav className="flex-1 overflow-y-auto p-2">
+              <SectionContent section={activePanelSection} />
+            </nav>
+          </>
+        )}
+      </div>
+      {isOpen && (
+        <div
+          className="group relative flex w-2 shrink-0 cursor-col-resize items-center justify-center"
+          onMouseDown={handleDragStart}
+          title="Drag to resize sidebar"
+          aria-label="Resize sidebar"
+          role="separator"
+          aria-orientation="vertical"
+        >
+          <div className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border transition-colors group-hover:bg-workspace-accent" />
+          <div className="relative z-10 flex flex-col gap-[5px]">
+            {[0, 1, 2, 3, 4].map((i) => (
+              <div
+                key={i}
+                className="h-[3px] w-[3px] rounded-full bg-muted-foreground/40 transition-colors group-hover:bg-workspace-accent"
+              />
+            ))}
           </div>
-          <nav className="flex-1 overflow-y-auto p-2">
-            <SectionContent section={activePanelSection} />
-          </nav>
-        </>
+        </div>
       )}
-    </div>
+    </>
   );
 }

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/workspace-layout.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/workspace-layout.tsx
@@ -164,7 +164,7 @@ export function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
     loadSkills();
   }, [currentWorkspaceId]);
 
-  // Keyboard shortcut: Cmd+K to toggle compare / AI pane (desktop only)
+  // Keyboard shortcut: Cmd+K to toggle the side chat pane (desktop only)
   useEffect(() => {
     if (isMobile) return;
     const handleKeyDown = (e: KeyboardEvent) => {

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/workspace-layout.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/workspace-layout.tsx
@@ -164,7 +164,7 @@ export function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
     loadSkills();
   }, [currentWorkspaceId]);
 
-  // Keyboard shortcut: Cmd+K to toggle AI pane (desktop only)
+  // Keyboard shortcut: Cmd+K to toggle compare / AI pane (desktop only)
   useEffect(() => {
     if (isMobile) return;
     const handleKeyDown = (e: KeyboardEvent) => {

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/agents.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/agents.ts
@@ -241,6 +241,8 @@ export const useAgentsStore = create<AgentsState>()(
             }
 
             // Right AI pane always prefers Abi unless the user picked another agent.
+            // Keep explicit=false so ChatAgentSelector can still show the Abi name
+            // (pane trigger bypasses "Auto") while New chat / refresh can re-apply.
             const abiAgent =
               formattedAgents.find(
                 (a) =>

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace-pane-send.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace-pane-send.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { useWorkspaceStore } from './workspace';
+
+describe('pane send workspace scoping', () => {
+  beforeEach(() => {
+    useWorkspaceStore.setState({
+      currentWorkspaceId: 'ws-a',
+      conversations: [],
+      activeConversationId: null,
+      paneConversationId: null,
+      paneOpenTabIds: [],
+      selectedAgent: 'agent-main',
+      paneAgent: 'agent-pane',
+    });
+  });
+
+  it('clears pane conversation when switching workspace', () => {
+    const paneId = useWorkspaceStore.getState().createConversation(undefined, { surface: 'pane' });
+    expect(useWorkspaceStore.getState().paneConversationId).toBe(paneId);
+    expect(useWorkspaceStore.getState().paneOpenTabIds).toContain(paneId);
+
+    useWorkspaceStore.getState().setCurrentWorkspace('ws-b');
+
+    expect(useWorkspaceStore.getState().currentWorkspaceId).toBe('ws-b');
+    expect(useWorkspaceStore.getState().paneConversationId).toBeNull();
+    expect(useWorkspaceStore.getState().paneOpenTabIds).toEqual([]);
+    expect(useWorkspaceStore.getState().activeConversationId).toBeNull();
+  });
+
+  it('keeps pane conversation when setCurrentWorkspace is a no-op same id', () => {
+    const paneId = useWorkspaceStore.getState().createConversation(undefined, { surface: 'pane' });
+    useWorkspaceStore.getState().setCurrentWorkspace('ws-a');
+    expect(useWorkspaceStore.getState().paneConversationId).toBe(paneId);
+  });
+
+  it('creates pane drafts in the current workspace so send can find them', () => {
+    const id = useWorkspaceStore.getState().createConversation(undefined, { surface: 'pane' });
+    const conv = useWorkspaceStore.getState().conversations.find((c) => c.id === id);
+    expect(conv?.workspaceId).toBe('ws-a');
+    expect(conv?.isDraft).toBe(true);
+    expect(useWorkspaceStore.getState().getWorkspaceConversations().some((c) => c.id === id)).toBe(
+      true
+    );
+  });
+});

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
@@ -838,6 +838,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
 
       set((state) => {
         const existingById = new Map(state.conversations.map((c) => [c.id, c]));
+        const apiIds = new Set(fromApi.map((c) => c.id));
         const mergedWorkspaceConversations = fromApi.map((apiConv) => {
           const existing = existingById.get(apiConv.id);
           if (!existing) return apiConv;
@@ -845,15 +846,48 @@ export const useWorkspaceStore = create<WorkspaceState>()(
             ...apiConv,
             // Preserve loaded message history if we already have it in memory.
             messages: existing.messages.length > 0 ? existing.messages : apiConv.messages,
+            isDraft: false,
           };
+        });
+        // Keep local-only threads that sync would otherwise drop (drafts, in-flight
+        // first sends, open pane tabs). Dropping them left paneConversationId
+        // pointing at a missing row so send cleared the composer with no UI update.
+        const localOnly = state.conversations.filter((c) => {
+          if (c.workspaceId !== targetWorkspaceId || apiIds.has(c.id)) return false;
+          return (
+            Boolean(c.isDraft) ||
+            c.messages.length > 0 ||
+            c.id === state.activeConversationId ||
+            c.id === state.paneConversationId ||
+            state.paneOpenTabIds.includes(c.id)
+          );
         });
         const otherWorkspaces = state.conversations.filter(
           (c) => c.workspaceId !== targetWorkspaceId
         );
-        const conversations = [...mergedWorkspaceConversations, ...otherWorkspaces].sort(
+        const conversations = [
+          ...mergedWorkspaceConversations,
+          ...localOnly,
+          ...otherWorkspaces,
+        ].sort(
           (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
         );
-        return { conversations };
+        const knownIds = new Set(conversations.map((c) => c.id));
+        const paneOpenTabIds = state.paneOpenTabIds.filter((id) => knownIds.has(id));
+        const paneConversationId =
+          state.paneConversationId && knownIds.has(state.paneConversationId)
+            ? state.paneConversationId
+            : null;
+        const activeConversationId =
+          state.activeConversationId && knownIds.has(state.activeConversationId)
+            ? state.activeConversationId
+            : null;
+        return {
+          conversations,
+          paneOpenTabIds,
+          paneConversationId,
+          activeConversationId,
+        };
       });
     } catch (error) {
       console.error('Failed to sync workspace conversations:', error);

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
@@ -490,12 +490,19 @@ export const useWorkspaceStore = create<WorkspaceState>()(
         id && !state.paneOpenTabIds.includes(id)
           ? [...state.paneOpenTabIds, id]
           : state.paneOpenTabIds;
+      // Opening a history tab syncs the composer agent for that thread, but must
+      // NOT mark paneAgentExplicitlySelected. That flag is only for picker choices;
+      // treating tabs as explicit locked non-Abi agents across New chat / refresh.
+      if (!id) {
+        return {
+          paneConversationId: null,
+          paneOpenTabIds,
+        };
+      }
       return {
         paneConversationId: id,
         paneOpenTabIds,
-        ...(conv?.agent
-          ? { paneAgent: conv.agent, paneAgentExplicitlySelected: true }
-          : {}),
+        ...(conv?.agent ? { paneAgent: conv.agent } : {}),
       };
     }),
   openPaneTab: (id) => {
@@ -514,9 +521,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
       return {
         paneOpenTabIds,
         paneConversationId: nextId,
-        ...(conv?.agent
-          ? { paneAgent: conv.agent, paneAgentExplicitlySelected: true }
-          : {}),
+        ...(conv?.agent ? { paneAgent: conv.agent } : {}),
       };
     }),
 
@@ -1466,7 +1471,8 @@ export const useWorkspaceStore = create<WorkspaceState>()(
         expandedSections: state.expandedSections,
         selectedAgent: state.selectedAgent,
         paneAgent: state.paneAgent,
-        paneAgentExplicitlySelected: state.paneAgentExplicitlySelected,
+        // Do not persist paneAgentExplicitlySelected (same as main chat): a hard
+        // refresh should re-default the right pane to Abi via agents sync.
         paneConversationId: state.paneConversationId,
         paneOpenTabIds: state.paneOpenTabIds,
         activePanelSection: state.activePanelSection,
@@ -1476,6 +1482,9 @@ export const useWorkspaceStore = create<WorkspaceState>()(
       onRehydrateStorage: () => (state) => {
         // After hydration completes, fetch workspaces from API
         if (state) {
+          // Drop legacy persisted paneAgentExplicitlySelected so hard refresh
+          // re-defaults the right pane to Abi (agents sync), matching main chat.
+          state.paneAgentExplicitlySelected = false;
           // Use setTimeout to ensure we're outside the hydration cycle
           setTimeout(() => {
             state.fetchWorkspaces();

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
@@ -216,9 +216,15 @@ interface WorkspaceState {
   openAppModule: OpenAppModule | null;
   setOpenAppModule: (mod: OpenAppModule | null) => void;
 
-  // Context panel
+  // Context panel (right AI / compare surface)
   contextPanelOpen: boolean;
   toggleContextPanel: () => void;
+  /** Width of the secondary left section panel (px). Persisted. */
+  sectionPanelWidth: number;
+  setSectionPanelWidth: (width: number) => void;
+  /** Width of the right AI / compare pane (px). Persisted. */
+  aiPaneWidth: number;
+  setAiPaneWidth: (width: number) => void;
 
   // Chat state
   conversations: Conversation[];
@@ -244,7 +250,13 @@ interface WorkspaceState {
   paneAgentExplicitlySelected: boolean;
   setPaneAgent: (agent: AgentType, explicit?: boolean) => void;
   clearPaneAgentExplicitSelection: () => void;
-  createConversation: (projectId?: string) => string;
+  /** Independent conversation bound to the right AI / compare pane. */
+  paneConversationId: string | null;
+  setPaneConversationId: (id: string | null) => void;
+  createConversation: (
+    projectId?: string,
+    options?: { surface?: 'main' | 'pane' },
+  ) => string;
   setActiveConversation: (id: string | null) => void;
   /** Record the latest agent used in a conversation (mirrors the backend,
    *  which updates conversation.agent on every send). */
@@ -436,9 +448,15 @@ export const useWorkspaceStore = create<WorkspaceState>()(
   openAppModule: null,
   setOpenAppModule: (mod) => set({ openAppModule: mod }),
 
-  // Context panel
+  // Context panel (right AI / compare surface)
   contextPanelOpen: false,
   toggleContextPanel: () => set((state) => ({ contextPanelOpen: !state.contextPanelOpen })),
+  sectionPanelWidth: 256,
+  setSectionPanelWidth: (width) =>
+    set({ sectionPanelWidth: Math.max(200, Math.min(480, Math.round(width))) }),
+  aiPaneWidth: 440,
+  setAiPaneWidth: (width) =>
+    set({ aiPaneWidth: Math.max(320, Math.min(720, Math.round(width))) }),
 
   // Chat state
   conversations: [],
@@ -457,20 +475,33 @@ export const useWorkspaceStore = create<WorkspaceState>()(
   setPaneAgent: (agent, explicit = false) =>
     set({ paneAgent: agent, paneAgentExplicitlySelected: explicit }),
   clearPaneAgentExplicitSelection: () => set({ paneAgentExplicitlySelected: false }),
+  paneConversationId: null,
+  setPaneConversationId: (id) =>
+    set((state) => {
+      const conv = id ? state.conversations.find((c) => c.id === id) : null;
+      return {
+        paneConversationId: id,
+        ...(conv?.agent
+          ? { paneAgent: conv.agent, paneAgentExplicitlySelected: true }
+          : {}),
+      };
+    }),
 
-  createConversation: (projectId?: string) => {
+  createConversation: (projectId?: string, options?: { surface?: 'main' | 'pane' }) => {
     const id = generateConversationId();
     const workspaceId = get().currentWorkspaceId;
+    const surface = options?.surface ?? 'main';
     if (!workspaceId) {
       console.error('Cannot create conversation: no workspace selected');
       return id;
     }
+    const agent = surface === 'pane' ? get().paneAgent : get().selectedAgent;
     const newConversation: Conversation = {
       id,
       workspaceId,
       title: 'New Conversation',
       messages: [],
-      agent: get().selectedAgent,
+      agent,
       createdAt: new Date(),
       updatedAt: new Date(),
       pinned: false,
@@ -479,7 +510,9 @@ export const useWorkspaceStore = create<WorkspaceState>()(
     };
     set((state) => ({
       conversations: [newConversation, ...state.conversations],
-      activeConversationId: id,
+      ...(surface === 'pane'
+        ? { paneConversationId: id }
+        : { activeConversationId: id }),
     }));
     return id;
   },
@@ -1387,7 +1420,10 @@ export const useWorkspaceStore = create<WorkspaceState>()(
         selectedAgent: state.selectedAgent,
         paneAgent: state.paneAgent,
         paneAgentExplicitlySelected: state.paneAgentExplicitlySelected,
+        paneConversationId: state.paneConversationId,
         activePanelSection: state.activePanelSection,
+        sectionPanelWidth: state.sectionPanelWidth,
+        aiPaneWidth: state.aiPaneWidth,
       }),
       onRehydrateStorage: () => (state) => {
         // After hydration completes, fetch workspaces from API

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
@@ -814,7 +814,16 @@ export const useWorkspaceStore = create<WorkspaceState>()(
   },
 
   setCurrentWorkspace: (id) => {
-    set({ currentWorkspaceId: id, activeConversationId: null });
+    set((state) => ({
+      currentWorkspaceId: id,
+      activeConversationId: null,
+      // Pane tabs are workspace-scoped. Leaving paneConversationId on a thread
+      // from the previous workspace made send update a hidden conversation while
+      // the right pane stayed empty (composer cleared, nothing visible).
+      ...(state.currentWorkspaceId !== id
+        ? { paneConversationId: null, paneOpenTabIds: [] as string[] }
+        : {}),
+    }));
   },
 
   syncWorkspaceConversations: async (workspaceId) => {
@@ -908,10 +917,26 @@ export const useWorkspaceStore = create<WorkspaceState>()(
       const mapped = mapApiConversation(apiConversation);
 
       set((state) => {
-        const alreadyExists = state.conversations.some((c) => c.id === mapped.id);
-        const conversations = alreadyExists
-          ? state.conversations.map((c) => (c.id === mapped.id ? mapped : c))
-          : [mapped, ...state.conversations];
+        const existing = state.conversations.find((c) => c.id === mapped.id);
+        // Preserve optimistic local messages (e.g. user just sent) that the API
+        // snapshot does not include yet. Blind replace made send look like a no-op.
+        const apiIds = new Set(mapped.messages.map((m) => m.id));
+        const localOnly = existing
+          ? existing.messages.filter((m) => !apiIds.has(m.id))
+          : [];
+        const merged: Conversation = {
+          ...mapped,
+          messages:
+            mapped.messages.length === 0 && localOnly.length > 0
+              ? existing!.messages
+              : localOnly.length > 0
+                ? [...mapped.messages, ...localOnly]
+                : mapped.messages,
+          isDraft: false,
+        };
+        const conversations = existing
+          ? state.conversations.map((c) => (c.id === merged.id ? merged : c))
+          : [merged, ...state.conversations];
         // If this conversation is the one on screen, reflect its latest agent
         // in the composer (unless the user just explicitly picked another one).
         const syncAgent =
@@ -1519,6 +1544,17 @@ export const useWorkspaceStore = create<WorkspaceState>()(
           // Drop legacy persisted paneAgentExplicitlySelected so hard refresh
           // re-defaults the right pane to Abi (agents sync), matching main chat.
           state.paneAgentExplicitlySelected = false;
+          // Drop pane tabs that belong to another workspace (or missing rows).
+          const ws = state.currentWorkspaceId;
+          const known = new Set(
+            state.conversations
+              .filter((c) => !ws || c.workspaceId === ws)
+              .map((c) => c.id)
+          );
+          state.paneOpenTabIds = (state.paneOpenTabIds || []).filter((id) => known.has(id));
+          if (state.paneConversationId && !known.has(state.paneConversationId)) {
+            state.paneConversationId = null;
+          }
           // Use setTimeout to ensure we're outside the hydration cycle
           setTimeout(() => {
             state.fetchWorkspaces();

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
@@ -253,6 +253,12 @@ interface WorkspaceState {
   /** Independent conversation bound to the right AI / compare pane. */
   paneConversationId: string | null;
   setPaneConversationId: (id: string | null) => void;
+  /** Open conversation tabs in the right chat pane (Cursor-style). */
+  paneOpenTabIds: string[];
+  /** Open (or focus) a conversation as a pane tab. */
+  openPaneTab: (id: string) => void;
+  /** Close a pane tab; focuses a neighbor or blank new chat. */
+  closePaneTab: (id: string) => void;
   createConversation: (
     projectId?: string,
     options?: { surface?: 'main' | 'pane' },
@@ -476,11 +482,38 @@ export const useWorkspaceStore = create<WorkspaceState>()(
     set({ paneAgent: agent, paneAgentExplicitlySelected: explicit }),
   clearPaneAgentExplicitSelection: () => set({ paneAgentExplicitlySelected: false }),
   paneConversationId: null,
+  paneOpenTabIds: [],
   setPaneConversationId: (id) =>
     set((state) => {
       const conv = id ? state.conversations.find((c) => c.id === id) : null;
+      const paneOpenTabIds =
+        id && !state.paneOpenTabIds.includes(id)
+          ? [...state.paneOpenTabIds, id]
+          : state.paneOpenTabIds;
       return {
         paneConversationId: id,
+        paneOpenTabIds,
+        ...(conv?.agent
+          ? { paneAgent: conv.agent, paneAgentExplicitlySelected: true }
+          : {}),
+      };
+    }),
+  openPaneTab: (id) => {
+    get().setPaneConversationId(id);
+  },
+  closePaneTab: (id) =>
+    set((state) => {
+      const paneOpenTabIds = state.paneOpenTabIds.filter((tabId) => tabId !== id);
+      if (state.paneConversationId !== id) {
+        return { paneOpenTabIds };
+      }
+      const closedIndex = state.paneOpenTabIds.indexOf(id);
+      const nextId =
+        paneOpenTabIds[Math.min(closedIndex, paneOpenTabIds.length - 1)] ?? null;
+      const conv = nextId ? state.conversations.find((c) => c.id === nextId) : null;
+      return {
+        paneOpenTabIds,
+        paneConversationId: nextId,
         ...(conv?.agent
           ? { paneAgent: conv.agent, paneAgentExplicitlySelected: true }
           : {}),
@@ -511,7 +544,12 @@ export const useWorkspaceStore = create<WorkspaceState>()(
     set((state) => ({
       conversations: [newConversation, ...state.conversations],
       ...(surface === 'pane'
-        ? { paneConversationId: id }
+        ? {
+            paneConversationId: id,
+            paneOpenTabIds: state.paneOpenTabIds.includes(id)
+              ? state.paneOpenTabIds
+              : [...state.paneOpenTabIds, id],
+          }
         : { activeConversationId: id }),
     }));
     return id;
@@ -731,10 +769,19 @@ export const useWorkspaceStore = create<WorkspaceState>()(
     const conv = get().conversations.find(c => c.id === id);
     
     // Optimistic delete
-    set((state) => ({
-      conversations: state.conversations.filter((c) => c.id !== id),
-      activeConversationId: state.activeConversationId === id ? null : state.activeConversationId,
-    }));
+    set((state) => {
+      const paneOpenTabIds = state.paneOpenTabIds.filter((tabId) => tabId !== id);
+      const paneConversationId =
+        state.paneConversationId === id
+          ? paneOpenTabIds[paneOpenTabIds.length - 1] ?? null
+          : state.paneConversationId;
+      return {
+        conversations: state.conversations.filter((c) => c.id !== id),
+        activeConversationId: state.activeConversationId === id ? null : state.activeConversationId,
+        paneOpenTabIds,
+        paneConversationId,
+      };
+    });
     
     // Sync with backend
     try {
@@ -1421,6 +1468,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
         paneAgent: state.paneAgent,
         paneAgentExplicitlySelected: state.paneAgentExplicitlySelected,
         paneConversationId: state.paneConversationId,
+        paneOpenTabIds: state.paneOpenTabIds,
         activePanelSection: state.activePanelSection,
         sectionPanelWidth: state.sectionPanelWidth,
         aiPaneWidth: state.aiPaneWidth,


### PR DESCRIPTION
## Summary
- Replace the right AI mini-widget with a real `ChatInterface` surface (`surface=\"pane\"`): bubbles, tool-call UI, uploads, composer, agent selector, independent conversation.
- Cursor-style chrome: open-chat tabs (plus new/history/close); Columns2 \"Send to both\" when the pane is open.
- Left section panel and right chat pane are drag-resizable (widths persisted).
- Pane-send fixes from zen tip: restore send when conversation id is orphaned; stop no-op across workspace switches.

## Stacking
- **Depends on:** #1128 (P5 Abi pane + admin tools). Base branch is `feat/abi-pane-nexus-admin-tools`.
- Slice E + tip pane-send only. Stripped Users/OTP/create-on-invite/CLI bloat from earlier megabranch tip.

## Test plan
- [ ] Open Sparkles / Cmd-K: right pane is full chat UI with tab strip
- [ ] History (clock) opens recent chats; Plus starts New chat; close focuses neighbor
- [ ] Send in right pane works (new chat + after workspace switch)
- [ ] Pick different agents left vs right; Columns2 sends same prompt to both
- [ ] Drag left/right edges: widths persist after reload
- [ ] Closing pane does not clobber main chat conversation/URL