### PR TITLE
feat(nexus): default AI pane to Abi with org/workspace admin tools

### DIFF
--- a/libs/naas-abi/naas_abi/agents/AbiAgent.py
+++ b/libs/naas-abi/naas_abi/agents/AbiAgent.py
@@ -37,7 +37,8 @@ Respond only based on what your available agents and tools can actually deliver.
 <tasks>
 1. Match the user request to the best available agent or tool.
 2. If a match is found, delegate to that agent or tool with full context and report the result back verbatim.
-3. If no match is found, tell the user you do not have the capibilities to handle its request and propose him alternatives based on your available agents and tools.
+3. For organization/workspace/user admin requests (list orgs, create workspaces, invite or remove members, update roles or your own profile), use the Nexus admin tools directly. Do not invent success.
+4. If no match is found, tell the user you do not have the capabilities to handle its request and propose alternatives based on your available agents and tools.
 </tasks>
 
 <tools>
@@ -145,6 +146,10 @@ Respond only based on what your available agents and tools can actually deliver.
             agent_recommendation_tools
         )
         tools += sparql_query_tools_list
+
+        from naas_abi.agents.tools.nexus_admin_tools import nexus_admin_tools
+
+        tools += nexus_admin_tools()
 
         # NOTE: coding-workspace filesystem tools (write_file/read_file/list_dir)
         # are injected generically for every agent via default_tools, so the

