### PR TITLE
fix(dev): resolve the project root instead of trusting cwd, and tell users to cd after scaffolding

### DIFF
--- a/libs/naas-abi-cli/naas_abi_cli/cli/dev.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/dev.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import collections
 import errno
+import functools
 import hashlib
 import json
 import os
@@ -40,6 +41,8 @@ from rich.console import Console, Group
 from rich.live import Live
 from rich.table import Table
 from rich.text import Text
+
+from naas_abi_cli.cli.bootstrap import find_abi_project_root
 
 DEV_DIR_NAME = ".abi/dev"
 INSTANCE_FILENAME = "instance.json"
@@ -108,9 +111,29 @@ class ServiceSpec:
 # Project paths / instance allocation
 # =============================================================================
 
+@functools.lru_cache(maxsize=1)
 def _project_root() -> Path:
-    # The `abi` entrypoint chdir's to the project root before dispatching.
-    return Path.cwd().resolve()
+    # Nothing chdir's to the project root: `maybe_rerun_in_project_context`
+    # re-execs us inside the project venv but passes `cwd=invocation_cwd`
+    # deliberately, so cwd is whatever the user typed from. Trusting it means
+    # a run from a subdirectory scatters `.abi/dev`, `storage/` and `.dagster/`
+    # into that subdirectory, and a run from outside any project spawns
+    # services against an ambient env that has no `naas_abi_core` — which
+    # surfaces late and misleadingly as "oxigraph did not become ready".
+    #
+    # Resolve the root the same way bootstrap did, so the directory we treat
+    # as the project is by construction the one whose venv we are running in.
+    root = find_abi_project_root()
+    if root is None:
+        raise click.ClickException(
+            f"No ABI project found in {Path.cwd()} or any parent directory.\n"
+            "`abi dev` operates on a project: it needs a `pyproject.toml` that "
+            "depends on ABI.\n"
+            "If you just ran `abi new project`, cd into the generated project "
+            "first:\n"
+            "    cd <project-name> && abi dev up"
+        )
+    return root
 
 
 def _dev_dir() -> Path:

--- a/libs/naas-abi-cli/naas_abi_cli/cli/dev_test.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/dev_test.py
@@ -10,6 +10,9 @@ the literal. These two must not drift back together.
 import importlib
 from typing import TYPE_CHECKING
 
+import click
+import pytest
+
 # `naas_abi_cli.cli` re-exports the click Group as `dev`, which shadows the
 # module of the same name — import the module explicitly.
 dev = importlib.import_module("naas_abi_cli.cli.dev")
@@ -264,3 +267,105 @@ def test_custom_browser_host_is_allowed_by_cors(monkeypatch) -> None:
     finally:
         monkeypatch.undo()
         importlib.reload(dev)
