### PR TITLE
fix(dev): auto-seed ABI_API_KEY=abi for local abi dev

### DIFF
--- a/libs/naas-abi-cli/naas_abi_cli/cli/dev.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/dev.py
@@ -306,6 +306,9 @@ def _launch_oxigraph(spec: ServiceSpec) -> int:
 
 def _launch_api(spec: ServiceSpec, ports: dict[str, int]) -> int:
     env = os.environ.copy()
+    # Local-dev default so Bearer auth works without a hand-authored .env.
+    # Never overwrites an explicit value from the parent environment.
+    env.setdefault("ABI_API_KEY", DEFAULT_API_KEY)
     env["ABI_PORT"] = str(spec.port)
     env["ABI_HOST"] = env.get("ABI_HOST", BIND_HOST)
     # Point the triple-store adapter at the worktree-local oxigraph server.
@@ -829,6 +832,7 @@ RECENT_DUMP_LINES = 30
 # (dotenv) — pre-populating those skips the random-password path.
 DEFAULT_ADMIN_EMAIL = "admin@example.com"
 DEFAULT_ADMIN_PASSWORD = "admin"  # nosec B105 - dev-only, fixed local creds
+DEFAULT_API_KEY = "abi"  # nosec B105 - local-dev only, matches /token default
 
 
 def _ensure_default_admin_env() -> tuple[str, str]:
@@ -869,6 +873,37 @@ def _ensure_default_admin_env() -> tuple[str, str]:
         existing.get(email_key, DEFAULT_ADMIN_EMAIL),
         existing.get(pw_key, DEFAULT_ADMIN_PASSWORD),
     )
+
+
+def _ensure_default_api_key_env() -> str:
+    """Write ``ABI_API_KEY=abi`` to `.env` if missing (local-dev only).
+
+    Also ``setdefault`` into the current process so spawned children inherit
+    the key via ``os.environ.copy()``. Does not overwrite an existing value
+    in `.env` or the process environment. Production / remote deploys must
+    set ``ABI_API_KEY`` explicitly; this helper is only called from
+    ``abi dev up``.
+    """
+    env_path = _project_root() / ".env"
+    existing: dict[str, str] = {}
+    if env_path.exists():
+        for raw in env_path.read_text().splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, _, v = line.partition("=")
+            existing[k.strip()] = v.strip()
+
+    if "ABI_API_KEY" not in existing:
+        with env_path.open("a", encoding="utf-8") as fh:
+            if env_path.stat().st_size > 0 and not env_path.read_text().endswith("\n"):
+                fh.write("\n")
+            fh.write("\n# `abi dev` default API key (local-only)\n")
+            fh.write(f"ABI_API_KEY={DEFAULT_API_KEY}\n")
+
+    resolved = existing.get("ABI_API_KEY", DEFAULT_API_KEY)
+    os.environ.setdefault("ABI_API_KEY", resolved)
+    return os.environ["ABI_API_KEY"]
 
 
 def _stream_log_to_console(
@@ -1315,6 +1350,7 @@ def dev_up(services: tuple[str, ...], detach: bool) -> None:
     # seed adopts them instead of generating a random password. Done before
     # the api process spawns and reads .env via the dotenv adapter.
     admin_email, admin_password = _ensure_default_admin_env()
+    _ensure_default_api_key_env()
 
     started: list[ServiceSpec] = []
     try:

--- a/libs/naas-abi-cli/naas_abi_cli/cli/dev_test.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/dev_test.py
@@ -88,6 +88,65 @@ def test_api_preserves_preexisting_cors_origins(monkeypatch) -> None:
     assert "https://example.test" in captured["env"]["ABI_CORS_EXTRA_ORIGINS"].split(",")
 
 
+def test_api_env_defaults_abi_api_key(monkeypatch) -> None:
+    """Missing ABI_API_KEY must not leave the API child unauthenticated."""
+    captured: dict = {}
+    monkeypatch.delenv("ABI_API_KEY", raising=False)
+    monkeypatch.setattr(
+        dev,
+        "_spawn",
+        lambda spec, cmd, cwd, env: captured.update(env=env) or 1234,
+    )
+
+    dev._launch_api(_spec("api", PORTS["api"]), PORTS)
+
+    assert captured["env"]["ABI_API_KEY"] == "abi"
+
+
+def test_api_env_preserves_explicit_abi_api_key(monkeypatch) -> None:
+    captured: dict = {}
+    monkeypatch.setenv("ABI_API_KEY", "custom-dev-key")
+    monkeypatch.setattr(
+        dev,
+        "_spawn",
+        lambda spec, cmd, cwd, env: captured.update(env=env) or 1234,
+    )
+
+    dev._launch_api(_spec("api", PORTS["api"]), PORTS)
+
+    assert captured["env"]["ABI_API_KEY"] == "custom-dev-key"
+
+
+def test_ensure_default_api_key_writes_env_when_missing(
+    monkeypatch, tmp_path
+) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text("OTHER=1\n")
+    monkeypatch.setattr(dev, "_project_root", lambda: tmp_path)
+    monkeypatch.delenv("ABI_API_KEY", raising=False)
+
+    key = dev._ensure_default_api_key_env()
+
+    assert key == "abi"
+    assert "ABI_API_KEY=abi" in env_file.read_text()
+    assert "OTHER=1" in env_file.read_text()
+
+
+def test_ensure_default_api_key_does_not_overwrite_env_file(
+    monkeypatch, tmp_path
+) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text("ABI_API_KEY=keep-me\n")
+    monkeypatch.setattr(dev, "_project_root", lambda: tmp_path)
+    monkeypatch.delenv("ABI_API_KEY", raising=False)
+
+    key = dev._ensure_default_api_key_env()
+
+    assert key == "keep-me"
+    assert env_file.read_text().count("ABI_API_KEY=") == 1
+    assert "ABI_API_KEY=keep-me" in env_file.read_text()
+
+
 # =============================================================================
 # Bind / probe targets stay on the literal
 # =============================================================================

--- a/libs/naas-abi-core/naas_abi_core/apps/api/api.py
+++ b/libs/naas-abi-core/naas_abi_core/apps/api/api.py
@@ -159,7 +159,10 @@ async def login(form_data: Annotated[OAuth2PasswordRequestForm, Depends()]):
     if form_data.password != "abi":
         raise HTTPException(status_code=400, detail="Incorrect username or password")
 
-    return {"access_token": "abi", "token_type": "bearer"}
+    return {
+        "access_token": os.environ.get("ABI_API_KEY", "abi"),
+        "token_type": "bearer",
+    }
 
 
 # Create Agents API Router


### PR DESCRIPTION
## Summary
- Seed `ABI_API_KEY=abi` into `.env` on `abi dev up` when missing (local-dev only; never overwrites an existing value).
- Inject the same default into the API child process via `env.setdefault`, since Bearer auth reads `os.environ` directly.
- Align `POST /token` to return `os.environ.get("ABI_API_KEY", "abi")` so the minted token matches auth.

## Test plan
- [x] `uv run pytest libs/naas-abi-cli/naas_abi_cli/cli/dev_test.py` (17 passed)
- [x] `abi dev down` then `abi dev up -d`; wait for `/docs` 200
- [x] `POST /agents/Ollama/completion` with `Authorization: Bearer abi` and prompt `Reply with exactly: pong` -> `"pong"` (200)
- [x] CI green
- Nexus UI chat: skipped (API smoke sufficient)