### PR TITLE
feat(nexus): email OTP sign-in alongside magic link

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/api/endpoints/auth.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/api/endpoints/auth.py
@@ -8,6 +8,7 @@ from naas_abi.apps.nexus.apps.api.app.services.auth.adapters.primary import (
     ForgotPasswordRequest,
     MagicLinkRequest,
     MagicLinkVerifyRequest,
+    OtpVerifyRequest,
     PasswordChangeRequest,
     RefreshTokenRequest,
     RefreshTokenResponse,
@@ -44,6 +45,7 @@ from naas_abi.apps.nexus.apps.api.app.services.auth.adapters.primary import (
     update_me,
     upload_avatar,
     verify_magic_link,
+    verify_otp,
 )
 from naas_abi.apps.nexus.apps.api.app.services.auth.service import (
     create_access_token,
@@ -59,6 +61,7 @@ __all__ = [
     "ForgotPasswordRequest",
     "MagicLinkRequest",
     "MagicLinkVerifyRequest",
+    "OtpVerifyRequest",
     "PasswordChangeRequest",
     "RefreshTokenRequest",
     "RefreshTokenResponse",
@@ -97,5 +100,6 @@ __all__ = [
     "update_me",
     "upload_avatar",
     "verify_magic_link",
+    "verify_otp",
     "verify_password",
 ]

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/config.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/config.py
@@ -388,17 +388,22 @@ class Settings(BaseSettings):
     magic_link_expire_minutes: int = 15
     magic_link_max_active: int = 5
     magic_link_path: str = "/auth/magic-link"
+    otp_code_length: int = 6
+    otp_max_attempts: int = 5
     magic_link_email_app_name: str = "NEXUS"
-    magic_link_email_subject_template: str = "Your {app_name} magic sign-in link"
+    magic_link_email_subject_template: str = "Your {app_name} sign-in code: {otp_code}"
     magic_link_email_text_template: str = (
-        "Use the link below to sign in to {app_name}:\n\n"
-        "{magic_link_url}\n\n"
-        "This link expires in {expire_minutes} minutes."
+        "Your {app_name} sign-in code is: {otp_code}\n\n"
+        "Enter this code in the app to continue.\n\n"
+        "Or use this magic link:\n{magic_link_url}\n\n"
+        "This code and link expire in {expire_minutes} minutes."
     )
     magic_link_email_html_template: str = (
-        "<p>Use the link below to sign in to {app_name}:</p>"
-        '<p><a href="{magic_link_url}">Sign in to {app_name}</a></p>'
-        "<p>This link expires in {expire_minutes} minutes.</p>"
+        "<p>Your {app_name} sign-in code is:</p>"
+        '<p style="font-size:28px;letter-spacing:6px;font-weight:700;">{otp_code}</p>'
+        "<p>Enter this code in the app to continue.</p>"
+        '<p>Or <a href="{magic_link_url}">sign in with this magic link</a>.</p>'
+        "<p>This code and link expire in {expire_minutes} minutes.</p>"
     )
 
     # Outgoing email "From" metadata. Transport details (host, credentials,

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/models.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/models.py
@@ -209,6 +209,8 @@ class MagicLinkTokenModel(Base):
     id = Column(String, primary_key=True)
     user_id = Column(String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
     token = Column(String, nullable=False, unique=True, index=True)
+    otp_code_hash = Column(String, nullable=True)
+    otp_attempts = Column(Integer, nullable=False, default=0)
     expires_at = Column(DateTime(timezone=False), nullable=False)
     used = Column(Boolean, nullable=False, default=False)
     created_at = Column(DateTime(timezone=False), nullable=False, default=_utcnow)

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/auth/adapters/primary/__init__.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/auth/adapters/primary/__init__.py
@@ -30,12 +30,14 @@ from naas_abi.apps.nexus.apps.api.app.services.auth.adapters.primary.auth__prima
     update_me,
     upload_avatar,
     verify_magic_link,
+    verify_otp,
 )
 from naas_abi.apps.nexus.apps.api.app.services.auth.adapters.primary.auth__primary_adapter__schemas import (  # noqa: E501
     AuthResponse,
     ForgotPasswordRequest,
     MagicLinkRequest,
     MagicLinkVerifyRequest,
+    OtpVerifyRequest,
     PasswordChangeRequest,
     RefreshTokenRequest,
     RefreshTokenResponse,
@@ -58,6 +60,7 @@ __all__ = [
     "MagicLinkRequest",
     "MagicLinkVerifyRequest",
     "MAX_AVATAR_SIZE",
+    "OtpVerifyRequest",
     "PasswordChangeRequest",
     "RefreshTokenRequest",
     "RefreshTokenResponse",
@@ -94,4 +97,5 @@ __all__ = [
     "update_me",
     "upload_avatar",
     "verify_magic_link",
+    "verify_otp",
 ]

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/auth/adapters/primary/auth__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/auth/adapters/primary/auth__primary_adapter__FastAPI.py
@@ -28,6 +28,7 @@ from naas_abi.apps.nexus.apps.api.app.services.auth.adapters.primary.auth__prima
     ForgotPasswordRequest,
     MagicLinkRequest,
     MagicLinkVerifyRequest,
+    OtpVerifyRequest,
     PasswordChangeRequest,
     RefreshTokenRequest,
     RefreshTokenResponse,
@@ -44,9 +45,11 @@ from naas_abi.apps.nexus.apps.api.app.services.auth.service import (
     EmailAlreadyRegisteredError,
     EmailAlreadyTakenError,
     ExpiredMagicLinkError,
+    ExpiredOtpError,
     ExpiredResetTokenError,
     InvalidCredentialsError,
     InvalidMagicLinkError,
+    InvalidOtpError,
     InvalidResetTokenError,
     UserNotFoundError,
 )
@@ -111,9 +114,13 @@ def _get_email_service(request: Request) -> EmailService | None:
         return None
 
 
-@router.get("/config", response_model=dict[str, bool])
-async def get_auth_config() -> dict[str, bool]:
-    return {"password_auth_enabled": settings.auth_password_enabled}
+@router.get("/config", response_model=dict[str, bool | int])
+async def get_auth_config() -> dict[str, bool | int]:
+    return {
+        "password_auth_enabled": settings.auth_password_enabled,
+        "otp_auth_enabled": True,
+        "otp_code_length": settings.otp_code_length,
+    }
 
 
 @router.post("/register", response_model=AuthResponse)
@@ -373,12 +380,20 @@ async def request_magic_link(
     identifier = get_rate_limit_identifier(request)
     await check_rate_limit(identifier, "/api/auth/magic-link/request")
 
-    token = await auth_service.request_magic_link(payload.email)
-    if token is not None:
-        await _send_magic_link_email(payload.email, token, email_service)
+    challenge = await auth_service.request_magic_link(payload.email)
+    if challenge is not None:
+        await _send_magic_link_email(
+            payload.email,
+            challenge.token,
+            challenge.otp_code,
+            email_service,
+        )
     return {
         "status": "success",
-        "message": "If an account exists with this email, a magic sign-in link has been sent.",
+        "message": (
+            "If an account exists with this email, a sign-in code has been sent. "
+            "You can also use the magic link in the email."
+        ),
     }
 
 
@@ -404,6 +419,44 @@ async def verify_magic_link(
         ) from exc
 
     await log_login(user.id, success=True, request=request, details={"method": "magic_link"})
+    return AuthResponse(
+        user=to_user_schema(user),
+        access_token=tokens.access_token,
+        refresh_token=tokens.refresh_token,
+        expires_in=tokens.expires_in,
+    )
+
+
+@router.post("/otp/verify", response_model=AuthResponse)
+async def verify_otp(
+    request: Request,
+    payload: OtpVerifyRequest,
+    auth_service: AuthService = Depends(get_auth_service),
+) -> AuthResponse:
+    identifier = get_rate_limit_identifier(request)
+    await check_rate_limit(identifier, "/api/auth/otp/verify")
+    # Also bound guesses per email so a distributed attacker cannot spray codes.
+    await check_rate_limit(f"email:{payload.email.lower()}", "/api/auth/otp/verify")
+
+    try:
+        user, tokens = await auth_service.verify_otp(
+            email=payload.email,
+            code=payload.code,
+            user_agent=request.headers.get("user-agent"),
+            ip_address=request.client.host if request.client else None,
+        )
+    except InvalidOtpError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid or expired sign-in code",
+        ) from exc
+    except ExpiredOtpError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Sign-in code has expired",
+        ) from exc
+
+    await log_login(user.id, success=True, request=request, details={"method": "email_otp"})
     return AuthResponse(
         user=to_user_schema(user),
         access_token=tokens.access_token,
@@ -502,6 +555,7 @@ def _delete_old_avatar(
 async def _send_magic_link_email(
     to_email: str,
     token: str,
+    otp_code: str,
     email_service: EmailService | None,
 ) -> None:
     query = urlencode({"token": token})
@@ -509,8 +563,9 @@ async def _send_magic_link_email(
 
     if email_service is None:
         logger.info(
-            "Email service unavailable. Magic link for %s: %s",
+            "Email service unavailable. Sign-in code for %s: %s (link: %s)",
             to_email,
+            otp_code,
             magic_link_url,
         )
         return
@@ -519,6 +574,7 @@ async def _send_magic_link_email(
     template_values = {
         "app_name": app_name,
         "magic_link_url": magic_link_url,
+        "otp_code": otp_code,
         "expire_minutes": settings.magic_link_expire_minutes,
     }
     subject = settings.magic_link_email_subject_template.format_map(

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/auth/adapters/primary/auth__primary_adapter__FastAPI_test.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/auth/adapters/primary/auth__primary_adapter__FastAPI_test.py
@@ -9,25 +9,32 @@ from naas_abi.apps.nexus.apps.api.app.core.config import settings
 from naas_abi.apps.nexus.apps.api.app.services.auth.adapters.primary import (
     auth__primary_adapter__FastAPI as auth_api,
 )
+from naas_abi.apps.nexus.apps.api.app.services.auth.service import MagicLinkChallenge
 
 
 @pytest.mark.asyncio
-async def test_request_magic_link_never_logs_token(caplog) -> None:
+async def test_request_magic_link_response_never_includes_secrets(monkeypatch) -> None:
     auth_service = AsyncMock()
-    auth_service.request_magic_link = AsyncMock(return_value="sensitive-magic-token")
+    auth_service.request_magic_link = AsyncMock(
+        return_value=MagicLinkChallenge(token="sensitive-magic-token", otp_code="123456")
+    )
     fake_request = type(
         "Req", (), {"headers": {}, "client": type("Client", (), {"host": "127.0.0.1"})()}
     )()
+    send_mock = AsyncMock()
+    monkeypatch.setattr(auth_api, "_send_magic_link_email", send_mock)
 
     response = await auth_api.request_magic_link(
         request=fake_request,
         payload=auth_api.MagicLinkRequest(email="user@example.com"),
         auth_service=auth_service,
-        email_service=None,
+        email_service=SimpleNamespace(send=lambda **_: None),
     )
 
     assert response["status"] == "success"
-    assert "sensitive-magic-token" not in caplog.text
+    assert "sensitive-magic-token" not in str(response)
+    assert "123456" not in str(response)
+    send_mock.assert_awaited_once()
     auth_service.request_magic_link.assert_awaited_once_with("user@example.com")
 
 
@@ -73,16 +80,22 @@ async def test_send_magic_link_email_uses_configured_templates(monkeypatch) -> N
     monkeypatch.setattr(settings, "magic_link_path", "/auth/magic-link")
     monkeypatch.setattr(settings, "magic_link_expire_minutes", 20)
     monkeypatch.setattr(settings, "magic_link_email_app_name", "ABI Platform")
-    monkeypatch.setattr(settings, "magic_link_email_subject_template", "Login to {app_name}")
+    monkeypatch.setattr(
+        settings,
+        "magic_link_email_subject_template",
+        "Login to {app_name}: {otp_code}",
+    )
     monkeypatch.setattr(
         settings,
         "magic_link_email_text_template",
-        "Open this link for {app_name}: {magic_link_url} (expires in {expire_minutes} min)",
+        "Code {otp_code}. Open this link for {app_name}: {magic_link_url} "
+        "(expires in {expire_minutes} min)",
     )
     monkeypatch.setattr(
         settings,
         "magic_link_email_html_template",
-        '<p>{app_name}</p><a href="{magic_link_url}">open</a><p>{expire_minutes}</p>',
+        '<p>{app_name}</p><p>{otp_code}</p><a href="{magic_link_url}">open</a>'
+        "<p>{expire_minutes}</p>",
     )
     monkeypatch.setattr(settings, "email_from_address", "no-reply@example.com")
     monkeypatch.setattr(settings, "email_from_name", "ABI")
@@ -90,9 +103,12 @@ async def test_send_magic_link_email_uses_configured_templates(monkeypatch) -> N
     sent: dict = {}
     email_service = SimpleNamespace(send=lambda **kwargs: sent.update(kwargs))
 
-    await auth_api._send_magic_link_email("user@example.com", "token-123", email_service)
+    await auth_api._send_magic_link_email(
+        "user@example.com", "token-123", "654321", email_service
+    )
 
-    assert sent["subject"] == "Login to ABI Platform"
+    assert sent["subject"] == "Login to ABI Platform: 654321"
+    assert "654321" in sent["text_body"]
     assert "https://platform.example.com/auth/magic-link?token=token-123" in sent["text_body"]
     assert "ABI Platform" in sent["html_body"]
     assert sent["from_email"] == "no-reply@example.com"
@@ -105,9 +121,11 @@ async def test_send_magic_link_email_logs_when_no_service(caplog) -> None:
 
     caplog.set_level(logging.INFO, logger=auth_api.logger.name)
 
-    await auth_api._send_magic_link_email("user@example.com", "token-456", None)
+    await auth_api._send_magic_link_email("user@example.com", "token-456", "111222", None)
 
     assert any(
-        "Magic link for user@example.com" in record.message and "token-456" in record.message
+        "Sign-in code for user@example.com" in record.message
+        and "111222" in record.message
+        and "token-456" in record.message
         for record in caplog.records
     )

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/auth/adapters/primary/auth__primary_adapter__schemas.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/auth/adapters/primary/auth__primary_adapter__schemas.py
@@ -29,6 +29,11 @@ class MagicLinkVerifyRequest(BaseModel):
     token: str = Field(..., min_length=1)
 
 
+class OtpVerifyRequest(BaseModel):
+    email: EmailStr
+    code: str = Field(..., min_length=4, max_length=16)
+
+
 class User(UserBase):
     id: str
     created_at: datetime

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/auth/adapters/secondary/postgres.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/auth/adapters/secondary/postgres.py
@@ -75,6 +75,8 @@ class AuthSecondaryAdapterPostgres(AuthPersistencePort):
             expires_at=model.expires_at,
             used=bool(model.used),
             created_at=model.created_at,
+            otp_code_hash=model.otp_code_hash,
+            otp_attempts=int(model.otp_attempts or 0),
         )
 
     async def get_user_by_id(self, user_id: str) -> AuthUserRecord | None:
@@ -277,12 +279,15 @@ class AuthSecondaryAdapterPostgres(AuthPersistencePort):
         token: str,
         expires_at: datetime,
         created_at: datetime,
+        otp_code_hash: str | None = None,
     ) -> None:
         self.db.add(
             MagicLinkTokenModel(
                 id=token_id,
                 user_id=user_id,
                 token=token,
+                otp_code_hash=otp_code_hash,
+                otp_attempts=0,
                 expires_at=expires_at,
                 used=False,
                 created_at=created_at,
@@ -301,6 +306,35 @@ class AuthSecondaryAdapterPostgres(AuthPersistencePort):
         if row is None:
             return None
         return self._to_magic_link_token_record(row)
+
+    async def get_latest_unused_magic_link_for_user(
+        self, user_id: str
+    ) -> MagicLinkTokenRecord | None:
+        result = await self.db.execute(
+            select(MagicLinkTokenModel)
+            .where(
+                (MagicLinkTokenModel.user_id == user_id)
+                & (MagicLinkTokenModel.used.is_(False))
+                & (MagicLinkTokenModel.otp_code_hash.is_not(None))
+            )
+            .order_by(MagicLinkTokenModel.created_at.desc())
+            .limit(1)
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            return None
+        return self._to_magic_link_token_record(row)
+
+    async def increment_magic_link_otp_attempts(self, token_id: str) -> int:
+        result = await self.db.execute(
+            select(MagicLinkTokenModel).where(MagicLinkTokenModel.id == token_id)
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            return 0
+        row.otp_attempts = int(row.otp_attempts or 0) + 1
+        await self.db.flush()
+        return int(row.otp_attempts)
 
     async def mark_magic_link_token_used(self, token_id: str) -> None:
         result = await self.db.execute(

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/auth/port.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/auth/port.py
@@ -37,6 +37,8 @@ class MagicLinkTokenRecord:
     expires_at: datetime
     used: bool
     created_at: datetime
+    otp_code_hash: str | None = None
+    otp_attempts: int = 0
 
 
 class AuthPersistencePort(ABC):
@@ -128,11 +130,23 @@ class AuthPersistencePort(ABC):
         token: str,
         expires_at: datetime,
         created_at: datetime,
+        otp_code_hash: str | None = None,
     ) -> None:
         raise NotImplementedError
 
     @abstractmethod
     async def get_magic_link_token(self, token: str) -> MagicLinkTokenRecord | None:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def get_latest_unused_magic_link_for_user(
+        self, user_id: str
+    ) -> MagicLinkTokenRecord | None:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def increment_magic_link_otp_attempts(self, token_id: str) -> int:
+        """Increment OTP attempt counter; return the new count."""
         raise NotImplementedError
 
     @abstractmethod

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/auth/service.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/auth/service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hmac
 import secrets
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -26,6 +27,14 @@ class AuthTokens:
     access_token: str
     refresh_token: str
     expires_in: int
+
+
+@dataclass
+class MagicLinkChallenge:
+    """One email challenge: long URL token + short typed OTP."""
+
+    token: str
+    otp_code: str
 
 
 @dataclass
@@ -91,6 +100,25 @@ class InvalidMagicLinkError(ValueError):
 class ExpiredMagicLinkError(ValueError):
     def __str__(self) -> str:
         return "expired_magic_link"
+
+
+@dataclass
+class InvalidOtpError(ValueError):
+    def __str__(self) -> str:
+        return "invalid_otp"
+
+
+@dataclass
+class ExpiredOtpError(ValueError):
+    def __str__(self) -> str:
+        return "expired_otp"
+
+
+def generate_otp_code(length: int | None = None) -> str:
+    digits = length if length is not None else settings.otp_code_length
+    if digits < 4 or digits > 10:
+        digits = 6
+    return f"{secrets.randbelow(10**digits):0{digits}d}"
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
@@ -387,7 +415,7 @@ class AuthService:
         await self.adapter.commit()
         return updated
 
-    async def request_magic_link(self, email: str) -> str | None:
+    async def request_magic_link(self, email: str) -> MagicLinkChallenge | None:
         normalized_email = email.lower()
         user = await self.adapter.get_user_by_email(normalized_email)
         if user is None:
@@ -408,6 +436,8 @@ class AuthService:
 
         token = secrets.token_urlsafe(32)
         token_hash = hash_token(token)
+        otp_code = generate_otp_code()
+        otp_code_hash = hash_token(otp_code)
         now = now_utc_naive()
         expires_at = now + timedelta(minutes=settings.magic_link_expire_minutes)
 
@@ -422,9 +452,10 @@ class AuthService:
             token=token_hash,
             expires_at=expires_at,
             created_at=now,
+            otp_code_hash=otp_code_hash,
         )
         await self.adapter.commit()
-        return token
+        return MagicLinkChallenge(token=token, otp_code=otp_code)
 
     async def verify_magic_link(
         self,
@@ -445,18 +476,72 @@ class AuthService:
         await self.adapter.mark_magic_link_token_used(magic_token.id)
         await self.adapter.commit()
 
-        access_token, jti = create_access_token(data={"sub": user.id})
-        refresh_token = await create_refresh_token(
+        return user, await self._issue_session_tokens(
             user_id=user.id,
+            user_agent=user_agent,
+            ip_address=ip_address,
+        )
+
+    async def verify_otp(
+        self,
+        email: str,
+        code: str,
+        user_agent: str | None,
+        ip_address: str | None,
+    ) -> tuple[AuthUserRecord, AuthTokens]:
+        normalized_email = email.lower().strip()
+        normalized_code = "".join(ch for ch in code.strip() if ch.isdigit())
+        if len(normalized_code) != settings.otp_code_length:
+            raise InvalidOtpError()
+
+        user = await self.adapter.get_user_by_email(normalized_email)
+        if user is None:
+            raise InvalidOtpError()
+
+        magic_token = await self.adapter.get_latest_unused_magic_link_for_user(user.id)
+        if magic_token is None or not magic_token.otp_code_hash:
+            raise InvalidOtpError()
+        if magic_token.expires_at < now_utc_naive():
+            await self.adapter.mark_magic_link_token_used(magic_token.id)
+            await self.adapter.commit()
+            raise ExpiredOtpError()
+        if magic_token.otp_attempts >= settings.otp_max_attempts:
+            await self.adapter.mark_magic_link_token_used(magic_token.id)
+            await self.adapter.commit()
+            raise InvalidOtpError()
+
+        code_hash = hash_token(normalized_code)
+        if not hmac.compare_digest(code_hash, magic_token.otp_code_hash):
+            attempts = await self.adapter.increment_magic_link_otp_attempts(magic_token.id)
+            if attempts >= settings.otp_max_attempts:
+                await self.adapter.mark_magic_link_token_used(magic_token.id)
+            await self.adapter.commit()
+            raise InvalidOtpError()
+
+        await self.adapter.mark_magic_link_token_used(magic_token.id)
+        await self.adapter.commit()
+
+        return user, await self._issue_session_tokens(
+            user_id=user.id,
+            user_agent=user_agent,
+            ip_address=ip_address,
+        )
+
+    async def _issue_session_tokens(
+        self,
+        user_id: str,
+        user_agent: str | None,
+        ip_address: str | None,
+    ) -> AuthTokens:
+        access_token, jti = create_access_token(data={"sub": user_id})
+        refresh_token = await create_refresh_token(
+            user_id=user_id,
             access_token_jti=jti,
             user_agent=user_agent,
             ip_address=ip_address,
         )
-        return (
-            user,
-            AuthTokens(
-                access_token=access_token,
-                refresh_token=refresh_token,
-                expires_in=settings.access_token_expire_minutes * 60,
-            ),
+        return AuthTokens(
+            access_token=access_token,
+            refresh_token=refresh_token,
+            expires_in=settings.access_token_expire_minutes * 60,
         )

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/auth/service_test.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/auth/service_test.py
@@ -5,10 +5,14 @@ from unittest.mock import AsyncMock
 
 import pytest
 from naas_abi.apps.nexus.apps.api.app.core.config import settings
-from naas_abi.apps.nexus.apps.api.app.services.auth.port import AuthUserRecord
+from naas_abi.apps.nexus.apps.api.app.services.auth.port import (
+    AuthUserRecord,
+    MagicLinkTokenRecord,
+)
 from naas_abi.apps.nexus.apps.api.app.services.auth.service import (
     AuthService,
     InvalidMagicLinkError,
+    InvalidOtpError,
     PasswordAuthenticationDisabledError,
 )
 from naas_abi.apps.nexus.apps.api.app.services.refresh_token import hash_token
@@ -64,17 +68,21 @@ async def test_request_magic_link_stores_hashed_token(monkeypatch) -> None:
     )
     service = AuthService(adapter=adapter)
 
-    raw_token = await service.request_magic_link("USER@EXAMPLE.COM")
+    challenge = await service.request_magic_link("USER@EXAMPLE.COM")
 
-    assert raw_token
+    assert challenge
+    assert len(challenge.otp_code) == settings.otp_code_length
     adapter.mark_unused_magic_link_tokens_used.assert_awaited_once_with(
         "user-1",
         keep_latest_unused=4,
     )
     adapter.create_magic_link_token.assert_awaited_once()
     stored_token = adapter.create_magic_link_token.await_args.kwargs["token"]
-    assert stored_token == hash_token(raw_token)
-    assert stored_token != raw_token
+    assert stored_token == hash_token(challenge.token)
+    assert stored_token != challenge.token
+    stored_otp = adapter.create_magic_link_token.await_args.kwargs["otp_code_hash"]
+    assert stored_otp == hash_token(challenge.otp_code)
+    assert stored_otp != challenge.otp_code
 
 
 @pytest.mark.asyncio
@@ -90,9 +98,9 @@ async def test_request_magic_link_with_non_positive_max_active_invalidates_all(m
     )
     service = AuthService(adapter=adapter)
 
-    raw_token = await service.request_magic_link("user@example.com")
+    challenge = await service.request_magic_link("user@example.com")
 
-    assert raw_token
+    assert challenge
     adapter.mark_unused_magic_link_tokens_used.assert_awaited_once_with(
         "user-1",
         keep_latest_unused=0,
@@ -105,9 +113,9 @@ async def test_request_magic_link_for_unknown_user_does_not_create_account() -> 
     adapter.get_user_by_email.return_value = None
     service = AuthService(adapter=adapter)
 
-    token = await service.request_magic_link("unknown@example.com")
+    challenge = await service.request_magic_link("unknown@example.com")
 
-    assert token is None
+    assert challenge is None
     adapter.create_user_with_personal_workspace.assert_not_called()
     adapter.create_magic_link_token.assert_not_called()
     adapter.commit.assert_not_called()
@@ -129,9 +137,9 @@ async def test_request_magic_link_for_unknown_user_creates_account_when_enabled(
     )
     service = AuthService(adapter=adapter)
 
-    token = await service.request_magic_link("unknown@example.com")
+    challenge = await service.request_magic_link("unknown@example.com")
 
-    assert token
+    assert challenge
     adapter.create_user_with_personal_workspace.assert_awaited_once()
     adapter.create_magic_link_token.assert_awaited_once()
     adapter.commit.assert_awaited_once()
@@ -155,3 +163,85 @@ async def test_password_login_disabled(monkeypatch) -> None:
 
     with pytest.raises(PasswordAuthenticationDisabledError):
         await service.login_user("user@example.com", "pass", None, None)
+
+
+@pytest.mark.asyncio
+async def test_verify_otp_accepts_valid_code(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "otp_code_length", 6)
+    monkeypatch.setattr(settings, "otp_max_attempts", 5)
+    code = "482913"
+    adapter = AsyncMock()
+    adapter.get_user_by_email.return_value = AuthUserRecord(
+        id="user-1",
+        email="user@example.com",
+        name="User",
+        hashed_password="hashed",
+        created_at=datetime.utcnow(),
+    )
+    adapter.get_latest_unused_magic_link_for_user.return_value = MagicLinkTokenRecord(
+        id="ml-1",
+        user_id="user-1",
+        token="link-hash",
+        expires_at=datetime.utcnow().replace(year=2099),
+        used=False,
+        created_at=datetime.utcnow(),
+        otp_code_hash=hash_token(code),
+        otp_attempts=0,
+    )
+    monkeypatch.setattr(
+        "naas_abi.apps.nexus.apps.api.app.services.auth.service.create_refresh_token",
+        AsyncMock(return_value="refresh"),
+    )
+    monkeypatch.setattr(
+        "naas_abi.apps.nexus.apps.api.app.services.auth.service.create_access_token",
+        lambda data, expires_delta=None: ("access", "jti"),
+    )
+    service = AuthService(adapter=adapter)
+
+    user, tokens = await service.verify_otp(
+        email="USER@example.com",
+        code=code,
+        user_agent=None,
+        ip_address=None,
+    )
+
+    assert user.id == "user-1"
+    assert tokens.access_token == "access"
+    adapter.mark_magic_link_token_used.assert_awaited_with("ml-1")
+
+
+@pytest.mark.asyncio
+async def test_verify_otp_rejects_wrong_code_and_increments(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "otp_code_length", 6)
+    monkeypatch.setattr(settings, "otp_max_attempts", 5)
+    adapter = AsyncMock()
+    adapter.get_user_by_email.return_value = AuthUserRecord(
+        id="user-1",
+        email="user@example.com",
+        name="User",
+        hashed_password="hashed",
+        created_at=datetime.utcnow(),
+    )
+    adapter.get_latest_unused_magic_link_for_user.return_value = MagicLinkTokenRecord(
+        id="ml-1",
+        user_id="user-1",
+        token="link-hash",
+        expires_at=datetime.utcnow().replace(year=2099),
+        used=False,
+        created_at=datetime.utcnow(),
+        otp_code_hash=hash_token("111111"),
+        otp_attempts=0,
+    )
+    adapter.increment_magic_link_otp_attempts.return_value = 1
+    service = AuthService(adapter=adapter)
+
+    with pytest.raises(InvalidOtpError):
+        await service.verify_otp(
+            email="user@example.com",
+            code="000000",
+            user_agent=None,
+            ip_address=None,
+        )
+
+    adapter.increment_magic_link_otp_attempts.assert_awaited_once_with("ml-1")
+    adapter.mark_magic_link_token_used.assert_not_awaited()

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/migrations/0038_add_magic_link_otp.sql
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/migrations/0038_add_magic_link_otp.sql
@@ -1,0 +1,10 @@
+-- Email OTP codes ride on magic_link_tokens (same challenge, two verify paths).
+ALTER TABLE magic_link_tokens
+    ADD COLUMN IF NOT EXISTS otp_code_hash TEXT;
+
+ALTER TABLE magic_link_tokens
+    ADD COLUMN IF NOT EXISTS otp_attempts INTEGER NOT NULL DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS idx_magic_link_tokens_user_unused
+    ON magic_link_tokens (user_id, created_at DESC)
+    WHERE used = FALSE;

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/tests/test_auth.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/tests/test_auth.py
@@ -67,6 +67,29 @@ class TestMagicLink:
         )
         assert response.status_code == 410
 
+    async def test_verify_otp(self, client, test_user, monkeypatch):
+        from naas_abi.apps.nexus.apps.api.app.services.auth import service as auth_service_module
+
+        monkeypatch.setattr(auth_service_module, "generate_otp_code", lambda length=None: "482913")
+
+        await client.post("/api/auth/magic-link/request", json={"email": test_user["email"]})
+
+        response = await client.post(
+            "/api/auth/otp/verify",
+            json={"email": test_user["email"], "code": "482913"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert "access_token" in data
+        assert data["user"]["id"] == test_user["id"]
+
+        # One-time use: same code cannot be reused.
+        replay = await client.post(
+            "/api/auth/otp/verify",
+            json={"email": test_user["email"], "code": "482913"},
+        )
+        assert replay.status_code == 400
+
 
 class TestProtectedEndpoints:
     """AUTH-03/04: Access control on protected endpoints."""

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/auth/login/login-form.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/auth/login/login-form.tsx
@@ -21,13 +21,22 @@ function isLightColor(hex: string): boolean {
 export default function LoginForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { login, requestMagicLink, isLoading, error, clearError, isAuthenticated } = useAuthStore();
+  const {
+    login,
+    requestMagicLink,
+    verifyOtp,
+    isLoading,
+    error,
+    clearError,
+    isAuthenticated,
+  } = useAuthStore();
   const tenant = useTenant();
 
   const [email, setEmail] = useState(searchParams.get('email') ?? '');
   const [password, setPassword] = useState('');
+  const [otpCode, setOtpCode] = useState('');
   const [showPassword, setShowPassword] = useState(false);
-  const [fieldErrors, setFieldErrors] = useState<{ email?: string; password?: string }>({});
+  const [fieldErrors, setFieldErrors] = useState<{ email?: string; password?: string; otp?: string }>({});
   const [mounted, setMounted] = useState(false);
   const [passwordAuthEnabled, setPasswordAuthEnabled] = useState<boolean | null>(() => {
     if (typeof window === 'undefined') return null;
@@ -36,7 +45,7 @@ export default function LoginForm() {
     if (cached === 'false') return false;
     return null;
   });
-  const [linkSent, setLinkSent] = useState(false);
+  const [codeSent, setCodeSent] = useState(false);
 
   useEffect(() => {
     setMounted(true);
@@ -64,6 +73,24 @@ export default function LoginForm() {
     e.preventDefault();
     clearError();
 
+    if (!passwordAuthEnabled && codeSent) {
+      const digits = otpCode.replace(/\D/g, '');
+      const errors: { otp?: string } = {};
+      if (digits.length !== 6) {
+        errors.otp = 'Enter the 6-digit code from your email';
+      }
+      setFieldErrors(errors);
+      if (Object.keys(errors).length > 0) return;
+
+      const workspaceId = await verifyOtp(email, digits);
+      if (workspaceId) {
+        router.push(`/workspace/${workspaceId}/chat`);
+      } else if (!useAuthStore.getState().error) {
+        router.push('/');
+      }
+      return;
+    }
+
     const errors: { email?: string; password?: string } = {};
     if (!email.trim()) {
       errors.email = 'Email is required';
@@ -83,7 +110,10 @@ export default function LoginForm() {
       }
     } else {
       const success = await requestMagicLink(email);
-      if (success) setLinkSent(true);
+      if (success) {
+        setCodeSent(true);
+        setOtpCode('');
+      }
     }
   };
 
@@ -208,7 +238,7 @@ export default function LoginForm() {
               }}
               placeholder="you@example.com"
               required
-              disabled={isLoading}
+              disabled={isLoading || (!passwordAuthEnabled && codeSent)}
               className={cn(
                 'flex h-11 w-full px-4 py-2 text-sm',
                 'focus:outline-none focus:ring-2 focus:ring-primary/20',
@@ -279,10 +309,68 @@ export default function LoginForm() {
             </div>
           )}
 
-          {linkSent && !passwordAuthEnabled && (
-            <p className="text-center text-sm text-emerald-600">
-              If an account exists for <strong>{email}</strong>, a sign-in link is on its way.
-            </p>
+          {!passwordAuthEnabled && codeSent && (
+            <div className="space-y-2">
+              <p className="text-sm" style={{ color: mutedTextColor }}>
+                If an account exists for <strong style={{ color: textColor }}>{email}</strong>, enter
+                the 6-digit code from your email. You can also use the magic link in that email.
+              </p>
+              <label
+                htmlFor="otp"
+                className="text-sm font-medium"
+                style={{ color: textColor }}
+              >
+                Sign-in code
+              </label>
+              <input
+                id="otp"
+                type="text"
+                inputMode="numeric"
+                autoComplete="one-time-code"
+                pattern="[0-9]*"
+                maxLength={6}
+                value={otpCode}
+                onChange={(e) => {
+                  setOtpCode(e.target.value.replace(/\D/g, '').slice(0, 6));
+                  if (fieldErrors.otp) setFieldErrors((fe) => ({ ...fe, otp: undefined }));
+                }}
+                placeholder="123456"
+                required
+                disabled={isLoading}
+                className={cn(
+                  'flex h-11 w-full px-4 py-2 text-center text-lg tracking-[0.35em]',
+                  'focus:outline-none focus:ring-2 focus:ring-primary/20',
+                  'disabled:cursor-not-allowed disabled:opacity-50'
+                )}
+                aria-invalid={!!fieldErrors.otp}
+                aria-describedby={fieldErrors.otp ? 'otp-error' : undefined}
+                style={{
+                  ...inputStyle,
+                  ...(fieldErrors.otp
+                    ? { border: '1px solid #ef4444', backgroundColor: '#fee2e2' }
+                    : {}),
+                }}
+              />
+              {fieldErrors.otp && (
+                <p id="otp-error" className="text-xs text-destructive">
+                  {fieldErrors.otp}
+                </p>
+              )}
+              <button
+                type="button"
+                className="text-sm hover:underline"
+                style={{ color: primaryColor }}
+                disabled={isLoading}
+                onClick={() => {
+                  clearError();
+                  setCodeSent(false);
+                  setOtpCode('');
+                  setFieldErrors({});
+                }}
+              >
+                Use a different email
+              </button>
+            </div>
           )}
 
           <button
@@ -303,10 +391,18 @@ export default function LoginForm() {
             {isLoading ? (
               <>
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                {passwordAuthEnabled ? 'Signing in...' : 'Sending magic link...'}
+                {passwordAuthEnabled
+                  ? 'Signing in...'
+                  : codeSent
+                    ? 'Verifying...'
+                    : 'Sending code...'}
               </>
+            ) : passwordAuthEnabled ? (
+              'Sign in'
+            ) : codeSent ? (
+              'Verify code'
             ) : (
-              passwordAuthEnabled ? 'Sign in' : 'Send magic link'
+              'Send sign-in code'
             )}
           </button>
         </form>

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/auth.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/auth.ts
@@ -32,6 +32,7 @@ export interface AuthState {
   // Actions
   requestMagicLink: (email: string) => Promise<boolean>;
   verifyMagicLink: (token: string) => Promise<boolean>;
+  verifyOtp: (email: string, code: string) => Promise<string | null>;
   login: (email: string, password: string) => Promise<string | null>;
   register: (email: string, password: string, name: string) => Promise<boolean>;
   logout: () => void;
@@ -123,6 +124,68 @@ export const useAuthStore = create<AuthState>()(
             error: error instanceof Error ? error.message : 'Magic link verification failed',
           });
           return false;
+        }
+      },
+
+      verifyOtp: async (email: string, code: string): Promise<string | null> => {
+        set({ isLoading: true, error: null });
+
+        try {
+          const apiBase = getApiUrl();
+          const response = await fetch(`${apiBase}/api/auth/otp/verify`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify({ email, code }),
+          });
+
+          if (!response.ok) {
+            const data = await response.json();
+            throw new Error(data.detail || 'Invalid or expired sign-in code');
+          }
+
+          const data = await response.json();
+          const normalizeAvatar = (a?: string) => (a && a.startsWith('/') ? `${apiBase}${a}` : a);
+
+          setAuthFlagCookie();
+
+          set({
+            user: { ...data.user, avatar: normalizeAvatar(data.user?.avatar) },
+            token: data.access_token,
+            refreshToken: data.refresh_token ?? null,
+            isAuthenticated: true,
+            isLoading: false,
+            error: null,
+          });
+
+          try {
+            const wsResponse = await fetch(`${apiBase}/api/workspaces`, {
+              headers: { Authorization: `Bearer ${data.access_token}` },
+            });
+            if (wsResponse.ok) {
+              const workspaces = await wsResponse.json();
+              if (Array.isArray(workspaces) && workspaces.length > 0) {
+                const sorted = [...workspaces].sort((a, b) => {
+                  const ac = a.created_at ?? '';
+                  const bc = b.created_at ?? '';
+                  if (ac !== bc) return ac < bc ? -1 : 1;
+                  return (a.slug ?? '').localeCompare(b.slug ?? '');
+                });
+                return sorted[0].id;
+              }
+            }
+          } catch {
+            // Non-fatal: fall back to middleware redirect
+          }
+
+          return null;
+        } catch (error) {
+          clearAuthFlagCookie();
+          set({
+            isLoading: false,
+            error: error instanceof Error ? error.message : 'Invalid or expired sign-in code',
+          });
+          return null;
         }
       },
 


### PR DESCRIPTION
## Summary
- Add a 6-digit email OTP on the existing passwordless magic-link challenge so users can type a code instead of click-link + confirm.
- Keep magic link as email fallback; same token row, expiry, one-time use, hashed secrets, rate limits, and max OTP attempts.
- Login UI (when password auth is off): send code → enter OTP → session; magic-link page unchanged.

## Stacking
- Wave 1 independent off `main`.
- **P7** (#1125 create-on-invite) depends on this for invite sign-in email / OTP path.

## Test plan
- [ ] `cd libs/naas-abi/naas_abi/apps/nexus/apps/api && uv run pytest app/services/auth/service_test.py app/services/auth/adapters/primary/auth__primary_adapter__FastAPI_test.py -v`
- [ ] With password auth disabled: request sign-in, enter emailed 6-digit code, land in workspace
- [ ] Confirm magic link in the same email still works (confirm page)
- [ ] Wrong code increments attempts; after `otp_max_attempts` code is invalidated
- [ ] Replay of a used code returns 400
- [ ] Migration `0038_add_magic_link_otp.sql` applies cleanly on API startup