### PR TITLE
feat(core): agent message hooks + formatter-clean scaffolds

### DIFF
--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/agent_test.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/agent_test.py
@@ -1,0 +1,90 @@
+"""Tests for the agent scaffold produced by `abi new agent`.
+
+The generated agent ships with the `onHumanMessage` / `onAImessage` message
+hooks already wired, as empty stubs the user fills in. These tests pin that
+contract: the file must import, the hooks must really override the base class,
+and the shipped no-op bodies must be safe to run untouched.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+from langchain_core.language_models.fake_chat_models import FakeListChatModel
+from naas_abi_core.services.agent.Agent import (
+    Agent,
+    AgentConfiguration,
+    AgentSharedState,
+)
+
+from naas_abi_cli.cli.new.agent import new_agent
+
+
+def _generate(tmp_path: Path) -> Any:
+    """Run the generator and import the agent class it produced."""
+    new_agent("my-test", str(tmp_path))
+
+    generated = tmp_path / "MyTestAgent.py"
+    assert generated.exists(), f"generator produced: {list(tmp_path.iterdir())}"
+
+    spec = importlib.util.spec_from_file_location("MyTestAgent", generated)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["MyTestAgent"] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop("MyTestAgent", None)
+    return module.MyTestAgent
+
+
+def test_generated_agent_defines_both_message_hooks(tmp_path: Path) -> None:
+    agent_cls = _generate(tmp_path)
+
+    # Defined on the generated class itself, not merely inherited.
+    assert "onHumanMessage" in vars(agent_cls)
+    assert "onAImessage" in vars(agent_cls)
+    assert agent_cls.onHumanMessage is not Agent.onHumanMessage
+    assert agent_cls.onAImessage is not Agent.onAImessage
+
+
+def test_generated_hooks_ship_as_safe_noops(tmp_path: Path) -> None:
+    """The scaffold must run untouched: empty bodies that return nothing."""
+    agent_cls = _generate(tmp_path)
+    instance = agent_cls.__new__(agent_cls)
+
+    assert instance.onHumanMessage(None) is None
+    assert instance.onAImessage(None, "any-agent") is None
+
+
+def test_generated_agent_hooks_fire_on_a_real_turn(tmp_path: Path) -> None:
+    """The hooks are wired by default -- a subclass filling them in gets called."""
+    agent_cls = _generate(tmp_path)
+
+    human: list[Any] = []
+    ai: list[tuple[Any, str]] = []
+
+    class _Probe(agent_cls):  # type: ignore[misc,valid-type]
+        def onHumanMessage(self, message: Any) -> None:
+            human.append(message.content)
+
+        def onAImessage(self, message: Any, agent_name: str) -> None:
+            ai.append((message.content, agent_name))
+
+    agent = _Probe(
+        name="Probe",
+        description="probe",
+        chat_model=FakeListChatModel(responses=["hello from the model"]),
+        tools=[],
+        agents=[],
+        memory=None,
+        state=AgentSharedState(thread_id="0"),
+        configuration=AgentConfiguration(system_prompt="you are a probe"),
+    )
+
+    assert agent.invoke("ping") == "hello from the model"
+    assert human == ["ping"]
+    assert ai == [("hello from the model", "Probe")]

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/agent_test.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/agent_test.py
@@ -9,10 +9,13 @@ and the shipped no-op bodies must be safe to run untouched.
 from __future__ import annotations
 
 import importlib.util
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
 
+import pytest
 from langchain_core.language_models.fake_chat_models import FakeListChatModel
 from naas_abi_core.services.agent.Agent import (
     Agent,
@@ -39,6 +42,29 @@ def _generate(tmp_path: Path) -> Any:
     finally:
         sys.modules.pop("MyTestAgent", None)
     return module.MyTestAgent
+
+
+RUFF = shutil.which("ruff")
+
+
+@pytest.mark.skipif(RUFF is None, reason="ruff not on PATH")
+@pytest.mark.parametrize(
+    "agent_name", ["a", "my-test", "super-long-enterprise-reporting-assistant"]
+)
+def test_generated_agent_passes_ruff(tmp_path: Path, agent_name: str) -> None:
+    """The scaffold must clear the repo's own lint gate, whatever it is named."""
+    assert RUFF is not None  # guaranteed by the skipif above
+    new_agent(agent_name, str(tmp_path))
+    (generated,) = tmp_path.glob("*Agent.py")
+
+    for command in (["format", "--check"], ["check"]):
+        result = subprocess.run(
+            [RUFF, *command, str(generated)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
 
 
 def test_generated_agent_defines_both_message_hooks(tmp_path: Path) -> None:

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/agent/{{agent_name_pascal}}Agent.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/agent/{{agent_name_pascal}}Agent.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Optional
 
+from langchain_core.messages import AnyMessage
 from naas_abi_core.services.agent.Agent import (
     Agent,
     AgentConfiguration,
@@ -89,3 +90,42 @@ Help the user accomplish their tasks using the tools available to you.
             state=agent_shared_state,
             configuration=agent_configuration,
         )
+
+    # ------------------------------------------------------------------
+    # Message hooks
+    #
+    # Already wired: the runtime calls these on every message, you only have
+    # to fill in the body. They are observation points -- whatever you return
+    # is ignored, and if you raise, the error is logged and swallowed so the
+    # conversation keeps going.
+    #
+    # They run inline on the streaming thread, so keep them quick. Hand slow
+    # work (HTTP calls, big writes) off to a queue or a thread yourself.
+    # ------------------------------------------------------------------
+
+    def onHumanMessage(self, message: AnyMessage) -> None:
+        """Called every time the user sends a new message to this agent.
+
+        Runs once per turn, before the message reaches the model.
+
+        Args:
+            message (AnyMessage): The HumanMessage that was just received.
+        """
+        # Example -- replace with whatever you need:
+        # from naas_abi_core.utils.Logger import logger
+        # logger.info(f"[{self.name}] human: {message.content}")
+
+    def onAImessage(self, message: AnyMessage, agent_name: str) -> None:
+        """Called every time a new AI message is emitted.
+
+        Fires for messages from this agent *and* from any of its sub-agents --
+        use ``agent_name`` to tell them apart. Messages that only carry tool
+        calls are not reported here.
+
+        Args:
+            message (AnyMessage): The AIMessage that was just emitted.
+            agent_name (str): Name of the agent that produced the message.
+        """
+        # Example -- replace with whatever you need:
+        # from naas_abi_core.utils.Logger import logger
+        # logger.info(f"[{agent_name}] ai: {message.content}")

--- a/libs/naas-abi-cli/naas_abi_cli/cli/utils/Copier.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/utils/Copier.py
@@ -1,5 +1,7 @@
 import os
 import shutil
+import subprocess
+import sys
 
 import jinja2
 from jinja2 import Environment, meta
@@ -27,11 +29,15 @@ class Copier:
         # Normalize paths to avoid double-joining relative segments during recursion.
         self.templates_path = os.path.abspath(templates_path)
         self.destination_path = os.path.abspath(destination_path)
+        # Files this Copier wrote, so the post-render format pass touches only
+        # generated code and never the rest of the user's project.
+        self._generated_files: list[str] = []
 
     def _template_file_to_file(self, template_path: str, destination_path: str) -> None:
         destination_path = self._template_string(destination_path)
         with open(destination_path, "w", encoding="utf-8") as file:
             file.write(self._template_file(template_path))
+        self._generated_files.append(destination_path)
 
     def _template_file(self, template_path: str) -> str:
         with open(template_path, "r", encoding="utf-8") as file:
@@ -41,10 +47,51 @@ class Copier:
         vp = ValueProvider(self.values)
         vp.collect_values(template_string)
         self.values = {**self.values, **vp}
-        return jinja2.Template(template_string).render(self.values)
+        # keep_trailing_newline: Jinja strips a single trailing newline by
+        # default, which would emit generated files with no final newline --
+        # `ruff format --check` rejects those. Harmless for the rendered
+        # path strings this also handles, since paths carry no trailing newline.
+        return jinja2.Template(template_string, keep_trailing_newline=True).render(
+            self.values
+        )
+
+    def _format_generated_python(self) -> None:
+        """Best-effort `ruff format` over the Python files we just wrote.
+
+        Rendering shifts line lengths -- a name longer or shorter than the
+        `{{placeholder}}` moves wrapping -- so a template that is itself
+        formatter-clean still renders unformatted code for some names. The only
+        reliable fix is to format *after* rendering.
+
+        Ruff is not a runtime dependency of this CLI, so a missing binary is not
+        an error: the generated code is valid either way, it just may not match
+        `ruff format`. Never let this step break generation.
+        """
+        targets = [f for f in self._generated_files if f.endswith(".py")]
+        if not targets:
+            return
+
+        ruff = shutil.which("ruff")
+        command = [ruff] if ruff else [sys.executable, "-m", "ruff"]
+
+        try:
+            subprocess.run(  # nosec B603 - fixed argv, paths are ones we just wrote
+                [*command, "format", "--quiet", *targets],
+                capture_output=True,
+                check=False,
+                timeout=120,
+            )
+        except (OSError, subprocess.SubprocessError):
+            # No ruff available, or it failed/timed out. Generation still succeeded.
+            pass
 
     def copy(self, values: dict, templates_path: str | None = None):
         self.values = values
+
+        # Only the outermost call formats, once the whole tree has been written.
+        is_root_call = templates_path is None
+        if is_root_call:
+            self._generated_files = []
 
         if templates_path is None:
             templates_path = self.templates_path
@@ -80,3 +127,6 @@ class Copier:
                 self.copy(self.values, os.path.join(templates_path, file))
             else:
                 print(f"Skipping {file}")
+
+        if is_root_call:
+            self._format_generated_python()

--- a/libs/naas-abi-cli/naas_abi_cli/cli/utils/Copier_test.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/utils/Copier_test.py
@@ -1,0 +1,112 @@
+"""Tests for Copier's rendering and post-render formatting.
+
+Generated Python has to survive the repo's own lint gate, so the Copier keeps
+the trailing newline Jinja would otherwise strip and runs `ruff format` over
+the files it wrote. Both are easy to regress silently, hence these tests.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from naas_abi_cli.cli.utils.Copier import Copier
+
+RUFF = shutil.which("ruff")
+needs_ruff = pytest.mark.skipif(RUFF is None, reason="ruff not on PATH")
+
+
+def _render(tmp_path: Path, template: str, values: dict, filename: str) -> Path:
+    templates = tmp_path / "templates"
+    templates.mkdir()
+    (templates / filename).write_text(template, encoding="utf-8")
+
+    destination = tmp_path / "out"
+    destination.mkdir()
+
+    Copier(str(templates), str(destination)).copy(values=values)
+    return destination / filename.replace("{{name}}", values.get("name", ""))
+
+
+def test_generated_python_keeps_its_trailing_newline(tmp_path: Path) -> None:
+    """Jinja strips one trailing newline by default; ruff format rejects that."""
+    out = _render(tmp_path, "x = '{{name}}'\n", {"name": "Thing"}, "mod.py")
+
+    assert out.read_text(encoding="utf-8").endswith("\n")
+
+
+def test_non_python_files_also_keep_their_trailing_newline(tmp_path: Path) -> None:
+    out = _render(tmp_path, "key: {{name}}\n", {"name": "value"}, "conf.yaml")
+
+    assert out.read_text(encoding="utf-8") == "key: value\n"
+
+
+@needs_ruff
+@pytest.mark.parametrize(
+    "name",
+    [
+        "A",
+        "Medium",
+        "SuperExtremelyLongAndVerboseEnterpriseReportingAssistant",
+    ],
+)
+def test_generated_python_is_ruff_format_clean_at_any_name_length(
+    tmp_path: Path, name: str
+) -> None:
+    """Rendering shifts wrapping, so only formatting *after* render is reliable.
+
+    This template renders to a call that fits on one line for a short name and
+    must wrap for a long one -- exactly the case a pre-formatted template gets
+    wrong.
+    """
+    assert RUFF is not None  # guaranteed by the skipif above
+    template = (
+        "def run(self, parameters: {{name}}Parameters, other: {{name}}Config) -> dict:\n"
+        "    return do_something({{name}}Parameters(**kwargs), {{name}}Config(**kwargs))\n"
+    )
+    out = _render(tmp_path, template, {"name": name}, "mod.py")
+
+    result = subprocess.run(
+        [RUFF, "format", "--check", str(out)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+@needs_ruff
+def test_formatting_only_touches_generated_files(tmp_path: Path) -> None:
+    """The destination may be the user's project -- never reformat their code."""
+    templates = tmp_path / "templates"
+    templates.mkdir()
+    (templates / "generated.py").write_text("x = {{name}}\n", encoding="utf-8")
+
+    destination = tmp_path / "out"
+    destination.mkdir()
+    untouched = destination / "pre_existing.py"
+    # Deliberately unformatted: ruff would rewrite this if it were included.
+    original = "y   =    1\n\n\n\nz=2\n"
+    untouched.write_text(original, encoding="utf-8")
+
+    Copier(str(templates), str(destination)).copy(values={"name": "1"})
+
+    assert untouched.read_text(encoding="utf-8") == original
+
+
+def test_generation_succeeds_when_ruff_is_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ruff is not a runtime dependency -- its absence must not break scaffolding."""
+    monkeypatch.setattr("naas_abi_cli.cli.utils.Copier.shutil.which", lambda _: None)
+
+    def _boom(*args, **kwargs):
+        raise FileNotFoundError("no ruff here")
+
+    monkeypatch.setattr("naas_abi_cli.cli.utils.Copier.subprocess.run", _boom)
+
+    out = _render(tmp_path, "x = '{{name}}'\n", {"name": "Thing"}, "mod.py")
+
+    assert out.read_text(encoding="utf-8") == "x = 'Thing'\n"

--- a/libs/naas-abi-core/naas_abi_core/services/agent/AGENTS.md
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/AGENTS.md
@@ -54,6 +54,30 @@ build_graph(patcher=None)                       # construct LangGraph StateGraph
 workflow -> StateGraph                          # compiled workflow
 ```
 
+## Subclass Hooks
+
+Override these on an agent that inherits from `Agent` to observe the
+conversation. They are no-ops on the base class:
+
+```python
+onHumanMessage(message)              # a new human message entered the conversation
+onAImessage(message, agent_name)     # a new AI message was emitted
+```
+
+Fire-and-forget by contract: the runtime discards whatever they return and
+swallows (logs) any exception they raise, so a hook can never alter or break a
+turn. They run inline on the streaming thread — keep them cheap, and hand slow
+work off to a queue or thread yourself.
+
+- `onHumanMessage` fires once per turn from `stream()` (and so from `invoke()` /
+  `stream_invoke()`), before the message reaches the model.
+- `onAImessage` fires for messages from this agent *and* its sub-agents;
+  `agent_name` identifies the producer. Assistant messages that only carry tool
+  calls do not count — those surface through the `on_tool_usage` callback.
+
+Distinct from the `on_tool_usage` / `on_tool_response` / `on_ai_message`
+*callback registration* methods, which take a callable and are set per-instance.
+
 ## Subdirectories
 
 | Path | Contents |
@@ -86,6 +110,7 @@ Propagate across async tasks / raw threads with `contextvars.copy_context()`.
 ```bash
 uv run pytest libs/naas-abi-core/naas_abi_core/services/agent/Agent_test.py
 uv run pytest libs/naas-abi-core/naas_abi_core/services/agent/Agent_events_test.py
+uv run pytest libs/naas-abi-core/naas_abi_core/services/agent/Agent_hooks_test.py
 uv run pytest libs/naas-abi-core/naas_abi_core/services/agent/IntentAgent_test.py
 uv run pytest libs/naas-abi-core/naas_abi_core/services/agent/OpencodeAgent_test.py
 uv run pytest libs/naas-abi-core/naas_abi_core/services/agent/OpencodeSessionService_test.py

--- a/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
@@ -1762,6 +1762,7 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
     def _notify_ai_message(self, message: AnyMessage, agent_name: str):
         self._event_queue.put(AIMessageEvent(payload=message, agent_name=agent_name))
         self._on_ai_message(message, agent_name)
+        self._call_hook(self.onAImessage, message, agent_name)
         content = self._stringify_content(getattr(message, "content", None))
         self._publish_agent_event(
             AgentAIMessageEmitted(
@@ -1797,6 +1798,46 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
         for agent in self._agents:
             agent._event_queue = self._event_queue
             agent._sync_event_queue_with_subagents()
+
+    def _call_hook(self, hook: Callable[..., Any], *args: Any) -> None:
+        """Invoke a subclass hook best-effort.
+
+        The return value is discarded and exceptions are swallowed: a hook is
+        purely an observation point and must never alter or break the
+        conversation flow.
+        """
+        try:
+            hook(*args)
+        except Exception as exc:  # noqa: BLE001
+            name = getattr(hook, "__name__", "hook")
+            logger.warning(f"Agent '{self._name}': {name} raised: {exc}")
+
+    # Subclass hooks. No-ops on the base class -- override them in an agent that
+    # inherits from Agent to observe the conversation as it happens. Nothing is
+    # expected back: the return value is ignored and a raising hook is logged
+    # and swallowed rather than propagated.
+
+    def onHumanMessage(self, message: AnyMessage) -> None:
+        """Called every time a new human message enters the conversation.
+
+        Fires once per user turn, before the message reaches the model.
+
+        Args:
+            message (AnyMessage): The HumanMessage that was just received.
+        """
+
+    def onAImessage(self, message: AnyMessage, agent_name: str) -> None:
+        """Called every time a new AI message is emitted.
+
+        Fires for assistant messages produced by this agent and by any of its
+        sub-agents -- ``agent_name`` tells them apart. Assistant messages that
+        only carry tool calls do not count as AI messages here; those are
+        reported through the ``on_tool_usage`` callback instead.
+
+        Args:
+            message (AnyMessage): The AIMessage that was just emitted.
+            agent_name (str): Name of the agent that produced the message.
+        """
 
     def on_tool_usage(self, callback: Callable[[AnyMessage], None]):
         """Register a callback to be called when a tool is used.
@@ -1866,10 +1907,13 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
             )
         )
 
