### PR TITLE
docs: expose the onto2py executable from the abi CLI install

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ It also covers the full stack from ingestion to UI, so you are not stitching tog
 ### Get started
 
 ```bash
-uv tool install naas-abi-cli --force --upgrade
+uv tool install naas-abi-cli --force --upgrade --with-executables-from naas-abi-core
 
 abi new project my_ai   # replace "my_ai" with your project name
 cd my_ai
@@ -165,7 +165,7 @@ brew install pnpm        # or: npm install -g pnpm
 uv sync
 
 # Install the CLI from this repo (editable, picks up your changes)
-uv tool install --editable libs/naas-abi-cli --force --upgrade
+uv tool install --editable libs/naas-abi-cli --force --upgrade --with-executables-from naas-abi-core
 ```
 
 ### Start the dev stack

--- a/libs/naas-abi-cli/Makefile
+++ b/libs/naas-abi-cli/Makefile
@@ -1,3 +1,3 @@
 install:
 	#@echo "Starting `abi` setup on your machine. It will replace any existing `abi`. You will then have access to the `abi` command in your terminal."
-	uv tool install --editable . --force
+	uv tool install --editable . --force --with-executables-from naas-abi-core


### PR DESCRIPTION
## What

Add `--with-executables-from naas-abi-core` to the three documented `uv tool install` commands, so `onto2py` lands on `PATH` alongside `abi`.

- `README.md:44` — quickstart install
- `README.md:168` — editable dev install
- `libs/naas-abi-cli/Makefile:3` — `make install`

## Why

`naas-abi-core` already declares the console script:

```toml
# libs/naas-abi-core/pyproject.toml
[project.scripts]
onto2py = "naas_abi_core.utils.onto2py.__main__:main"
```

…and `naas-abi-cli` already depends on `naas-abi-core`. So **the onto2py code already ships with every `uv tool install naas-abi-cli`** — it just never gets linked, because `uv tool install` only creates executables for the package it was explicitly asked to install.

This is a one-flag docs change: no new dependency, no version bump, and no second copy of the library in the tool environment.

### Why not install the standalone package

`uv tool install ... --with "onto2py @ git+https://github.com/jupyter-naas/onto2py"` also works, but puts a second, drift-prone copy of the same library in the same environment — and both copies declare the same `onto2py` console script, so which one wins is arbitrary. The in-tree copy is the one the CLI already uses.

## Verification

Both variants installed into an isolated `UV_TOOL_DIR`/`UV_TOOL_BIN_DIR` (real tool install untouched):

```
Installed 1 executable from `naas-abi-core`: onto2py
Installed 1 executable: abi
```

The resulting binary was run end-to-end against a real ontology (`ABIOntology.ttl`), producing a ~49KB generated module.

## Out of scope — two pre-existing bugs found while verifying

Flagged rather than fixed here:

1. **onto2py's SHA cache never engages via the CLI.** `onto2py()` writes the marker-stamped, ruff-formatted `.py`, then returns *marker-less* code; `__main__.py` overwrites that same file with the return value. Confirmed: generated files carry no `# onto2py-source-sha256:` line, so every run fully regenerates and discards ruff formatting. Passing an explicit output path does not avoid it — the default output path *is* the canonical one. Also affects the standalone `jupyter-naas/onto2py` copy. Fixing it means deciding whether `__main__` should write at all.

2. **The root `Makefile` `onto2py` target is dead.** It invokes `python -m lib.abi.utils.onto2py` (the `lib/` tree no longer exists) and globs `src/`, which does not exist in the monorepo. Left untouched since it cannot run here and a fix could not be tested.