### PR TITLE
feat(onboarding): default new projects to OpenRouter + Gemma 4

### DIFF
--- a/libs/naas-abi-cli/naas_abi_cli/cli/deploy/templates/local/docker-compose.yml
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/deploy/templates/local/docker-compose.yml
@@ -52,9 +52,12 @@ x-abi-template: &abi_template
     # Cached volumes for performance
     - venv_cache:/app/.venv       # Python virtual environment cache
     - huggingface_cache:/root/.cache/huggingface  # Docling / HF model weights
-  # Ollama serves the default chat + embedding models and runs on the *host*,
-  # not in the stack. `host.docker.internal` is built in on Docker Desktop
-  # (macOS/Windows) but not on Linux Docker, where host-gateway supplies it.
+  # Models come from OpenRouter by default, so nothing below is needed out of
+  # the box. It is pre-wired for the opt-in local path: if you enable
+  # `naas_abi_marketplace.ai.ollama` in config.local.yaml, Ollama runs on the
+  # *host*, not in the stack. `host.docker.internal` is built in on Docker
+  # Desktop (macOS/Windows) but not on Linux Docker, where host-gateway
+  # supplies it.
   #
   # LINUX ONLY: host-gateway makes the host *resolvable*, it does not change
   # what Ollama listens on. A stock Linux install binds 127.0.0.1:11434, so

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/config_template_test.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/config_template_test.py
@@ -3,6 +3,12 @@
 The ``code`` feature flag (in-app coding workspaces) must only be enabled when a
 project is generated with the coding stack (``--with-coding`` → ``include_coding``),
 and only for workspace admins (owner + admin) — never for members/viewers.