+        human_message = HumanMessage(content=prompt)
+        self._call_hook(self.onHumanMessage, human_message)
+
         notified = {}
 
         for chunk in self.graph.stream(
-            {"messages": [HumanMessage(content=prompt)]},
+            {"messages": [human_message]},
             config={"configurable": {"thread_id": self._state.thread_id}},
             subgraphs=True,
         ):

--- a/libs/naas-abi-core/naas_abi_core/services/agent/Agent_events_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/Agent_events_test.py
@@ -67,6 +67,8 @@ class _StubAgent:
     _identity = Agent._identity
     _publish_agent_event = Agent._publish_agent_event
     _stringify_content = Agent._stringify_content
+    _call_hook = Agent._call_hook
+    onAImessage = Agent.onAImessage
     _notify_tool_usage = Agent._notify_tool_usage
     _notify_tool_response = Agent._notify_tool_response
     _notify_ai_message = Agent._notify_ai_message

--- a/libs/naas-abi-core/naas_abi_core/services/agent/Agent_hooks_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/Agent_hooks_test.py
@@ -1,0 +1,193 @@
+# mypy: disable-error-code="arg-type,misc"
+"""Tests for the `onHumanMessage` / `onAImessage` subclass hooks.
+
+These hooks exist so an agent inheriting from `Agent` can observe the
+conversation. They are fire-and-forget by contract: the runtime ignores what
+they return and never lets a failing hook break the turn.
+
+As in `Agent_events_test.py`, we bind the real methods onto an Agent-shaped
+stub — a real `Agent` needs a live chat model plus LangGraph compilation, which
+is far more surface than these wiring tests need.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from langchain_core.messages import AIMessage, HumanMessage
+from naas_abi_core.services.agent.Agent import Agent
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+class _HookAgent:
+    """Agent-shaped stub exposing only what the hooks + their call sites need."""
+
+    def __init__(self, name: str = "tester", chunks: list[Any] | None = None) -> None:
+        self._name = name
+        self._agents: list[Any] = []
+        self._event_queue = SimpleNamespace(put=lambda _: None)
+        self._on_ai_message = lambda _, __: None
+        self._state = SimpleNamespace(thread_id="t-1")
+        self.graph = SimpleNamespace(stream=lambda *a, **kw: iter(chunks or []))
+        self.human_calls: list[Any] = []
+        self.ai_calls: list[tuple[Any, str]] = []
+
+    # Bind the real implementations so we exercise the actual code paths.
+    _identity = Agent._identity
+    _publish_agent_event = Agent._publish_agent_event
+    _stringify_content = Agent._stringify_content
+    _has_tool_calls = staticmethod(Agent._has_tool_calls)
+    _call_hook = Agent._call_hook
+    onHumanMessage = Agent.onHumanMessage
+    onAImessage = Agent.onAImessage
+    _notify_ai_message = Agent._notify_ai_message
+    stream = Agent.stream
+
+
+class _RecordingAgent(_HookAgent):
+    """Subclass that overrides both hooks, the way a user's agent would."""
+
+    def onHumanMessage(self, message: Any) -> None:
+        self.human_calls.append(message)
+
+    def onAImessage(self, message: Any, agent_name: str) -> None:
+        self.ai_calls.append((message, agent_name))
+
+
+class _RaisingAgent(_HookAgent):
+    """Subclass whose hooks blow up — the runtime must absorb that."""
+
+    def onHumanMessage(self, message: Any) -> None:
+        raise RuntimeError("boom in human hook")
+
+    def onAImessage(self, message: Any, agent_name: str) -> None:
+        raise RuntimeError("boom in ai hook")
+
+
+class _ReturningAgent(_HookAgent):
+    """Subclass whose hooks return values — the runtime must ignore them."""
+
+    def onHumanMessage(self, message: Any) -> Any:
+        return "ignored"
+
+    def onAImessage(self, message: Any, agent_name: str) -> Any:
+        return {"also": "ignored"}
+
+
+# ---------------------------------------------------------------------------
+# Base class behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_base_hooks_are_noops_returning_none() -> None:
+    agent = _HookAgent()
+
+    assert agent.onHumanMessage(HumanMessage(content="hi")) is None
+    assert agent.onAImessage(AIMessage(content="hello"), "tester") is None
+
+
+# ---------------------------------------------------------------------------
+# onAImessage
+# ---------------------------------------------------------------------------
+
+
+def test_notify_ai_message_invokes_on_ai_message_hook() -> None:
+    agent = _RecordingAgent()
+    message = AIMessage(content="hello world")
+
+    agent._notify_ai_message(message, "tester")
+
+    assert len(agent.ai_calls) == 1
+    received, agent_name = agent.ai_calls[0]
+    assert received is message
+    assert agent_name == "tester"
+
+
+def test_on_ai_message_hook_receives_originating_sub_agent_name() -> None:
+    """Sub-agent output flows through the parent's notifier, so the hook must
+    report who actually produced the message, not the parent."""
+    agent = _RecordingAgent(name="supervisor")
+
+    agent._notify_ai_message(AIMessage(content="from the specialist"), "specialist")
+
+    assert agent.ai_calls[0][1] == "specialist"
+
+
+def test_raising_on_ai_message_hook_does_not_break_notification() -> None:
+    agent = _RaisingAgent()
+    seen: list[Any] = []
+    agent._on_ai_message = lambda message, name: seen.append((message, name))
+
+    agent._notify_ai_message(AIMessage(content="hello"), "tester")  # must not raise
+
+    # The registered callback still ran: a broken hook is isolated.
+    assert len(seen) == 1
+
+
+def test_returning_on_ai_message_hook_value_is_ignored() -> None:
+    agent = _ReturningAgent()
+
+    assert agent._notify_ai_message(AIMessage(content="hello"), "tester") is None
+
+
+# ---------------------------------------------------------------------------
+# onHumanMessage
+# ---------------------------------------------------------------------------
+
+
+def test_stream_invokes_on_human_message_hook_with_the_human_message() -> None:
+    agent = _RecordingAgent()
+
+    list(agent.stream("what is the weather?"))
+
+    assert len(agent.human_calls) == 1
+    message = agent.human_calls[0]
+    assert isinstance(message, HumanMessage)
+    assert message.content == "what is the weather?"
+
+
+def test_stream_fires_on_human_message_once_per_turn() -> None:
+    agent = _RecordingAgent()
+
+    list(agent.stream("first"))
+    list(agent.stream("second"))
+
+    assert [m.content for m in agent.human_calls] == ["first", "second"]
+
+
+def test_raising_hooks_do_not_break_stream() -> None:
+    """Both hooks blow up on the same turn; the stream must still complete."""
+    chunk = ((), {"call_model": {"messages": [AIMessage(content="hi")]}})
+    agent = _RaisingAgent(chunks=[chunk])
+    seen: list[Any] = []
+    agent._on_ai_message = lambda message, name: seen.append((message, name))
+
+    assert list(agent.stream("hello")) == [chunk]
+    # onAImessage also raised, yet the registered callback still ran.
+    assert len(seen) == 1
+
+
+def test_returning_on_human_message_hook_value_is_ignored() -> None:
+    agent = _ReturningAgent()
+
+    assert list(agent.stream("hello")) == []
+
+
+def test_stream_feeds_the_same_human_message_to_the_graph() -> None:
+    """The message handed to the hook is the one the graph actually receives."""
+    captured: list[Any] = []
+
+    def capturing_stream(payload: Any, **kwargs: Any) -> Any:
+        captured.append(payload)
+        return iter([])
+
+    agent = _RecordingAgent()
+    agent.graph = SimpleNamespace(stream=capturing_stream)
+
+    list(agent.stream("trace me"))
+
+    assert captured[0]["messages"][0] is agent.human_calls[0]

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,3 +2,11 @@
 namespace_packages = True
 explicit_package_bases = True
 mypy_path = $MYPY_CONFIG_FILE_DIR/.venv
