### PR TITLE
feat(new): resolve the framework from the .abi submodule instead of PyPI

### DIFF
--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/project.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/project.py
@@ -17,12 +17,17 @@ ABI_SUBMODULE_URL = "https://github.com/jupyter-naas/abi.git"
 ABI_SUBMODULE_PATH = ".abi"
 
 
-def _add_abi_submodule(project_path: str) -> None:
+def _add_abi_submodule(project_path: str) -> bool:
     """Add the upstream ABI repo as a git submodule at `.abi/`.
 
     Agents working in the scaffolded project can then read framework
-    docs/source locally instead of fetching them over the network.
-    Failures are non-fatal — the project is still usable without it.
+    docs/source locally instead of fetching them over the network, and
+    `pyproject.toml` can point uv at `.abi/libs/*` instead of PyPI.
+
+    Failures are non-fatal — the project is still usable without it, resolving
+    the framework from PyPI. Returns whether `.abi/libs` is actually usable,
+    which is what decides how `pyproject.toml` is rendered; claiming success we
+    do not have would leave uv pointed at paths that don't exist.
     """
     if shutil.which("git") is None:
         click.secho(
@@ -31,7 +36,7 @@ def _add_abi_submodule(project_path: str) -> None:
             f"{ABI_SUBMODULE_URL} {ABI_SUBMODULE_PATH}",
             fg="yellow",
         )
-        return
+        return False
 
     if not os.path.isdir(os.path.join(project_path, ".git")):
         subprocess.run(["git", "init", "-q"], cwd=project_path, check=True)
@@ -57,6 +62,11 @@ def _add_abi_submodule(project_path: str) -> None:
             f"{ABI_SUBMODULE_URL} {ABI_SUBMODULE_PATH}",
             fg="yellow",
         )
+        return False
+
+    # A clone that succeeded but landed an unexpected layout is still unusable
+    # as a dependency source, so check for the directory uv will be told about.
+    return os.path.isdir(os.path.join(project_path, ABI_SUBMODULE_PATH, "libs"))
 
 
 @new.command("project")
