### PR TITLE
fix(nexus): Abi Processing hang + honor agent LLM picks

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/service.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/service.py
@@ -5,6 +5,7 @@ import logging
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
+from urllib.parse import quote
 from uuid import uuid4
 
 import numpy as np
@@ -63,6 +64,19 @@ class ResolvedProvider:
     api_key: str | None
     account_id: str | None
     model: str
+
+
+def _abi_inprocess_endpoint(llm_model_id: str | None = None) -> str:
+    """Build the in-process ABI endpoint, optionally pinning an LLM override.
+
+    ``provider.model`` for ABI is the agent identity (class_name). The agent's
+    selected chat model lives in ``agent.model_id`` and is threaded through the
+    endpoint query string so ``stream_with_abi_inprocess`` can rebind the LLM
+    for that turn without changing ProviderConfig schemas.
+    """
+    if not llm_model_id or not str(llm_model_id).strip():
+        return "inprocess://abi"
+    return f"inprocess://abi?llm={quote(str(llm_model_id).strip(), safe='')}"
 
 
 # Metadata keys tracking "refresh" (regenerate) lineage on messages.
@@ -1130,6 +1144,55 @@ class ChatService:
         workspace_id: str | None = None,
     ) -> ResolvedProvider | None:
         if provider and getattr(provider, "enabled", False):
