### PR TITLE
feat(dev): make abi dev up boot observable, and stop dagster duplicating the ontology bootstrap

### DIFF
--- a/libs/naas-abi-cli/naas_abi_cli/cli/dev.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/dev.py
@@ -95,6 +95,27 @@ ALT_NEXUS_WEB_DIR = ALT_NEXUS_ROOT / "apps" / "web"
 # the API URL is available when Next.js starts polling it.
 ALL_SERVICES = ("oxigraph", "api", "dagster", "nexus-web")
 
+# `abi dev up` exists to watch the stack come up, and the slowest part of api
+# boot — `Engine.load()`, behind the lazy app factory — narrates itself only at
+# DEBUG. At the library default (WARNING) that whole phase is silent, so a boot
+# that is merely slow is indistinguishable from one that is wedged. Default the
+# api and dagster processes to DEBUG here and let `--log-level` dial it back.
+LOG_LEVELS = ("CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG")
+DEFAULT_LOG_LEVEL = "DEBUG"
+
+
+def _resolve_log_level(log_level: str | None) -> str:
+    """Pick the LOG_LEVEL handed to the api/dagster processes.
+
+    Explicit `--log-level` wins; otherwise a LOG_LEVEL already exported in the
+    parent environment is honoured (so the flag adds a knob without taking the
+    existing one away), and DEBUG is the fallback.
+    """
+    if log_level:
+        return log_level.upper()
+    inherited = os.environ.get("LOG_LEVEL", "").strip()
+    return inherited.upper() if inherited else DEFAULT_LOG_LEVEL
+
 
 @dataclass(frozen=True)
 class ServiceSpec:
@@ -304,11 +325,16 @@ def _launch_oxigraph(spec: ServiceSpec) -> int:
     return _spawn(spec, cmd, _project_root(), env)
 
 
-def _launch_api(spec: ServiceSpec, ports: dict[str, int]) -> int:
+def _launch_api(
+    spec: ServiceSpec, ports: dict[str, int], log_level: str | None = None
+) -> int:
     env = os.environ.copy()
     # Local-dev default so Bearer auth works without a hand-authored .env.
     # Never overwrites an explicit value from the parent environment.
     env.setdefault("ABI_API_KEY", DEFAULT_API_KEY)
+    # Engine boot phases (services → modules → ontologies) are DEBUG-level;
+    # without this the long silence after "naas_abi_core imported" is opaque.
+    env["LOG_LEVEL"] = _resolve_log_level(log_level)
     env["ABI_PORT"] = str(spec.port)
     env["ABI_HOST"] = env.get("ABI_HOST", BIND_HOST)
     # Point the triple-store adapter at the worktree-local oxigraph server.
@@ -339,10 +365,16 @@ def _launch_api(spec: ServiceSpec, ports: dict[str, int]) -> int:
     return _spawn(spec, cmd, _project_root(), env)
 
 
-def _launch_dagster(spec: ServiceSpec, ports: dict[str, int]) -> int:
+def _launch_dagster(
+    spec: ServiceSpec, ports: dict[str, int], log_level: str | None = None
+) -> int:
     env = os.environ.copy()
     env.setdefault("DAGSTER_HOME", str(_project_root() / ".dagster"))
     Path(env["DAGSTER_HOME"]).mkdir(parents=True, exist_ok=True)
