### PR TITLE
perf(bus): batch triple-store publishes and stop logging every bus message

### DIFF
--- a/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_BusService.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_BusService.py
@@ -100,6 +100,13 @@ class BusAdapterConfiguration(GenericLoader):
 
 class BusServiceConfiguration(BaseModel):
     bus_adapter: BusAdapterConfiguration
+    # Log a durable event for every message crossing the bus. Off by default:
+    # it costs one event-log append per message, and engine boot alone
+    # publishes one message per ontology triple. Turn on to debug bus traffic.
+    emit_message_events: bool = False
 
     def load(self) -> BusService:
-        return BusService(adapter=self.bus_adapter.load())
+        return BusService(
+            adapter=self.bus_adapter.load(),
+            emit_message_events=self.emit_message_events,
+        )

--- a/libs/naas-abi-core/naas_abi_core/services/bus/BusPorts.py
+++ b/libs/naas-abi-core/naas_abi_core/services/bus/BusPorts.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from threading import Thread
 
 
@@ -42,6 +42,24 @@ class IBusAdapter(ABC):
         connected after this call returns will not see the message.
         """
         raise NotImplementedError()
+
+    def publish_many(
+        self, topic: str, messages: Sequence[tuple[str, bytes]]
+    ) -> None:
+        """Publish a batch of ``(routing_key, payload)`` pairs on ``topic``.
+
+        Subscribers observe exactly what they would have observed from the
+        equivalent sequence of :meth:`publish` calls — this is a transport
+        optimisation, not a delivery-semantics change. Adapters backed by a
+        transactional store should override it to commit the whole batch in
+        one round-trip; bulk producers (e.g. loading an ontology into the
+        triple store) otherwise pay a full commit per message.
+
+        The default implementation just loops, so adapters need not
+        implement it.
+        """
+        for routing_key, payload in messages:
+            self.publish(topic, routing_key, payload)
 
     @abstractmethod
     def subscribe(

--- a/libs/naas-abi-core/naas_abi_core/services/bus/BusService.py
+++ b/libs/naas-abi-core/naas_abi_core/services/bus/BusService.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from threading import Thread
 
 from naas_abi_core import logger
@@ -14,9 +14,23 @@ from naas_abi_core.services.ServiceBase import ServiceBase
 class BusService(ServiceBase):
     __adapter: IBusAdapter
 
-    def __init__(self, adapter: IBusAdapter):
+    def __init__(self, adapter: IBusAdapter, emit_message_events: bool = False):
+        """Wrap ``adapter`` with optional event-log telemetry.
+
+        ``emit_message_events`` turns on a durable ``BusMessagePublished`` /
+        ``BusMessageEnqueued`` event for *every* message crossing the bus.
+        It defaults to **off**: the bus is a high-volume transport, and one
+        fsync'd event-log append per message is a 3x write amplification that
+        drowns real events. Engine boot alone publishes one message per
+        ontology triple, so leaving this on costs tens of thousands of event
+        rows before the process serves its first request.
+
+        Turn it on deliberately when debugging bus traffic. ``BusError``
+        events are always emitted — failures are rare and worth recording.
+        """
         super().__init__()
         self.__adapter = adapter
+        self._emit_message_events = emit_message_events
 
     def __publish_event(self, event: object) -> None:
         if not self.services_wired:
@@ -48,14 +62,51 @@ class BusService(ServiceBase):
                 )
             )
             raise
-        self.__publish_event(
-            BusMessagePublished(
-                topic=topic,
-                routing_key=routing_key,
-                size_bytes=len(payload),
+        if self._emit_message_events:
+            self.__publish_event(
+                BusMessagePublished(
+                    topic=topic,
+                    routing_key=routing_key,
+                    size_bytes=len(payload),
+                )
             )
-        )
         return result
+
+    def publish_many(
+        self, topic: str, messages: Sequence[tuple[str, bytes]]
+    ) -> None:
+        """Publish a batch of ``(routing_key, payload)`` pairs on ``topic``.
+
+        Delivery is identical to calling :meth:`publish` per message; the
+        adapter is free to commit the batch in one round-trip. Prefer this
+        over a publish loop whenever the message count scales with input
+        size (bulk triple inserts, imports, backfills).
+        """
+        if not messages:
+            return
+        if topic.startswith("evt."):
+            return self.__adapter.publish_many(topic, messages)
+        try:
+            self.__adapter.publish_many(topic, messages)
+        except Exception as exc:
+            self.__publish_event(
+                BusError(
+                    topic=topic,
+                    routing_key=messages[0][0],
+                    operation="publish_many",
+                    message=str(exc),
+                )
+            )
+            raise
+        if self._emit_message_events:
+            for routing_key, payload in messages:
+                self.__publish_event(
+                    BusMessagePublished(
+                        topic=topic,
+                        routing_key=routing_key,
+                        size_bytes=len(payload),
+                    )
+                )
 
     def subscribe(
         self, topic: str, routing_key: str, callback: Callable[[bytes], None]
@@ -78,13 +129,14 @@ class BusService(ServiceBase):
                 )
             )
             raise
-        self.__publish_event(
-            BusMessageEnqueued(
-                topic=topic,
-                routing_key=routing_key,
-                size_bytes=len(payload),
+        if self._emit_message_events:
+            self.__publish_event(
+                BusMessageEnqueued(
+                    topic=topic,
+                    routing_key=routing_key,
+                    size_bytes=len(payload),
+                )
             )
-        )
         return result
 
     def dequeue(

--- a/libs/naas-abi-core/naas_abi_core/services/bus/adapters/secondary/PythonQueueAdapter.py
+++ b/libs/naas-abi-core/naas_abi_core/services/bus/adapters/secondary/PythonQueueAdapter.py
@@ -2,7 +2,7 @@ import os
 import sqlite3
 import threading
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from threading import Event, Thread
 
 from naas_abi_core.services.bus.BusPorts import IBusAdapter
@@ -78,6 +78,12 @@ class PythonQueueAdapter(IBusAdapter):
         self._conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_bus_pubsub_topic_seq "
             "ON bus_pubsub(topic, seq)"
+        )
+        # The TTL sweep in publish() filters on created_at; without this the
+        # DELETE degrades to a full table scan on every publish.
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_bus_pubsub_created_at "
+            "ON bus_pubsub(created_at)"
         )
         self._conn.commit()
         self._db_lock = threading.RLock()
@@ -181,12 +187,25 @@ class PythonQueueAdapter(IBusAdapter):
     # ------------------------------------------------------------------
 
     def publish(self, topic: str, routing_key: str, payload: bytes) -> None:
+        self.publish_many(topic, ((routing_key, payload),))
+
+    def publish_many(
+        self, topic: str, messages: Sequence[tuple[str, bytes]]
+    ) -> None:
+        """Append a batch of messages in a single transaction.
+
+        One commit (and one fsync) for the whole batch instead of one per
+        message. Subscribers see the same rows in the same order either way;
+        they just become visible together.
+        """
+        if not messages:
+            return
         now = time.time()
         with self._db_lock:
-            self._conn.execute(
+            self._conn.executemany(
                 "INSERT INTO bus_pubsub(topic, routing_key, payload, created_at) "
                 "VALUES(?, ?, ?, ?)",
-                (topic, routing_key, payload, now),
+                [(topic, routing_key, payload, now) for routing_key, payload in messages],
             )
             # Opportunistic TTL cleanup so the log doesn't grow unbounded.
             # Rows older than the retention window are long past any live

--- a/libs/naas-abi-core/naas_abi_core/services/bus/tests/BusService_events_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/bus/tests/BusService_events_test.py
@@ -22,11 +22,19 @@ class _FakeAdapter(IBusAdapter):
         self.enqueued: list[tuple[str, str, bytes]] = []
         self.publish_raises: Exception | None = None
         self.enqueue_raises: Exception | None = None
+        self.publish_many_calls = 0
 
     def publish(self, topic: str, routing_key: str, payload: bytes) -> None:
         if self.publish_raises is not None:
             raise self.publish_raises
         self.published.append((topic, routing_key, payload))
+
+    def publish_many(self, topic: str, messages) -> None:
+        self.publish_many_calls += 1
+        if self.publish_raises is not None:
+            raise self.publish_raises
+        for routing_key, payload in messages:
+            self.published.append((topic, routing_key, payload))
 
     def subscribe(
         self, topic: str, routing_key: str, callback: Callable[[bytes], None]
@@ -65,9 +73,11 @@ class _FakeServices:
         return self._events
 
 
-def _wired() -> tuple[_FakeAdapter, BusService, _FakeEventService]:
+def _wired(emit_message_events: bool = True) -> tuple[_FakeAdapter, BusService, _FakeEventService]:
+    # Per-message telemetry is off by default (see BusService docstring); the
+    # tests below that assert on it opt in explicitly.
     adapter = _FakeAdapter()
-    svc = BusService(adapter)
+    svc = BusService(adapter, emit_message_events=emit_message_events)
     events = _FakeEventService()
     svc.set_services(_FakeServices(events))
     return adapter, svc, events
@@ -124,6 +134,92 @@ def test_enqueue_emits_bus_message_enqueued() -> None:
     assert evt.topic == "jobs.x"
     assert evt.routing_key == "rk.1"
     assert evt.size_bytes == len(b"payload")
+
+
+# ---------------------------------------------------------------------------
+# Per-message telemetry is opt-in — the bus is a hot path.
+# ---------------------------------------------------------------------------
+
+
+def test_publish_emits_no_event_by_default() -> None:
+    adapter, svc, events = _wired(emit_message_events=False)
+    svc.publish("topic.x", "key.a", b"hello")
+    svc.enqueue("jobs.x", "rk.1", b"payload")
+
+    # Messages still reach the adapter; they just don't each become a
+    # durable event-log row.
+    assert adapter.published == [("topic.x", "key.a", b"hello")]
+    assert adapter.enqueued == [("jobs.x", "rk.1", b"payload")]
+    assert events.published == []
+
+
+def test_publish_failure_still_emits_bus_error_when_telemetry_off() -> None:
+    adapter, svc, events = _wired(emit_message_events=False)
+    adapter.publish_raises = RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        svc.publish("topic.x", "rk", b"data")
+
+    errors = [e for e in events.published if isinstance(e, BusError)]
+    assert len(errors) == 1
+    assert errors[0].operation == "publish"
+
+
+# ---------------------------------------------------------------------------
+# publish_many — same delivery as a publish loop, one adapter round-trip.
+# ---------------------------------------------------------------------------
+
+
+def test_publish_many_forwards_every_message_in_order() -> None:
+    adapter, svc, _events = _wired(emit_message_events=False)
+    svc.publish_many("triple_store", [("rk.a", b"one"), ("rk.b", b"two")])
+
+    assert adapter.published == [
+        ("triple_store", "rk.a", b"one"),
+        ("triple_store", "rk.b", b"two"),
+    ]
+    # One batched adapter call, not one per message.
+    assert adapter.publish_many_calls == 1
+
+
+def test_publish_many_empty_is_a_noop() -> None:
+    adapter, svc, events = _wired()
+    svc.publish_many("triple_store", [])
+
+    assert adapter.published == []
+    assert adapter.publish_many_calls == 0
+    assert events.published == []
+
+
+def test_publish_many_emits_one_event_per_message_when_enabled() -> None:
+    _adapter, svc, events = _wired(emit_message_events=True)
+    svc.publish_many("triple_store", [("rk.a", b"one"), ("rk.b", b"two")])
+
+    assert [type(e) for e in events.published] == [
+        BusMessagePublished,
+        BusMessagePublished,
+    ]
+    assert [e.routing_key for e in events.published] == ["rk.a", "rk.b"]
+
+
+def test_publish_many_evt_topic_emits_nothing() -> None:
+    adapter, svc, events = _wired(emit_message_events=True)
+    svc.publish_many("evt.abc123", [("id-1", b"x")])
+
+    assert adapter.published == [("evt.abc123", "id-1", b"x")]
+    assert events.published == []
+
+
+def test_publish_many_failure_emits_bus_error_and_reraises() -> None:
+    adapter, svc, events = _wired()
+    adapter.publish_raises = RuntimeError("batch down")
+
+    with pytest.raises(RuntimeError):
+        svc.publish_many("triple_store", [("rk.a", b"one")])
+
+    errors = [e for e in events.published if isinstance(e, BusError)]
+    assert len(errors) == 1
+    assert errors[0].operation == "publish_many"
 
 
 # ---------------------------------------------------------------------------

--- a/libs/naas-abi-core/naas_abi_core/services/bus/tests/bus__secondary_adapter__generic_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/bus/tests/bus__secondary_adapter__generic_test.py
@@ -13,6 +13,8 @@ class GenericBusSecondaryAdapterTest(ABC):
         # Pub/sub: every matching subscriber receives every matching message.
         assert callable(getattr(adapter_class, "publish", None))
         assert callable(getattr(adapter_class, "subscribe", None))
+        # Batch publish: defaulted on the port, so every adapter has it.
+        assert callable(getattr(adapter_class, "publish_many", None))
         # Work queue: exactly one consumer per message, durable.
         assert callable(getattr(adapter_class, "enqueue", None))
         assert callable(getattr(adapter_class, "dequeue", None))

--- a/libs/naas-abi-core/naas_abi_core/services/triple_store/TripleStoreService.py
+++ b/libs/naas-abi-core/naas_abi_core/services/triple_store/TripleStoreService.py
@@ -171,20 +171,10 @@ class TripleStoreService(ServiceBase, ITripleStoreService):
         if self.services_wired is False:
             return
 
-        # Notify listeners of the insert
-        for s, p, o in triples.triples((None, None, None)):
-            triple_bytes = f"{s.n3()} {p.n3()} {o.n3()} .\n".encode()
-
-            try:
-                topic = f"ts.insert.g.{self._hash_value(str(graph_name))}.s.{self._hash_value(s)}.p.{self._hash_value(p)}.o.{self._hash_value(o)}"
-                self.services.bus.publish(
-                    "triple_store",
-                    topic,
-                    triple_bytes,
-                )
-            except Exception as e:
-                logger.error(f"Error publishing triple: {e}")
-                raise
+        # Notify listeners of the insert. Batched: a bulk load (an ontology
+        # file, an import) produces one message per triple, and a per-message
+        # round-trip to the bus makes engine boot scale with triple count.
+        self.__publish_triples("insert", triples, graph_name)
 
     def remove(
         self,
@@ -217,19 +207,33 @@ class TripleStoreService(ServiceBase, ITripleStoreService):
             return
 
         # Notify listeners of the delete
-        for s, p, o in triples.triples((None, None, None)):
-            triple_bytes = f"{s.n3()} {p.n3()} {o.n3()} .\n".encode()
+        self.__publish_triples("delete", triples, graph_name)
 
-            try:
-                topic = f"ts.delete.g.{self._hash_value(str(graph_name))}.s.{self._hash_value(s)}.p.{self._hash_value(p)}.o.{self._hash_value(o)}"
-                self.services.bus.publish(
-                    "triple_store",
-                    topic,
-                    triple_bytes,
-                )
-            except Exception as e:
-                logger.error(f"Error publishing triple: {e}")
-                raise
+    def __publish_triples(
+        self, operation: str, triples: Graph, graph_name: URIRef
+    ) -> None:
+        """Broadcast one bus message per triple, in a single batch.
+
+        Routing keys are unchanged (``ts.<operation>.g.<h>.s.<h>.p.<h>.o.<h>``),
+        so subscriber bindings keep matching exactly as before.
+        """
+        graph_hash = self._hash_value(str(graph_name))
+        messages: list[tuple[str, bytes]] = []
+        for s, p, o in triples.triples((None, None, None)):
+            routing_key = (
+                f"ts.{operation}.g.{graph_hash}"
+                f".s.{self._hash_value(s)}"
+                f".p.{self._hash_value(p)}"
+                f".o.{self._hash_value(o)}"
+            )
+            messages.append((routing_key, f"{s.n3()} {p.n3()} {o.n3()} .\n".encode()))
+        if not messages:
+            return
+        try:
+            self.services.bus.publish_many("triple_store", messages)
+        except Exception as e:
+            logger.error(f"Error publishing triples: {e}")
+            raise
 
     def get(self) -> Graph:
         return self.__triple_store_adapter.get()

--- a/libs/naas-abi-core/naas_abi_core/services/triple_store/TripleStoreService_events_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/triple_store/TripleStoreService_events_test.py
@@ -93,6 +93,9 @@ class _NoopBus:
     def publish(self, *_args, **_kwargs) -> None:
         return None
 
+    def publish_many(self, *_args, **_kwargs) -> None:
+        return None
+
     def subscribe(self, *_args, **_kwargs) -> None:
         return None
 

--- a/libs/naas-abi-core/naas_abi_core/services/triple_store/TripleStoreService_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/triple_store/TripleStoreService_test.py
@@ -22,6 +22,10 @@ class _FakeBus:
     def publish(self, topic: str, routing_key: str, payload: bytes) -> None:
         self.published.append((topic, routing_key, payload))
 
+    def publish_many(self, topic: str, messages) -> None:
+        for routing_key, payload in messages:
+            self.published.append((topic, routing_key, payload))
+
     def subscribe(
         self,
         topic: str,


### PR DESCRIPTION
## Symptom

A fresh `abi new project` + `abi dev up` appears to hang: the API prints its uvicorn banner and then goes quiet for ~6 minutes, and `dagster dev` dies with

```
dagster._core.errors.DagsterExecutionInterruptedError
  ... PythonQueueAdapter.py, line 194, in publish
      self._conn.execute(
```

The API is not actually deadlocked — it eventually serves normally. It is grinding.

## Root cause: ~3 fsync'd SQLite commits per ontology triple

1. `TripleStoreService.insert()` publishes **one bus message per triple**, each its own transaction.
2. `BusService.publish()` then logs a durable `BusMessagePublished` event for **every** message, which `EventService` appends to `events.sqlite` and re-broadcasts on the bus.

Measured on the reported project's own storage:

| | |
|---|---|
| triples inserted at boot (`sum(TriplesInserted.triple_count)`) | 41,530 |
| `BusMessagePublished` rows | 40,872 |
| share of the event log that is bus self-telemetry | **99.7%** |
| wall time, continuous (only one inter-event gap > 1s in 373s) | **361s** |
| SQLite on disk | ~65 MB |

It degrades **superlinearly** because four engine boots (api reloader parent + child, `dagster dev`, dagster code server) hammer the same WAL concurrently:

| processes | per-event cost |
|---|---|
| 1 | 0.23 ms |
| 2 | 0.83 ms |
| 3 | `sqlite3.OperationalError: database is locked` — the event adapter cannot even set `journal_mode` |

`dagster dev`'s code-server load exceeds its startup timeout, the parent SIGINTs the child, and dagster's `capture_interrupts` handler raises wherever the process happens to be — inside `PythonQueueAdapter.publish`. That is the traceback users report.

## Changes

- **`IBusAdapter.publish_many()`** — batch publish, *defaulted on the port* (loops `publish`), so `RabbitMQAdapter` and any custom adapter keep working untouched. `PythonQueueAdapter` overrides it to commit the whole batch in one transaction.
- **`BusService.publish_many()`**, used by `TripleStoreService` for `insert`/`remove`. Routing keys are byte-identical, so **subscriber bindings are unaffected** — this is a transport optimisation, not a semantics change.
- **Per-message telemetry is now opt-in.** `BusMessagePublished` / `BusMessageEnqueued` move behind `BusService(emit_message_events=...)`, default off, surfaced as `BusServiceConfiguration.emit_message_events`. `BusError` is still always emitted. These two events have **no consumers anywhere in the repo** — only the emitter, the generated ontology classes, and one test.
- **Index `bus_pubsub(created_at)`** — the TTL sweep in `publish()` was a full table scan on every call (confirmed via `EXPLAIN QUERY PLAN`).

## Result

Replaying the real boot workload (41,530 triples, single process):

| | before | after |
|---|---|---|
| wall time | 10.44s | **0.19s** (54x) |
| event rows | 41,530 | **0** |
| SQLite written | 98.6 MB | **5.0 MB** |

The cross-process contention disappears with the writes, so the multi-process case improves by more than the single-process number suggests.

## Testing

- Bus + event suites: **83 passed, 0 failed**, including new tests for `publish_many` ordering, batching, the `evt.` recursion guard, `BusError` on batch failure, and telemetry-off-by-default.
- `triple_store` and `engine` suites: failure lists **byte-identical to `main`'s baseline** (6 and 12 pre-existing failures respectively — signature drift and missing Docker/`pika`, all unrelated).
- `ruff check` clean on changed files.

## Reviewer note

The judgement call worth a second opinion is making bus telemetry **default-off** rather than deleting it or keeping it on. It has no consumers today and costs a durable append per message on a hot path, so off-by-default seemed right — but if these events are wanted for an upcoming observability feature, the alternative is to keep them on and rely on `publish_many` alone (which still collapses N commits into 1, but leaves the ~41k event rows per boot).