--- a/libs/naas-abi/naas_abi/agents/tools/nexus_admin_tools.py
+++ b/libs/naas-abi/naas_abi/agents/tools/nexus_admin_tools.py
@@ -1,0 +1,660 @@
+"""Nexus org/workspace admin tools for AbiAgent.
+
+Call Nexus services in-process with a fresh DB session. Caller identity comes
+from ``agent_user_id`` (set by the chat stream boundary). Mutating membership
+requires org/workspace owner or admin, matching the FastAPI adapters.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from collections.abc import Awaitable, Callable
+from datetime import datetime
+from typing import Any, TypeVar
+
+from langchain_core.tools import BaseTool, tool
+from naas_abi_core.services.agent.context import agent_user_id, agent_workspace_id
+
+T = TypeVar("T")
+
+_SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+_WS_ROLES = frozenset({"admin", "member", "viewer"})
+_ORG_ROLES = frozenset({"owner", "admin", "member"})
+
+
+def _run_async(coro: Awaitable[T]) -> T:
+    """Run an async coroutine from a sync tool call.
+
+    Agent tool execution usually happens on a worker thread (no running loop).
+    If a loop is already running, offload ``asyncio.run`` to a fresh thread so
+    asyncpg sessions are not shared across loops.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    result: list[T] = []
+    error: list[BaseException] = []
+
+    def _target() -> None:
+        try:
+            result.append(asyncio.run(coro))
+        except BaseException as exc:  # noqa: BLE001
+            error.append(exc)
+
+    import threading
+
+    thread = threading.Thread(target=_target, daemon=True)
+    thread.start()
+    thread.join()
+    if error:
+        raise error[0]
+    return result[0]
+
+
+def _require_user_id() -> str | dict[str, str]:
+    user_id = agent_user_id.get()
+    if not user_id:
+        return {
+            "error": (
+                "No authenticated user on this agent session. "
+                "Open the right AI pane while signed in and try again."
+            )
+        }
+    return user_id
+
+
+async def _with_db(
+    fn: Callable[[Any], Awaitable[T]],
+) -> T:
+    from naas_abi.apps.nexus.apps.api.app.core.database import AsyncSessionLocal
+
+    async with AsyncSessionLocal() as db:
+        try:
+            out = await fn(db)
+            await db.commit()
+            return out
+        except Exception:
+            await db.rollback()
+            raise
+
+
+def _workspace_service(db: Any) -> Any:
+    from naas_abi.apps.nexus.apps.api.app.services.workspaces.adapters.secondary.postgres import (
+        WorkspaceSecondaryAdapterPostgres,
+    )
+    from naas_abi.apps.nexus.apps.api.app.services.workspaces.service import (
+        WorkspaceService,
+    )
+
+    return WorkspaceService(adapter=WorkspaceSecondaryAdapterPostgres(db=db))
+
+
+def _organization_service(db: Any) -> Any:
+    from naas_abi.apps.nexus.apps.api.app.services.organizations.adapters.secondary.postgres import (
+        OrganizationSecondaryAdapterPostgres,
+    )
+    from naas_abi.apps.nexus.apps.api.app.services.organizations.service import (
+        OrganizationService,
+    )
+
+    return OrganizationService(adapter=OrganizationSecondaryAdapterPostgres(db=db))
+
+
+def _auth_service(db: Any) -> Any:
+    from naas_abi.apps.nexus.apps.api.app.services.auth.adapters.secondary.postgres import (
+        AuthSecondaryAdapterPostgres,
+    )
+    from naas_abi.apps.nexus.apps.api.app.services.auth.service import AuthService
+
+    return AuthService(adapter=AuthSecondaryAdapterPostgres(db=db))
+
+
+def _record_to_dict(record: Any) -> dict[str, Any]:
+    if record is None:
+        return {}
+    if hasattr(record, "__dataclass_fields__"):
+        out: dict[str, Any] = {}
+        for key in record.__dataclass_fields__:
+            value = getattr(record, key)
+            if isinstance(value, datetime):
+                out[key] = value.isoformat()
+            else:
+                out[key] = value
+        return out
+    if isinstance(record, dict):
+        return record
+    return {"value": str(record)}
+
+
+def nexus_admin_tools() -> list[BaseTool]:
+    @tool
+    def list_organizations() -> Any:
+        """List organizations the signed-in user belongs to (id, name, slug)."""
+        user_id = _require_user_id()
+        if isinstance(user_id, dict):
+            return user_id
+
+        async def _run(db: Any) -> Any:
+            rows = await _organization_service(db).list_organizations(user_id=user_id)
+            return [_record_to_dict(row) for row in rows]
+
+        try:
+            return _run_async(_with_db(_run))
+        except Exception as exc:  # noqa: BLE001
+            return {"error": str(exc)}
+
+    @tool
+    def list_workspaces(organization_id: str = "") -> Any:
+        """List workspaces visible to the signed-in user.
+
+        Pass organization_id to list workspaces under that org (must be a member).
+        Leave organization_id empty to list all workspaces the user belongs to.
+        """
+        user_id = _require_user_id()
+        if isinstance(user_id, dict):
+            return user_id
+        org_id = (organization_id or "").strip()
+
+        async def _run(db: Any) -> Any:
+            if org_id:
+                org = _organization_service(db)
+                role = await org.get_organization_role(user_id=user_id, org_id=org_id)
+                if role is None:
+                    return {"error": "Not a member of this organization", "organization_id": org_id}
+                rows = await org.list_workspaces(org_id=org_id, user_id=user_id)
+                return [_record_to_dict(row) for row in rows]
+            rows = await _workspace_service(db).list_workspaces(user_id=user_id)
+            return [_record_to_dict(row) for row in rows]
+
+        try:
+            return _run_async(_with_db(_run))
+        except Exception as exc:  # noqa: BLE001
+            return {"error": str(exc)}
+
+    @tool
+    def create_workspace(name: str, slug: str, organization_id: str) -> Any:
+        """Create a workspace under an organization. Caller becomes owner.
+
+        Requires org owner or admin. slug must be lowercase letters, digits, hyphens.
+        """
+        user_id = _require_user_id()
+        if isinstance(user_id, dict):
+            return user_id
+        name = (name or "").strip()
+        slug = (slug or "").strip().lower()
+        organization_id = (organization_id or "").strip()
+        if not name or not slug or not organization_id:
+            return {"error": "name, slug, and organization_id are required"}
+        if not _SLUG_RE.match(slug):
+            return {
+                "error": "slug must be lowercase letters, digits, and hyphens only",
+                "slug": slug,
+            }
+
+        async def _run(db: Any) -> Any:
+            from naas_abi.apps.nexus.apps.api.app.services.workspaces.port import (
+                WorkspaceCreateInput,
+            )
+            from naas_abi.apps.nexus.apps.api.app.services.workspaces.service import (
+                WorkspaceSlugAlreadyExistsError,
+            )
+
+            org = _organization_service(db)
+            role = await org.get_organization_role(user_id=user_id, org_id=organization_id)
+            if role not in ("owner", "admin"):
+                return {
+                    "error": "Only organization owners/admins can create workspaces",
+                    "organization_id": organization_id,
+                    "role": role,
+                }
+            try:
+                record = await _workspace_service(db).create_workspace(
+                    WorkspaceCreateInput(
+                        name=name,
+                        slug=slug,
+                        owner_id=user_id,
+                        organization_id=organization_id,
+                    )
+                )
+            except WorkspaceSlugAlreadyExistsError:
+                return {"error": "Slug already exists", "slug": slug}
+            return {"status": "created", "workspace": _record_to_dict(record)}
+
+        try:
+            return _run_async(_with_db(_run))
+        except Exception as exc:  # noqa: BLE001
+            return {"error": str(exc)}
+
+    @tool
+    def list_workspace_members(workspace_id: str = "") -> Any:
+        """List members of a workspace (email, name, role, user_id).
+
+        Defaults to the current chat workspace when workspace_id is omitted.
+        """
+        user_id = _require_user_id()
+        if isinstance(user_id, dict):
+            return user_id
+        workspace_id = (workspace_id or "").strip() or (agent_workspace_id.get() or "")
+        if not workspace_id:
+            return {"error": "workspace_id is required"}
+
+        async def _run(db: Any) -> Any:
+            from naas_abi.apps.nexus.apps.api.app.services.workspaces.service import (
+                WorkspacePermissionError,
+            )
+
+            ws = _workspace_service(db)
+            try:
+                await ws.require_workspace_access(user_id=user_id, workspace_id=workspace_id)
+            except WorkspacePermissionError:
+                return {"error": "No access to this workspace", "workspace_id": workspace_id}
+            rows = await ws.list_workspace_members(workspace_id=workspace_id)
+            return [_record_to_dict(row) for row in rows]
+
+        try:
+            return _run_async(_with_db(_run))
+        except Exception as exc:  # noqa: BLE001
+            return {"error": str(exc)}
+
+    @tool
+    def invite_workspace_member(
+        email: str,
+        workspace_id: str = "",
+        role: str = "member",
+    ) -> Any:
+        """Invite an existing Nexus user (by email) into a workspace.
+
+        Requires workspace owner/admin. role: admin, member, or viewer.
+        The user must already have a Nexus account (magic-link signup on Zen).
+        Defaults to the current chat workspace when workspace_id is omitted.
+        """
+        user_id = _require_user_id()
+        if isinstance(user_id, dict):
+            return user_id
+        email = (email or "").strip().lower()
+        workspace_id = (workspace_id or "").strip() or (agent_workspace_id.get() or "")
+        role = (role or "member").strip().lower()
+        if not email or not workspace_id:
+            return {"error": "email and workspace_id are required"}
+        if role not in _WS_ROLES:
+            return {"error": f"role must be one of {sorted(_WS_ROLES)}", "role": role}
+
+        async def _run(db: Any) -> Any:
+            from naas_abi.apps.nexus.apps.api.app.services.workspaces.service import (
+                WorkspaceMemberAlreadyExistsError,
+            )
+
+            ws = _workspace_service(db)
+            caller_role = await ws.get_workspace_role(user_id=user_id, workspace_id=workspace_id)
+            if caller_role not in ("owner", "admin"):
+                return {
+                    "error": "Only workspace owners/admins can invite members",
+                    "workspace_id": workspace_id,
+                    "role": caller_role,
+                }
+            try:
+                member = await ws.invite_workspace_member(
+                    workspace_id=workspace_id,
+                    email=email,
+                    role=role,
+                )
+            except WorkspaceMemberAlreadyExistsError:
+                return {"error": "User is already a member", "email": email}
+            if member is None:
+                return {
+                    "error": (
+                        "User not found. On Zen they must sign in once via magic link "
+                        "before they can be invited."
+                    ),
+                    "email": email,
+                }
+            return {"status": "invited", "member": _record_to_dict(member)}
+
+        try:
+            return _run_async(_with_db(_run))
+        except Exception as exc:  # noqa: BLE001
+            return {"error": str(exc)}
+
+    @tool
+    def remove_workspace_member(user_id_to_remove: str, workspace_id: str = "") -> Any:
+        """Remove a member from a workspace. Requires workspace owner/admin.
+
+        Defaults to the current chat workspace when workspace_id is omitted.
+        """
+        user_id = _require_user_id()
+        if isinstance(user_id, dict):
+            return user_id
+        target = (user_id_to_remove or "").strip()
+        workspace_id = (workspace_id or "").strip() or (agent_workspace_id.get() or "")
+        if not target or not workspace_id:
+            return {"error": "user_id_to_remove and workspace_id are required"}
+        if target == user_id:
+            return {"error": "Cannot remove yourself from the workspace"}
+
+        async def _run(db: Any) -> Any:
+            ws = _workspace_service(db)
+            caller_role = await ws.get_workspace_role(user_id=user_id, workspace_id=workspace_id)
+            if caller_role not in ("owner", "admin"):
+                return {
+                    "error": "Only workspace owners/admins can remove members",
+                    "workspace_id": workspace_id,
+                    "role": caller_role,
+                }
+            removed = await ws.remove_workspace_member(
+                workspace_id=workspace_id, user_id=target
+            )
+            if not removed:
+                return {"error": "Member not found", "user_id": target}
+            return {"status": "removed", "user_id": target, "workspace_id": workspace_id}
+
+        try:
+            return _run_async(_with_db(_run))
+        except Exception as exc:  # noqa: BLE001
+            return {"error": str(exc)}
+
+    @tool
+    def update_workspace_member_role(
+        user_id_to_update: str,
+        role: str,
+        workspace_id: str = "",
+    ) -> Any:
+        """Update a workspace member's role (admin/member/viewer).
+
+        Requires workspace owner/admin. Defaults to the current chat workspace
+        when workspace_id is omitted.
+        """
+        user_id = _require_user_id()
+        if isinstance(user_id, dict):
+            return user_id
+        target = (user_id_to_update or "").strip()
+        workspace_id = (workspace_id or "").strip() or (agent_workspace_id.get() or "")
+        role = (role or "").strip().lower()
+        if not target or not workspace_id or not role:
+            return {"error": "user_id_to_update, role, and workspace_id are required"}
+        if role not in _WS_ROLES:
+            return {"error": f"role must be one of {sorted(_WS_ROLES)}", "role": role}
+
+        async def _run(db: Any) -> Any:
+            ws = _workspace_service(db)
+            caller_role = await ws.get_workspace_role(user_id=user_id, workspace_id=workspace_id)
+            if caller_role not in ("owner", "admin"):
+                return {
+                    "error": "Only workspace owners/admins can update members",
+                    "workspace_id": workspace_id,
+                    "role": caller_role,
+                }
+            changed = await ws.update_workspace_member(
+                workspace_id=workspace_id,
+                user_id=target,
+                updates={"role": role},
+            )
+            if not changed:
+                return {"error": "Member not found", "user_id": target}
+            return {
+                "status": "updated",
+                "user_id": target,
+                "workspace_id": workspace_id,
+                "role": role,
+            }
+
+        try:
+            return _run_async(_with_db(_run))
+        except Exception as exc:  # noqa: BLE001
+            return {"error": str(exc)}
+
+    @tool
+    def list_organization_members(organization_id: str) -> Any:
+        """List members of an organization (email, name, role, user_id).
+
+        Caller must be an organization member.
+        """
+        user_id = _require_user_id()
+        if isinstance(user_id, dict):
+            return user_id
+        organization_id = (organization_id or "").strip()
+        if not organization_id:
+            return {"error": "organization_id is required"}
+
+        async def _run(db: Any) -> Any:
+            org = _organization_service(db)
+            role = await org.get_organization_role(user_id=user_id, org_id=organization_id)
+            if role is None:
+                return {"error": "Not a member of this organization", "organization_id": organization_id}
+            rows = await org.list_members(org_id=organization_id)
+            return [_record_to_dict(row) for row in rows]
+
+        try:
+            return _run_async(_with_db(_run))
+        except Exception as exc:  # noqa: BLE001
+            return {"error": str(exc)}
+
+    @tool
+    def invite_organization_member(
+        organization_id: str,
+        email: str,
+        role: str = "member",
+    ) -> Any:
+        """Invite an existing Nexus user into an organization.
+
+        Requires org owner/admin. role: owner, admin, or member.
+        """
+        user_id = _require_user_id()
+        if isinstance(user_id, dict):
+            return user_id
+        organization_id = (organization_id or "").strip()
+        email = (email or "").strip().lower()
+        role = (role or "member").strip().lower()
+        if not organization_id or not email:
+            return {"error": "organization_id and email are required"}
+        if role not in _ORG_ROLES:
+            return {"error": f"role must be one of {sorted(_ORG_ROLES)}", "role": role}
+
+        async def _run(db: Any) -> Any:
+            from naas_abi.apps.nexus.apps.api.app.core.datetime_compat import UTC
+            from naas_abi.apps.nexus.apps.api.app.services.organizations.service import (
+                OrganizationMemberAlreadyExistsError,
+            )
+
+            org = _organization_service(db)
+            caller_role = await org.get_organization_role(
+                user_id=user_id, org_id=organization_id
+            )
+            if caller_role not in ("owner", "admin"):
+                return {
+                    "error": "Only organization owners/admins can invite members",
+                    "organization_id": organization_id,
+                    "role": caller_role,
+                }
+            try:
+                member = await org.invite_member(
+                    org_id=organization_id,
+                    email=email,
+                    role=role,
+                    now=datetime.now(UTC).replace(tzinfo=None),
+                )
+            except OrganizationMemberAlreadyExistsError:
+                return {"error": "User is already a member", "email": email}
+            if member is None:
+                return {
+                    "error": (
+                        "User not found. On Zen they must sign in once via magic link "
+                        "before they can be invited."
+                    ),
+                    "email": email,
+                }
+            return {"status": "invited", "member": _record_to_dict(member)}
+
+        try:
+            return _run_async(_with_db(_run))
+        except Exception as exc:  # noqa: BLE001
+            return {"error": str(exc)}
+
+    @tool
+    def remove_organization_member(organization_id: str, user_id_to_remove: str) -> Any:
+        """Remove a member from an organization. Requires org owner/admin."""
+        user_id = _require_user_id()
+        if isinstance(user_id, dict):
+            return user_id
+        organization_id = (organization_id or "").strip()
+        target = (user_id_to_remove or "").strip()
+        if not organization_id or not target:
+            return {"error": "organization_id and user_id_to_remove are required"}
+        if target == user_id:
+            return {"error": "Cannot remove yourself from the organization"}
+
+        async def _run(db: Any) -> Any:
+            org = _organization_service(db)
+            caller_role = await org.get_organization_role(
+                user_id=user_id, org_id=organization_id
+            )
+            if caller_role not in ("owner", "admin"):
+                return {
+                    "error": "Only organization owners/admins can remove members",
+                    "organization_id": organization_id,
+                    "role": caller_role,
+                }
+            removed = await org.remove_member(org_id=organization_id, user_id=target)
+            if not removed:
+                return {
+                    "error": "Member not found or is the organization owner",
+                    "user_id": target,
+                }
+            return {
+                "status": "removed",
+                "user_id": target,
+                "organization_id": organization_id,
+            }
+
+        try:
+            return _run_async(_with_db(_run))
+        except Exception as exc:  # noqa: BLE001
+            return {"error": str(exc)}
+
+    @tool
+    def update_organization_member_role(
+        organization_id: str,
+        user_id_to_update: str,
+        role: str,
+    ) -> Any:
+        """Update an organization member's role (owner/admin/member).
+
+        Requires org owner/admin. Cannot change your own role.
+        """
+        user_id = _require_user_id()
+        if isinstance(user_id, dict):
+            return user_id
+        organization_id = (organization_id or "").strip()
+        target = (user_id_to_update or "").strip()
+        role = (role or "").strip().lower()
+        if not organization_id or not target or not role:
+            return {
+                "error": "organization_id, user_id_to_update, and role are required"
+            }
+        if role not in _ORG_ROLES:
+            return {"error": f"role must be one of {sorted(_ORG_ROLES)}", "role": role}
+        if target == user_id:
+            return {"error": "Cannot change your own organization role"}
+
+        async def _run(db: Any) -> Any:
+            org = _organization_service(db)
+            caller_role = await org.get_organization_role(
+                user_id=user_id, org_id=organization_id
+            )
+            if caller_role not in ("owner", "admin"):
+                return {
+                    "error": "Only organization owners/admins can update member roles",
+                    "organization_id": organization_id,
+                    "role": caller_role,
+                }
+            member = await org.update_member_role(
+                org_id=organization_id, user_id=target, role=role
+            )
+            if member is None:
+                return {"error": "Member not found", "user_id": target}
+            return {"status": "updated", "member": _record_to_dict(member)}
+
+        try:
+            return _run_async(_with_db(_run))
+        except Exception as exc:  # noqa: BLE001
+            return {"error": str(exc)}
+
+    @tool
+    def update_my_profile(
+        name: str = "",
+        email: str = "",
+        company: str = "",
+        role: str = "",
+        bio: str = "",
+    ) -> Any:
+        """Update the signed-in user's own profile fields.
+
+        Only provided (non-empty) fields are changed: name, email, company, role, bio.
+        Admins cannot edit another user's profile via API; invite/role tools manage access.
+        """
+        user_id = _require_user_id()
+        if isinstance(user_id, dict):
+            return user_id
+
+        payload = {
+            "name": name.strip() or None,
+            "email": email.strip() or None,
+            "company": company.strip() or None,
+            "role": role.strip() or None,
+            "bio": bio.strip() or None,
+        }
+        if not any(payload.values()):
+            return {"error": "Provide at least one of: name, email, company, role, bio"}
+
+        async def _run(db: Any) -> Any:
+            from naas_abi.apps.nexus.apps.api.app.services.auth.service import (
+                EmailAlreadyTakenError,
+                UserNotFoundError,
+            )
+
+            try:
+                user = await _auth_service(db).update_profile(
+                    user_id=user_id,
+                    name=payload["name"],
+                    email=payload["email"],
+                    company=payload["company"],
+                    role=payload["role"],
+                    bio=payload["bio"],
+                )
+            except EmailAlreadyTakenError:
+                return {"error": "Email already taken"}
+            except UserNotFoundError:
+                return {"error": "User not found"}
+            return {
+                "status": "updated",
+                "user": {
+                    "id": user.id,
+                    "email": user.email,
+                    "name": user.name,
+                    "company": getattr(user, "company", None),
+                    "role": getattr(user, "role", None),
+                    "bio": getattr(user, "bio", None),
+                },
+            }
+
+        try:
+            return _run_async(_with_db(_run))
+        except Exception as exc:  # noqa: BLE001
+            return {"error": str(exc)}
+
+    return [
+        list_organizations,
+        list_workspaces,
+        create_workspace,
+        list_workspace_members,
+        invite_workspace_member,
+        remove_workspace_member,
+        update_workspace_member_role,
+        list_organization_members,
+        invite_organization_member,
+        remove_organization_member,
+        update_organization_member_role,
+        update_my_profile,
+    ]