+
+The AI defaults are pinned here too: every generated config must boot on the
+OpenRouter gateway with Gemma 4 for chat and text-embedding-3-small for
+embeddings. The engine validates ``model_registry`` defaults against the loaded
+modules after boot, so a default naming a model no provider registers is a
+fail-fast crash in every new project.
 """
 
 from __future__ import annotations
@@ -10,14 +16,20 @@ from __future__ import annotations
 import os
 
 import jinja2
+import pytest
 import yaml
 
 import naas_abi_cli
 
-_TEMPLATE = os.path.join(
-    os.path.dirname(naas_abi_cli.__file__),
-    "cli/new/templates/project/config.local.yaml",
+_TEMPLATES_DIR = os.path.join(
+    os.path.dirname(naas_abi_cli.__file__), "cli/new/templates/project"
 )
+_TEMPLATE = os.path.join(_TEMPLATES_DIR, "config.local.yaml")
+
+# Every generated config points at these; the openrouter module registers both.
+_DEFAULT_CHAT_MODEL = "gemma-4-26b-a4b-it"
+_DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small"
+_ALL_CONFIGS = ("config.yaml", "config.local.yaml", "config.remote.yaml")
 
 _BASE_VALUES = {
     "project_name": "Demo",
@@ -29,11 +41,21 @@ _BASE_VALUES = {
 }
 
 
+def _render(filename: str, *, include_coding: bool = False) -> dict:
+    src = open(os.path.join(_TEMPLATES_DIR, filename), encoding="utf-8").read()
+    rendered = jinja2.Template(src).render(
+        {**_BASE_VALUES, "include_coding": include_coding}
+    )
+    return yaml.safe_load(rendered)  # also asserts the render is valid YAML
+
+
 def _render_feature_flags(*, include_coding: bool) -> dict:
-    src = open(_TEMPLATE, encoding="utf-8").read()
-    rendered = jinja2.Template(src).render({**_BASE_VALUES, "include_coding": include_coding})
-    doc = yaml.safe_load(rendered)  # also asserts the render is valid YAML
+    doc = _render("config.local.yaml", include_coding=include_coding)
     return doc["modules"][0]["config"]["nexus_config"]["feature_flags"]
+
+
+def _enabled_modules(doc: dict) -> set[str]:
+    return {m["module"] for m in doc["modules"] if m.get("enabled")}
 
 
 def test_code_enabled_for_admins_when_coding_included() -> None:
@@ -53,3 +75,39 @@ def test_code_absent_when_coding_not_included() -> None:
     assert "code" not in ff["enabled_features"]
     for role in ("owner", "admin", "member", "viewer"):
         assert "code" not in ff["role_baseline"][role]
+
+
+@pytest.mark.parametrize("filename", _ALL_CONFIGS)
+def test_openrouter_is_the_only_ai_provider_enabled(filename: str) -> None:
+    doc = _render(filename)
+    enabled = _enabled_modules(doc)
+
+    assert "naas_abi_marketplace.ai.openrouter" in enabled
+    # Ollama and the other providers ship commented out — enabling two AI
+    # modules would make the registry defaults ambiguous.
+    assert "naas_abi_marketplace.ai.ollama" not in enabled
+    assert "naas_abi_marketplace.ai.chatgpt" not in enabled
+    assert doc["global_config"]["ai_mode"] == "cloud"
+
+
+@pytest.mark.parametrize("filename", _ALL_CONFIGS)
+def test_model_registry_defaults_are_the_cheap_openrouter_pair(filename: str) -> None:
+    registry = _render(filename)["services"]["model_registry"]
+
+    assert registry["default_chat_model"] == _DEFAULT_CHAT_MODEL
+    assert registry["default_embedding_model"] == _DEFAULT_EMBEDDING_MODEL
+
+
+@pytest.mark.parametrize("filename", _ALL_CONFIGS)
+def test_tool_binding_agents_are_pinned_to_the_default_chat_model(
+    filename: str,
+) -> None:
+    """AbiAgent and OntologyEngineerAgent default to claude-sonnet-5 upstream,
+    which the openrouter module does not register — leaving them unpinned
+    crashes a generated project at boot."""
+    naas_abi = next(
+        m for m in _render(filename)["modules"] if m["module"] == "naas_abi"
+    )["config"]
+
+    assert naas_abi["abi_agent_model"] == _DEFAULT_CHAT_MODEL
+    assert naas_abi["ontology_engineer_model"] == _DEFAULT_CHAT_MODEL

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/project.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/project.py
@@ -177,14 +177,15 @@ def new_project(
         )
 
     # Run dependency install without shell to avoid quoting issues on paths with spaces.
-    # ai-ollama is the marketplace extra the generated config.yaml enables: it
-    # serves both default models locally, so the project needs no API keys.
+    # ai-openrouter is the marketplace extra the generated config.yaml enables:
+    # one gateway key serves both defaults — Gemma 4 for chat and
+    # text-embedding-3-small for embeddings.
     subprocess.run(
         [
             "uv",
             "add",
             "naas-abi-core[all]",
-            "naas-abi-marketplace[ai-ollama]",
+            "naas-abi-marketplace[ai-openrouter]",
             "naas-abi",
             "naas-abi-cli",
         ],

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/project/README.md
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/project/README.md
@@ -1,31 +1,22 @@
 # {{ project_name }}
 
-An [ABI](https://github.com/jupyter-naas/abi) project. It runs **locally by
-default** — models are served by Ollama on your machine, so there are **no API
-keys to configure** and no data leaves the box.
+An [ABI](https://github.com/jupyter-naas/abi) project. It runs on
+[OpenRouter](https://openrouter.ai) by default — **one API key** serves chat,
+the agents, and embeddings, so there is a single credential to manage and
+nothing to install locally.
 
 ## Prerequisites
 
 - [uv](https://docs.astral.sh/uv/getting-started/installation/) — Python package manager
-- [Ollama](https://ollama.com/download) — serves the default models
+- An [OpenRouter API key](https://openrouter.ai/keys)
 
-Install Ollama and pull the two default models (~2.2GB total, one time):
-
-```bash
-# macOS
-brew install ollama && brew services start ollama
-# Linux, and inside a WSL distro
-curl -fsSL https://ollama.com/install.sh | sh
-
-ollama pull qwen2.5:3b         # default chat model
-ollama pull nomic-embed-text   # default embedding model
-```
-
-Check it's up:
+Put the key in `.env`:
 
 ```bash
-curl http://localhost:11434/api/tags
+OPENROUTER_API_KEY=sk-or-...
 ```
+
+`uv run abi config validate` prompts for it and writes it there if it's missing.
 
 ## Run it
 
@@ -33,9 +24,7 @@ curl http://localhost:11434/api/tags
 uv run abi dev up
 ```
 
-That's it — no keys, no extra setup. The command prints the URLs it serves.
-
-To chat from the terminal instead:
+The command prints the URLs it serves. To chat from the terminal instead:
 
 ```bash
 uv run abi chat
@@ -47,13 +36,92 @@ uv run abi chat
 
 | Setting | Value |
 |---|---|
-| `global_config.ai_mode` | `local` |
-| Default chat model | `qwen-2.5-3b` (Alibaba Qwen2.5 3B, 32k context, tool-capable) |
-| Default embedding model | `nomic-embed-text` (768 dims, 2048-token input limit) |
-| AI provider module | `naas_abi_marketplace.ai.ollama` |
+| `global_config.ai_mode` | `cloud` |
+| Default chat model | `gemma-4-26b-a4b-it` (Google Gemma 4, 262k context, tool-capable) |
+| Default embedding model | `text-embedding-3-small` (1536 dims, 8k input) |
+| AI provider module | `naas_abi_marketplace.ai.openrouter` |
 | Default agent | `{{ project_name_pascal }}Agent` (in `src/`) |
 
-Two things worth knowing about those numbers:
+Gemma 4 26B-A4B is a sparse mixture-of-experts: 26B total parameters but only
+~4B active per token, so it prices and responds like a small model while still
+reading a 262k context and emitting structured tool calls. Paired with
+`text-embedding-3-small` it is the cheapest default that keeps the agents
+working; both bill through the same OpenRouter key.
+
+`config.local.yaml` (docker-compose) and `config.remote.yaml` (remote
+deployment) use the same two defaults.
+
+### Swapping the chat model
+
+Edit `services.model_registry` in `config.yaml`. Anything the enabled provider
+module registers works, for example:
+
+```yaml
+model_registry:
+  default_chat_model: "gemma-4-31b-it"   # dense sibling, stronger per token
+  default_embedding_model: "text-embedding-3-small"
+```
+
+`AbiAgent` and `OntologyEngineerAgent` bind tools, and `config.yaml` pins them
+to the same default via `abi_agent_model` / `ontology_engineer_model` — change
+those too if you want the agents on a different model from plain chat. Whatever
+you pick must emit **structured tool calls**; a model that only writes prose
+leaves the agents silently answering without ever calling a tool.
+
+### Using another cloud provider
+
+1. Add the API key to `.env`, e.g. `OPENAI_API_KEY=sk-...`
+2. Uncomment the provider module in `config.yaml` (e.g. `ai.chatgpt`) and
+   replace `SECRET_REF` with a secret reference:
+
+{% raw %}
+   ```yaml
+   - module: naas_abi_marketplace.ai.chatgpt
+     enabled: true
+     config:
+       openai_api_key: "{{ secret.OPENAI_API_KEY }}"
+   ```
+{% endraw %}
+
+3. Point `services.model_registry` at that provider's models, e.g.
+   `default_chat_model: "gpt-5"`.
+
+Also add the marketplace extra for the module you enabled:
+
+```bash
+uv add "naas-abi-marketplace[ai-chatgpt]"
+```
+
+> **Why `SECRET_REF` instead of the real snippet in `config.yaml`?** That file
+> is rendered as a Jinja template *before* it is parsed as YAML, so a secret
+> reference is resolved even inside a `#` comment — a commented-out example
+> would make the project prompt for a key you don't have. Hence the placeholder
+> there and the real snippet here.
+
+## Running fully locally instead (Ollama)
+
+If you'd rather keep every token on your machine — no keys, no data leaving the
+box — swap the provider for [Ollama](https://ollama.com/download):
+
+```bash
+uv add "naas-abi-marketplace[ai-ollama]"
+
+# macOS
+brew install ollama && brew services start ollama
+# Linux, and inside a WSL distro
+curl -fsSL https://ollama.com/install.sh | sh
+
+ollama pull qwen2.5:3b         # chat model
+ollama pull nomic-embed-text   # embedding model
+curl http://localhost:11434/api/tags   # check it's up
+```
+
+Then in `config.yaml`: enable the commented `naas_abi_marketplace.ai.ollama`
+module, comment out the `ai.openrouter` one, set `global_config.ai_mode` to
+`local`, and point the defaults (plus `abi_agent_model` /
+`ontology_engineer_model`) at `qwen-2.5-3b` / `nomic-embed-text`.
+
+Two things worth knowing about those local models:
 
 - The chat model asks Ollama for its full 32k context explicitly. Ollama
   otherwise defaults to 4096 whatever the model supports, and truncates
@@ -65,10 +133,40 @@ Two things worth knowing about those numbers:
   documents before embedding them**, or long ones get indexed by their opening
   paragraph alone with nothing to indicate it.
 
+### What a 3B local model can and can't do
+
+Measured through the real agent loop on a fresh project:
+
+| | result |
+|---|---|
+| single-step tool use (8 tools) | 8/8 correct |
+| argument accuracy, incl. typed `int` | 6/6 |
+| routing under a long system prompt | 4/4 |
+| multi-turn with history | 2/2 |
+| **two-step chains with 9 tools bound** | **fails** |
+
+A 3B model is good at chat and one-shot tool use, but multi-step chaining breaks
+as the tool set grows — at 2–4 tools it chains fine, at 9 it does not. `Abi`
+binds 9 tools and delegates via `transfer_to_*`, so its supervisor behaviour is
+the weak spot locally; the scaffolded project agent (5 tools) is comfortable.
+If you need Abi to be reliable, point `abi_agent_model` at a bigger local model
+or back at a cloud provider.
+
+Any Ollama tag works without adding a model file:
+
+```python
+registry.get_chat_model("qwen2.5:1.5b", provider="ollama")
+```
+
+Verify a swapped model by binding a real tool and checking `response.tool_calls`
+is non-empty; Ollama's `capabilities` list is not a reliable signal. Notably
+`qwen2.5-coder` advertises tool support but does not deliver it, and `phi3.5`
+has none.
+
 ### Linux + Docker (`abi deploy local`)
 
 `uv run abi dev up` runs natively and needs nothing extra. The **containerised**
-deployment does, on Linux only.
+deployment does, on Linux only, and only when using Ollama.
 
 Ollama's Linux install listens on `127.0.0.1:11434`. The stack reaches the host
 through `host.docker.internal`, which resolves to the Docker bridge address —
@@ -105,84 +203,6 @@ isn't, set it explicitly:
 ```bash
 export ABI_OLLAMA_BASE_URL=http://$(ip route show default | awk '{print $3}'):11434
 ```
-
-### Using a cloud model instead
-
-Local models are the default, not a limitation. To use a cloud provider:
-
-1. Add the API key to `.env`, e.g. `OPENAI_API_KEY=sk-...`
-2. Uncomment the provider module in `config.yaml` (`ai.chatgpt` or
-   `ai.openrouter`) and replace `SECRET_REF` with a secret reference:
-
-{% raw %}
-   ```yaml
-   - module: naas_abi_marketplace.ai.chatgpt
-     enabled: true
-     config:
-       openai_api_key: "{{ secret.OPENAI_API_KEY }}"
-   ```
-{% endraw %}
-
-3. Set `global_config.ai_mode` to `cloud`.
-4. Point `services.model_registry` at that provider's models, e.g.
-   `default_chat_model: "gpt-5"` and
-   `default_embedding_model: "text-embedding-3-large"`.
-
-Also add the marketplace extra for the module you enabled:
-
-```bash
-uv add "naas-abi-marketplace[ai-chatgpt]"
-```
-
-> **Why `SECRET_REF` instead of the real snippet in `config.yaml`?** That file
-> is rendered as a Jinja template *before* it is parsed as YAML, so a secret
-> reference is resolved even inside a `#` comment — a commented-out example
-> would make the project prompt for a key you don't have. Hence the placeholder
-> there and the real snippet here.
-
-### What the local default can and can't do
-
-Measured through the real agent loop on a fresh project:
-
-| | result |
-|---|---|
-| single-step tool use (8 tools) | 8/8 correct |
-| argument accuracy, incl. typed `int` | 6/6 |
-| routing under a long system prompt | 4/4 |
-| multi-turn with history | 2/2 |
-| **two-step chains with 9 tools bound** | **fails** |
-
-A 3B model is good at chat and one-shot tool use, but multi-step chaining breaks
-as the tool set grows — at 2–4 tools it chains fine, at 9 it does not. `Abi`
-binds 9 tools and delegates via `transfer_to_*`, so its supervisor behaviour is
-the weak spot locally; the scaffolded project agent (5 tools) is comfortable.
-
-If you need Abi to be reliable, point `abi_agent_model` in `config.yaml` at a
-bigger local model or a cloud provider.
-
-### Swapping the local model
-
-Qwen2.5 3B supports tool calling, so the same model backs plain chat and the
-agents that bind tools (`AbiAgent`, `OntologyEngineerAgent`). Any Ollama tag
-works without adding a model file — e.g. on a constrained machine:
-
-```bash
-ollama pull qwen2.5:1.5b   # ~1GB, but weaker at tool routing (6/8 vs 8/8)
-```
-
-```python
-registry.get_chat_model("qwen2.5:1.5b", provider="ollama")
-```
-
-To change the defaults project-wide, edit `services.model_registry` in
-`config.yaml`.
-
-If you swap the chat model, pick one that emits **structured tool calls** —
-`AbiAgent` and `OntologyEngineerAgent` bind tools and silently stop working
-otherwise (they just answer in prose and never call the tool). Verify by binding
-a real tool and checking `response.tool_calls` is non-empty; Ollama's
-`capabilities` list is not a reliable signal. Notably `qwen2.5-coder` advertises
-tool support but does not deliver it, and `phi3.5` has none.
 
 ## Project layout
 

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/project/config.local.yaml
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/project/config.local.yaml
@@ -11,41 +11,30 @@ api:
     - "https://{{ secret.PUBLIC_API_HOST }}"
 
 global_config:
-  # Local by default: models are served by Ollama, so the stack starts with no
-  # API keys. Switch to "cloud" when you enable a cloud provider module below.
-  ai_mode: "local"
+  # Cloud by default: models are served through the OpenRouter gateway, so a
+  # single OPENROUTER_API_KEY covers chat, agents and embeddings. Switch to
+  # "local" when you enable the Ollama module below instead.
+  ai_mode: "cloud"
   public_api_host: "{{ secret.PUBLIC_API_HOST }}"
 
 opencode:
   auth_file_path: "~/.local/share/opencode/auth.json"
-  # No providers by default — the coding agent needs a cloud model, and listing
-  # one here would make the project prompt for an API key on first boot.
-  #
-  # To enable one: add its key to .env, uncomment the block, and replace
-  # SECRET_REF with a Jinja secret reference for that variable (see the README
-  # section "Using a cloud model instead" for the exact snippet — it cannot be
-  # written here, because this file is Jinja-rendered before it is parsed as
-  # YAML, so even a commented-out reference would be resolved and prompt).
-  #
-  # providers:
-  #   - id: "openrouter"
-  #     key: "SECRET_REF"
-  #     type: "api"
-  #   - id: "openai"
-  #     key: "SECRET_REF"
-  #     type: "api"
-  providers: []
+  # The coding agent reuses the same gateway key as the rest of the stack.
+  providers:
+    - id: "openrouter"
+      key: "{{ secret.OPENROUTER_API_KEY }}"
+      type: "api"
 
 modules:
   - module: naas_abi
     enabled: true
     config:
       # AbiAgent and OntologyEngineerAgent bind tools. Both default to
-      # "claude-sonnet-5" upstream, which would fail at boot with no cloud
-      # module enabled, so they are pinned to the local default — Qwen2.5 3B
-      # supports tool calling, so one model covers chat and agents alike.
-      abi_agent_model: "qwen-2.5-3b"
-      ontology_engineer_model: "qwen-2.5-3b"
+      # "claude-sonnet-5" upstream, which the openrouter module does not
+      # register, so they are pinned to the project default — Gemma 4 supports
+      # tool calling, so one model covers chat and agents alike.
+      abi_agent_model: "gemma-4-26b-a4b-it"
+      ontology_engineer_model: "gemma-4-26b-a4b-it"
       nexus_config:
         frontend_url: "https://{{ secret.PUBLIC_WEB_HOST }}"
         database_url: "postgresql+asyncpg://{{ secret.POSTGRES_USER }}:{{ secret.POSTGRES_PASSWORD }}@postgres:5432/nexus"
@@ -118,33 +107,40 @@ modules:
                   - email: "admin@example.com"
                     role: "owner"
 
-  # Local models via Ollama — the only AI provider enabled by default, so the
-  # stack boots with zero credentials.
-  #
-  # Prerequisite on the Docker host (one time):
-  #   ollama pull qwen2.5:3b && ollama pull nomic-embed-text
-  #
-  # Ollama runs on the host, not in the stack, so the container reaches it via
-  # host.docker.internal (compose maps that to host-gateway for Linux Docker).
-  # docker-compose.yml sets ABI_OLLAMA_BASE_URL, which this default mirrors.
-  - module: naas_abi_marketplace.ai.ollama
+  # OpenRouter — the only AI provider enabled by default. One gateway key
+  # serves both the default chat model (Gemma 4 26B-A4B) and the default
+  # embedding model (text-embedding-3-small), so there is a single credential
+  # to manage. Get a key at https://openrouter.ai/keys and put it in .env as
+  # OPENROUTER_API_KEY.
+  - module: naas_abi_marketplace.ai.openrouter
     enabled: true
     config:
-      base_url: "http://host.docker.internal:11434"
+      openrouter_api_key: "{{ secret.OPENROUTER_API_KEY }}"
 
-  # Cloud providers are opt-in. To switch: add the key to .env, uncomment the
-  # block, replace SECRET_REF as the README describes, set global_config.ai_mode
-  # to "cloud", and update the model_registry defaults below.
+  # Local models via Ollama are opt-in — no credentials, nothing leaves the
+  # box. Ollama runs on the Docker host, not in the stack, so the container
+  # reaches it via host.docker.internal (compose maps that to host-gateway for
+  # Linux Docker). To switch: uncomment the block, run
+  #   ollama pull qwen2.5:3b && ollama pull nomic-embed-text
+  # on the host, set global_config.ai_mode to "local", and point the
+  # model_registry defaults below at "qwen-2.5-3b" / "nomic-embed-text".
+  # Install the extra with `uv add "naas-abi-marketplace[ai-ollama]"`.
+  #
+  # - module: naas_abi_marketplace.ai.ollama
+  #   enabled: true
+  #   config:
+  #     base_url: "http://host.docker.internal:11434"
+  #
+  # Other cloud providers work the same way. Add the key to .env, uncomment the
+  # block, and replace SECRET_REF with a Jinja secret reference for that
+  # variable (it cannot be written here, because this file is Jinja-rendered
+  # before it is parsed as YAML, so even a commented-out reference would be
+  # resolved and prompt).
   #
   # - module: naas_abi_marketplace.ai.chatgpt
   #   enabled: true
   #   config:
   #     openai_api_key: "SECRET_REF"
-  #
-  # - module: naas_abi_marketplace.ai.openrouter
-  #   enabled: true
-  #   config:
-  #     openrouter_api_key: "SECRET_REF"
 {% endraw %}
   - module: {{ project_name_snake }}
     enabled: true
@@ -153,19 +149,22 @@ default_agent: "{{ project_name_snake }} {{ project_name_pascal }}Agent"
 
 {% raw %}
 services:
-  # Default models for the in-memory model registry, both served locally by the
-  # naas_abi_marketplace.ai.ollama module: Qwen2.5 3B for chat and
-  # nomic-embed-text for embeddings. The values are the models' canonical ids,
+  # Default models for the in-memory model registry, both served by the
+  # naas_abi_marketplace.ai.openrouter module: Gemma 4 26B-A4B for chat and
+  # text-embedding-3-small for embeddings — a cheap pairing that still supports
+  # tool calling and a 262k context. The values are the models' canonical ids,
   # so agents with no explicit model fall back to these.
   #
   # These are validated after modules load — if a default can't be resolved the
   # engine fails fast, so keep them in step with the enabled modules above.
-  # Cloud equivalents, once you enable those modules:
-  #   default_chat_model: "claude-opus-4.8"        # ai.openrouter
-  #   default_embedding_model: "text-embedding-3-large"  # ai.chatgpt
+  # Alternatives, once the matching module is enabled:
+  #   default_chat_model: "gemma-4-31b-it"   # ai.openrouter, dense, stronger
+  #   default_chat_model: "claude-opus-4.8"  # ai.openrouter, frontier, pricier
+  #   default_chat_model: "qwen-2.5-3b"      # ai.ollama, local
+  #   default_embedding_model: "nomic-embed-text"  # ai.ollama, local
   model_registry:
-    default_chat_model: "qwen-2.5-3b"
-    default_embedding_model: "nomic-embed-text"
+    default_chat_model: "gemma-4-26b-a4b-it"
+    default_embedding_model: "text-embedding-3-small"
   secret:
     secret_adapters:
       - adapter: "dotenv"

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/project/config.remote.yaml
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/project/config.remote.yaml
@@ -11,66 +11,67 @@ api:
     - "https://{{ secret.PUBLIC_API_HOST }}"
 
 global_config:
-  # Local by default: models are served by Ollama, so the stack starts with no
-  # API keys. Switch to "cloud" when you enable a cloud provider module below.
-  ai_mode: "local"
+  # Cloud by default: models are served through the OpenRouter gateway, so a
+  # single OPENROUTER_API_KEY covers chat, agents and embeddings — and the
+  # remote host needs no inference hardware of its own.
+  ai_mode: "cloud"
   public_api_host: "{{ secret.PUBLIC_API_HOST }}"
 
 opencode:
   auth_file_path: "~/.local/share/opencode/auth.json"
-  # No providers by default — the coding agent needs a cloud model, and listing
-  # one here would make the project prompt for an API key on first boot.
-  #
-  # To enable one: add its key to .env, uncomment the block, and replace
-  # SECRET_REF with a Jinja secret reference for that variable (see the README
-  # section "Using a cloud model instead" for the exact snippet — it cannot be
-  # written here, because this file is Jinja-rendered before it is parsed as
-  # YAML, so even a commented-out reference would be resolved and prompt).
-  #
-  # providers:
-  #   - id: "openrouter"
-  #     key: "SECRET_REF"
-  #     type: "api"
-  #   - id: "openai"
-  #     key: "SECRET_REF"
-  #     type: "api"
-  providers: []
+  # The coding agent reuses the same gateway key as the rest of the stack.
+  providers:
+    - id: "openrouter"
+      key: "{{ secret.OPENROUTER_API_KEY }}"
+      type: "api"
 
 modules:
   - module: naas_abi
     enabled: true
     config:
       # AbiAgent and OntologyEngineerAgent bind tools. Both default to
-      # "claude-sonnet-5" upstream, which would fail at boot with no cloud
-      # module enabled, so they are pinned to the local default — Qwen2.5 3B
-      # supports tool calling, so one model covers chat and agents alike.
-      abi_agent_model: "qwen-2.5-3b"
-      ontology_engineer_model: "qwen-2.5-3b"
+      # "claude-sonnet-5" upstream, which the openrouter module does not
+      # register, so they are pinned to the project default — Gemma 4 supports
+      # tool calling, so one model covers chat and agents alike.
+      abi_agent_model: "gemma-4-26b-a4b-it"
+      ontology_engineer_model: "gemma-4-26b-a4b-it"
       nexus_config:
         database_url: "postgresql+asyncpg://{{ secret.POSTGRES_USER }}:{{ secret.POSTGRES_PASSWORD }}@{{ secret.POSTGRES_HOST }}:{{ secret.POSTGRES_PORT }}/nexus"
         # Enable password login by default so first sign-in works without an SMTP
         # setup (magic-link email). Configure SMTP + set this false to require it.
         auth_password_enabled: true
 
-  # Local models via Ollama — enabled by default so a remote deployment starts
-  # without credentials too. A remote host needs an Ollama server reachable from
-  # the app: run one alongside it and point ABI_OLLAMA_BASE_URL (or `base_url`
-  # below) at it, e.g. http://ollama:11434 on the same network.
-  #
-  # For a hosted deployment serving many users, a cloud provider is usually the
-  # better trade — uncomment one below and swap the model_registry defaults.
-  - module: naas_abi_marketplace.ai.ollama
+  # OpenRouter — the only AI provider enabled by default. One gateway key
+  # serves both the default chat model (Gemma 4 26B-A4B) and the default
+  # embedding model (text-embedding-3-small). For a hosted deployment serving
+  # many users this is usually the right trade: no inference hardware to run,
+  # and one credential to rotate. Get a key at https://openrouter.ai/keys and
+  # put it in .env.remote as OPENROUTER_API_KEY.
+  - module: naas_abi_marketplace.ai.openrouter
     enabled: true
+    config:
+      openrouter_api_key: "{{ secret.OPENROUTER_API_KEY }}"
 
+  # Local models via Ollama are opt-in. A remote host needs an Ollama server
+  # reachable from the app: run one alongside it and point ABI_OLLAMA_BASE_URL
+  # (or `base_url` below) at it, e.g. http://ollama:11434 on the same network.
+  # Then set global_config.ai_mode to "local" and point the model_registry
+  # defaults below at "qwen-2.5-3b" / "nomic-embed-text". Install the extra with
+  # `uv add "naas-abi-marketplace[ai-ollama]"`.
+  #
+  # - module: naas_abi_marketplace.ai.ollama
+  #   enabled: true
+  #
+  # Other cloud providers work the same way. Add the key to .env.remote,
+  # uncomment the block, and replace SECRET_REF with a Jinja secret reference
+  # for that variable (it cannot be written here, because this file is
+  # Jinja-rendered before it is parsed as YAML, so even a commented-out
+  # reference would be resolved and prompt).
+  #
   # - module: naas_abi_marketplace.ai.chatgpt
   #   enabled: true
   #   config:
   #     openai_api_key: "SECRET_REF"
-  #
-  # - module: naas_abi_marketplace.ai.openrouter
-  #   enabled: true
-  #   config:
-  #     openrouter_api_key: "SECRET_REF"
 {% endraw %}
   - module: {{ project_name_snake }}
     enabled: true
@@ -79,19 +80,22 @@ default_agent: "{{ project_name_snake }} {{ project_name_pascal }}Agent"
 
 {% raw %}
 services:
-  # Default models for the in-memory model registry, both served locally by the
-  # naas_abi_marketplace.ai.ollama module: Qwen2.5 3B for chat and
-  # nomic-embed-text for embeddings. The values are the models' canonical ids,
+  # Default models for the in-memory model registry, both served by the
+  # naas_abi_marketplace.ai.openrouter module: Gemma 4 26B-A4B for chat and
+  # text-embedding-3-small for embeddings — a cheap pairing that still supports
+  # tool calling and a 262k context. The values are the models' canonical ids,
   # so agents with no explicit model fall back to these.
   #
   # These are validated after modules load — if a default can't be resolved the
   # engine fails fast, so keep them in step with the enabled modules above.
-  # Cloud equivalents, once you enable those modules:
-  #   default_chat_model: "claude-opus-4.8"        # ai.openrouter
-  #   default_embedding_model: "text-embedding-3-large"  # ai.chatgpt
+  # Alternatives, once the matching module is enabled:
+  #   default_chat_model: "gemma-4-31b-it"   # ai.openrouter, dense, stronger
+  #   default_chat_model: "claude-opus-4.8"  # ai.openrouter, frontier, pricier
+  #   default_chat_model: "qwen-2.5-3b"      # ai.ollama, local
+  #   default_embedding_model: "nomic-embed-text"  # ai.ollama, local
   model_registry:
-    default_chat_model: "qwen-2.5-3b"
-    default_embedding_model: "nomic-embed-text"
+    default_chat_model: "gemma-4-26b-a4b-it"
+    default_embedding_model: "text-embedding-3-small"
   secret:
     secret_adapters:
       - adapter: "dotenv"

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/project/config.yaml
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/project/config.yaml
@@ -11,42 +11,30 @@ api:
     - "https://{{ secret.PUBLIC_API_HOST }}"
 
 global_config:
-  # Local by default: models are served by Ollama on this machine, so a fresh
-  # project runs with no API keys and no data leaving the box. Switch to
-  # "cloud" when you enable a cloud provider module below.
-  ai_mode: "local"
+  # Cloud by default: models are served through the OpenRouter gateway, so a
+  # single OPENROUTER_API_KEY covers chat, agents and embeddings. Switch to
+  # "local" when you enable the Ollama module below instead.
+  ai_mode: "cloud"
   public_api_host: "{{ secret.PUBLIC_API_HOST }}"
 
 opencode:
   auth_file_path: "~/.local/share/opencode/auth.json"
-  # No providers by default — the coding agent needs a cloud model, and listing
-  # one here would make the project prompt for an API key on first boot.
-  #
-  # To enable one: add its key to .env, uncomment the block, and replace
-  # SECRET_REF with a Jinja secret reference for that variable (see the README
-  # section "Using a cloud model instead" for the exact snippet — it cannot be
-  # written here, because this file is Jinja-rendered before it is parsed as
-  # YAML, so even a commented-out reference would be resolved and prompt).
-  #
-  # providers:
-  #   - id: "openrouter"
-  #     key: "SECRET_REF"
-  #     type: "api"
-  #   - id: "openai"
-  #     key: "SECRET_REF"
-  #     type: "api"
-  providers: []
+  # The coding agent reuses the same gateway key as the rest of the project.
+  providers:
+    - id: "openrouter"
+      key: "{{ secret.OPENROUTER_API_KEY }}"
+      type: "api"
 
 modules:
   - module: naas_abi
     enabled: true
     config:
       # AbiAgent and OntologyEngineerAgent bind tools. Both default to
-      # "claude-sonnet-5" upstream, which would fail at boot with no cloud
-      # module enabled, so they are pinned to the local default — Qwen2.5 3B
-      # supports tool calling, so one model covers chat and agents alike.
-      abi_agent_model: "qwen-2.5-3b"
-      ontology_engineer_model: "qwen-2.5-3b"
+      # "claude-sonnet-5" upstream, which the openrouter module does not
+      # register, so they are pinned to the project default — Gemma 4 supports
+      # tool calling, so one model covers chat and agents alike.
+      abi_agent_model: "gemma-4-26b-a4b-it"
+      ontology_engineer_model: "gemma-4-26b-a4b-it"
       nexus_config:
         database_url: "sqlite+aiosqlite:///./storage/nexus.db"
         # Dev convenience: enable password login + seed an admin user. The
@@ -72,31 +60,36 @@ modules:
                   - email: "admin@example.com"
                     role: "owner"
 
-  # Local models via Ollama — the only AI provider enabled by default, so the
-  # project boots with zero credentials. Serves both the default chat model
-  # (Qwen2.5 3B) and the default embedding model (nomic-embed-text).
-  #
-  # Prerequisite (one time):
-  #   ollama pull qwen2.5:3b && ollama pull nomic-embed-text
-  #
-  # The endpoint is auto-detected — localhost, or the Windows host when running
-  # under WSL. Override with ABI_OLLAMA_BASE_URL or a `base_url` config key.
-  - module: naas_abi_marketplace.ai.ollama
+  # OpenRouter — the only AI provider enabled by default. One gateway key
+  # serves both the default chat model (Gemma 4 26B-A4B) and the default
+  # embedding model (text-embedding-3-small), so there is a single credential
+  # to manage. Get a key at https://openrouter.ai/keys and put it in .env as
+  # OPENROUTER_API_KEY.
+  - module: naas_abi_marketplace.ai.openrouter
     enabled: true
+    config:
+      openrouter_api_key: "{{ secret.OPENROUTER_API_KEY }}"
 
-  # Cloud providers are opt-in. To switch: add the key to .env, uncomment the
-  # block, replace SECRET_REF as the README describes, set global_config.ai_mode
-  # to "cloud", and update the model_registry defaults below.
+  # Local models via Ollama are opt-in — no credentials, nothing leaves the
+  # box. To switch: uncomment the block, run
+  #   ollama pull qwen2.5:3b && ollama pull nomic-embed-text
+  # set global_config.ai_mode to "local", and point the model_registry defaults
+  # below at "qwen-2.5-3b" / "nomic-embed-text". Install the extra with
+  # `uv add "naas-abi-marketplace[ai-ollama]"`.
+  #
+  # - module: naas_abi_marketplace.ai.ollama
+  #   enabled: true
+  #
+  # Other cloud providers work the same way. Add the key to .env, uncomment the
+  # block, and replace SECRET_REF with a Jinja secret reference for that
+  # variable (it cannot be written here, because this file is Jinja-rendered
+  # before it is parsed as YAML, so even a commented-out reference would be
+  # resolved and prompt).
   #
   # - module: naas_abi_marketplace.ai.chatgpt
   #   enabled: true
   #   config:
   #     openai_api_key: "SECRET_REF"
-  #
-  # - module: naas_abi_marketplace.ai.openrouter
-  #   enabled: true
-  #   config:
-  #     openrouter_api_key: "SECRET_REF"
 {% endraw %}
   - module: {{ project_name_snake }}
     enabled: true
@@ -105,19 +98,22 @@ default_agent: "{{ project_name_snake }} {{ project_name_pascal }}Agent"
 
 {% raw %}
 services:
-  # Default models for the in-memory model registry, both served locally by the
-  # naas_abi_marketplace.ai.ollama module: Qwen2.5 3B for chat and
-  # nomic-embed-text for embeddings. The values are the models' canonical ids,
+  # Default models for the in-memory model registry, both served by the
+  # naas_abi_marketplace.ai.openrouter module: Gemma 4 26B-A4B for chat and
+  # text-embedding-3-small for embeddings — a cheap pairing that still supports
+  # tool calling and a 262k context. The values are the models' canonical ids,
   # so agents with no explicit model fall back to these.
   #
   # These are validated after modules load — if a default can't be resolved the
   # engine fails fast, so keep them in step with the enabled modules above.
-  # Cloud equivalents, once you enable those modules:
-  #   default_chat_model: "claude-opus-4.8"        # ai.openrouter
-  #   default_embedding_model: "text-embedding-3-large"  # ai.chatgpt
+  # Alternatives, once the matching module is enabled:
+  #   default_chat_model: "gemma-4-31b-it"   # ai.openrouter, dense, stronger
+  #   default_chat_model: "claude-opus-4.8"  # ai.openrouter, frontier, pricier
+  #   default_chat_model: "qwen-2.5-3b"      # ai.ollama, local
+  #   default_embedding_model: "nomic-embed-text"  # ai.ollama, local
   model_registry:
-    default_chat_model: "qwen-2.5-3b"
-    default_embedding_model: "nomic-embed-text"
+    default_chat_model: "gemma-4-26b-a4b-it"
+    default_embedding_model: "text-embedding-3-small"
   secret:
     secret_adapters:
       - adapter: "dotenv"

--- a/libs/naas-abi-cli/uv.lock
+++ b/libs/naas-abi-cli/uv.lock
@@ -2668,7 +2668,7 @@ requires-dist = [
     { name = "yahooquery", marker = "extra == 'applications-yahoofinance'", specifier = "==2.4.1" },
     { name = "yfinance", marker = "extra == 'applications-yahoofinance'", specifier = "==0.2.66" },
 ]
-provides-extras = ["ai-bedrock", "ai-chatgpt", "ai-claude", "ai-deepseek", "ai-gemini", "ai-gemma", "ai-grok", "ai-llama", "ai-mistral", "ai-ollama", "ai-perplexity", "ai-qwen", "applications-agicap", "applications-airtable", "applications-algolia", "applications-arxiv", "applications-bodo", "applications-datagouv", "applications-exchangeratesapi", "applications-git", "applications-github", "applications-gmail", "applications-google-calendar", "applications-google-drive", "applications-google-sheets", "applications-googlesearch", "applications-hubspot", "applications-linkedin", "applications-naas", "applications-nebari", "applications-newsapi", "applications-notion", "applications-openrouter", "applications-openweathermap", "applications-pennylane", "applications-postgres", "applications-powerpoint", "applications-pubmed", "applications-sanax", "applications-sendgrid", "applications-sharepoint", "applications-spotify", "applications-twilio", "applications-worldbank", "applications-yahoofinance", "domains-ontology-engineer", "domains-document"]
+provides-extras = ["ai-bedrock", "ai-chatgpt", "ai-claude", "ai-deepseek", "ai-gemini", "ai-gemma", "ai-grok", "ai-llama", "ai-mistral", "ai-ollama", "ai-openrouter", "ai-perplexity", "ai-qwen", "applications-agicap", "applications-airtable", "applications-algolia", "applications-arxiv", "applications-bodo", "applications-datagouv", "applications-exchangeratesapi", "applications-git", "applications-github", "applications-gmail", "applications-google-calendar", "applications-google-drive", "applications-google-sheets", "applications-googlesearch", "applications-hubspot", "applications-linkedin", "applications-naas", "applications-nebari", "applications-newsapi", "applications-notion", "applications-openrouter", "applications-openweathermap", "applications-pennylane", "applications-postgres", "applications-powerpoint", "applications-pubmed", "applications-sanax", "applications-sendgrid", "applications-sharepoint", "applications-spotify", "applications-twilio", "applications-worldbank", "applications-yahoofinance", "domains-ontology-engineer", "domains-document"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -4551,8 +4551,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [

--- a/libs/naas-abi-core/naas_abi_core/models/Model.py
+++ b/libs/naas-abi-core/naas_abi_core/models/Model.py
@@ -86,6 +86,8 @@ class CanonicalModelId(StrEnum):
     GEMINI_2_5_FLASH = "gemini-2.5-flash"
     GEMINI_2_5_PRO = "gemini-2.5-pro"
     GEMMA_3_27B_IT = "gemma-3-27b-it"
+    GEMMA_4_26B_A4B_IT = "gemma-4-26b-a4b-it"
+    GEMMA_4_31B_IT = "gemma-4-31b-it"
 
     # Chat — xAI family
     GROK_4_1_FAST = "grok-4.1-fast"

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/models/google/gemma_4_26b_a4b_it.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/models/google/gemma_4_26b_a4b_it.py
@@ -1,0 +1,39 @@
+from langchain_openai import ChatOpenAI
+from naas_abi_core.models.Model import (
+    CanonicalModelId,
+    ChatModel,
+    ModelDefinition,
+    ModelProvider,
+)
+from naas_abi_marketplace.ai.openrouter import ABIModule
+from pydantic import SecretStr
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+class Gemma426BA4BItModel(ModelDefinition):
+    """Gemma 4 26B-A4B — a sparse mixture-of-experts with only 4B active
+    parameters, so it prices and responds like a small model while reading a
+    262k context. Tool calling is supported, which is why it can back both
+    plain chat and the tool-binding agents in a generated project.
+    """
+
+    CANONICAL_ID = CanonicalModelId.GEMMA_4_26B_A4B_IT
+    MODEL_ID = "google/gemma-4-26b-a4b-it"
+    PROVIDER = ModelProvider.OPENROUTER
+
+    model: ChatModel = ChatModel(
+        model_id=MODEL_ID,
+        provider=PROVIDER,
+        model=ChatOpenAI(
+            model=MODEL_ID,
+            temperature=0,
+            timeout=120,
+            max_retries=3,
+            api_key=SecretStr(ABIModule.get_instance().configuration.openrouter_api_key),
+            base_url=OPENROUTER_BASE_URL,
+        ),
+    )
+
+
+model: ChatModel = Gemma426BA4BItModel.model

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/models/google/gemma_4_31b_it.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/models/google/gemma_4_31b_it.py
@@ -1,0 +1,38 @@
+from langchain_openai import ChatOpenAI
+from naas_abi_core.models.Model import (
+    CanonicalModelId,
+    ChatModel,
+    ModelDefinition,
+    ModelProvider,
+)
+from naas_abi_marketplace.ai.openrouter import ABIModule
+from pydantic import SecretStr
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+class Gemma431BItModel(ModelDefinition):
+    """Gemma 4 31B — the dense sibling of ``gemma-4-26b-a4b-it``. Stronger per
+    token and slightly pricier; swap the model registry defaults to this
+    canonical id when a generated project needs more headroom.
+    """
+
+    CANONICAL_ID = CanonicalModelId.GEMMA_4_31B_IT
+    MODEL_ID = "google/gemma-4-31b-it"
+    PROVIDER = ModelProvider.OPENROUTER
+
+    model: ChatModel = ChatModel(
+        model_id=MODEL_ID,
+        provider=PROVIDER,
+        model=ChatOpenAI(
+            model=MODEL_ID,
+            temperature=0,
+            timeout=120,
+            max_retries=3,
+            api_key=SecretStr(ABIModule.get_instance().configuration.openrouter_api_key),
+            base_url=OPENROUTER_BASE_URL,
+        ),
+    )
+
+
+model: ChatModel = Gemma431BItModel.model

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/on_load_test.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/ai/openrouter/on_load_test.py
@@ -1,6 +1,7 @@
 """Tests that the openrouter module registers its models against the
 ModelRegistry during on_load — focused on the OpenAI embedding models