+            # ABI provider.model is an agent identity (class_name / name), not an LLM
+            # model id. The Nexus UI often overwrites model with agent.modelId
+            # (e.g. "qwen-2.5-3b"), which breaks in-process lookup. When we have
+            # agent_id, re-resolve the ABI agent ref and normalize the endpoint.
+            if getattr(provider, "type", None) == "abi" and agent_id:
+                try:
+                    agent = await self.get_agent(context=context, agent_id=agent_id)
+                    if agent:
+                        inprocess_agent_ref = (
+                            agent.class_name or agent.name or agent.id
+                        )
+                        external_agent_ref = (
+                            agent.name or agent.class_name or agent.id
+                        )
+                        endpoint = (getattr(provider, "endpoint", None) or "").rstrip(
+                            "/"
+                        )
+                        # Ollama / empty endpoints are not ABI servers.
+                        if (
+                            not endpoint
+                            or endpoint.startswith("inprocess://")
+                            or "11434" in endpoint
+                            or endpoint.endswith("/v1")
+                        ):
+                            return ResolvedProvider(
+                                id=provider.id or f"abi-inprocess-{agent.id}",
+                                name=provider.name or "ABI (In-Process)",
+                                type="abi",
+                                enabled=True,
+                                endpoint=_abi_inprocess_endpoint(agent.model_id),
+                                api_key=None,
+                                account_id=None,
+                                model=inprocess_agent_ref,
+                            )
+                        return ResolvedProvider(
+                            id=provider.id,
+                            name=provider.name,
+                            type="abi",
+                            enabled=True,
+                            endpoint=endpoint,
+                            api_key=provider.api_key,
+                            account_id=provider.account_id,
+                            model=external_agent_ref,
+                        )
+                except Exception:
+                    logging.getLogger(__name__).warning(
+                        "Failed to rewrite ABI provider from agent_id",
+                        exc_info=True,
+                    )
             return ResolvedProvider(
                 id=provider.id,
                 name=provider.name,
@@ -1173,7 +1236,7 @@ class ChatService:
                             name="ABI (In-Process)",
                             type="abi",
                             enabled=True,
-                            endpoint="inprocess://abi",
+                            endpoint=_abi_inprocess_endpoint(agent.model_id),
                             api_key=None,
                             account_id=None,
                             model=inprocess_agent_ref,
@@ -1237,7 +1300,7 @@ class ChatService:
                         name="ABI (In-Process)",
                         type="abi",
                         enabled=True,
-                        endpoint="inprocess://abi",
+                        endpoint=_abi_inprocess_endpoint(None),
                         api_key=None,
                         account_id=None,
                         model=agent_id,

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/provider_runtime.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/provider_runtime.py
@@ -4,6 +4,7 @@ Supports: Anthropic (Claude), OpenAI, Ollama, Cloudflare Workers AI, and custom 
 """
 
 import importlib
+import os
 import pkgutil
 import threading
 from collections.abc import AsyncGenerator
@@ -750,12 +751,27 @@ async def complete_with_abi(
 
         # Per-request isolation: never execute against the cached singleton.
         agent = _duplicate_inprocess_agent(template_agent, thread_id)
+        llm_override = _llm_override_from_endpoint(config.endpoint)
+        if llm_override:
+            override_model = _build_override_chat_model(llm_override)
+            if override_model is not None:
+                _rebind_agent_chat_model(agent, override_model)
 
         if hasattr(agent, "ainvoke"):
-            return await agent.ainvoke(latest_user_message, thread_id=thread_id)
-        if hasattr(agent, "invoke"):
-            return agent.invoke(latest_user_message)
-        raise ValueError(f"In-process ABI agent '{config.model}' cannot be invoked")
+            result = await agent.ainvoke(latest_user_message, thread_id=thread_id)
+        elif hasattr(agent, "invoke"):
+            result = agent.invoke(latest_user_message)
+        else:
+            raise ValueError(f"In-process ABI agent '{config.model}' cannot be invoked")
+        if isinstance(result, str) and result.strip():
+            return result
+        if isinstance(result, str):
+            return (
+                "The agent finished without producing a reply. "
+                "Try another model in the agent picker (OpenRouter Claude when "
+                "OPENROUTER_API_KEY is set), or send the message again."
+            )
+        return str(result) if result is not None else ""
 
     if not endpoint:
         raise ValueError("ABI endpoint is required")
@@ -1306,6 +1322,147 @@ def _resolve_inprocess_abi_agent(agent_name: str):
         return instance
 
 
+def _llm_override_from_endpoint(endpoint: str | None) -> str | None:
+    """Extract ``?llm=`` from an ``inprocess://abi?...`` endpoint."""
+    if not endpoint or not endpoint.startswith("inprocess://"):
+        return None
+    parsed = urlparse(endpoint)
+    raw = dict(parse_qsl(parsed.query, keep_blank_values=False)).get("llm")
+    if not raw:
+        return None
+    value = str(raw).strip()
+    return value or None
+
+
+def _secret_value(name: str) -> str:
+    value = (os.environ.get(name) or "").strip()
+    if value:
+        return value
+    try:
+        from naas_abi import ABIModule
+
+        secret_value = ABIModule.get_instance().engine.services.secret.get(name)
+        return str(secret_value).strip() if secret_value else ""
+    except Exception:
+        return ""
+
+
+def _build_override_chat_model(model_id: str) -> Any | None:
+    """Build a LangChain chat model for a picker-selected model id.
+
+    Prefer the running model registry (ollama / loaded cloud modules). Fall back
+    to OpenRouter (then Anthropic) when a cloud key is present so Claude can
+    run even if the openrouter marketplace module is disabled.
+    """
+    mid = model_id.strip()
+    if not mid:
+        return None
+
+    # Registry path (works for qwen-2.5-3b / ollama and any loaded cloud module).
+    try:
+        from naas_abi import ABIModule
+
+        registry = ABIModule.get_instance().engine.services.model_registry
+        provider_guesses: list[str | None] = [None]
+        lower = mid.lower()
+        if lower.startswith("ollama/") or lower.startswith("qwen") or ":" in mid:
+            provider_guesses.append("ollama")
+        if "claude" in lower or lower.startswith("anthropic/"):
+            provider_guesses.extend(["openrouter", "anthropic"])
+        if "/" in mid:
+            provider_guesses.append("openrouter")
+        seen: set[str | None] = set()
+        for prov in provider_guesses:
+            if prov in seen:
+                continue
+            seen.add(prov)
+            try:
+                chat = (
+                    registry.get_chat_model(mid, provider=prov)
+                    if prov
+                    else registry.get_chat_model(mid)
+                )
+                return getattr(chat, "model", chat)
+            except Exception:
+                continue
+    except Exception:
+        pass
+
+    # Strip accidental provider prefixes for client constructors.
+    bare = mid
+    for prefix in ("openrouter/", "ollama/", "anthropic/", "openai/"):
+        if bare.lower().startswith(prefix):
+            bare = bare[len(prefix) :]
+            break
+
+    if mid.lower().startswith("ollama/") or (
+        ":" in bare and "claude" not in bare.lower() and "/" not in bare
+    ):
+        try:
+            from langchain_ollama import ChatOllama
+
+            tag = bare if ":" in bare else mid.split("/", 1)[-1]
+            return ChatOllama(model=tag)
+        except Exception:
+            return None
+
+    openrouter_key = _secret_value("OPENROUTER_API_KEY")
+    if openrouter_key:
+        try:
+            from langchain_openai import ChatOpenAI
+            from pydantic import SecretStr
+
+            or_model = mid if "/" in mid else (
+                f"anthropic/{bare}" if "claude" in bare.lower() else bare
+            )
+            return ChatOpenAI(
+                model=or_model,
+                api_key=SecretStr(openrouter_key),
+                base_url="https://openrouter.ai/api/v1",
+            )
+        except Exception:
+            pass
+
+    anthropic_key = _secret_value("ANTHROPIC_API_KEY")
+    if anthropic_key and "claude" in mid.lower():
+        try:
+            from langchain_anthropic import ChatAnthropic
+
+            return ChatAnthropic(model=bare, api_key=anthropic_key)
+        except Exception:
+            pass
+
+    return None
+
+
+def _rebind_agent_chat_model(agent: Any, chat_model: Any) -> None:
+    """Swap the LLM on a duplicated in-process agent and rebind its tools."""
+    from naas_abi_core.models.Model import ChatModel
+    from naas_abi_core.services.agent.Agent import Agent
+    from naas_abi_core.services.agent.tools.utils import can_bind_tools
+
+    base = chat_model.model if isinstance(chat_model, ChatModel) else chat_model
+    agent._chat_model = base
+    if hasattr(base, "output_version"):
+        agent._chat_model_output_version = base.output_version
+
+    tools_to_bind: list[Any] = []
+    tools_to_bind.extend(getattr(agent, "_structured_tools", []) or [])
+    tools_to_bind.extend(getattr(agent, "_native_tools", []) or [])
+
+    if tools_to_bind and can_bind_tools(base):
+        agent._chat_model_with_tools = base.bind_tools(tools_to_bind)
+        gated = [t for t in tools_to_bind if not Agent._requires_workspace(t)]
+        agent._chat_model_without_workspace_tools = (
+            base.bind_tools(gated)
+            if len(gated) != len(tools_to_bind)
+            else agent._chat_model_with_tools
+        )
+    else:
+        agent._chat_model_with_tools = base
+        agent._chat_model_without_workspace_tools = base
+
+
 def _duplicate_inprocess_agent(template: Any, thread_id: str | None) -> Any:
     """Return a per-request copy of the cached template agent.
 
@@ -1439,6 +1596,21 @@ async def stream_with_abi_inprocess(
     # two requests overlapped — see jupyter-naas/abi#991.
     assert thread_id is not None, "thread_id is required"
     agent = _duplicate_inprocess_agent(template_agent, thread_id)
+    llm_override = _llm_override_from_endpoint(config.endpoint)
+    if llm_override:
+        override_model = _build_override_chat_model(llm_override)
+        if override_model is not None:
+            _rebind_agent_chat_model(agent, override_model)
+            logger.info(
+                "ABI in-process LLM override agent=%s model=%s",
+                agent_name,
+                llm_override,
+            )
+        else:
+            logger.warning(
+                "ABI LLM override %r could not be constructed; using agent default",
+                llm_override,
+            )
 
     logger.debug(
         f"Agent.state.thread_id: {getattr(getattr(agent, 'state', None), 'thread_id', None)}"
@@ -1480,12 +1652,21 @@ async def stream_with_abi_inprocess(
                 fallback_text = await agent.ainvoke(latest_user_message, thread_id=thread_id)
                 if isinstance(fallback_text, str) and fallback_text.strip():
                     yield fallback_text
+                    emitted = True
+            if not emitted:
+                yield (
+                    "The agent finished without producing a reply. "
+                    "Try another model in the agent picker (OpenRouter Claude when "
+                    "OPENROUTER_API_KEY is set), or send the message again."
+                )
         except Exception as exc:
             logger.error(f"In-process ABI streaming error: {exc}")
             yield f"\n\n**Error:** Failed to stream ABI agent response: {str(exc)}"
         return
 
     stream_iter = iter(agent.stream_invoke(latest_user_message))
+    emitted_text = False
+    pending_message_replay: list[str] = []
 
     while True:
         try:
@@ -1505,11 +1686,14 @@ async def stream_with_abi_inprocess(
             if text == "[DONE]" or event_name == "done":
                 break
 
-            # Only forward the real-time ai_message events.
-            # Skip "message" events - those are a post-hoc replay of the final
-            # state and would duplicate the content already streamed via ai_message.
+            # Prefer real-time ai_message events. Keep final ``message`` replay
+            # as a fallback when the model emitted call_model but no text
+            # (common with tool-heavy local qwen on Abi/Zen).
             if event_name == "ai_message" and text.strip():
+                emitted_text = True
                 yield text
+            elif event_name == "message" and text.strip():
+                pending_message_replay.append(text)
             elif event_name == "tool_usage" and text.strip():
                 yield {"event": "tool_usage", "tool": text}
             elif event_name == "tool_response" and text.strip():
@@ -1519,4 +1703,17 @@ async def stream_with_abi_inprocess(
             elif event_name == "agent_routing" and text.strip():
                 yield {"event": "agent_routing", "agent": text}
         elif isinstance(event, str) and event.strip():
+            emitted_text = True
             yield event
+
+    if not emitted_text and pending_message_replay:
+        for chunk in pending_message_replay:
+            yield chunk
+        emitted_text = True
+
+    if not emitted_text:
+        yield (
+            "The agent finished without producing a reply. "
+            "Try another model in the agent picker (OpenRouter Claude when "
+            "OPENROUTER_API_KEY is set), or send the message again."
+        )

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/providers/adapters/primary/providers__primary_adapter__schemas.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/providers/adapters/primary/providers__primary_adapter__schemas.py
@@ -1,10 +1,45 @@
 from __future__ import annotations
 
+import os
+
 from naas_abi.apps.nexus.apps.api.app.services.providers.providers__schema import (
     ProviderInfo,
     ProviderModelInfo,
 )
 from pydantic import BaseModel
+
+# Env vars that mean "this provider can actually be called", even when the
+# marketplace module is not loaded (Zen local-first often keeps cloud modules
+# disabled). Used for Nexus chat model picker compatibility fields.
+_PROVIDER_API_KEY_ENV: dict[str, str] = {
+    "openrouter": "OPENROUTER_API_KEY",
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "chatgpt": "OPENAI_API_KEY",
+    "xai": "XAI_API_KEY",
+    "mistral": "MISTRAL_API_KEY",
+    "google": "GOOGLE_API_KEY",
+    "gemini": "GOOGLE_API_KEY",
+    "perplexity": "PERPLEXITY_API_KEY",
+}
+
+
+def _env_has_api_key(provider_id: str) -> bool:
+    if provider_id == "ollama":
+        return True
+    env_name = _PROVIDER_API_KEY_ENV.get(provider_id)
+    if not env_name:
+        return False
+    value = (os.environ.get(env_name) or "").strip()
+    if value:
+        return True
+    try:
+        from naas_abi import ABIModule
+
+        secret_value = ABIModule.get_instance().engine.services.secret.get(env_name)
+        return bool(secret_value and str(secret_value).strip())
+    except Exception:
+        return False
 
 
 class Model(BaseModel):
@@ -18,6 +53,8 @@ class Model(BaseModel):
     description: str | None = None
     image: str | None = None
     context_window: int | None = None
+    # Frontend chat picker expects ``id`` (alias of model_id).
+    id: str | None = None
 
 
 class ModelUpdate(BaseModel):
@@ -49,6 +86,9 @@ class Provider(BaseModel):
     status_page_url: str | None = None
     headquarters: str | None = None
     datacenters: list[str] | None = None
+    # Frontend integrations / agent picker compatibility fields.
+    type: str | None = None
+    has_api_key: bool = False
 
 
 def to_model_schema(model: ProviderModelInfo) -> Model:
@@ -63,10 +103,12 @@ def to_model_schema(model: ProviderModelInfo) -> Model:
         description=model.description,
         image=model.image,
         context_window=model.context_window,
+        id=model.model_id,
     )
 
 
 def to_provider_schema(provider: ProviderInfo) -> Provider:
+    has_key = bool(provider.configured) or _env_has_api_key(provider.id)
     return Provider(
         id=provider.id,
         name=provider.name,
@@ -83,4 +125,6 @@ def to_provider_schema(provider: ProviderInfo) -> Provider:
         status_page_url=provider.status_page_url,
         headquarters=provider.headquarters,
         datacenters=list(provider.datacenters) if provider.datacenters is not None else None,
+        type=provider.id,
+        has_api_key=has_key,
     )

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/chat/components/chat-agent-selector-utils.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/chat/components/chat-agent-selector-utils.test.ts
@@ -1,5 +1,34 @@
 import { describe, expect, it } from 'vitest';
-import { modelOptionHints, parseModelLabel } from './chat-agent-selector-utils';
+import {
+  availableModelOptions,
+  formatAgentModelSubtitle,
+  inferModelProviderLabel,
+  modelOptionHints,
+  normalizeAvailableProviders,
+  parseModelLabel,
+  shortenModelLabel,
+} from './chat-agent-selector-utils';
+import type { Agent } from '@/stores/agents';
+
+const baseAgent = {
+  id: 'zen',
+  name: 'Zen',
+  description: '',
+  icon: 'sparkles' as const,
+  systemPrompt: '',
+  providerId: null,
+  provider: 'abi',
+  modelId: null,
+  resolvedModelId: 'qwen-2.5-3b',
+  logoUrl: null,
+  enabled: true,
+  tools: [],
+  capabilities: { memory: false, reasoning: false, vision: false },
+  intentMappings: [],
+  isDefault: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+} satisfies Agent;
 
 describe('parseModelLabel', () => {
   it('splits title and badges from model names', () => {
@@ -22,5 +51,111 @@ describe('modelOptionHints', () => {
     const hints = modelOptionHints('claude-opus-5-high', 'Opus 5 High');
     expect(hints.thinking).toBe(true);
     expect(hints.effort).toBe('High');
+  });
+});
+
+describe('shortenModelLabel', () => {
+  it('strips provider prefixes and path segments', () => {
+    expect(shortenModelLabel('openrouter/anthropic/claude-sonnet-5')).toBe('claude-sonnet-5');
+    expect(shortenModelLabel('ollama/qwen-2.5-3b')).toBe('qwen-2.5-3b');
+  });
+});
+
+describe('formatAgentModelSubtitle', () => {
+  it('formats local-first ABI resolved model as ollama meta', () => {
+    expect(formatAgentModelSubtitle(baseAgent, 'qwen-2.5-3b', [])).toBe(
+      'ollama · qwen-2.5-3b'
+    );
+  });
+
+  it('uses catalog provider when present', () => {
+    expect(
+      formatAgentModelSubtitle(baseAgent, 'claude-sonnet-5', [
+        {
+          canonicalId: 'claude-sonnet-5',
+          modelId: 'claude-sonnet-5',
+          provider: 'openrouter',
+          name: 'Claude Sonnet 5',
+        },
+      ])
+    ).toBe('openrouter · claude-sonnet-5');
+  });
+
+  it('returns null when model is missing', () => {
+    expect(formatAgentModelSubtitle(baseAgent, null, [])).toBeNull();
+  });
+});
+
+describe('inferModelProviderLabel', () => {
+  it('keeps non-abi agent provider', () => {
+    expect(
+      inferModelProviderLabel(
+        { ...baseAgent, provider: 'openrouter', modelId: 'claude-sonnet-5' },
+        'claude-sonnet-5',
+        []
+      )
+    ).toBe('openrouter');
+  });
+});
+
+describe('normalizeAvailableProviders', () => {
+  it('maps catalog shape (configured/model_id) to picker shape', () => {
+    const normalized = normalizeAvailableProviders([
+      {
+        id: 'openrouter',
+        name: 'OpenRouter',
+        configured: false,
+        has_api_key: true,
+        models: [
+          {
+            canonical_id: 'claude-sonnet-5',
+            model_id: 'anthropic/claude-sonnet-5',
+            name: 'Claude Sonnet 5',
+          },
+        ],
+      },
+    ]);
+    expect(normalized[0]).toMatchObject({
+      id: 'openrouter',
+      type: 'openrouter',
+      has_api_key: true,
+      models: [{ id: 'anthropic/claude-sonnet-5', name: 'Claude Sonnet 5' }],
+    });
+  });
+});
+
+describe('availableModelOptions', () => {
+  it('includes ollama always and cloud only when keyed', () => {
+    const options = availableModelOptions(
+      [
+        {
+          id: 'ollama',
+          type: 'ollama',
+          name: 'Ollama',
+          has_api_key: false,
+          models: [{ id: 'qwen-2.5-3b', name: 'Qwen 2.5 3B' }],
+        },
+        {
+          id: 'openrouter',
+          type: 'openrouter',
+          name: 'OpenRouter',
+          has_api_key: true,
+          models: [{ id: 'claude-sonnet-5', name: 'Claude Sonnet 5' }],
+        },
+        {
+          id: 'anthropic',
+          type: 'anthropic',
+          name: 'Anthropic',
+          has_api_key: false,
+          models: [{ id: 'claude-opus-5', name: 'Claude Opus 5' }],
+        },
+      ],
+      [],
+      'qwen-2.5-3b'
+    );
+    const labels = options.map((o) => o.label);
+    expect(labels).toContain('ollama · qwen-2.5-3b');
+    expect(labels).toContain('openrouter · claude-sonnet-5');
+    expect(labels.some((l) => l.includes('claude-opus-5'))).toBe(false);
   });
 });

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/chat/components/chat-agent-selector-utils.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/chat/components/chat-agent-selector-utils.ts
@@ -39,8 +39,24 @@ export interface ModelOption {
   id: string;
   label: string;
   badges: string[];
+  provider?: string;
 }
 
+/** Compact model id for muted meta (Cursor-style secondary text). */
+export function shortenModelLabel(modelId: string): string {
+  let s = modelId.trim();
+  if (!s) return s;
+  s = s.replace(/^(ollama|openrouter|openai|anthropic|google|xai|mistral)\//i, '');
+  if (s.includes('/')) {
+    s = s.split('/').filter(Boolean).pop() || s;
+  }
+  return s;
+}
+
+/**
+ * Resolve which LLM id an agent row should advertise.
+ * Prefer explicit modelId, then backend resolved_model_id, then provider default.
+ */
 export function resolveAgentModelId(
   agent: Agent | undefined,
   providers: ProviderConfig[],
@@ -49,6 +65,10 @@ export function resolveAgentModelId(
   if (!agent) return null;
   if (agent.provider) {
     const provider = providers.find((p) => p.type === agent.provider && p.enabled);
+    // ABI agents: model on the provider config is agent identity, not the LLM.
+    if (agent.provider === 'abi') {
+      return agent.modelId || agent.resolvedModelId || null;
+    }
     return agent.modelId || provider?.model || agent.resolvedModelId || null;
   }
   if (agent.providerId) {
@@ -67,18 +87,155 @@ export function resolveAgentModelId(
   );
 }
 
+/** Infer a short provider label for muted subtitle text. */
+export function inferModelProviderLabel(
+  agent: Agent,
+  modelId: string,
+  catalog: CatalogModel[]
+): string {
+  if (agent.provider && agent.provider !== 'abi') {
+    return agent.provider.toLowerCase();
+  }
+  const entry = catalog.find((m) => m.modelId === modelId || m.canonicalId === modelId);
+  if (entry?.provider) return entry.provider.toLowerCase();
+
+  const hay = modelId.toLowerCase();
+  if (hay.includes('claude') || hay.includes('anthropic')) return 'anthropic';
+  if (hay.includes('gpt') || hay.includes('o1') || hay.includes('o3')) return 'openai';
+  if (hay.includes('gemini')) return 'google';
+  if (hay.includes('grok')) return 'xai';
+  // Local-first default for ABI / unresolved ids (qwen, llama, etc.).
+  return 'ollama';
+}
+
+/**
+ * Cursor-style muted meta next to an agent name, e.g. `ollama · qwen-2.5-3b`.
+ * Returns null when no model can be resolved.
+ */
+export function formatAgentModelSubtitle(
+  agent: Agent,
+  modelId: string | null | undefined,
+  catalog: CatalogModel[]
+): string | null {
+  if (!modelId) return null;
+  const provider = inferModelProviderLabel(agent, modelId, catalog);
+  return `${provider} · ${shortenModelLabel(modelId)}`;
+}
+
+export interface AvailableProviderModels {
+  id: string;
+  type: string;
+  name: string;
+  has_api_key: boolean;
+  models: Array<{ id: string; name: string }>;
+}
+
+/** Normalize catalog `/api/providers/available` into the picker shape. */
+export function normalizeAvailableProviders(raw: unknown): AvailableProviderModels[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.map((entry) => {
+    const p = entry as Record<string, unknown>;
+    const id = String(p.id || '');
+    const configured = Boolean(p.configured);
+    const hasKey = Boolean(p.has_api_key ?? configured);
+    const modelsRaw = Array.isArray(p.models) ? p.models : [];
+    return {
+      id,
+      type: String(p.type || id),
+      name: String(p.name || id),
+      has_api_key: hasKey,
+      models: modelsRaw
+        .map((m) => {
+          const row = m as Record<string, unknown>;
+          const modelId = String(row.id || row.model_id || row.canonical_id || '');
+          if (!modelId) return null;
+          return {
+            id: modelId,
+            name: String(row.name || modelId),
+          };
+        })
+        .filter((m): m is { id: string; name: string } => m != null),
+    };
+  });
+}
+
+/**
+ * Build switcher options from `/api/providers/available`.
+ * Ollama is always included; cloud providers only when a key is present.
+ */
+export function availableModelOptions(
+  available: AvailableProviderModels[],
+  catalog: CatalogModel[],
+  currentModelId?: string | null
+): ModelOption[] {
+  const merged = new Map<string, ModelOption>();
+  const providers = normalizeAvailableProviders(available);
+
+  for (const p of providers) {
+    const usable = p.type === 'ollama' || p.has_api_key;
+    if (!usable) continue;
+    for (const m of p.models || []) {
+      if (!m?.id) continue;
+      const parsed = parseModelLabel(m.name || m.id);
+      const key = `${p.type}:${m.id}`;
+      merged.set(key, {
+        id: m.id,
+        provider: p.type,
+        label: `${p.type} · ${shortenModelLabel(m.id)}`,
+        badges: parsed.badges,
+      });
+    }
+  }
+
+  // Catalog fills gaps for providers already represented above.
+  const enabledTypes = new Set(
+    providers
+      .filter((p) => p.type === 'ollama' || p.has_api_key)
+      .map((p) => p.type.toLowerCase())
+  );
+  for (const m of catalog) {
+    if (!m.modelId || !enabledTypes.has((m.provider || '').toLowerCase())) continue;
+    const key = `${m.provider}:${m.modelId}`;
+    if (merged.has(key)) continue;
+    const parsed = parseModelLabel(m.name ?? m.modelId);
+    merged.set(key, {
+      id: m.modelId,
+      provider: m.provider,
+      label: `${m.provider} · ${shortenModelLabel(m.modelId)}`,
+      badges: parsed.badges,
+    });
+  }
+
+  if (currentModelId && ![...merged.values()].some((o) => o.id === currentModelId)) {
+    const label = modelDisplayName(catalog, currentModelId) ?? currentModelId;
+    const parsed = parseModelLabel(label);
+    merged.set(`current:${currentModelId}`, {
+      id: currentModelId,
+      label: shortenModelLabel(currentModelId),
+      badges: parsed.badges,
+    });
+  }
+
+  return Array.from(merged.values()).sort((a, b) => a.label.localeCompare(b.label));
+}
+
 export function modelsForAgent(
   agent: Agent,
   catalog: CatalogModel[],
   providerModels: Array<{ id: string; name: string }>
 ): ModelOption[] {
-  const providerType = agent.provider ?? '';
+  const providerType = agent.provider && agent.provider !== 'abi' ? agent.provider : '';
   const fromCatalog = catalog
     .filter((m) => !providerType || m.provider === providerType)
     .map((m) => {
       const label = m.name ?? m.modelId;
       const parsed = parseModelLabel(label);
-      return { id: m.modelId || m.canonicalId, label: parsed.title, badges: parsed.badges };
+      return {
+        id: m.modelId || m.canonicalId,
+        provider: m.provider,
+        label: parsed.title,
+        badges: parsed.badges,
+      };
     });
 
   const fromProvider = providerModels.map((m) => {

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/chat/components/chat-agent-selector.css
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/chat/components/chat-agent-selector.css
@@ -46,8 +46,8 @@
   bottom: calc(100% + 6px);
   left: 0;
   display: flex;
-  width: min(320px, calc(100vw - 24px));
-  max-height: min(360px, 55vh);
+  width: min(360px, calc(100vw - 24px));
+  max-height: min(420px, 60vh);
   flex-direction: column;
   overflow: hidden;
   border: 1px solid var(--border-hex);
@@ -126,27 +126,46 @@
   -webkit-overflow-scrolling: touch;
 }
 
+.chat-agent-selector-row-group {
+  display: flex;
+  flex-direction: column;
+}
+
 .chat-agent-selector-row {
   display: flex;
   width: 100%;
-  align-items: center;
-  gap: var(--space-2);
-  padding: 8px var(--space-2);
+  align-items: stretch;
+  gap: 0;
   border: none;
   border-radius: var(--org-border-radius, 0px);
   background: transparent;
   font-size: var(--font-size-sm, 14px);
   color: var(--foreground-hex);
   text-align: left;
-  cursor: pointer;
 }
 
-.chat-agent-selector-row:hover {
+.chat-agent-selector-row:hover,
+.chat-agent-selector-row:has(.chat-agent-selector-row-main:focus-visible) {
   background: var(--muted-bg-hex);
 }
 
 .chat-agent-selector-row.is-active {
   background: color-mix(in srgb, var(--workspace-accent, #22c55e) 12%, transparent);
+}
+
+.chat-agent-selector-row-main {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 8px var(--space-2);
+  border: none;
+  border-radius: var(--org-border-radius, 0px);
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
 }
 
 .chat-agent-selector-row-body {
@@ -159,6 +178,100 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   font-weight: var(--font-weight-medium, 500);
+}
+
+/* Cursor-style muted meta: provider · model */
+.chat-agent-selector-row-meta {
+  margin-top: 1px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+  font-weight: var(--font-weight-normal, 400);
+  color: var(--muted-foreground-hex);
+  opacity: 0.9;
+}
+
+.chat-agent-selector-model-toggle {
+  display: flex;
+  width: 32px;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: var(--org-border-radius, 0px);
+  background: transparent;
+  color: var(--muted-foreground-hex);
+  cursor: pointer;
+}
+
+.chat-agent-selector-model-toggle:hover,
+.chat-agent-selector-model-toggle.is-open {
+  color: var(--foreground-hex);
+  background: color-mix(in srgb, var(--muted-bg-hex) 80%, transparent);
+}
+
+.chat-agent-selector-model-chevron {
+  transition: transform 0.15s ease;
+}
+
+.chat-agent-selector-model-chevron.is-open {
+  transform: rotate(90deg);
+}
+
+.chat-agent-selector-models {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 0 0 6px 12px;
+  margin: 0 4px 4px;
+  border-left: 1px solid var(--border-hex);
+}
+
+.chat-agent-selector-model-row {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 6px 8px;
+  border: none;
+  border-radius: var(--org-border-radius, 0px);
+  background: transparent;
+  color: var(--muted-foreground-hex);
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.chat-agent-selector-model-row:hover:not(:disabled) {
+  background: var(--muted-bg-hex);
+  color: var(--foreground-hex);
+}
+
+.chat-agent-selector-model-row.is-active {
+  color: var(--foreground-hex);
+  background: color-mix(in srgb, var(--workspace-accent, #22c55e) 10%, transparent);
+}
+
+.chat-agent-selector-model-row:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}
+
+.chat-agent-selector-model-label {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-agent-selector-models-empty {
+  margin: 0;
+  padding: 6px 8px 8px;
+  font-size: 11px;
+  line-height: 1.35;
+  color: var(--muted-foreground-hex);
 }
 
 .chat-agent-selector-check {

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/chat/components/chat-agent-selector.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/chat/components/chat-agent-selector.tsx
@@ -1,13 +1,25 @@
 'use client';
 
-import { Check, ChevronDown, X } from 'lucide-react';
+import { Check, ChevronDown, ChevronRight, X } from 'lucide-react';
 import { createPortal } from 'react-dom';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { cn } from '@/lib/utils';
 import { useIsMobile } from '@/hooks/use-is-mobile';
 import { useAgentList } from '@/components/ui/dialogs';
 import { useWorkspaceStore } from '@/stores/workspace';
-import type { Agent } from '@/stores/agents';
+import { useAgentsStore, type Agent } from '@/stores/agents';
+import { useIntegrationsStore } from '@/stores/integrations';
+import { useModelsStore } from '@/stores/models';
+import { getApiUrl } from '@/lib/config';
+import { authFetch } from '@/stores/auth';
+import {
+  availableModelOptions,
+  formatAgentModelSubtitle,
+  normalizeAvailableProviders,
+  resolveAgentModelId,
+  type AvailableProviderModels,
+  type ModelOption,
+} from './chat-agent-selector-utils';
 import './chat-agent-selector.css';
 
 function AutoToggle({
@@ -40,7 +52,8 @@ export type ChatAgentSelectorSource = 'chat' | 'pane';
 
 /**
  * Compact agent picker for the chat composer.
- * Panel = Search + Auto toggle + agents list (no dual-panel / model drill-down).
+ * Panel = Search + Auto toggle + agents list with muted model meta.
+ * Expanding a row shows available models (local Ollama + cloud when keyed).
  * Mobile: bottom sheet. Desktop: compact popover above the trigger.
  *
  * `source="pane"` binds to the right AI / compare surface (paneAgent).
@@ -53,6 +66,9 @@ export function ChatAgentSelector({
   const [mounted, setMounted] = useState(false);
   const [open, setOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
+  const [modelMenuAgentId, setModelMenuAgentId] = useState<string | null>(null);
+  const [availableProviders, setAvailableProviders] = useState<AvailableProviderModels[]>([]);
+  const [switchingModel, setSwitchingModel] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const sheetRef = useRef<HTMLDivElement>(null);
   const isMobile = useIsMobile();
@@ -71,6 +87,9 @@ export function ChatAgentSelector({
     isPane ? s.clearPaneAgentExplicitSelection : s.clearAgentExplicitSelection
   );
   const { defaultAgents, customAgents, filteredAgents } = useAgentList(searchQuery);
+  const { updateAgent } = useAgentsStore();
+  const { providers, getProviderForAgent: getLegacyProviderForAgent } = useIntegrationsStore();
+  const { models, fetchModels } = useModelsStore();
 
   const enabledAgents = useMemo(
     () => [...defaultAgents, ...customAgents],
@@ -104,6 +123,7 @@ export function ChatAgentSelector({
   const closePicker = useCallback(() => {
     setOpen(false);
     setSearchQuery('');
+    setModelMenuAgentId(null);
   }, []);
 
   useEffect(() => {
@@ -159,6 +179,28 @@ export function ChatAgentSelector({
     };
   }, [open, isMobile]);
 
+  // Load catalog + keyed provider model lists when the picker opens.
+  useEffect(() => {
+    if (!open) return;
+    fetchModels();
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await authFetch(`${getApiUrl()}/api/providers/available`);
+        if (!res.ok || cancelled) return;
+        const data = normalizeAvailableProviders(await res.json());
+        if (!cancelled) {
+          setAvailableProviders(data);
+        }
+      } catch {
+        // Subtitle still works from agent.resolvedModelId + catalog.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, fetchModels]);
+
   const openPicker = () => {
     setOpen(true);
   };
@@ -178,6 +220,41 @@ export function ChatAgentSelector({
     closePicker();
   };
 
+  const agentModelId = useCallback(
+    (agent: Agent) =>
+      resolveAgentModelId(agent, providers, getLegacyProviderForAgent),
+    [providers, getLegacyProviderForAgent]
+  );
+
+  const agentSubtitle = useCallback(
+    (agent: Agent) => formatAgentModelSubtitle(agent, agentModelId(agent), models),
+    [agentModelId, models]
+  );
+
+  const modelOptionsFor = useCallback(
+    (agent: Agent): ModelOption[] =>
+      availableModelOptions(availableProviders, models, agentModelId(agent)),
+    [availableProviders, models, agentModelId]
+  );
+
+  const selectModel = async (agent: Agent, option: ModelOption) => {
+    if (switchingModel) return;
+    setSwitchingModel(true);
+    try {
+      // Persist model_id on the agent row. Agent identity (class_name / provider=abi)
+      // stays intact. In-process ABI runtime still binds its own chat model until
+      // the backend honors model_id as an LLM override; subtitle updates immediately.
+      await updateAgent(agent.id, {
+        modelId: option.id,
+        resolvedModelId: option.id,
+      });
+      setSelectedAgent(agent.id, true);
+      setModelMenuAgentId(null);
+    } finally {
+      setSwitchingModel(false);
+    }
+  };
+
   // Pane surface: always show the resolved agent name (Abi by default).
   // Main chat keeps Cursor-style "Auto" until the user picks an agent.
   const triggerLabel = isPane
@@ -186,25 +263,98 @@ export function ChatAgentSelector({
       ? 'Auto'
       : activeAgent?.name ?? 'Agent';
 
+  const triggerTitle = (() => {
+    if (!activeAgent) return undefined;
+    const sub = agentSubtitle(activeAgent);
+    if (isPane) return sub ? `${activeAgent.name} (${sub})` : activeAgent.name;
+    if (autoMode) return sub ? `Auto · ${sub}` : 'Auto agent selection';
+    return sub ? `${activeAgent.name} (${sub})` : activeAgent.name;
+  })();
+
   if (!mounted || !activeAgent) {
     return null;
   }
 
   const renderAgentRow = (agent: Agent) => {
     const isSelected = selectedAgent === agent.id && !autoMode;
+    const subtitle = agentSubtitle(agent);
+    const modelsOpen = modelMenuAgentId === agent.id;
+    const options = modelsOpen ? modelOptionsFor(agent) : [];
+    const currentId = agentModelId(agent);
 
     return (
-      <button
-        key={agent.id}
-        type="button"
-        className={cn('chat-agent-selector-row', isSelected && 'is-active')}
-        onClick={() => selectAgent(agent)}
-      >
-        <div className="chat-agent-selector-row-body">
-          <div className="chat-agent-selector-row-title">{agent.name}</div>
+      <div key={agent.id} className="chat-agent-selector-row-group">
+        <div className={cn('chat-agent-selector-row', isSelected && 'is-active')}>
+          <button
+            type="button"
+            className="chat-agent-selector-row-main"
+            onClick={() => selectAgent(agent)}
+          >
+            <div className="chat-agent-selector-row-body">
+              <div className="chat-agent-selector-row-title">{agent.name}</div>
+              {subtitle ? (
+                <div className="chat-agent-selector-row-meta">{subtitle}</div>
+              ) : null}
+            </div>
+            {isSelected ? <Check size={14} className="chat-agent-selector-check" /> : null}
+          </button>
+          <button
+            type="button"
+            className={cn(
+              'chat-agent-selector-model-toggle',
+              modelsOpen && 'is-open'
+            )}
+            aria-label={`Models for ${agent.name}`}
+            aria-expanded={modelsOpen}
+            title="Switch model"
+            onClick={(e) => {
+              e.stopPropagation();
+              setModelMenuAgentId((id) => (id === agent.id ? null : agent.id));
+            }}
+          >
+            <ChevronRight
+              size={14}
+              className={cn(
+                'chat-agent-selector-model-chevron',
+                modelsOpen && 'is-open'
+              )}
+            />
+          </button>
         </div>
-        {isSelected ? <Check size={14} className="chat-agent-selector-check" /> : null}
-      </button>
+        {modelsOpen ? (
+          <div className="chat-agent-selector-models" role="listbox" aria-label="Available models">
+            {options.length === 0 ? (
+              <p className="chat-agent-selector-models-empty">
+                No alternate models yet. Local Ollama stays default; cloud options appear when a
+                provider key is configured.
+              </p>
+            ) : (
+              options.map((option) => {
+                const isCurrent = option.id === currentId;
+                return (
+                  <button
+                    key={`${option.provider ?? 'm'}:${option.id}`}
+                    type="button"
+                    role="option"
+                    aria-selected={isCurrent}
+                    disabled={switchingModel}
+                    className={cn(
+                      'chat-agent-selector-model-row',
+                      isCurrent && 'is-active'
+                    )}
+                    onClick={() => selectModel(agent, option)}
+                  >
+                    <span className="chat-agent-selector-model-label">{option.label}</span>
+                    {isCurrent ? (
+                      <Check size={12} className="chat-agent-selector-check" />
+                    ) : null}
+                  </button>
+                );
+              })
+            )}
+          </div>
+        ) : null}
+      </div>
     );
   };
 
@@ -291,13 +441,7 @@ export function ChatAgentSelector({
         type="button"
         className={cn('chat-agent-selector-trigger', open && 'is-open')}
         onClick={() => (open ? closePicker() : openPicker())}
-        title={
-          isPane
-            ? activeAgent.name
-            : autoMode
-              ? 'Auto agent selection'
-              : activeAgent.name
-        }
+        title={triggerTitle}
       >
         <span className="chat-agent-selector-trigger-label">{triggerLabel}</span>
         <ChevronDown

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
@@ -863,8 +863,21 @@ export function ChatInterface({
       // E.g., agent.provider = "xai" → find provider with type = "xai"
       provider = providers.find(p => p.type === agent.provider && p.enabled);
       
-      // Override the model if agent specifies one
-      if (provider && agent.modelId) {
+      // Override the model if agent specifies one.
+      // ABI is special: provider.model is the agent identity for in-process /
+      // /agents/{name} routing, not the LLM id (qwen-2.5-3b).
+      if (provider && provider.type === 'abi') {
+        provider = {
+          ...provider,
+          model: agent.class_name || agent.name || agent.id,
+          endpoint:
+            !provider.endpoint ||
+            provider.endpoint.includes('11434') ||
+            provider.endpoint.startsWith('inprocess://')
+              ? 'inprocess://abi'
+              : provider.endpoint,
+        };
+      } else if (provider && agent.modelId) {
         provider = { ...provider, model: agent.modelId };
       }
     } else if (agent?.providerId) {
@@ -2334,7 +2347,11 @@ export function ChatInterface({
         const finalBody = thinkingContent
           ? `<think>${thinkingContent}</think>\n\n${responseContent}`
           : responseContent;
-        const finalContent = finalBody.trim();
+        // Empty stream (call_model then DONE) used to leave the caret / Processing
+        // line stuck. Surface a recoverable error instead.
+        const finalContent =
+          finalBody.trim() ||
+          'No reply was returned. Try again, or pick OpenRouter Claude in the agent model menu if the local model stalled.';
         // Mark any still-running tool as done
         streamToolCalls.forEach((t) => { if (t.status === 'running') t.status = 'done'; });
         const finalToolCalls = streamToolCalls.length > 0 ? [...streamToolCalls] : undefined;
@@ -2343,7 +2360,7 @@ export function ChatInterface({
           finalContent,
           thinkingDuration,
           streamSources.length > 0 ? streamSources : undefined,
-          hasDetailedActivity ? streamActivityLine : null,
+          null,
           finalToolCalls,
           executionTime,
         );

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/integrations.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/integrations.ts
@@ -70,16 +70,22 @@ export const useIntegrationsStore = create<IntegrationsState>()(
           const API_BASE = getApiUrl();
           const res = await authFetch(`${API_BASE}/api/providers/available`);
           if (!res.ok) return;
-          const data: Array<{ id: string; name: string; type: ProviderType; has_api_key: boolean; models: Array<{ id: string; name: string }> }> = await res.json();
-          const mapped: ProviderConfig[] = data.map((p) => {
-            // Choose a sensible default model (first in registry list)
-            const defaultModel = p.models?.[0]?.id || '';
-            const isOllama = p.type === 'ollama';
+          const data: Array<Record<string, unknown>> = await res.json();
+          const mapped: ProviderConfig[] = data.map((raw) => {
+            const id = String(raw.id || '');
+            const type = String(raw.type || id) as ProviderType;
+            const models = Array.isArray(raw.models) ? raw.models : [];
+            const first = models[0] as Record<string, unknown> | undefined;
+            const defaultModel = String(
+              first?.id || first?.model_id || first?.canonical_id || ''
+            );
+            const hasKey = Boolean(raw.has_api_key ?? raw.configured);
+            const isOllama = type === 'ollama' || id === 'ollama';
             return {
-              id: p.id,
-              name: p.name,
-              type: p.type,
-              enabled: isOllama ? true : p.has_api_key,
+              id,
+              name: String(raw.name || id),
+              type,
+              enabled: isOllama ? true : hasKey,
               endpoint: isOllama ? OLLAMA_DEFAULT : undefined,
               model: defaultModel,
               createdAt: new Date(),


### PR DESCRIPTION
## Summary
- Fix Abi/Zen chat hanging on Processing: empty in-process streams now fall back to final message replay and surface a recoverable error instead of leaving the caret stuck.
- Honor `agent.model_id` for ABI in-process turns via `inprocess://abi?llm=...`, rebinding the agent chat model per request (OpenRouter/Anthropic when keyed) while keeping agent identity/tools.
- Make `/api/providers/available` expose picker-compatible `type`, `has_api_key`, and model `id` fields (key detection from env even when a cloud module is not loaded).

## Test plan
- [ ] Local Nexus: send `hi` to Abi with default local model; confirm no infinite Processing (reply or clear error).
- [ ] With `OPENROUTER_API_KEY` set: open agent picker, confirm Claude Sonnet 5 / OpenRouter models appear.
- [ ] Select `claude-sonnet-5` on Abi, send a short prompt, confirm a real cloud reply while agent stays Abi.
- [ ] Repeat on Zen agent.
- [ ] `pnpm test -- src/app/workspace/*/chat/components/chat-agent-selector-utils.test.ts`