### PR TITLE
fix(nexus): central chat ... export menu (text + transcript)

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-export-button.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-export-button.tsx
@@ -1,99 +1,132 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { Download, Loader2 } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { MoreHorizontal } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { authFetch } from '@/stores/auth';
-import { getApiUrl } from '@/lib/config';
+import {
+  downloadConversationTranscript,
+  type TranscriptFormat,
+} from '@/lib/chat-transcript-export';
 import { useWorkspaceStore } from '@/stores/workspace';
 
 interface ChatExportButtonProps {
   className?: string;
+  /**
+   * Conversation to export. Defaults to the central thread
+   * (`activeConversationId`). Pass `paneConversationId` from the AI pane.
+   */
+  conversationId?: string | null;
 }
 
 /**
- * Exports the open conversation. Lives in the shell chrome (desktop Header,
- * mobile top bar) rather than above the composer, so it costs no vertical
- * space in the thread and does not shift the composer when the first message
- * arrives. Reads the store directly so any chrome can render it unwired.
+ * Overflow menu for conversation export. Lives in shell chrome (desktop Header,
+ * mobile top bar, AI pane controls) so it costs no vertical space in the thread.
+ * Uses the same client transcript helpers as the right AI pane.
  */
-export function ChatExportButton({ className }: ChatExportButtonProps) {
+export function ChatExportButton({ className, conversationId }: ChatExportButtonProps) {
   const [mounted, setMounted] = useState(false);
-  const [exporting, setExporting] = useState(false);
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const activeConversationId = useWorkspaceStore((s) => s.activeConversationId);
+  const resolvedId = conversationId !== undefined ? conversationId : activeConversationId;
   const conversation = useWorkspaceStore(
-    (s) => s.conversations.find((c) => c.id === s.activeConversationId) ?? null
+    (s) => (resolvedId ? s.conversations.find((c) => c.id === resolvedId) ?? null : null)
   );
 
   useEffect(() => setMounted(true), []);
 
-  const handleExport = async () => {
-    if (!conversation || exporting) return;
-    setExporting(true);
-    try {
-      // Built from local state rather than read back from the server: the PATCH
-      // that persists tool calls may still be in flight when the user exports.
-      const messagesMetadata = conversation.messages
-        .filter((m) => m.role === 'assistant' && (m.toolCalls?.length || m.executionTime !== undefined))
-        .map((m) => ({
-          message_id: m.id,
-          execution_time: m.executionTime ?? null,
-          steps: (m.toolCalls ?? []).map((t) => ({
-            tool_name: t.toolName,
-            prefix: t.prefix,
-            status: t.status,
-            input: t.input ?? null,
-            output: t.output ?? null,
-          })),
-          sources: m.sources ?? [],
-        }));
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [open]);
 
-      const response = await authFetch(
-        `${getApiUrl()}/api/chat/conversations/${conversation.id}/export`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ format: 'txt', messages_metadata: messagesMetadata }),
-        }
-      );
+  const canExport = Boolean(
+    conversation && conversation.messages.some((m) => m.role === 'user' || m.role === 'assistant')
+  );
 
-      if (!response.ok) throw new Error('Failed to export conversation');
-
-      const blob = await response.blob();
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement('a');
-      link.href = url;
-      link.download = `conversation-${conversation.id}-${Date.now()}.txt`;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      URL.revokeObjectURL(url);
-    } catch (error) {
-      console.error('Export failed:', error);
-      alert('Failed to export conversation. Please try again.');
-    } finally {
-      setExporting(false);
-    }
+  const handleExport = (format: TranscriptFormat) => {
+    if (!conversation || !canExport) return;
+    downloadConversationTranscript(
+      {
+        id: conversation.id,
+        title: conversation.title,
+        workspaceId: conversation.workspaceId,
+        messages: conversation.messages.map((m) => ({
+          role: m.role,
+          content: m.content,
+          agent: m.agent,
+          timestamp: m.timestamp,
+        })),
+      },
+      format
+    );
+    setOpen(false);
   };
 
-  // Nothing to export until a thread has content, and the store only holds
-  // conversations after hydration, so stay absent on the server pass.
-  if (!mounted || !conversation || conversation.messages.length === 0) return null;
+  // Store only holds conversations after hydration; stay absent on the server pass
+  // and when no thread is selected.
+  if (!mounted || !conversation) return null;
 
   return (
-    <button
-      type="button"
-      onClick={handleExport}
-      disabled={exporting}
-      className={cn(
-        'flex h-8 w-8 items-center justify-center rounded-md transition-colors',
-        'text-muted-foreground hover:bg-muted hover:text-foreground',
-        exporting && 'cursor-wait opacity-60',
-        className
+    <div ref={rootRef} className={cn('relative', className)}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className={cn(
+          'flex h-8 w-8 items-center justify-center rounded-md transition-colors',
+          'text-muted-foreground hover:bg-muted hover:text-foreground',
+          open && 'bg-muted text-foreground'
+        )}
+        title="More"
+        aria-label="More chat actions"
+        aria-expanded={open}
+        aria-haspopup="menu"
+      >
+        <MoreHorizontal size={16} />
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          aria-label="Chat actions"
+          className="absolute right-0 top-full z-40 mt-1 w-52 rounded-md border border-border bg-popover py-1 shadow-lg"
+        >
+          <button
+            type="button"
+            role="menuitem"
+            disabled={!canExport}
+            onClick={() => handleExport('md')}
+            className={cn(
+              'flex w-full px-3 py-2 text-left text-xs transition-colors',
+              canExport
+                ? 'text-foreground hover:bg-muted'
+                : 'cursor-not-allowed text-muted-foreground'
+            )}
+          >
+            Export transcript
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            disabled={!canExport}
+            onClick={() => handleExport('txt')}
+            className={cn(
+              'flex w-full px-3 py-2 text-left text-xs transition-colors',
+              canExport
+                ? 'text-foreground hover:bg-muted'
+                : 'cursor-not-allowed text-muted-foreground'
+            )}
+          >
+            Export as text
+          </button>
+        </div>
       )}
-      title="Export conversation"
-      aria-label="Export conversation"
-    >
-      {exporting ? <Loader2 size={16} className="animate-spin" /> : <Download size={16} />}
-    </button>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replaces the central conversation header download icon with a `...` overflow menu matching the right AI pane.
- Menu offers **Export transcript** (markdown) and **Export as text** (plain text).
- Uses existing `downloadConversationTranscript` helpers; drops the old single-format server export button path from that control.

Fixes #1133

## Test plan
- [ ] Open a workspace chat with messages
- [ ] In the central header (left of Abi), click `...` (not a download icon)
- [ ] Export transcript downloads `.md`
- [ ] Export as text downloads `.txt`
- [ ] Right pane `...` menu still works the same way
- [ ] Mobile chat thread chrome shows the same `...` control