+    # Dagster loads the same engine in its code server, so it goes silent in
+    # the same way the api does. This is our loguru sink, not dagster's own
+    # `--log-level` (left at its default so the daemon doesn't drown the pane).
+    env["LOG_LEVEL"] = _resolve_log_level(log_level)
     env["OXIGRAPH_URL"] = _oxigraph_url(ports)
     cmd = [
         "uv",
@@ -472,7 +504,9 @@ SERVICE_READY_PATHS = {
 }
 
 
-def _start_service(name: str, ports: dict[str, int]) -> ServiceSpec:
+def _start_service(
+    name: str, ports: dict[str, int], log_level: str | None = None
+) -> ServiceSpec:
     existing_spec = _service_spec(name, ports[name])
 
     existing_pid = _read_pid(existing_spec)
@@ -504,11 +538,11 @@ def _start_service(name: str, ports: dict[str, int]) -> ServiceSpec:
     if name == "oxigraph":
         pid = _launch_oxigraph(spec)
     elif name == "api":
-        pid = _launch_api(spec, ports)
+        pid = _launch_api(spec, ports, log_level)
     elif name == "nexus-web":
         pid = _launch_nexus_web(spec, ports)
     elif name == "dagster":
-        pid = _launch_dagster(spec, ports)
+        pid = _launch_dagster(spec, ports, log_level)
     else:
         raise click.ClickException(f"Unknown service: {name}")
     _pid_path(spec).write_text(f"{pid}\n")
@@ -1003,7 +1037,11 @@ def _build_hint(
     return out
 
 
-def _follow_until_interrupt(started: list[ServiceSpec], ports: dict[str, int]) -> None:
+def _follow_until_interrupt(
+    started: list[ServiceSpec],
+    ports: dict[str, int],
+    log_level: str | None = None,
+) -> None:
     """Live status bar + hint pinned at the bottom; logs scroll above them.
 
     The terminal's own scrollback works (no alt-screen). Hotkeys 1/2/3 filter
@@ -1155,7 +1193,7 @@ def _follow_until_interrupt(started: list[ServiceSpec], ports: dict[str, int]) -
             # 4. Re-spawn services in the original order.
             started.clear()
             for name in selected_names:
-                spec = _start_service(name, ports)
+                spec = _start_service(name, ports, log_level)
                 started.append(spec)
                 # Same boot-dependency wait as the initial `dev_up`.
                 if name == "oxigraph" and any(
@@ -1335,12 +1373,28 @@ def dev() -> None:
     default=False,
     help="Run in the background and return to the shell immediately.",
 )
-def dev_up(services: tuple[str, ...], detach: bool) -> None:
+@click.option(
+    "--log-level",
+    "log_level",
+    type=click.Choice(LOG_LEVELS, case_sensitive=False),
+    default=None,
+    help=(
+        "LOG_LEVEL for the api and dagster processes. "
+        f"Default: $LOG_LEVEL, else {DEFAULT_LOG_LEVEL} "
+        "(engine boot phases are logged at DEBUG)."
+    ),
+)
+def dev_up(
+    services: tuple[str, ...], detach: bool, log_level: str | None
+) -> None:
     """Start the selected dev services.
 
     By default this stays in the foreground and streams interleaved logs from
     every started service until you hit Ctrl+C (which stops them cleanly).
     Pass `-d/--detach` to spawn them in the background instead.
+
+    The api and dagster processes run at LOG_LEVEL=DEBUG so engine boot
+    narrates itself; pass `--log-level INFO` (or lower) to quieten them.
     """
     selected = _validate_services(services)
     instance = _load_or_create_instance()
@@ -1355,7 +1409,7 @@ def dev_up(services: tuple[str, ...], detach: bool) -> None:
     started: list[ServiceSpec] = []
     try:
         for name in selected:
-            spec = _start_service(name, ports)
+            spec = _start_service(name, ports, log_level)
             started.append(spec)
             # api & dagster connect to the oxigraph HTTP endpoint at engine
             # boot; block briefly until it answers so they don't race-crash.
@@ -1402,7 +1456,7 @@ def dev_up(services: tuple[str, ...], detach: bool) -> None:
         )
     )
 
-    _follow_until_interrupt(started, ports)
+    _follow_until_interrupt(started, ports, log_level)
 
 
 @dev.command("down")

--- a/libs/naas-abi-cli/naas_abi_cli/cli/dev.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/dev.py
@@ -366,11 +366,21 @@ def _launch_api(
 
 
 def _launch_dagster(
-    spec: ServiceSpec, ports: dict[str, int], log_level: str | None = None
+    spec: ServiceSpec,
+    ports: dict[str, int],
+    log_level: str | None = None,
+    skip_ontology_loading: bool = True,
 ) -> int:
     env = os.environ.copy()
     env.setdefault("DAGSTER_HOME", str(_project_root() / ".dagster"))
     Path(env["DAGSTER_HOME"]).mkdir(parents=True, exist_ok=True)
+    # dagster and the api share this stack's single oxigraph, so the ontology
+    # bootstrap only needs to happen once. Letting both do it doubles tens of
+    # thousands of triple inserts and makes them contend for the same writes.
+    # The api owns it — except when it isn't running, where dagster has to do
+    # the bootstrap itself or the store stays empty.
+    if skip_ontology_loading:
+        env["ABI_SKIP_ONTOLOGY_LOADING"] = "true"
     # Dagster loads the same engine in its code server, so it goes silent in
     # the same way the api does. This is our loguru sink, not dagster's own
     # `--log-level` (left at its default so the daemon doesn't drown the pane).
@@ -505,7 +515,10 @@ SERVICE_READY_PATHS = {
 
 
 def _start_service(
-    name: str, ports: dict[str, int], log_level: str | None = None
+    name: str,
+    ports: dict[str, int],
+    log_level: str | None = None,
+    selected: list[str] | None = None,
 ) -> ServiceSpec:
     existing_spec = _service_spec(name, ports[name])
 
@@ -542,7 +555,12 @@ def _start_service(
     elif name == "nexus-web":
         pid = _launch_nexus_web(spec, ports)
     elif name == "dagster":
-        pid = _launch_dagster(spec, ports, log_level)
+        # No explicit selection == the default `abi dev up`, which starts the
+        # api too, so it is the ontology owner.
+        api_is_running = "api" in (selected if selected is not None else ALL_SERVICES)
+        pid = _launch_dagster(
+            spec, ports, log_level, skip_ontology_loading=api_is_running
+        )
     else:
         raise click.ClickException(f"Unknown service: {name}")
     _pid_path(spec).write_text(f"{pid}\n")
@@ -1193,7 +1211,7 @@ def _follow_until_interrupt(
             # 4. Re-spawn services in the original order.
             started.clear()
             for name in selected_names:
-                spec = _start_service(name, ports, log_level)
+                spec = _start_service(name, ports, log_level, selected_names)
                 started.append(spec)
                 # Same boot-dependency wait as the initial `dev_up`.
                 if name == "oxigraph" and any(
@@ -1409,7 +1427,7 @@ def dev_up(
     started: list[ServiceSpec] = []
     try:
         for name in selected:
-            spec = _start_service(name, ports, log_level)
+            spec = _start_service(name, ports, log_level, selected)
             started.append(spec)
             # api & dagster connect to the oxigraph HTTP endpoint at engine
             # boot; block briefly until it answers so they don't race-crash.

--- a/libs/naas-abi-cli/naas_abi_cli/cli/dev_test.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/dev_test.py
@@ -241,6 +241,63 @@ def test_dagster_own_log_level_is_left_alone(monkeypatch) -> None:
     assert "--log-level" not in captured["cmd"]
 
 
+# =============================================================================
+# Ontology bootstrap ownership
+#
+# api and dagster share this stack's single oxigraph. The bootstrap is tens of
+# thousands of triples, so having both apply it doubles the work and makes the
+# two processes contend for the same writes.
+# =============================================================================
+
+def test_dagster_defers_the_ontology_bootstrap_to_the_api(monkeypatch) -> None:
+    env = _captured_env(monkeypatch, dev._launch_dagster)
+
+    assert env["ABI_SKIP_ONTOLOGY_LOADING"] == "true"
+
+
+def test_dagster_bootstraps_when_the_api_is_not_running(monkeypatch) -> None:
+    """Nothing else would load the schema, so the store would stay empty."""
+    env = _captured_env(
+        monkeypatch, dev._launch_dagster, skip_ontology_loading=False
+    )
+
+    assert "ABI_SKIP_ONTOLOGY_LOADING" not in env
+
+
+def test_api_always_owns_the_bootstrap(monkeypatch) -> None:
+    assert "ABI_SKIP_ONTOLOGY_LOADING" not in _captured_env(
+        monkeypatch, dev._launch_api
+    )
+
+
+def test_start_service_gives_dagster_the_bootstrap_without_an_api(
+    monkeypatch, tmp_path
+) -> None:
+    """`abi dev up --service dagster` must not leave the schema unloaded."""
+    captured: dict = {}
+    monkeypatch.setattr(dev, "_read_pid", lambda spec: None)
+    monkeypatch.setattr(dev, "_find_free_port", lambda service, preferred: preferred)
+    monkeypatch.setattr(
+        dev,
+        "_launch_dagster",
+        lambda spec, ports, log_level=None, skip_ontology_loading=True: captured.update(
+            skip=skip_ontology_loading
+        )
+        or 1234,
+    )
+    monkeypatch.setattr(dev, "_pid_path", lambda spec: tmp_path / f"{spec.name}.pid")
+
+    dev._start_service("dagster", dict(PORTS), None, ["dagster"])
+    assert captured["skip"] is False
+
+    dev._start_service("dagster", dict(PORTS), None, ["api", "dagster"])
+    assert captured["skip"] is True
+
+    # No explicit selection == the default `abi dev up`, which starts the api.
+    dev._start_service("dagster", dict(PORTS), None, None)
+    assert captured["skip"] is True
+
+
 def test_health_probe_targets_the_literal(monkeypatch) -> None:
     """`localhost` may resolve to ::1 and report a live IPv4 service as down."""
     seen: list[str] = []

--- a/libs/naas-abi-cli/naas_abi_cli/cli/dev_test.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/dev_test.py
@@ -184,6 +184,63 @@ def test_dagster_binds_the_ipv4_literal(monkeypatch) -> None:
     assert cmd[cmd.index("--host") + 1] == "127.0.0.1"
 
 
+# =============================================================================
+# Boot visibility
+#
+# `Engine.load()` runs behind the api's lazy app factory and narrates itself
+# only at DEBUG. At the library default (WARNING) a slow boot and a wedged one
+# look identical from the log pane, so `abi dev up` raises the level itself.
+# =============================================================================
+
+def _captured_env(monkeypatch, launch, **kwargs) -> dict:
+    captured: dict = {}
+    monkeypatch.setattr(
+        dev,
+        "_spawn",
+        lambda spec, cmd, cwd, env: captured.update(env=env) or 1234,
+    )
+    name = "api" if launch is dev._launch_api else "dagster"
+    launch(_spec(name, PORTS[name]), PORTS, **kwargs)
+    return captured["env"]
+
+
+def test_api_and_dagster_default_to_debug(monkeypatch) -> None:
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+
+    for launch in (dev._launch_api, dev._launch_dagster):
+        assert _captured_env(monkeypatch, launch)["LOG_LEVEL"] == "DEBUG"
+
+
+def test_explicit_log_level_wins(monkeypatch) -> None:
+    monkeypatch.setenv("LOG_LEVEL", "ERROR")
+
+    for launch in (dev._launch_api, dev._launch_dagster):
+        env = _captured_env(monkeypatch, launch, log_level="info")
+        assert env["LOG_LEVEL"] == "INFO"
+
+
+def test_inherited_log_level_is_honoured(monkeypatch) -> None:
+    """The new flag adds a knob; it must not take the existing one away."""
+    monkeypatch.setenv("LOG_LEVEL", "warning")
+
+    for launch in (dev._launch_api, dev._launch_dagster):
+        assert _captured_env(monkeypatch, launch)["LOG_LEVEL"] == "WARNING"
+
+
+def test_dagster_own_log_level_is_left_alone(monkeypatch) -> None:
+    """Our loguru sink is LOG_LEVEL; dagster's daemon flag would only add noise."""
+    captured: dict = {}
+    monkeypatch.setattr(
+        dev,
+        "_spawn",
+        lambda spec, cmd, cwd, env: captured.update(cmd=cmd) or 1234,
+    )
+
+    dev._launch_dagster(_spec("dagster", PORTS["dagster"]), PORTS)
+
+    assert "--log-level" not in captured["cmd"]
+
+
 def test_health_probe_targets_the_literal(monkeypatch) -> None:
     """`localhost` may resolve to ::1 and report a live IPv4 service as down."""
     seen: list[str] = []

--- a/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration.py
@@ -264,6 +264,26 @@ class GlobalConfig(BaseModel):
     skip_ontology_loading: bool = False
     public_api_host: str = "localhost:9879"
 
+    @model_validator(mode="after")
+    def apply_skip_ontology_loading_override(self) -> Self:
+        """Let a launcher opt one process out of the ontology bootstrap.
+
+        Several processes can share a single triple store — `abi dev up` runs
+        the api and dagster against the same oxigraph — but the bootstrap is
+        the same tens of thousands of triples every time, so having each one
+        apply it is pure duplicated work plus cross-process write contention.
+        `config.yaml` cannot express that: it is per-project, and these are
+        per-process. The env var lets the launcher nominate a single owner.
+
+        Opt-in only. A truthy value forces the skip on; anything else leaves
+        the configured value alone, so this can never silently re-enable
+        loading for a project that turned it off in `config.yaml`.
+        """
+        override = os.environ.get("ABI_SKIP_ONTOLOGY_LOADING", "").strip().lower()
+        if override in ("1", "true", "yes", "on"):
+            self.skip_ontology_loading = True
+        return self
+
 
 # Process-wide cache of the parsed configuration. Without this, every
 # caller (api.py at import, Engine.__init__, etc.) constructs a fresh

--- a/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_test.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_test.py
@@ -143,3 +143,47 @@ opencode:
     assert len(configuration.opencode.providers) == 1
     assert configuration.opencode.providers[0].id == "openrouter"
     assert configuration.opencode.providers[0].key == "test-opencode"
+
+
+# =============================================================================
+# ABI_SKIP_ONTOLOGY_LOADING
+#
+# Processes sharing one triple store (`abi dev up` runs the api and dagster
+# against the same oxigraph) must not each replay the ontology bootstrap.
+# `config.yaml` is per-project and cannot express a per-process decision, so
+# the launcher nominates an owner via the environment.
+# =============================================================================
+
+def _global_config(dotenv_path: str):
+    return EngineConfiguration.from_yaml_content(
+        _configuration_yaml(title="BASE", dotenv_path=dotenv_path)
+    ).global_config
+
+
+def _dotenv(tmp_path):
+    path = tmp_path / ".env.bootstrap"
+    path.write_text("ENV=local\n", encoding="utf-8")
+    return str(path)
+
+
+def test_skip_ontology_loading_defaults_to_false(tmp_path, monkeypatch):
+    monkeypatch.delenv("ABI_SKIP_ONTOLOGY_LOADING", raising=False)
+
+    assert _global_config(_dotenv(tmp_path)).skip_ontology_loading is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on", " true "])
+def test_env_override_forces_the_skip_on(tmp_path, monkeypatch, value):
+    monkeypatch.setenv("ABI_SKIP_ONTOLOGY_LOADING", value)
+
+    assert _global_config(_dotenv(tmp_path)).skip_ontology_loading is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "", "nonsense"])
+def test_non_truthy_env_leaves_the_configured_value_alone(
+    tmp_path, monkeypatch, value
+):
+    """Opt-in only: this must never re-enable loading a project turned off."""
+    monkeypatch.setenv("ABI_SKIP_ONTOLOGY_LOADING", value)
+
+    assert _global_config(_dotenv(tmp_path)).skip_ontology_loading is False

