### PR TITLE
fix(agent): survive embedding-provider failures instead of hanging the chat

### DIFF
--- a/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
@@ -2186,8 +2186,15 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
             try:
                 final_state = self.invoke(prompt)
             except Exception as e:  # noqa: BLE001
-                logger.error(
-                    f"Agent invoke thread error for '{self._name}': {e}", exc_info=True
+                # Traceback via `.opt(exception=True)`, not `exc_info=True`:
+                # loguru has no `exc_info` kwarg and treats any extra kwarg as a
+                # `str.format()` argument. Provider errors embed a JSON body
+                # (`... - {'error': {'message': ...}}`), so formatting raises
+                # KeyError from inside this handler — the thread then dies
+                # without queueing a FinalStateEvent and the caller hangs
+                # instead of seeing the error.
+                logger.opt(exception=True).error(
+                    f"Agent invoke thread error for '{self._name}': {e}"
                 )
                 final_state = (
                     f"I encountered an error while processing your request: {e}"
@@ -2235,7 +2242,15 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
                 elif isinstance(message, FinalStateEvent):
                     final_state = message.payload
                     break
-
+            except Empty:
+                # An empty queue is the only state in which a dead worker can be
+                # observed reliably: if `run_invoke` died before queueing a
+                # FinalStateEvent, nothing will ever arrive. This check used to
+                # sit after the `get()` above, so it was unreachable in exactly
+                # that case — `get` raised Empty, we swallowed it, and the loop
+                # spun forever instead of reporting the dead thread.
+                # `empty()` is re-checked to close the race where the worker
+                # queues an event and exits between the timeout and `is_alive()`.
                 if (
                     not thread.is_alive()
                     and self._event_queue.empty()
@@ -2245,8 +2260,6 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
                     raise RuntimeError(
                         "Agent thread has died and no final state event was received."
                     )
-            except Empty:
-                pass
 
         response = self._content_to_text(final_state)
         logger.debug(f"Response: {response}")

--- a/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
@@ -2186,13 +2186,13 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
             try:
                 final_state = self.invoke(prompt)
             except Exception as e:  # noqa: BLE001
-                # Traceback via `.opt(exception=True)`, not `exc_info=True`:
-                # loguru has no `exc_info` kwarg and treats any extra kwarg as a
-                # `str.format()` argument. Provider errors embed a JSON body
-                # (`... - {'error': {'message': ...}}`), so formatting raises
-                # KeyError from inside this handler — the thread then dies
-                # without queueing a FinalStateEvent and the caller hangs
-                # instead of seeing the error.
+                # `exc_info` is a stdlib-logging kwarg; loguru treats any kwarg as
+                # a `str.format` argument, so passing it makes loguru re-format an
+                # already-interpolated message. Provider errors carry literal
+                # braces (e.g. OpenRouter's `{'error': {...}}` body), which then
+                # raise `KeyError` from inside the logging call and mask the real
+                # failure. `logger.opt(exception=True)` attaches the traceback
+                # without touching the message.
                 logger.opt(exception=True).error(
                     f"Agent invoke thread error for '{self._name}': {e}"
                 )

--- a/libs/naas-abi-core/naas_abi_core/services/agent/Agent_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/Agent_test.py
@@ -586,3 +586,95 @@ def test_normalize_coerces_present_but_invalid_input_in_tooluse_block():
 
     assert normalized is not message
     assert normalized.content[0]["toolUse"]["input"] == {}
+
+
+def test_stream_invoke_surfaces_error_containing_braces():
+    """Regression guard: an invoke failure must reach the caller as a message.
+
+    loguru has no ``exc_info`` kwarg — it treats extra kwargs as ``str.format()``
+    arguments. Provider errors embed a JSON body (``- {'error': {...}}``), so
+    logging one with ``exc_info=True`` raised ``KeyError`` from inside the error
+    handler itself: the thread died before queueing a ``FinalStateEvent`` and the
+    stream blew up with "Agent thread has died" instead of reporting the error.
+    """
+    from langchain_core.language_models.fake_chat_models import FakeListChatModel
+    from naas_abi_core.services.agent.Agent import Agent, AgentConfiguration
+
+    agent = Agent(
+        name="Test Agent",
+        description="A test agent",
+        chat_model=FakeListChatModel(responses=["unused"]),
+        tools=[],
+        agents=[],
+        configuration=AgentConfiguration(),
+    )
+
+    provider_error = (
+        "Error code: 402 - {'error': {'message': 'Insufficient credits.', 'code': 402}}"
+    )
+
+    def _raise(_prompt):
+        raise RuntimeError(provider_error)
+
+    agent.invoke = _raise  # type: ignore[method-assign]
+
+    events = list(agent.stream_invoke("hello"))
+
+    text = " ".join(e["data"] for e in events if e["event"] == "message")
+    assert "I encountered an error while processing your request" in text, events
+    assert "Insufficient credits" in text, events
+    assert events[-1] == {"event": "done", "data": "[DONE]"}
+
+
+def test_stream_invoke_reports_dead_thread_instead_of_hanging():
+    """Regression guard: a worker that dies silently must not hang the stream.
+
+    The liveness check used to sit *after* ``self._event_queue.get(timeout=...)``
+    inside the same ``try``. When the worker died without queueing anything the
+    queue stayed empty forever, so ``get`` raised ``Empty`` on every iteration,
+    the handler swallowed it, and the guard it was written for was unreachable —
+    the SSE stream spun forever and the caller never got an answer.
+    """
+    import threading
+
+    from langchain_core.language_models.fake_chat_models import FakeListChatModel
+    from naas_abi_core.services.agent.Agent import Agent, AgentConfiguration
+
+    class _UnformattableError(Exception):
+        """Dies while the error handler is building its message, so the worker
+        thread exits without ever queueing a FinalStateEvent."""
+
+        def __str__(self) -> str:
+            raise ValueError("boom while formatting")
+
+    agent = Agent(
+        name="Test Agent",
+        description="A test agent",
+        chat_model=FakeListChatModel(responses=["unused"]),
+        tools=[],
+        agents=[],
+        configuration=AgentConfiguration(),
+    )
+
+    def _raise(_prompt):
+        raise _UnformattableError()
+
+    agent.invoke = _raise  # type: ignore[method-assign]
+
+    outcome: dict = {}
+
+    def _consume():
+        try:
+            list(agent.stream_invoke("hello"))
+        except BaseException as exc:  # noqa: BLE001
+            outcome["error"] = exc
+        else:
+            outcome["error"] = None
+
+    consumer = threading.Thread(target=_consume, daemon=True)
+    consumer.start()
+    consumer.join(timeout=30)
+
+    assert not consumer.is_alive(), "stream_invoke hung on a dead worker thread"
+    assert isinstance(outcome.get("error"), RuntimeError), outcome
+    assert "Agent thread has died" in str(outcome["error"]), outcome

--- a/libs/naas-abi-core/naas_abi_core/services/agent/IntentAgent.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/IntentAgent.py
@@ -330,25 +330,41 @@ class IntentAgent(Agent):
                         logger.debug("❌ Agent not found, going to call_model")
                         return Command(goto="call_model", update=command_update)
 
-        # Map intents using vector similarity search
-        intents = pd.filter_(
-            self._intent_mapper.map_intent(last_human_message.content, k=10),
-            lambda matches: matches["score"] > self._threshold,
-        )
-        if len(intents) == 0:
-            _, prompted_intents = self._intent_mapper.map_prompt(
-                last_human_message.content, k=10
-            )
+        # Map intents using vector similarity search.
+        #
+        # Intent mapping is a routing optimisation, not a correctness
+        # requirement: building the index calls out to the embedding provider,
+        # which can be unreachable, rate limited or out of credit. Letting that
+        # escape kills the whole graph run, so a missing embedding provider
+        # takes down every conversation — including plain "hello". Degrade to an
+        # empty mapping instead and let the model route the conversation. The
+        # background warmup in `IntentMapper.warm_all_in_background` already
+        # tolerates the same failure; this keeps the request path consistent.
+        try:
             intents = pd.filter_(
-                prompted_intents, lambda matches: matches["score"] > self._threshold
+                self._intent_mapper.map_intent(last_human_message.content, k=10),
+                lambda matches: matches["score"] > self._threshold,
             )
-
-            # If we have no intents, we return an empty intent mapping
             if len(intents) == 0:
-                return Command(
-                    update={"intent_mapping": {"intents": []}},
-                    goto=self.should_filter([]),
+                _, prompted_intents = self._intent_mapper.map_prompt(
+                    last_human_message.content, k=10
                 )
+                intents = pd.filter_(
+                    prompted_intents, lambda matches: matches["score"] > self._threshold
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                f"⚠️ Intent mapping unavailable for '{self.name}', falling back to "
+                f"model routing: {exc}"
+            )
+            intents = []
+
+        # If we have no intents, we return an empty intent mapping
+        if len(intents) == 0:
+            return Command(
+                update={"intent_mapping": {"intents": []}},
+                goto=self.should_filter([]),
+            )
 
         # Keep intents that are close to the best intent.
         max_score = intents[0]["score"]

--- a/libs/naas-abi-core/naas_abi_core/services/agent/IntentAgent_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/IntentAgent_test.py
@@ -137,3 +137,42 @@ def test_request_help_tool(agent):
     assert result is not None, result
     assert "I found multiple intents that could handle your request" in result, result
     assert "chatgpt" in result.lower() or "grok" in result.lower(), result
+
+
+def test_map_intents_degrades_when_embedding_provider_fails():
+    """Regression guard: a dead embedding provider must not kill the run.
+
+    Intent mapping builds its vector index lazily on the first message, so an
+    embedding provider that is unreachable, rate limited or out of credit used to
+    raise straight through the LangGraph node and fail every conversation —
+    including a plain "hello". It must degrade to an empty mapping and let the
+    model route the conversation instead.
+    """
+    from langchain_core.embeddings import Embeddings
+    from langchain_core.language_models.fake_chat_models import FakeListChatModel
+    from langchain_core.messages import HumanMessage
+
+    class _BrokenEmbeddings(Embeddings):
+        def embed_documents(self, texts: list[str]) -> list[list[float]]:
+            raise RuntimeError(
+                "Error code: 402 - {'error': {'message': 'Insufficient credits.'}}"
+            )
+
+        def embed_query(self, text: str) -> list[float]:
+            return self.embed_documents([text])[0]
+
+    agent = IntentAgent(
+        name="Broken Embeddings Agent",
+        description="An agent whose embedding provider is down",
+        chat_model=FakeListChatModel(responses=["hi"]),
+        embedding_model=_BrokenEmbeddings(),
+        tools=[],
+        agents=[],
+        intents=[],
+        configuration=AgentConfiguration(system_prompt="You are an helpful assistant."),
+    )
+
+    command = agent.map_intents({"messages": [HumanMessage(content="hello")]})
+
+    assert command.update == {"intent_mapping": {"intents": []}}, command
+    assert command.goto == "call_model", command


### PR DESCRIPTION
## What happens today

Create a project with `abi new project` (which now defaults to OpenRouter +
Gemma 4), point it at an OpenRouter key with no credits, and say `hello`. The
API logs a raw traceback and **the chat hangs forever** — no answer, no error,
no timeout.

```
openai.APIStatusError: Error code: 402 - {'error': {'message': 'Insufficient credits. ...'}}
During task with name 'map_intents' ...
```

The account having no credits is a user-fixable config problem. Everything that
happens *after* that 402 is not.

## Relationship to #1157 (merged)

**#1157 independently fixed defect 2 below while this branch was open, and has
already merged.** Both landed byte-identical *code* (`logger.opt(exception=True)`);
only the comment differed, which was enough to conflict, so this branch now
carries #1157's comment verbatim and merges cleanly with no conflict.

What remains unique here: **defects 1 and 3, plus regression tests for all
three** — #1157 shipped its fix without a test, so the brace-formatting bug it
solved is now pinned by `test_stream_invoke_surfaces_error_containing_braces`.

## Three defects on one path

**1. An embedding failure kills the whole conversation.**
`IntentAgent.map_intents` builds the intent vector index lazily on the first
message. Any embedding-provider error — 402, 401, rate limit, DNS — propagates
straight out of the LangGraph node and fails the run. Intent mapping is a
*routing optimisation*, not a correctness requirement: `should_filter([])`
already routes to `call_model`, and `IntentMapper.warm_all_in_background`
already swallows this exact failure. Only the request path was strict. Now it
degrades to an empty mapping and logs a warning.

**2. The error handler crashed on the error it was handling.** *(fixed by #1157 — kept here identically so the branches converge; test is new)*

```python
logger.error(f"...: {e}", exc_info=True)   # loguru, not stdlib logging
```

loguru has no `exc_info` kwarg — it treats extra kwargs as `str.format()`
arguments. Provider errors embed a JSON body, so `.format()` hit `{'error': ...}`
and raised `KeyError: "'error'"` **from inside the `except` block**. The worker
thread died before queueing a `FinalStateEvent`, so the user never saw the
error. Verified standalone:

```
logger.error(msg, exc_info=True)          -> KeyError: "'error'"
logger.opt(exception=True).error(msg)     -> OK
```

This was the only `exc_info=` in the codebase, and it sat on the one path that
reports *every* agent failure to the user — so any provider error with braces
in it was silently swallowed, not just this 402.

**3. The "thread died" guard was unreachable.**
The guard lived *after* `self._event_queue.get(timeout=0.05)` inside the same
`try`. When the worker dies without queueing anything the queue stays empty
forever, so `get` raised `Empty` every iteration, `except Empty: pass` swallowed
it, and the guard never ran — in precisely the case it was written for. Moved
into the `Empty` branch (keeping the `empty()` re-check to close the
put-then-die race).

## Tests

Three regression tests, each confirmed to fail without its fix:

| Test | Without the fix |
|---|---|
| `test_map_intents_degrades_when_embedding_provider_fails` | `RuntimeError: Error code: 402 ...` propagates |
| `test_stream_invoke_surfaces_error_containing_braces` | hangs (killed at 10 min) |
| `test_stream_invoke_reports_dead_thread_instead_of_hanging` | `AssertionError: stream_invoke hung on a dead worker thread` |

All three pass in ~1.8s with the fixes; the 24 neighbouring `Agent_events` /
`Agent_hooks` tests still pass; `make check-core` (ruff, mypy, bandit) and the
Nexus build pass via pre-commit.

## Not addressed here

- **The scaffold ships a pairing that needs a funded key.** `abi new project`
  defaults to `gemma-4-26b-a4b-it` + `text-embedding-3-small`, both billed
  through OpenRouter, and nothing checks the key has credit before first chat.
  With this PR the failure is now legible instead of a hang, but a first-run
  credential/credit check would be the real onboarding fix. Deliberately left
  out — changing the defaults from #1156 is a product call.
- `IntentMapper.map_prompt` just re-calls `map_intent` with the same arguments,
  so the "fallback" second lookup is guaranteed to return the same result.
  Pre-existing; left alone.
- `IntentAgent.py:147` fails `ruff format --check` on `main` already; not
  touched, to keep this diff to the bug.