+
+
+# =============================================================================
+# Project-root resolution
+#
+# Nothing chdir's to the project root before `abi dev` runs, so the working
+# directory is whatever the user typed from. Resolving the root from cwd rather
+# than trusting it is what keeps `.abi/dev`, `storage/` and `.dagster/` in one
+# place and stops services launching against an env with no `naas_abi_core`.
+# =============================================================================
+
+PYPROJECT = """\
+[project]
+name = "my-ai"
+dependencies = ["naas-abi-core[all]>=2.21.1"]
+"""
+
+
+@pytest.fixture(autouse=True)
+def _clear_project_root_cache():
+    """`_project_root` memoizes; a stale entry would leak across tests."""
+    cache_clear = getattr(dev._project_root, "cache_clear", None)
+    if cache_clear is not None:
+        cache_clear()
+    yield
+    cache_clear = getattr(dev._project_root, "cache_clear", None)
+    if cache_clear is not None:
+        cache_clear()
+
+
+def _make_project(tmp_path):
+    (tmp_path / "pyproject.toml").write_text(PYPROJECT)
+    return tmp_path.resolve()
+
+
+def test_project_root_resolves_from_the_project_root(monkeypatch, tmp_path) -> None:
+    root = _make_project(tmp_path)
+    monkeypatch.chdir(root)
+
+    assert dev._project_root() == root
+
+
+def test_project_root_resolves_upward_from_a_subdirectory(
+    monkeypatch, tmp_path
+) -> None:
+    """The quiet failure: cwd is a real project subdir, so nothing looks wrong.
+
+    Trusting cwd here scatters dev state into `src/` while the bootstrap has
+    already re-execed against the *project* venv — it appears to work.
+    """
+    root = _make_project(tmp_path)
+    nested = root / "src" / "my_ai" / "agents"
+    nested.mkdir(parents=True)
+    monkeypatch.chdir(nested)
+
+    assert dev._project_root() == root
+
+
+def test_dev_artifacts_stay_in_the_project_root(monkeypatch, tmp_path) -> None:
+    """`.abi/dev` must not follow the user's cwd down into the project."""
+    root = _make_project(tmp_path)
+    nested = root / "src"
+    nested.mkdir()
+    monkeypatch.chdir(nested)
+
+    assert dev._dev_dir() == root / dev.DEV_DIR_NAME
+    assert dev._instance_path() == root / dev.DEV_DIR_NAME / dev.INSTANCE_FILENAME
+    assert nested not in dev._instance_path().parents
+
+
+def test_project_root_refuses_to_run_outside_a_project(monkeypatch, tmp_path) -> None:
+    """`abi new project` scaffolds into a subdir, so this is the default slip."""
+    outside = tmp_path / "not-a-project"
+    outside.mkdir()
+    monkeypatch.chdir(outside)
+
+    with pytest.raises(click.ClickException) as excinfo:
+        dev._project_root()
+
+    message = str(excinfo.value)
+    # The message has to name the fix, not just the symptom: the observed
+    # failure was a misleading "oxigraph did not become ready" 15s later.
+    assert "No ABI project found" in message
+    assert "cd <project-name>" in message
+
+
+def test_ports_are_stable_regardless_of_invocation_directory(
+    monkeypatch, tmp_path
+) -> None:
+    """Offsets hash the project path — a cwd-derived root reallocates ports."""
+    root = _make_project(tmp_path)
+    nested = root / "src"
+    nested.mkdir()
+
+    monkeypatch.chdir(root)
+    from_root = dev._compute_offset(dev._project_root())
+
+    dev._project_root.cache_clear()
+    monkeypatch.chdir(nested)
+    from_nested = dev._compute_offset(dev._project_root())
+
+    assert from_root == from_nested

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/project.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/project.py
@@ -184,3 +184,28 @@ def new_project(
         cwd=project_path,
         check=True,
     )
