### PR TITLE
fix(agent): stop loguru exc_info kwarg from masking provider errors

### DIFF
--- a/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
@@ -2186,8 +2186,15 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
             try:
                 final_state = self.invoke(prompt)
             except Exception as e:  # noqa: BLE001
-                logger.error(
-                    f"Agent invoke thread error for '{self._name}': {e}", exc_info=True
+                # `exc_info` is a stdlib-logging kwarg; loguru treats any kwarg as
+                # a `str.format` argument, so passing it makes loguru re-format an
+                # already-interpolated message. Provider errors carry literal
+                # braces (e.g. OpenRouter's `{'error': {...}}` body), which then
+                # raise `KeyError` from inside the logging call and mask the real
+                # failure. `logger.opt(exception=True)` attaches the traceback
+                # without touching the message.
+                logger.opt(exception=True).error(
+                    f"Agent invoke thread error for '{self._name}': {e}"
                 )
                 final_state = (
                     f"I encountered an error while processing your request: {e}"


### PR DESCRIPTION
## Problem

`Agent.run_invoke` logs agent failures with:

```python
logger.error(f"Agent invoke thread error for '{self._name}': {e}", exc_info=True)
```

`exc_info` is a **stdlib-logging** kwarg. `naas_abi_core.utils.Logger.logger` is **loguru**, which treats any kwarg as a `str.format()` argument and re-formats the already-interpolated message.

Provider error bodies contain literal braces, so `str.format` reads them as replacement fields. An OpenRouter 402 body —

```
Error code: 402 - {'error': {'message': 'Insufficient credits...', 'code': 402, ...}}
```

— makes the **logging call itself** raise `KeyError: "'error'"` from inside the `except` handler. The real failure never reaches the logs; the user sees an unrelated `KeyError` traceback instead.

Reported in the wild: an account with no OpenRouter credits hit a 402 during `IntentAgent.map_intents` embedding, and the actual cause was completely hidden behind:

```
File ".../loguru/_logger.py", line 2055, in _log
    log_record["message"] = message.format(*args, **kwargs)
KeyError: "'error'"
```

## Fix

Use `logger.opt(exception=True).error(...)`, loguru's idiom for attaching a traceback. It does not reformat the message, so literal braces pass through untouched.

## Verification

Reproduction against the exact 402 message shape:

| | Result |
|---|---|
| `logger.error(msg, exc_info=True)` (before) | `RAISED KeyError: "'error'"` |
| `logger.opt(exception=True).error(msg)` (after) | logged cleanly, full traceback, no exception |

Existing tests — `Agent_test.py` + `Agent_events_test.py`: **25 passed, 7 errors** both before and after. The 7 errors are pre-existing and environmental (fixtures require `OPENAI_API_KEY`); the counts are identical on the unmodified baseline, so this change introduces no regression.

## Note

This is the only non-test `exc_info=True` passed to the loguru logger in `naas-abi-core` / `naas-abi-marketplace`. Other `exc_info=True` occurrences live under `apps/nexus`, which uses a different logger and is out of scope here.