--- a/libs/naas-abi/naas_abi/agents/tools/nexus_admin_tools.py
+++ b/libs/naas-abi/naas_abi/agents/tools/nexus_admin_tools.py
@@ -66,19 +66,49 @@ def _require_user_id() -> str | dict[str, str]:
     return user_id
 
 
+def _resolve_database_url() -> str:
+    """Prefer the engine-configured Nexus DB URL over import-time defaults.
+
+    ``app.core.database`` builds its engine at import time. Outside the API
+    process (and in agent worker threads that call ``asyncio.run``) that can
+    still point at ``localhost``. ABIModule.on_initialized holds the real URL.
+    """
+    try:
+        from naas_abi import ABIModule
+
+        url = ABIModule.get_instance().configuration.nexus_config.database_url
+        if isinstance(url, str) and url.strip():
+            return url.strip()
+    except Exception:  # noqa: BLE001
+        pass
+
+    from naas_abi.apps.nexus.apps.api.app.core import config as nexus_config
+
+    return str(nexus_config.settings.database_url)
+
+
 async def _with_db(
     fn: Callable[[Any], Awaitable[T]],
 ) -> T:
-    from naas_abi.apps.nexus.apps.api.app.core.database import AsyncSessionLocal
+    # Fresh engine per call: agent tools often run via asyncio.run() on a
+    # worker thread, so they must not reuse the API process's asyncpg pool.
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-    async with AsyncSessionLocal() as db:
-        try:
-            out = await fn(db)
-            await db.commit()
-            return out
-        except Exception:
-            await db.rollback()
-            raise
+    engine = create_async_engine(_resolve_database_url(), pool_pre_ping=True)
+    session_factory = async_sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+    try:
+        async with session_factory() as db:
+            try:
+                out = await fn(db)
+                await db.commit()
+                return out
+            except Exception:
+                await db.rollback()
+                raise
+    finally:
+        await engine.dispose()
 
 
 def _workspace_service(db: Any) -> Any:

--- a/libs/naas-abi/naas_abi/agents/tools/nexus_admin_tools.py
+++ b/libs/naas-abi/naas_abi/agents/tools/nexus_admin_tools.py
@@ -71,20 +71,40 @@ def _resolve_database_url() -> str:
 
     ``app.core.database`` builds its engine at import time. Outside the API
     process (and in agent worker threads that call ``asyncio.run``) that can
-    still point at ``localhost``. ABIModule.on_initialized holds the real URL.
+    still point at ``localhost``. Prefer ABIModule nexus_config, then Docker
+    ``POSTGRES_*`` env (Zen compose), then Settings.
     """
+    candidates: list[str] = []
     try:
         from naas_abi import ABIModule
 
         url = ABIModule.get_instance().configuration.nexus_config.database_url
         if isinstance(url, str) and url.strip():
-            return url.strip()
+            candidates.append(url.strip())
     except Exception:  # noqa: BLE001
         pass
 
-    from naas_abi.apps.nexus.apps.api.app.core import config as nexus_config
+    import os
 
-    return str(nexus_config.settings.database_url)
+    pg_host = (os.getenv("POSTGRES_HOST") or "").strip()
+    pg_user = (os.getenv("POSTGRES_USER") or "").strip()
+    pg_password = os.getenv("POSTGRES_PASSWORD") or ""
+    if pg_host and pg_user and pg_password and pg_host not in {"localhost", "127.0.0.1"}:
+        candidates.append(
+            f"postgresql+asyncpg://{pg_user}:{pg_password}@{pg_host}:5432/nexus"
+        )
+
+    try:
+        from naas_abi.apps.nexus.apps.api.app.core import config as nexus_config
+
+        candidates.append(str(nexus_config.settings.database_url))
+    except Exception:  # noqa: BLE001
+        pass
+
+    for url in candidates:
+        if url and "localhost" not in url and "127.0.0.1" not in url:
+            return url
+    return candidates[0] if candidates else "postgresql+asyncpg://nexus:nexus@localhost:5432/nexus"
 
 
 async def _with_db(

--- a/libs/naas-abi/naas_abi/agents/tools/nexus_admin_tools_test.py
+++ b/libs/naas-abi/naas_abi/agents/tools/nexus_admin_tools_test.py
@@ -1,0 +1,80 @@
+"""Unit tests for Nexus admin agent tools (authz + identity, no live DB)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from naas_abi.agents.tools import nexus_admin_tools as mod
+from naas_abi_core.services.agent.context import agent_user_id, agent_workspace_id
+
+
+def _tools_by_name() -> dict[str, Any]:
+    return {t.name: t for t in mod.nexus_admin_tools()}
+
+
+def test_tools_require_authenticated_user() -> None:
+    token = agent_user_id.set(None)
+    try:
+        tools = _tools_by_name()
+        result = tools["list_organizations"].invoke({})
+        assert isinstance(result, dict)
+        assert "error" in result
+        assert "signed in" in result["error"].lower()
+    finally:
+        agent_user_id.reset(token)
+
+
+def test_create_workspace_rejects_bad_slug() -> None:
+    token = agent_user_id.set("user-admin")
+    try:
+        tools = _tools_by_name()
+        result = tools["create_workspace"].invoke(
+            {
+                "name": "Bad",
+                "slug": "Not A Slug",
+                "organization_id": "org-1",
+            }
+        )
+        assert result["error"]
+        assert "slug" in result["error"].lower()
+    finally:
+        agent_user_id.reset(token)
+
+
+def test_invite_workspace_member_requires_admin() -> None:
+    user_token = agent_user_id.set("user-member")
+    ws_token = agent_workspace_id.set("ws-1")
+    tools = _tools_by_name()
+
+    mock_ws = MagicMock()
+    mock_ws.get_workspace_role = AsyncMock(return_value="member")
+    mock_ws.invite_workspace_member = AsyncMock()
+
+    async def fake_with_db(fn):  # type: ignore[no-untyped-def]
+        return await fn(MagicMock())
+
+    try:
+        with (
+            patch.object(mod, "_workspace_service", return_value=mock_ws),
+            patch.object(mod, "_with_db", side_effect=fake_with_db),
+        ):
+            result = tools["invite_workspace_member"].invoke(
+                {"email": "someone@naas.ai", "role": "member"}
+            )
+    finally:
+        agent_user_id.reset(user_token)
+        agent_workspace_id.reset(ws_token)
+
+    assert result["error"]
+    assert "owners/admins" in result["error"].lower()
+    mock_ws.invite_workspace_member.assert_not_called()
+
+
+def test_nexus_admin_tools_exported_names() -> None:
+    names = sorted(t.name for t in mod.nexus_admin_tools())
+    assert "create_workspace" in names
+    assert "invite_workspace_member" in names
+    assert "list_organization_members" in names
+    assert "update_my_profile" in names
+    assert len(names) >= 10

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/ai-pane.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/ai-pane.tsx
@@ -77,7 +77,19 @@ export function AIPane() {
   const { providers } = useIntegrationsStore();
   const { getSecretByKey } = useSecretsStore();
   
-  const currentAgent = mounted ? agents.find((a) => a.id === paneAgent) || agents.find((a) => a.id === 'abi') || agents[0] : null;
+  const currentAgent = mounted
+    ? agents.find((a) => a.id === paneAgent) ||
+      agents.find(
+        (a) =>
+          a.enabled &&
+          (a.name === 'Abi' ||
+            (typeof a.class_name === 'string' &&
+              a.class_name.toLowerCase().includes('abiagent')))
+      ) ||
+      agents.find((a) => a.isDefault && a.enabled) ||
+      agents.find((a) => a.enabled) ||
+      agents[0]
+    : null;
   
   // Get provider for agent with resolved secrets
   const getProviderForAgent = (agentId: string) => {
@@ -216,23 +228,37 @@ export function AIPane() {
     setIsLoading(true);
 
     try {
-      // Get provider for current agent (AI Pane uses paneAgent)
-      const provider = getProviderForAgent(paneAgent);
-      
-      // Build provider payload (may be null if no provider, API will fallback to Ollama)
-      const providerPayload = provider ? {
-        id: provider.id,
-        name: provider.name,
-        type: provider.type,
-        enabled: provider.enabled,
-        endpoint: provider.endpoint || getOllamaUrl(),
-        api_key: provider.apiKey,
-        account_id: provider.accountId,
-        model: provider.model,
-      } : null;
+      // Resolve the pane agent id (persisted paneAgent may be stale 'abi' string).
+      const agentData =
+        getAgent(paneAgent) ||
+        agents.find(
+          (a) =>
+            a.enabled &&
+            (a.name === 'Abi' ||
+              (typeof a.class_name === 'string' &&
+                a.class_name.toLowerCase().includes('abiagent')))
+        ) ||
+        null;
+      const resolvedAgentId = agentData?.id || paneAgent;
 
-      // Get agent's system prompt
-      const agentData = getAgent(paneAgent);
+      // For ABI-backed agents, omit the client provider so the API resolves
+      // in-process AbiAgent (with tools). Client integration mappings often
+      // point at Ollama and would bypass tool calling.
+      const usesAbiProvider = agentData?.provider === 'abi';
+      const provider = usesAbiProvider ? null : getProviderForAgent(resolvedAgentId);
+      const providerPayload = provider
+        ? {
+            id: provider.id,
+            name: provider.name,
+            type: provider.type,
+            enabled: provider.enabled,
+            endpoint: provider.endpoint || getOllamaUrl(),
+            api_key: provider.apiKey,
+            account_id: provider.accountId,
+            model: provider.model,
+          }
+        : null;
+
       const systemPrompt = agentData?.systemPrompt || null;
       
       // Build message history for the API (must include the current user message)
@@ -257,7 +283,7 @@ export function AIPane() {
           workspace_id: currentWorkspaceId,
           message: userContent,
           messages: fullHistory,
-          agent: paneAgent,
+          agent: resolvedAgentId,
           provider: providerPayload,
           system_prompt: systemPrompt,
         }),
@@ -549,7 +575,7 @@ export function AIPane() {
                 )}
               </div>
 
-              {/* Agent selector (AI Pane has its own selection, defaults to SupervisorAgent) */}
+              {/* Agent selector (AI Pane defaults to Abi) */}
               <div ref={modelMenuRef} className="relative">
                 <button
                   type="button"
@@ -560,7 +586,7 @@ export function AIPane() {
                     showAgentMenu && 'bg-muted'
                   )}
                 >
-                  <span>{currentAgent?.name || 'SupervisorAgent'}</span>
+                  <span>{currentAgent?.name || 'Abi'}</span>
                   <ChevronDown size={12} className="text-muted-foreground" />
                 </button>
                 
@@ -574,17 +600,17 @@ export function AIPane() {
                         key={agent.id}
                         type="button"
                         onClick={() => {
-                          setPaneAgent(agent.id);
+                          setPaneAgent(agent.id, true);
                           setShowAgentMenu(false);
                         }}
                         className={cn(
                           'flex w-full items-center gap-2 px-3 py-1.5 text-sm',
                           'hover:bg-muted',
-                          paneAgent === agent.id && 'bg-muted'
+                          (paneAgent === agent.id || currentAgent?.id === agent.id) && 'bg-muted'
                         )}
                       >
                         <span className="flex-1 text-left">{agent.name}</span>
-                        {paneAgent === agent.id && <Check size={12} />}
+                        {(paneAgent === agent.id || currentAgent?.id === agent.id) && <Check size={12} />}
                       </button>
                     ))}
                   </div>

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/agents.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/agents.ts
@@ -239,6 +239,25 @@ export const useAgentsStore = create<AgentsState>()(
             } else if (!currentSelected) {
               ws.setSelectedAgent(preferred.id);
             }