+
+    _show_next_steps(project_path)
+
+
+def _show_next_steps(project_path: str) -> None:
+    """Tell the user to cd before the next command.
+
+    Scaffolding lands in a *subdirectory*, so the shell is left one level above
+    the project. `abi dev` resolves the project from the working directory, so
+    skipping the cd starts services against the wrong directory entirely.
+    """
+    # A relative path is what the user can paste; fall back to absolute when the
+    # project is not under cwd (an explicit `project-path` argument elsewhere).
+    try:
+        cd_target = os.path.relpath(project_path, os.getcwd())
+    except ValueError:  # different drive on Windows
+        cd_target = project_path
+    if cd_target == ".":
+        cd_target = ""
+
+    click.secho(f"\n✓ Project ready at {project_path}", fg="green", bold=True)
+    click.secho("\nNext steps:", bold=True)
+    if cd_target:
+        click.echo(f"  cd {cd_target}")
+    click.echo("  abi dev up        # start the local dev stack")

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/project_test.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/project_test.py
@@ -1,0 +1,47 @@
+"""Tests for the post-scaffold guidance of `abi new project`.
+
+Scaffolding lands in a *subdirectory*, so the shell is left one level above the
+project. Without an explicit cd instruction the obvious next command — `abi dev
+up` — runs outside the project, which used to start services against an env
+with no `naas_abi_core` and fail 15s later with an unrelated-looking error.
+"""
+
+from naas_abi_cli.cli.new.project import _show_next_steps
+
+
+def test_next_steps_tell_the_user_to_cd(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    _show_next_steps(str(tmp_path / "my-ai"))
+
+    output = capsys.readouterr().out
+    assert "cd my-ai" in output
+    assert "abi dev up" in output
+
+
+def test_next_steps_use_a_relative_path_the_user_can_paste(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+    project_path = str(workdir / "nested" / "my-ai")
+
+    _show_next_steps(project_path)
+
+    output = capsys.readouterr().out
+    assert "cd nested/my-ai" in output
+    # The absolute path is noise in a command the user is meant to copy.
+    assert f"cd {project_path}" not in output
+
+
+def test_next_steps_omit_cd_when_already_in_the_project(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    _show_next_steps(str(tmp_path))
+
+    output = capsys.readouterr().out
+    assert "cd " not in output
+    assert "abi dev up" in output


### PR DESCRIPTION
## What broke

A fresh `abi new project` followed by `abi dev up` fails like this:

```
⚠ oxigraph did not become ready in 15s — downstream services may fail to start.
Startup failed; stopping services that did come up...
Error: Nexus web directory not found: /Users/…/<parent>/libs/naas-abi/naas_abi/apps/nexus/apps/web.
Check that the naas-abi package is checked out under `libs/naas-abi`.
```

Neither message points at the real cause: `abi dev up` ran one directory *above* the generated project. `abi new project` scaffolds into a subdirectory and then prints nothing, so the shell is left in the parent and the obvious next command runs in the wrong place.

The oxigraph log was the actual error, and it says something else entirely:

```
ModuleNotFoundError: No module named 'naas_abi_core'
```

Services launch as `uv run python -m …` with `cwd=_project_root()`. Outside a project there is no `pyproject.toml`, so `uv run` resolved against an ambient env. The "not ready in 15s" warning and the nexus-web error were both downstream noise.

## Root cause

`_project_root()` returned `Path.cwd()` under a comment claiming *"The `abi` entrypoint chdir's to the project root before dispatching."* Nothing does — `maybe_rerun_in_project_context` re-execs inside the project venv but passes `cwd=invocation_cwd` deliberately (`bootstrap.py:122`).

That leaves a second, quieter failure that nobody has reported yet: run `abi dev up` from a **subdirectory of a real project** (say `src/`) and it looks like it works. Bootstrap finds the root and re-execs into the correct venv, banner and all — but `dev.py` then treats `src/` as the project root, writes `.abi/dev`, `storage/` and `.dagster/` in there, and silently reallocates every port, since the offset is a hash of the root path.

## Changes

**`dev.py`** — `_project_root()` now resolves via the same `find_abi_project_root()` bootstrap uses, so the directory treated as the project is by construction the one whose venv we run in. When there is no project it raises with the fix in the message instead of starting services that cannot work:

```
No ABI project found in /Users/…/<parent> or any parent directory.
`abi dev` operates on a project: it needs a `pyproject.toml` that depends on ABI.
If you just ran `abi new project`, cd into the generated project first:
    cd <project-name> && abi dev up
```

**`new/project.py`** — prints a next-steps block with a relative, pasteable `cd`, so the failure is not reachable by following the happy path.

## Verification

Against the directory that actually produced the bug:

| invoked from | before | after |
|---|---|---|
| parent of the project | started 3 services, 2 died, misleading error | refused, with the cd instruction |
| project root | worked | works |
| project subdir (`src/`) | silently rooted at `src/`, ports reallocated | resolves to the project root |

- 8 new tests covering both bugs, including that dev artifacts and port offsets stay pinned to the project root regardless of invocation directory.
- Full `naas-abi-cli` suite: **167 passed**, plus one pre-existing unrelated failure (`test_setup_local_deploy_hardens_fuseki_for_reliability` — the compose template gained `curlimages/curl` in #1058 and the assertion was never updated). Confirmed it fails identically with these changes stashed.
- `ruff` and `mypy` clean on all four files.

## Known limitation, not addressed here

`find_abi_project_root()` matches any `pyproject.toml` whose text contains `naas-abi-*`, so inside this monorepo it stops at `libs/naas-abi-cli/` rather than the repo root. That behaviour is unchanged — it is what bootstrap already picks for the venv — but it means the subdirectory fix does not help for package directories *within* the monorepo. Worth a separate look; changing the resolver would move bootstrap's venv selection too.