+
+# The workspace packages ship no py.typed marker, so importing one from another
+# ("from naas_abi_core... import" inside naas_abi_cli) raises import-untyped and
+# silently degrades the imported symbols to Any. The Makefile check targets
+# already pass --follow-untyped-imports; setting it here means an ad-hoc
+# `uv run mypy <file>` behaves the same instead of reporting an error the real
+# check does not have.
+follow_untyped_imports = True

--- a/uv.lock
+++ b/uv.lock
@@ -3547,7 +3547,7 @@ wheels = [
 
 [[package]]
 name = "naas-abi"
-version = "2.50.1"
+version = "2.51.4"
 source = { editable = "libs/naas-abi" }
 dependencies = [
     { name = "aiosqlite" },
@@ -3629,7 +3629,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-cli"
-version = "2.9.8"
+version = "2.11.1"
 source = { editable = "libs/naas-abi-cli" }
 dependencies = [
     { name = "naas-abi" },
@@ -3655,7 +3655,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-core"
-version = "2.19.5"
+version = "2.21.1"
 source = { editable = "libs/naas-abi-core" }
 dependencies = [
     { name = "click" },
@@ -3786,7 +3786,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-marketplace"
-version = "3.28.1"
+version = "3.29.0"
 source = { editable = "libs/naas-abi-marketplace" }
 dependencies = [
     { name = "ijson" },


### PR DESCRIPTION
## What

Three commits:

1. **`naas-abi-core`** — two overridable hook methods on the base `Agent` class, so an inheriting agent can observe the conversation.
2. **`naas-abi-cli`** — `abi new agent` scaffolds those hooks already wired, as empty stubs to fill in.
3. **`naas-abi-cli`** — fixes generated code so it passes `ruff format --check`, and makes ad-hoc mypy match the real check.

## 1 + 2 — the hooks

```python
onHumanMessage(message)              # a new human message entered the conversation
onAImessage(message, agent_name)     # a new AI message was emitted
```

No-ops on the base class; subclasses override them purely to hook in and see what's flowing through.

**Contract — fire-and-forget:** the runtime discards whatever the hook returns, and swallows + logs any exception it raises, so a user hook can never alter or break a turn. Both go through a `_call_hook` helper mirroring the existing best-effort `_publish_agent_event` pattern.

**Where they fire:**
- `onHumanMessage` — once per turn from `stream()`, before the message reaches the model. `invoke()` and `stream_invoke()` delegate to `stream()`, so they are covered too.
- `onAImessage` — from `_notify_ai_message`, the single funnel. Sub-agent output flows through the parent's notifier, so the hook sees sub-agent messages too, with `agent_name` identifying the producer.

Assistant messages carrying only tool calls route to `_notify_tool_usage`, so they do not trigger `onAImessage` — those stay observable via the existing `on_tool_usage` callback.

Naming note: `on_ai_message` was already taken on this class as a *callback registration* method (it takes a callable). The camelCase names avoid the collision, so both mechanisms coexist.

## 3 — formatter-clean scaffolds

Two separate bugs, both in `Copier`:

- **Trailing newline.** Jinja's `keep_trailing_newline` defaults to `False`, so every rendered file lost its final newline and failed `ruff format --check`. This affected *every* `abi new *` command, not just agents.
- **Render-time rewrapping.** A generated name longer or shorter than the `{{placeholder}}` moves line breaks, so a template that is itself formatter-clean still emits unformatted code for some names. Hand-formatting templates cannot fix this.

Fixed by keeping the newline and running `ruff format` over the files just written. Two safeguards:
- **Only the generated files** — `abi new agent .` targets the user's cwd, so formatting the destination tree would reformat their project. The Copier records exactly what it wrote and formats only that.
- **Best-effort** — ruff is not a runtime dependency of the CLI, so a missing binary is skipped silently. Generated code is valid either way.

Result: generated files failing `ruff format --check` go from **8/11 to 0/11**, verified across name lengths from 1 to 56 characters.

**mypy:** `mypy.ini` gains `follow_untyped_imports`, which the Makefile check targets already pass on the command line. Without it, an ad-hoc `uv run mypy <file>` reported `import-untyped` on any cross-package import — an error the real check does not have. This now also clears on pre-existing files like `cli/agent.py`.

## Tests

- **`Agent_hooks_test.py`** (11) — hooks fire with the right arguments, sub-agent name reported correctly, raising hooks don't break `stream()` or `_notify_ai_message`, return values ignored, and the message handed to `onHumanMessage` is the object fed to the graph.
- **`cli/new/agent_test.py`** (5) — runs the real generator, imports the output, asserts the hooks genuinely override the base, the shipped no-ops are safe, both fire on a real turn via `invoke()` (backed by `FakeListChatModel`), and the scaffold passes both `ruff format --check` and `ruff check` at three name lengths.
- **`cli/utils/Copier_test.py`** (7, new) — trailing newline for Python and non-Python output, format-cleanliness across name lengths, that formatting never touches pre-existing files in the destination, and that generation still succeeds with ruff unavailable.

`Agent_events_test.py`'s `_StubAgent` binds `Agent._notify_ai_message` directly, so it gained the new hook members to keep exercising the real code path.

172 passed in the CLI suite, 24 in the core agent suites; ruff (both the pinned and `uvx` variants the Makefile uses), mypy, and the full pre-commit suite incl. Nexus build pass on every commit.

Two pre-existing failures confirmed **not** caused by this work, each by re-running against the unmodified file at `main`:
- `Agent_test.py::test_agent_stream_invoke` — live-LLM flake (identical `1 failed, 17 passed` on baseline; passes in isolation).
- `deploy/local_test.py::test_setup_local_deploy_hardens_fuseki_for_reliability` — fails identically with the baseline `Copier`.

Also left alone: generated workflow/pipeline/integration scaffolds trip 60 `F401` unused-import warnings under `ruff check`. Those are deliberate scaffold placeholders and predate this PR — the agent scaffold itself is clean.

## Note

Hooks run inline on the streaming thread. Ordering stays deterministic and testable, but a slow hook will stall the turn — documented in `AGENTS.md` and in the scaffold comment. Happy to switch to background-thread dispatch if you'd rather they be non-blocking in the strict sense.