### PR TITLE
fix(cli): ignore .dagster in generated project .gitignore

### DIFF
--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/project/.gitignore
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/project/.gitignore
@@ -1,3 +1,4 @@
 .venv
 .env
 storage
+.dagster/


### PR DESCRIPTION
`abi new project` scaffolds a `.gitignore` with only `.venv`, `.env` and `storage`.

But `abi dev up` sets `DAGSTER_HOME` to `<project>/.dagster` (`libs/naas-abi-cli/naas_abi_cli/cli/dev.py:375`), so every generated project accumulates Dagster run history, logs and storage there as untracked files. This repo's own `.gitignore` already has `.dagster/` (line 113) — this mirrors it in the project template.

## Verification
- Built the wheel and confirmed the template `.gitignore` ships in it (hatchling's VCS-based file selection includes it; no `force-include` entry needed).
- `pytest naas_abi_cli/cli/new/` — 49 passed, 3 skipped.