-routed through the OpenRouter gateway."""
+routed through the OpenRouter gateway, plus the Gemma 4 chat models a
+generated project defaults to."""
 
 from __future__ import annotations
 
@@ -9,6 +10,7 @@ from naas_abi_core.engine.EngineProxy import EngineProxy
 from naas_abi_core.engine.IEngine import IEngine
 from naas_abi_core.models.Model import (
     CanonicalModelId,
+    ChatModel,
     EmbeddingModel,
     ModelProvider,
 )
@@ -72,5 +74,23 @@ def test_openai_embeddings_register_as_embedding_models_on_openrouter() -> None:
             canonical_id, provider=ModelProvider.OPENROUTER
         )
         assert isinstance(got, EmbeddingModel)
+        assert got.provider == ModelProvider.OPENROUTER
+        assert got.model_id == model_id
+
+
+def test_gemma_4_chat_models_register_on_openrouter() -> None:
+    """`abi new project` points default_chat_model at gemma-4-26b-a4b-it, and
+    names gemma-4-31b-it as the swap-in alternative — both must resolve here or
+    a generated project fails its post-load default validation."""
+    module, registry = _make_module()
+    module.on_load()
+
+    cases = {
+        CanonicalModelId.GEMMA_4_26B_A4B_IT: "google/gemma-4-26b-a4b-it",
+        CanonicalModelId.GEMMA_4_31B_IT: "google/gemma-4-31b-it",
+    }
+    for canonical_id, model_id in cases.items():
+        got = registry.get_chat_model(canonical_id, provider=ModelProvider.OPENROUTER)
+        assert isinstance(got, ChatModel)
         assert got.provider == ModelProvider.OPENROUTER
         assert got.model_id == model_id