+
+            // Right AI pane always prefers Abi unless the user picked another agent.
+            const abiAgent =
+              formattedAgents.find(
+                (a) =>
+                  a.enabled &&
+                  (a.name === 'Abi' ||
+                    (typeof a.class_name === 'string' &&
+                      a.class_name.toLowerCase().includes('abiagent')))
+              ) ?? null;
+            const panePreferred = abiAgent ?? preferred;
+            const currentPane = ws.paneAgent;
+            if (!ws.paneAgentExplicitlySelected) {
+              ws.setPaneAgent(panePreferred.id);
+            } else if (currentPane && !formattedAgents.find((a) => a.id === currentPane)) {
+              ws.setPaneAgent(panePreferred.id);
+            } else if (!currentPane) {
+              ws.setPaneAgent(panePreferred.id);
+            }
           }
         } catch (error) {
           console.error('Failed to fetch agents:', error);

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
@@ -239,8 +239,11 @@ interface WorkspaceState {
   /** Mobile list→thread navigation in flight (conversation id or "new"). Not persisted. */
   mobilePendingChatSlug: string | null;
   setMobilePendingChatSlug: (slug: string | null) => void;
-  paneAgent: AgentType; // AI Pane agent selection
-  setPaneAgent: (agent: AgentType) => void;
+  paneAgent: AgentType; // AI Pane agent selection (defaults to Abi)
+  /** True when the user picked an AI Pane agent from the menu. */
+  paneAgentExplicitlySelected: boolean;
+  setPaneAgent: (agent: AgentType, explicit?: boolean) => void;
+  clearPaneAgentExplicitSelection: () => void;
   createConversation: (projectId?: string) => string;
   setActiveConversation: (id: string | null) => void;
   /** Record the latest agent used in a conversation (mirrors the backend,
@@ -449,8 +452,11 @@ export const useWorkspaceStore = create<WorkspaceState>()(
   setPendingComposerText: (text) => set({ pendingComposerText: text }),
   mobilePendingChatSlug: null,
   setMobilePendingChatSlug: (slug) => set({ mobilePendingChatSlug: slug }),
-  paneAgent: 'abi', // Default to SupervisorAgent - omniscient supervisor agent for AI Pane
-  setPaneAgent: (agent) => set({ paneAgent: agent }),
+  paneAgent: '', // Resolved to Abi after agents sync (see agents store)
+  paneAgentExplicitlySelected: false,
+  setPaneAgent: (agent, explicit = false) =>
+    set({ paneAgent: agent, paneAgentExplicitlySelected: explicit }),
+  clearPaneAgentExplicitSelection: () => set({ paneAgentExplicitlySelected: false }),
 
   createConversation: (projectId?: string) => {
     const id = generateConversationId();
@@ -1380,6 +1386,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
         expandedSections: state.expandedSections,
         selectedAgent: state.selectedAgent,
         paneAgent: state.paneAgent,
+        paneAgentExplicitlySelected: state.paneAgentExplicitlySelected,
         activePanelSection: state.activePanelSection,
       }),
       onRehydrateStorage: () => (state) => {


### PR DESCRIPTION
## Summary
- Default the right AI pane to Abi (resolve by name/class; omit client Ollama so in-process AbiAgent runs with tools).
- Add Nexus admin tools for orgs, workspaces, membership, and self profile updates with owner/admin checks.
- Resolve Nexus DB URL at tool call time, with `POSTGRES_*` fallback for Zen VM ops.

## Stacking
- Wave 1 independent off `main` (no file overlap with Users UI PRs).
- **P6** (#1123 compare + pane-send) stacks on this branch.

## Test plan
- [ ] Open right pane: default agent is Abi with tools available
- [ ] Abi can list/invite org and workspace members when caller is owner/admin
- [ ] Unit: `nexus_admin_tools_test.py` passes
- [ ] DB URL resolves from Nexus settings and falls back to `POSTGRES_*` when needed