--- a/libs/naas-abi-marketplace/uv.lock
+++ b/libs/naas-abi-marketplace/uv.lock
@@ -782,7 +782,7 @@ name = "cuda-bindings"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/a9/3a8241c6e19483ac1f1dcf5c10238205dcb8a6e9d0d4d4709240dff28ff4/cuda_bindings-13.2.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:721104c603f059780d287969be3d194a18d0cc3b713ed9049065a1107706759d", size = 5730273, upload-time = "2026-03-11T00:12:37.18Z" },
@@ -815,37 +815,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
 ]
 cufft = [
-    { name = "nvidia-cufft" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
 ]
 cufile = [
-    { name = "nvidia-cufile" },
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
 ]
 curand = [
-    { name = "nvidia-curand" },
+    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx" },
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -1797,6 +1797,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/47/16400cb42d18d7a6bb46f0626852c1718612e35dcb0dffa16bbaffdf5dd2/greenlet-3.3.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:c56692189a7d1c7606cb794be0a8381470d95c57ce5be03fb3d0ef57c7853b86", size = 278890, upload-time = "2026-02-20T20:19:39.263Z" },
     { url = "https://files.pythonhosted.org/packages/a3/90/42762b77a5b6aa96cd8c0e80612663d39211e8ae8a6cd47c7f1249a66262/greenlet-3.3.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ebd458fa8285960f382841da585e02201b53a5ec2bac6b156fc623b5ce4499f", size = 581120, upload-time = "2026-02-20T20:47:30.161Z" },
     { url = "https://files.pythonhosted.org/packages/bf/6f/f3d64f4fa0a9c7b5c5b3c810ff1df614540d5aa7d519261b53fba55d4df9/greenlet-3.3.2-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a443358b33c4ec7b05b79a7c8b466f5d275025e750298be7340f8fc63dff2a55", size = 594363, upload-time = "2026-02-20T20:55:56.965Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8b/1430a04657735a3f23116c2e0d5eb10220928846e4537a938a41b350bed6/greenlet-3.3.2-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4375a58e49522698d3e70cc0b801c19433021b5c37686f7ce9c65b0d5c8677d2", size = 605046, upload-time = "2026-02-20T21:02:45.234Z" },
     { url = "https://files.pythonhosted.org/packages/72/83/3e06a52aca8128bdd4dcd67e932b809e76a96ab8c232a8b025b2850264c5/greenlet-3.3.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e2cd90d413acbf5e77ae41e5d3c9b3ac1d011a756d7284d7f3f2b806bbd6358", size = 594156, upload-time = "2026-02-20T20:20:59.955Z" },
     { url = "https://files.pythonhosted.org/packages/70/79/0de5e62b873e08fe3cef7dbe84e5c4bc0e8ed0c7ff131bccb8405cd107c8/greenlet-3.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:442b6057453c8cb29b4fb36a2ac689382fc71112273726e2423f7f17dc73bf99", size = 1554649, upload-time = "2026-02-20T20:49:32.293Z" },
     { url = "https://files.pythonhosted.org/packages/5a/00/32d30dee8389dc36d42170a9c66217757289e2afb0de59a3565260f38373/greenlet-3.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:45abe8eb6339518180d5a7fa47fa01945414d7cca5ecb745346fc6a87d2750be", size = 1619472, upload-time = "2026-02-20T20:21:07.966Z" },
@@ -1805,6 +1806,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
     { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
     { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
     { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
     { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
     { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
@@ -1813,6 +1815,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -1821,6 +1824,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
     { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
     { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
     { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
     { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
     { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
@@ -1829,6 +1833,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
     { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
     { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
     { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
@@ -3312,7 +3317,7 @@ wheels = [
 
 [[package]]
 name = "naas-abi-core"
-version = "2.21.0"
+version = "2.21.1"
 source = { editable = "../naas-abi-core" }
 dependencies = [
     { name = "click" },
@@ -3743,7 +3748,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
@@ -3755,7 +3760,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -3785,9 +3790,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cusparse", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -3799,7 +3804,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3959,7 +3964,7 @@ resolution-markers = [
     "(python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/17/06/68c27a523103dad5837dc5b87e71285280c4f098c60e4fe8a8db6486ab09/opencv-python-4.11.0.86.tar.gz", hash = "sha256:03d60ccae62304860d232272e4a4fda93c39d595780cb40b161b310244b736a4", size = 95171956, upload-time = "2025-01-16T13:52:24.737Z" }
 wheels = [
@@ -3987,7 +3992,7 @@ resolution-markers = [
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/6f/5a28fef4c4a382be06afe3938c64cc168223016fa520c5abaf37e8862aa5/opencv_python-4.13.0.92-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:caf60c071ec391ba51ed00a4a920f996d0b64e3e46068aac1f646b5de0326a19", size = 46247052, upload-time = "2026-02-05T07:01:25.046Z" },
@@ -5959,8 +5964,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "jeepney", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## Problem

`abi dev up` looks wedged during api boot. The last thing it prints is:

```
[abi-boot] naas_abi_core imported (+0.49s)
[abi-boot] api() entered, starting uvicorn (+1.56s)
```

…and then nothing, for minutes.

The imports were never the problem — they finish in ~1.5s. The time goes into
`Engine.load()`, which runs behind the api's lazy app factory (`get_app()` →
`_load_runtime_routes()`). That phase *does* narrate itself — services →
modules → ontologies — but every one of those lines is `logger.debug`, and
`naas_abi_core.utils.Logger` defaults to `WARNING`.

So the whole slow phase is silent, and a boot that is merely slow is
indistinguishable from one that is wedged.

## 1. Make the boot observable

- `abi dev up` now starts the **api** and **dagster** processes with
  `LOG_LEVEL=DEBUG`, so engine boot narrates itself in the log pane.
- New `--log-level [CRITICAL|ERROR|WARNING|INFO|DEBUG]` flag to dial it back.
- Resolution order: `--log-level` → `$LOG_LEVEL` from the parent environment →
  `DEBUG`. The flag adds a knob without taking the existing one away.
- The level survives the in-place restart (`r` hotkey).

Dagster's own `--log-level` is deliberately **not** raised: our sink is loguru
via `LOG_LEVEL`, and turning up dagster's would only add daemon noise to the
pane without revealing any more of our own boot.

`abi dev up` is a local dev command whose entire purpose is the pinned status
panel and streamed logs, so DEBUG is the level that makes that panel honest.
This does not affect `abi deploy`, Docker, or CI paths.

## 2. Stop dagster duplicating the ontology bootstrap

With DEBUG on, the log shows what is actually happening: `_insert_new_schema`
walking the bundled ontologies, each file taking seconds, interleaved with
`sqlite3.OperationalError: database is locked`.

`abi dev up` runs the api **and** dagster from the same project root, so both
point at the same oxigraph and **both apply the full ontology bootstrap** —
18,068 triples across the 25 bundled ontologies (more once a project pulls in
marketplace modules), done twice, with the two processes contending for the
same writes.

`config.yaml` already has `global_config.skip_ontology_loading`, but it is
per-project and this is a per-process decision. So:

- `GlobalConfig` honours an `ABI_SKIP_ONTOLOGY_LOADING` env override.
- `abi dev up` sets it for the dagster process — the api owns the bootstrap.
- **Opt-in only**: a truthy value forces the skip on, anything else leaves the
  configured value alone, so it can never silently *re-enable* loading for a
  project that turned it off in `config.yaml`.
- dagster still bootstraps when the api is not in the selection
  (`abi dev up --service dagster`), or nothing would load the schema and the
  store would stay empty.

## Relationship to #1152

#1152 fixes the other half of this — the per-triple bus publish amplification
(`publish_many` batching, bus telemetry default-off, `bus_pubsub(created_at)`
index; 41.5k triples 10.44s → 0.19s). That is the bigger win and it is **not**
duplicated here.

The two are complementary and independent (no overlapping files): #1152 makes
each bootstrap cheap, this PR stops the second process from doing a redundant
one at all. Either can merge first.

## Tests

16 new tests, all passing:

- `dev_test.py` (25 passed): DEBUG default for both processes, explicit
  `--log-level` winning over the environment, inherited `LOG_LEVEL` honoured,
  dagster's own flag left alone, dagster deferring the bootstrap, dagster
  still bootstrapping with no api, api always owning it, and the
  `_start_service` selection logic.
- `EngineConfiguration_test.py`: the env override's truthy forms, the
  opt-in-only guarantee, and the unset default.

Engine suite baseline-diffed against the untouched `main` checkout: **FAILED
lists identical** (9 pre-existing failures — macOS `/tmp` symlink, config-cache
leakage, missing Docker), 39 → 51 passed. `ruff check` clean on changed files;
full pre-commit suite (ruff, mypy, bandit, Nexus build) passed on both commits.

Also verified `LOG_LEVEL=DEBUG` actually reaches the loguru sink, and that
nothing re-configures the logger after import (`reconfigure()` has exactly one
caller, at import time).