--- a/libs/naas-abi-marketplace/pyproject.toml
+++ b/libs/naas-abi-marketplace/pyproject.toml
@@ -92,6 +92,10 @@ ai-mistral = [
 ai-ollama = [
     "langchain-ollama>=0.3.4",
 ]
+# The openrouter gateway speaks the OpenAI wire protocol, so langchain-openai
+# (already a naas-abi-core dependency) is all it needs. The extra exists so a
+# generated project can name the module it enables.
+ai-openrouter = []
 ai-perplexity = [
     "langchain-perplexity>=0.1.2",
 ]

--- a/libs/naas-abi-marketplace/uv.lock
+++ b/libs/naas-abi-marketplace/uv.lock
@@ -782,7 +782,7 @@ name = "cuda-bindings"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/a9/3a8241c6e19483ac1f1dcf5c10238205dcb8a6e9d0d4d4709240dff28ff4/cuda_bindings-13.2.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:721104c603f059780d287969be3d194a18d0cc3b713ed9049065a1107706759d", size = 5730273, upload-time = "2026-03-11T00:12:37.18Z" },
@@ -815,37 +815,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
 ]
 cufft = [
-    { name = "nvidia-cufft" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
 ]
 cufile = [
-    { name = "nvidia-cufile" },
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
 ]
 curand = [
-    { name = "nvidia-curand" },
+    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx" },
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -1797,6 +1797,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/47/16400cb42d18d7a6bb46f0626852c1718612e35dcb0dffa16bbaffdf5dd2/greenlet-3.3.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:c56692189a7d1c7606cb794be0a8381470d95c57ce5be03fb3d0ef57c7853b86", size = 278890, upload-time = "2026-02-20T20:19:39.263Z" },
     { url = "https://files.pythonhosted.org/packages/a3/90/42762b77a5b6aa96cd8c0e80612663d39211e8ae8a6cd47c7f1249a66262/greenlet-3.3.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ebd458fa8285960f382841da585e02201b53a5ec2bac6b156fc623b5ce4499f", size = 581120, upload-time = "2026-02-20T20:47:30.161Z" },
     { url = "https://files.pythonhosted.org/packages/bf/6f/f3d64f4fa0a9c7b5c5b3c810ff1df614540d5aa7d519261b53fba55d4df9/greenlet-3.3.2-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a443358b33c4ec7b05b79a7c8b466f5d275025e750298be7340f8fc63dff2a55", size = 594363, upload-time = "2026-02-20T20:55:56.965Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8b/1430a04657735a3f23116c2e0d5eb10220928846e4537a938a41b350bed6/greenlet-3.3.2-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4375a58e49522698d3e70cc0b801c19433021b5c37686f7ce9c65b0d5c8677d2", size = 605046, upload-time = "2026-02-20T21:02:45.234Z" },
     { url = "https://files.pythonhosted.org/packages/72/83/3e06a52aca8128bdd4dcd67e932b809e76a96ab8c232a8b025b2850264c5/greenlet-3.3.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e2cd90d413acbf5e77ae41e5d3c9b3ac1d011a756d7284d7f3f2b806bbd6358", size = 594156, upload-time = "2026-02-20T20:20:59.955Z" },
     { url = "https://files.pythonhosted.org/packages/70/79/0de5e62b873e08fe3cef7dbe84e5c4bc0e8ed0c7ff131bccb8405cd107c8/greenlet-3.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:442b6057453c8cb29b4fb36a2ac689382fc71112273726e2423f7f17dc73bf99", size = 1554649, upload-time = "2026-02-20T20:49:32.293Z" },
     { url = "https://files.pythonhosted.org/packages/5a/00/32d30dee8389dc36d42170a9c66217757289e2afb0de59a3565260f38373/greenlet-3.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:45abe8eb6339518180d5a7fa47fa01945414d7cca5ecb745346fc6a87d2750be", size = 1619472, upload-time = "2026-02-20T20:21:07.966Z" },
@@ -1805,6 +1806,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
     { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
     { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
     { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
     { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
     { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
@@ -1813,6 +1815,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -1821,6 +1824,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
     { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
     { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
     { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
     { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
     { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
@@ -1829,6 +1833,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
     { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
     { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
     { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
@@ -3563,7 +3568,7 @@ requires-dist = [
     { name = "yahooquery", marker = "extra == 'applications-yahoofinance'", specifier = "==2.4.1" },
     { name = "yfinance", marker = "extra == 'applications-yahoofinance'", specifier = "==0.2.66" },
 ]
-provides-extras = ["ai-bedrock", "ai-chatgpt", "ai-claude", "ai-deepseek", "ai-gemini", "ai-gemma", "ai-grok", "ai-llama", "ai-mistral", "ai-ollama", "ai-perplexity", "ai-qwen", "applications-agicap", "applications-airtable", "applications-algolia", "applications-arxiv", "applications-bodo", "applications-datagouv", "applications-exchangeratesapi", "applications-git", "applications-github", "applications-gmail", "applications-google-calendar", "applications-google-drive", "applications-google-sheets", "applications-googlesearch", "applications-hubspot", "applications-linkedin", "applications-naas", "applications-nebari", "applications-newsapi", "applications-notion", "applications-openrouter", "applications-openweathermap", "applications-pennylane", "applications-postgres", "applications-powerpoint", "applications-pubmed", "applications-sanax", "applications-sendgrid", "applications-sharepoint", "applications-spotify", "applications-twilio", "applications-worldbank", "applications-yahoofinance", "domains-ontology-engineer", "domains-document"]
+provides-extras = ["ai-bedrock", "ai-chatgpt", "ai-claude", "ai-deepseek", "ai-gemini", "ai-gemma", "ai-grok", "ai-llama", "ai-mistral", "ai-ollama", "ai-openrouter", "ai-perplexity", "ai-qwen", "applications-agicap", "applications-airtable", "applications-algolia", "applications-arxiv", "applications-bodo", "applications-datagouv", "applications-exchangeratesapi", "applications-git", "applications-github", "applications-gmail", "applications-google-calendar", "applications-google-drive", "applications-google-sheets", "applications-googlesearch", "applications-hubspot", "applications-linkedin", "applications-naas", "applications-nebari", "applications-newsapi", "applications-notion", "applications-openrouter", "applications-openweathermap", "applications-pennylane", "applications-postgres", "applications-powerpoint", "applications-pubmed", "applications-sanax", "applications-sendgrid", "applications-sharepoint", "applications-spotify", "applications-twilio", "applications-worldbank", "applications-yahoofinance", "domains-ontology-engineer", "domains-document"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3743,7 +3748,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
@@ -3755,7 +3760,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -3785,9 +3790,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cusparse", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -3799,7 +3804,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3959,7 +3964,7 @@ resolution-markers = [
     "(python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/17/06/68c27a523103dad5837dc5b87e71285280c4f098c60e4fe8a8db6486ab09/opencv-python-4.11.0.86.tar.gz", hash = "sha256:03d60ccae62304860d232272e4a4fda93c39d595780cb40b161b310244b736a4", size = 95171956, upload-time = "2025-01-16T13:52:24.737Z" }
 wheels = [
@@ -3987,7 +3992,7 @@ resolution-markers = [
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/6f/5a28fef4c4a382be06afe3938c64cc168223016fa520c5abaf37e8862aa5/opencv_python-4.13.0.92-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:caf60c071ec391ba51ed00a4a920f996d0b64e3e46068aac1f646b5de0326a19", size = 46247052, upload-time = "2026-02-05T07:01:25.046Z" },
@@ -5959,8 +5964,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "jeepney", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -3547,7 +3547,7 @@ wheels = [
 
 [[package]]
 name = "naas-abi"
-version = "2.50.1"
+version = "2.51.4"
 source = { editable = "libs/naas-abi" }
 dependencies = [
     { name = "aiosqlite" },
@@ -3629,7 +3629,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-cli"
-version = "2.9.8"
+version = "2.13.0"
 source = { editable = "libs/naas-abi-cli" }
 dependencies = [
     { name = "naas-abi" },
@@ -3655,7 +3655,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-core"
-version = "2.19.5"
+version = "2.22.0"
 source = { editable = "libs/naas-abi-core" }
 dependencies = [
     { name = "click" },
@@ -3786,7 +3786,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-marketplace"
-version = "3.28.1"
+version = "3.30.0"
 source = { editable = "libs/naas-abi-marketplace" }
 dependencies = [
     { name = "ijson" },
@@ -3913,7 +3913,7 @@ requires-dist = [
     { name = "yahooquery", marker = "extra == 'applications-yahoofinance'", specifier = "==2.4.1" },
     { name = "yfinance", marker = "extra == 'applications-yahoofinance'", specifier = "==0.2.66" },
 ]
-provides-extras = ["ai-bedrock", "ai-chatgpt", "ai-claude", "ai-deepseek", "ai-gemini", "ai-gemma", "ai-grok", "ai-llama", "ai-mistral", "ai-ollama", "ai-perplexity", "ai-qwen", "applications-agicap", "applications-airtable", "applications-algolia", "applications-arxiv", "applications-bodo", "applications-datagouv", "applications-exchangeratesapi", "applications-git", "applications-github", "applications-gmail", "applications-google-calendar", "applications-google-drive", "applications-google-sheets", "applications-googlesearch", "applications-hubspot", "applications-linkedin", "applications-naas", "applications-nebari", "applications-newsapi", "applications-notion", "applications-openrouter", "applications-openweathermap", "applications-pennylane", "applications-postgres", "applications-powerpoint", "applications-pubmed", "applications-sanax", "applications-sendgrid", "applications-sharepoint", "applications-spotify", "applications-twilio", "applications-worldbank", "applications-yahoofinance", "domains-ontology-engineer", "domains-document"]
+provides-extras = ["ai-bedrock", "ai-chatgpt", "ai-claude", "ai-deepseek", "ai-gemini", "ai-gemma", "ai-grok", "ai-llama", "ai-mistral", "ai-ollama", "ai-openrouter", "ai-perplexity", "ai-qwen", "applications-agicap", "applications-airtable", "applications-algolia", "applications-arxiv", "applications-bodo", "applications-datagouv", "applications-exchangeratesapi", "applications-git", "applications-github", "applications-gmail", "applications-google-calendar", "applications-google-drive", "applications-google-sheets", "applications-googlesearch", "applications-hubspot", "applications-linkedin", "applications-naas", "applications-nebari", "applications-newsapi", "applications-notion", "applications-openrouter", "applications-openweathermap", "applications-pennylane", "applications-postgres", "applications-powerpoint", "applications-pubmed", "applications-sanax", "applications-sendgrid", "applications-sharepoint", "applications-spotify", "applications-twilio", "applications-worldbank", "applications-yahoofinance", "domains-ontology-engineer", "domains-document"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## What

`abi new project` currently scaffolds a **local-first** project: `naas_abi_marketplace.ai.ollama` serves both defaults, so a fresh project needs no API key — but it does need Ollama installed and two models pulled before it can answer anything.

This switches the default to the **OpenRouter** marketplace module. A single `OPENROUTER_API_KEY` now covers chat, the tool-binding agents, and embeddings.

| | before | after |
|---|---|---|
| `global_config.ai_mode` | `local` | `cloud` |
| AI provider module | `ai.ollama` | `ai.openrouter` |
| `default_chat_model` | `qwen-2.5-3b` | `gemma-4-26b-a4b-it` |
| `default_embedding_model` | `nomic-embed-text` | `text-embedding-3-small` |

Applied to all three generated configs — `config.yaml` (dev), `config.local.yaml` (docker-compose) and `config.remote.yaml`.

## Model choice

- **`gemma-4-26b-a4b-it`** — Gemma 4's sparse MoE: 26B total parameters, ~4B active per token, so it prices and responds like a small model while reading a 262k context and emitting structured tool calls (\$0.07/M in, \$0.34/M out). `gemma-4-31b-it` (dense, stronger per token) is also registered and named in the config comments as the one-line swap.
- **`text-embedding-3-small`** — the cheap side of the pair (\$0.02/M), already registered by the openrouter module and billed through the same key. Verified that OpenRouter's `/api/v1/embeddings` route exists (returns 401 without a key, not 404).

## Why the agents are pinned

`abi_agent_model` and `ontology_engineer_model` are pinned to the same model. Both default to `claude-sonnet-5` upstream, which the openrouter module does **not** register — leaving them unpinned would crash a generated project during the post-load default validation.

## Ollama is not removed

It stays as the documented opt-in local path: commented module blocks in each config, the `host.docker.internal` / `ABI_OLLAMA_BASE_URL` compose wiring left in place, and a README section that keeps the hard-won operational notes (silent context truncation, the 2048-token embedding cap, Linux `OLLAMA_HOST` binding, WSL).

## Changes

- `CanonicalModelId`: `GEMMA_4_26B_A4B_IT`, `GEMMA_4_31B_IT`
- new openrouter model files for both Gemma 4 variants
- new `ai-openrouter` marketplace extra; `abi new project` installs it instead of `ai-ollama`
- generated `README.md` rewritten OpenRouter-first
- parametrized render tests pinning the defaults, the enabled provider, and the agent pins across all three configs

## Behaviour change to note

A generated project now prompts for `OPENROUTER_API_KEY` during the closing `abi config validate`, where the Ollama default needed no credential. That is inherent to a cloud default and matches the pre-#1129 behaviour.

## Testing

- `config_template_test.py` — 11 passed
- `ai/openrouter/on_load_test.py` — 3 passed (Gemma 4 resolves through the real module loader)
- model registry + `cli/new` suites — 67 passed
- full pre-commit `make check` (ruff, mypy on core/cli/marketplace, bandit, Nexus build) — passed

Pre-existing, unrelated: `deploy/local_test.py::test_setup_local_deploy_hardens_fuseki_for_reliability` fails on `main` too — the fuseki→yasgui compose slice it inspects already contains `image: curlimages/curl:latest`.