@@ -128,6 +138,11 @@ def new_project(
         print(f"Folder {project_path} already exists and is not empty.")
         sys.exit(1)
 
+    # Added before the templates are rendered: whether `.abi/libs` exists is
+    # what decides if `pyproject.toml` resolves the framework from source or
+    # from PyPI, and that has to be baked into the file we are about to write.
+    abi_submodule_added = with_abi_submodule and _add_abi_submodule(project_path)
+
     copier = Copier(
         templates_path=os.path.join(
             os.path.dirname(naas_abi_cli.__file__), "cli/new/templates/project"
@@ -146,14 +161,12 @@ def new_project(
             # When the coding stack is provisioned (`--with-coding`), the config
             # enables the "code" feature flag for workspace admins by default.
             "include_coding": with_coding,
+            "use_local_abi_sources": abi_submodule_added,
         }
     )
 
     # Calling new_module to create the module in the src folder
     new_module(project_name, os.path.join(project_path, "src"), quiet=True)
-
-    if with_abi_submodule:
-        _add_abi_submodule(project_path)
 
     if with_local_deploy:
         setup_local_deploy(

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/project_test.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/project_test.py
@@ -1,0 +1,155 @@
+"""`.abi` submodule detection for `abi new project`.
+
+`_add_abi_submodule`'s return value decides whether the generated
+`pyproject.toml` points uv at `.abi/libs/*` or at PyPI. A false positive is not
+cosmetic: uv gets path sources for directories that do not exist, and the
+`uv add` at the end of project creation fails, so scaffolding dies halfway.
+Every path that does not leave a usable `.abi/libs` must report False.
+"""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+
+project = importlib.import_module("naas_abi_cli.cli.new.project")
+
+_FRAMEWORK_PACKAGES = {
+    "naas-abi",
+    "naas-abi-core",
+    "naas-abi-marketplace",
+    "naas-abi-cli",
+}
+
+
+def _submodule_dir(project_path):
+    return project_path / project.ABI_SUBMODULE_PATH / "libs"
+
+
+def test_returns_false_when_git_is_missing(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(project.shutil, "which", lambda _cmd: None)
+
+    assert project._add_abi_submodule(str(tmp_path)) is False
+
+
+def test_returns_false_when_the_clone_fails(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(project.shutil, "which", lambda _cmd: "/usr/bin/git")
+
+    def fake_run(cmd, **_kwargs):
+        if "submodule" in cmd:
+            raise subprocess.CalledProcessError(1, cmd)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(project.subprocess, "run", fake_run)
+
+    assert project._add_abi_submodule(str(tmp_path)) is False
+
+
+def test_returns_false_when_the_clone_leaves_no_libs(tmp_path, monkeypatch) -> None:
+    """A clone that 'succeeded' but has an unexpected layout is still unusable."""
+    monkeypatch.setattr(project.shutil, "which", lambda _cmd: "/usr/bin/git")
+    monkeypatch.setattr(
+        project.subprocess,
+        "run",
+        lambda cmd, **_kwargs: subprocess.CompletedProcess(cmd, 0),
+    )
+
+    assert project._add_abi_submodule(str(tmp_path)) is False
+
+
+def test_returns_true_when_libs_is_present(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(project.shutil, "which", lambda _cmd: "/usr/bin/git")
+
+    def fake_run(cmd, **_kwargs):
+        if "submodule" in cmd:
+            _submodule_dir(tmp_path).mkdir(parents=True)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(project.subprocess, "run", fake_run)
+
+    assert project._add_abi_submodule(str(tmp_path)) is True
+
+
+def test_git_init_is_skipped_when_already_a_repo(tmp_path, monkeypatch) -> None:
+    """`git submodule add` needs a repo, but re-initialising one is not free."""
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(project.shutil, "which", lambda _cmd: "/usr/bin/git")
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **_kwargs):
+        calls.append(cmd)
+        if "submodule" in cmd:
+            _submodule_dir(tmp_path).mkdir(parents=True)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(project.subprocess, "run", fake_run)
+
+    assert project._add_abi_submodule(str(tmp_path)) is True
+    assert not any("init" in cmd for cmd in calls)
+
+
+# =============================================================================
+# End-to-end wiring: `abi new project` must actually emit the live sources.
+#
+# The conditional above is only useful if `new_project` passes the flag through
+# to the template render, so drive the real command with the network calls
+# (submodule clone, `uv add`, `abi config validate`) stubbed out.
+# =============================================================================
+
+def _run_new_project(tmp_path, monkeypatch, *extra_args, submodule_ok: bool):
+    import tomllib
+
+    from click.testing import CliRunner
+
+    def fake_run(cmd, **kwargs):
+        if "submodule" in cmd and submodule_ok:
+            (tmp_path / "demo" / project.ABI_SUBMODULE_PATH / "libs").mkdir(
+                parents=True, exist_ok=True
+            )
+        elif "submodule" in cmd:
+            raise subprocess.CalledProcessError(1, cmd)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(project.subprocess, "run", fake_run)
+    monkeypatch.setattr(project.shutil, "which", lambda _cmd: "/usr/bin/git")
+
+    result = CliRunner().invoke(
+        project.new_project,
+        ["demo", str(tmp_path), "--domain", "localhost",
+         "--without-local-deploy", *extra_args],
+    )
+    assert result.exit_code == 0, result.output
+
+    generated = (tmp_path / "demo" / "pyproject.toml").read_text(encoding="utf-8")
+    return tomllib.loads(generated), generated
+
+
+def test_new_project_emits_live_sources(tmp_path, monkeypatch) -> None:
+    doc, _ = _run_new_project(tmp_path, monkeypatch, submodule_ok=True)
+
+    sources = doc["tool"]["uv"]["sources"]
+    assert set(sources) == _FRAMEWORK_PACKAGES
+    assert sources["naas-abi-core"] == {
+        "path": ".abi/libs/naas-abi-core",
+        "editable": True,
+    }
+
+
+def test_new_project_falls_back_to_pypi_when_the_clone_fails(
+    tmp_path, monkeypatch
+) -> None:
+    doc, rendered = _run_new_project(tmp_path, monkeypatch, submodule_ok=False)
+
+    assert "sources" not in doc["tool"]["uv"]
+    assert "# [tool.uv.sources]" in rendered
+
+
+def test_new_project_without_the_submodule_flag_uses_pypi(
+    tmp_path, monkeypatch
+) -> None:
+    doc, _ = _run_new_project(
+        tmp_path, monkeypatch, "--without-abi-submodule", submodule_ok=True
+    )
+
+    assert "sources" not in doc["tool"]["uv"]
+

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/pyproject_template_test.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/pyproject_template_test.py
@@ -1,0 +1,87 @@
+"""Render checks for the generated project's ``pyproject.toml``.
+
+A scaffolded project resolves the framework from the ``.abi`` submodule rather
+than PyPI, so it tracks the checked-out source instead of the last published
+release. That only works when ``.abi/libs`` is actually there: ``git`` may be
+missing, the clone may fail, or the user may pass ``--without-abi-submodule``.
+Emitting the path sources in those cases points uv at directories that do not
+exist and breaks project creation outright, so the block is conditional.
+"""
+
+from __future__ import annotations
+
+import os
+import tomllib
+
+import jinja2
+
+import naas_abi_cli
+
+_TEMPLATE = os.path.join(
+    os.path.dirname(naas_abi_cli.__file__),
+    "cli/new/templates/project/pyproject.toml",
+)
+
+_BASE_VALUES = {
+    "project_name": "demo",
+    "project_name_snake": "demo",
+    "project_name_pascal": "Demo",
+    "base_domain": "localhost",
+    "public_web_host": "localhost",
+    "public_api_host": "api.localhost",
+    "include_coding": False,
+}
+
+_FRAMEWORK_PACKAGES = {
+    "naas-abi",
+    "naas-abi-core",
+    "naas-abi-marketplace",
+    "naas-abi-cli",
+}
+
+
+def _render(*, use_local_abi_sources: bool) -> tuple[dict, str]:
+    src = open(_TEMPLATE, encoding="utf-8").read()
+    rendered = jinja2.Template(src).render(
+        {**_BASE_VALUES, "use_local_abi_sources": use_local_abi_sources}
+    )
+    # Parsing also asserts the render is valid TOML.
+    return tomllib.loads(rendered), rendered
+
+
+def test_sources_are_live_when_the_submodule_is_present() -> None:
+    doc, _ = _render(use_local_abi_sources=True)
+
+    sources = doc["tool"]["uv"]["sources"]
+    assert set(sources) == _FRAMEWORK_PACKAGES
+    for package, spec in sources.items():
+        assert spec["editable"] is True
+        assert spec["path"] == f".abi/libs/{package}"
+
+
+def test_no_sources_without_the_submodule() -> None:
+    """Live path sources here would point uv at directories that don't exist."""
+    doc, _ = _render(use_local_abi_sources=False)
+
+    assert "sources" not in doc["tool"]["uv"]
+
+
+def test_the_pypi_variant_still_documents_how_to_switch() -> None:
+    _, rendered = _render(use_local_abi_sources=False)
+
+    assert "git submodule add" in rendered
+    assert "# [tool.uv.sources]" in rendered
+
+
+def test_the_override_survives_both_variants() -> None:
+    """The onnxruntime pin is unrelated to sourcing and must not be lost."""
+    for use_local in (True, False):
+        doc, _ = _render(use_local_abi_sources=use_local)
+        assert doc["tool"]["uv"]["override-dependencies"] == ["onnxruntime<1.26"]
+
+
+def test_project_metadata_is_unaffected_by_the_switch() -> None:
+    for use_local in (True, False):
+        doc, _ = _render(use_local_abi_sources=use_local)
+        assert doc["project"]["name"] == "demo"
+        assert doc["build-system"]["build-backend"] == "setuptools.build_meta"

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/project/pyproject.toml
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/project/pyproject.toml
@@ -20,8 +20,23 @@ where = ["src"]
 override-dependencies = ["onnxruntime<1.26"]
 
 
+{% if use_local_abi_sources -%}
+# Resolve the framework from the `.abi` submodule rather than PyPI, so this
+# project tracks the checked-out source instead of the last published release.
+# Clone with `--recursive` (or run `git submodule update --init`) or these
+# paths will be empty and `uv sync` will fail.
+[tool.uv.sources]
+naas-abi = { path = ".abi/libs/naas-abi",  editable = true }
+naas-abi-core = { path = ".abi/libs/naas-abi-core",  editable = true }
+naas-abi-marketplace = { path = ".abi/libs/naas-abi-marketplace",  editable = true }
+naas-abi-cli = { path = ".abi/libs/naas-abi-cli",  editable = true }
+{%- else -%}
+# To resolve the framework from source instead of PyPI, add the submodule
+#   git submodule add https://github.com/jupyter-naas/abi.git .abi
+# then uncomment the block below and re-run `uv sync`.
 # [tool.uv.sources]
 # naas-abi = { path = ".abi/libs/naas-abi",  editable = true }
 # naas-abi-core = { path = ".abi/libs/naas-abi-core",  editable = true }
 # naas-abi-marketplace = { path = ".abi/libs/naas-abi-marketplace",  editable = true }
 # naas-abi-cli = { path = ".abi/libs/naas-abi-cli",  editable = true }
+{%- endif %}


### PR DESCRIPTION
## Problem

`abi new project` already adds `jupyter-naas/abi` as a git submodule at `.abi/`
(default on), but the generated `pyproject.toml` shipped the `[tool.uv.sources]`
block **commented out**:

```toml
# [tool.uv.sources]
# naas-abi = { path = ".abi/libs/naas-abi",  editable = true }
# ...
```

So every scaffolded project resolved `naas-abi*` from PyPI and sat on the last
*published* release, even though the matching source was sitting right there in
`.abi/libs/`.

That gap is not theoretical. A project created this morning was still running
`naas-abi-core 2.21.1` / `naas-abi-cli 2.11.1` hours after #1152 and #1153
merged, because `naas-abi-core 2.22.0` had not reached PyPI yet — so it kept
paying the slow-boot cost both PRs had already fixed on `main`.

## Change

Uncomment the block by default, so a new project tracks the checked-out source.

The block is **conditional**, because emitting path sources we cannot back is
worse than not emitting them at all — uv would be pointed at directories that
do not exist and the `uv add` at the end of scaffolding would fail outright,
killing project creation halfway. Three real paths lead there:

- `git` is not on PATH (already handled, non-fatally, today)
- the submodule clone fails (already handled, non-fatally, today)
- the user passes `--without-abi-submodule`

So `_add_abi_submodule()` now returns whether `.abi/libs` **actually landed** —
checking the directory, not just the exit code, since a clone that "succeeded"
into an unexpected layout is equally unusable — and that decides how
`pyproject.toml` renders. When it did not land, the generated file keeps the
commented hint plus the exact `git submodule add` command to switch later.

The submodule add moved ahead of the template render, since the decision has to
be baked into the file being written.

## Notes for reviewers

- **The template stays Jinja, not valid TOML.** That is consistent with the rest
  of the directory (`{{pipeline_name_pascal}}Pipeline.py` and friends are not
  valid Python either), and `Makefile:638` already excludes
  `libs/naas-abi-cli/naas_abi_cli/cli/new/templates` from the ruff gate. Both
  renders are asserted to parse as TOML in the tests.
- **Docker still builds**: the generated `Dockerfile` does `COPY . .` before
  `uv sync`, there is no `.dockerignore`, and `.abi` is not gitignored — so the
  submodule is in the build context.
- **Consumers must clone recursively.** A plain `git clone` of a generated
  project leaves `.abi` empty and `uv sync` fails. The generated comment says
  so explicitly.
- This makes new projects track the submodule's `main` (cloned `--depth 1`)
  rather than pinned PyPI releases. That is the intent, but it is a real change
  in what a fresh project is pinned to.

## Tests

16 new tests, all passing.

`project_test.py` — the `_add_abi_submodule` contract (git missing, clone
failure, clone-without-`libs`, success, `git init` skipped when already a repo)
plus three end-to-end tests that drive the real `new_project` command with the
network calls stubbed and assert the **generated** `pyproject.toml`: live
sources on success, PyPI fallback when the clone fails, PyPI fallback under
`--without-abi-submodule`.

`pyproject_template_test.py` — both renders parse as TOML, the source paths and
`editable` flags are correct, the PyPI variant still documents how to switch,
and the `onnxruntime` override and project metadata survive both branches.

Full `naas-abi-cli` suite: **180 passed, 1 failed** — the one failure
(`local_test.py::test_setup_local_deploy_hardens_fuseki_for_reliability`) is
**pre-existing**, verified identical on an untouched `main` checkout. Repo lint
gate (`Makefile:638`) clean; full pre-commit suite (ruff, mypy, bandit, Nexus
build) passed.