### PR TITLE
fix(ollama): cap generation with num_predict to stop runaway hangs

### DIFF
--- a/libs/naas-abi-marketplace/naas_abi_marketplace/ai/ollama/__init__.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/ai/ollama/__init__.py
@@ -137,6 +137,11 @@ class ABIModule(BaseModule):
                 model=provider_model_id,
                 base_url=base_url,
                 temperature=0,
+                # Bound generation so a degenerate, non-terminating loop on a
+                # small local model cannot run until it fills the context
+                # window (which never returns and hangs the caller). See
+                # models/qwen2_5_3b.py for the full rationale.
+                num_predict=2048,
             )
 
         self.engine.services.model_registry.register_chat_provider(

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/ai/ollama/models/qwen2_5_3b.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/ai/ollama/models/qwen2_5_3b.py
@@ -55,6 +55,15 @@ class Qwen25ThreeBModel(ModelDefinition):
             # long conversations or tool-heavy prompts lose their head with no
             # error. Costs ~1GB of extra KV cache (2.2GB -> 3.2GB resident).
             num_ctx=CONTEXT_WINDOW,
+            # Hard cap on tokens generated per call. A 3B model driven by a
+            # large tool-calling prompt (e.g. AbiAgent) can degenerate into a
+            # non-terminating repetition that never emits a stop token — it
+            # will fill the entire 32k window (observed 37k+ tokens) and the
+            # request never returns, so the UI sits at "processing" forever.
+            # Bounding generation turns that infinite hang into a finite (if
+            # truncated) response. Long-form answers that legitimately need
+            # more can raise this via the provider factory.
+            num_predict=2048,
         ),
     )
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
Asking the default `Abi` agent something that exercises its tool-calling prompt (e.g. **"What can you do?"**) never returns — the Nexus UI sits at "processing" indefinitely. A simple greeting works, which masked the issue.

## Root cause
The local `qwen2.5:3b` model, driven by AbiAgent's large tool-calling system prompt, degenerates into a **non-terminating repetition** that never emits a stop token. `ChatOllama` was configured with `num_ctx=32768` and `temperature=0` but **no `num_predict`**, so generation runs unbounded until it fills the entire 32k window.

Evidence from the Ollama server during a hang (single generation):
```
slot print_timing: id 0 | task 0 | n_decoded = 37936, tg = 3.77 t/s
```
37,936 tokens decoded and still climbing at ~3.77 tok/s on CPU → the request never returns.

## Fix
Cap generation at `num_predict=2048` in both:
- `ai/ollama/models/qwen2_5_3b.py` (the default chat model), and
- `ai/ollama/__init__.py` (the generic ollama chat provider factory, so off-catalog tags are bounded too).

This turns an infinite hang into a bounded (worst-case truncated) response. Callers that legitimately need more can raise the cap via the provider factory.

## Verification
- Before: `POST /agents/Abi/completion` with "What can you do?" → timed out at 150s with no response.
- After: same request returns a coherent answer in ~72s:
  > "…here are some of the services I offer: - Manage your workspace memberships… - Update your profile… - Edit slides decks… - Transfer complex tasks to other agents…"
- `stream-completion` (the UI path) now terminates with `event: done / [DONE]` instead of hanging.
- `ruff check` clean on the ollama module.

## Note (not fixed here)
CPU-only inference is ~3.77 tok/s, so even bounded orchestrator responses are slow (~1 min). For interactive use of the `Abi` orchestrator, a GPU-backed Ollama or a cloud model (`ai_mode: cloud` + key) is recommended; the direct `Ollama` agent stays fast because it emits short replies.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3436ea0-90ab-4340-9379-d4b6c03f199c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3436ea0-90ab-4340-9379-d4b6c03f199c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

