### PR TITLE
fix: prompt for new module CLI (#1112) + green CI

### DIFF
--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/module.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/module.py
@@ -89,8 +89,15 @@ def new_module(module_name: str, module_path: str = ".", quiet: bool = False):
     )
 
     if not quiet:
+        # Configuration file requires an importable module namespace rather than an
+        # actual file path on the filesystem (so we need to replace '/' with '.')
         print(f"\nModule '{module_name}' has been created at:\n  {module_path}\n")
         print("To enable this module, add the following to your config.yaml:\n")
         print("modules:")
-        print(f"  - module: {module_path}")
+        print(f"  - module: {module_path.replace("/", ".")})
         print("    enabled: true\n")
+        print(
+            "Note: please check the module import namespace root level that might need "
+            "to be updated depending on your actual project structure.\n"
+        )
+

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/module.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/module.py
@@ -90,14 +90,16 @@ def new_module(module_name: str, module_path: str = ".", quiet: bool = False):
 
     if not quiet:
         # Configuration file requires an importable module namespace rather than an
-        # actual file path on the filesystem (so we need to replace '/' with '.')
+        # actual file path on the filesystem, so the path is made relative to the
+        # current working directory and its separators replaced with '.'
+        module_namespace = os.path.relpath(module_path, os.getcwd()).replace(os.sep, ".")
+
         print(f"\nModule '{module_name}' has been created at:\n  {module_path}\n")
         print("To enable this module, add the following to your config.yaml:\n")
         print("modules:")
-        print(f"  - module: {module_path.replace("/", ".")})
+        print(f"  - module: {module_namespace}")
         print("    enabled: true\n")
         print(
             "Note: please check the module import namespace root level that might need "
             "to be updated depending on your actual project structure.\n"
         )
-

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/module.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/module.py
@@ -92,5 +92,5 @@ def new_module(module_name: str, module_path: str = ".", quiet: bool = False):
         print(f"\nModule '{module_name}' has been created at:\n  {module_path}\n")
         print("To enable this module, add the following to your config.yaml:\n")
         print("modules:")
-        print(f"  - path: {module_path}")
+        print(f"  - module: {module_path}")
         print("    enabled: true\n")

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/module_test.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/module_test.py
@@ -1,0 +1,46 @@
+import os
+
+import pytest
+
+from naas_abi_cli.cli.new.module import new_module
+
+
+@pytest.mark.parametrize(
+    "given_path,expected_namespace",
+    [
+        # Default: the module is created directly under the current directory.
+        (".", "my_test_module"),
+        # Explicit relative path: separators become dots.
+        (os.path.join("src", "custom", "modules"), "src.custom.modules.my_test_module"),
+        # A leading "./" must not leak into the namespace.
+        (os.path.join(".", "src", "modules"), "src.modules.my_test_module"),
+    ],
+)
+def test_new_module_prints_importable_namespace(
+    tmp_path,
+    monkeypatch,
+    capsys,
+    given_path: str,
+    expected_namespace: str,
+) -> None:
+    """The config.yaml hint must show a dotted, importable module namespace.
+
+    The namespace is derived from the destination path relative to the current
+    working directory, so an absolute path never leaks into the output.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    new_module("my-test-module", given_path)
+
+    stdout = capsys.readouterr().out
+    assert f"  - module: {expected_namespace}" in stdout
+    # A filesystem separator in the namespace means the path was not converted.
+    assert f"  - module: {expected_namespace}{os.sep}" not in stdout
+
+
+def test_new_module_quiet_prints_nothing(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    new_module("my-test-module", ".", quiet=True)
+
+    assert capsys.readouterr().out == ""


### PR DESCRIPTION
Supersedes #1113 (from a fork with `maintainerCanModify: false`, so the fix could not be pushed onto that branch). Closes #1112.

Contains @AlexTorxFM's two commits from #1113 unchanged, plus one fix commit on top.

## Why #1113's CI was red

`check (3.11)` and `check (3.12)` both failed at `make check` → `check-core`, with ruff reporting 6 `invalid-syntax` errors:

```python
print(f"  - module: {module_path.replace("/", ".")})
```

Two problems on one line:
1. The f-string is **unterminated** — the closing `"` before `)` is missing. Invalid in every Python version.
2. It reuses double quotes inside its own replacement field. Nested same-type quotes need PEP 701 (3.12+), and ruff is pinned to `target-version = "py311"`, so this is rejected even on the 3.12 job.

## Fix

```python
module_namespace = os.path.relpath(module_path, os.getcwd()).replace(os.sep, ".")
...
print(f"  - module: {module_namespace}")
```

Two separable changes:

- **Syntax repair** (required for CI): terminate the f-string and stop nesting double quotes.
- **Namespace derivation** (correctness): `module_path` is absolutised when the default `.` is used (`os.path.join(os.getcwd(), ...)` at line 30), so `.replace("/", ".")` printed a namespace like `.Users.me.dev.project.my_module`. Deriving it relative to the cwd yields `my_module`, and also strips a leading `./` from explicit paths. Happy to drop this half if you'd rather keep the PR minimal.

The `- module:` key itself is correct — `ModuleConfig` in `EngineConfiguration.py:240` accepts `module` (dotted namespace) with `path` as the legacy form.

## Tests

Added `libs/naas-abi-cli/naas_abi_cli/cli/new/module_test.py` (co-located `_test.py`, matching the convention of `utils_test.py`). This branch was previously never executed by any test, which is how a hard syntax error reached CI.

Covers the printed namespace for default / nested / `./`-prefixed paths, and that `quiet=True` prints nothing.

## Verification

Ran `check-core`'s three stages verbatim, plus the tests:

| Step | Result |
|---|---|
| `uvx ruff check libs/naas-abi-core libs/naas-abi-cli libs/naas-abi --exclude ...` | All checks passed |
| `mypy -p naas_abi_cli --follow-untyped-imports ...` | Success: no issues found in 70 source files |
| `uvx bandit -c bandit.yaml -r ... -ll -ii` | exit 0 (0 high) |
| `pytest naas_abi_cli/cli/new/` | 24 passed |

Also exercised the CLI end to end — default now prints `- module: my_demo_module`, and `src/custom/modules` prints `- module: src.custom.modules.other_module`.

Note: the caveat from #1113 about the namespace root still applies for paths outside the cwd; the "Note:" line the author added covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)