### PR TITLE
fix(nexus-web): stop prod clients from racing to localhost API

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/Dockerfile.release
+++ b/libs/naas-abi/naas_abi/apps/nexus/Dockerfile.release
@@ -11,10 +11,20 @@ COPY docker-entrypoint.sh ./docker-entrypoint.sh
 
 WORKDIR /app/apps/web
 
-# Deployments (e.g. Zen) may bake Custom Maps descriptors into the Next bundle.
-# NEXT_PUBLIC_* is inlined at build time; empty default keeps upstream generic.
+# Deployments (e.g. Zen) bake public client config into the Next bundle.
+# NEXT_PUBLIC_* is inlined at build time; empty defaults keep upstream generic.
+# Baking API URL / env avoids a client race where async chunks call getApiUrl()
+# before /runtime-config.js runs and fall back to localhost:9879.
 ARG NEXT_PUBLIC_MAPS_CUSTOM_DATASETS=
+ARG NEXT_PUBLIC_API_URL=
+ARG NEXT_PUBLIC_NEXUS_ENV=
+ARG NEXT_PUBLIC_FRONTEND_URL=
+ARG NEXT_PUBLIC_WS_PATH=/ws/socket.io
 ENV NEXT_PUBLIC_MAPS_CUSTOM_DATASETS=$NEXT_PUBLIC_MAPS_CUSTOM_DATASETS
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+ENV NEXT_PUBLIC_NEXUS_ENV=$NEXT_PUBLIC_NEXUS_ENV
+ENV NEXT_PUBLIC_FRONTEND_URL=$NEXT_PUBLIC_FRONTEND_URL
+ENV NEXT_PUBLIC_WS_PATH=$NEXT_PUBLIC_WS_PATH
 
 RUN pnpm install --frozen-lockfile
 RUN pnpm build

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/layout.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/layout.tsx
@@ -87,14 +87,46 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
+function getServerRuntimeConfig() {
+  return {
+    apiUrl:
+      process.env.NEXUS_API_URL ||
+      process.env.NEXT_PUBLIC_API_URL ||
+      '',
+    env:
+      process.env.NEXUS_ENV ||
+      process.env.NEXT_PUBLIC_NEXUS_ENV ||
+      'local',
+    websocketPath:
+      process.env.NEXUS_WS_PATH ||
+      process.env.NEXT_PUBLIC_WS_PATH ||
+      '/ws/socket.io',
+    frontendUrl:
+      process.env.NEXUS_FRONTEND_URL ||
+      process.env.NEXT_PUBLIC_FRONTEND_URL ||
+      '',
+  };
+}
+
 export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  // Inline first so client modules never race an external /runtime-config.js
+  // load (App Router can schedule async chunks before beforeInteractive src).
+  const runtimeConfig = getServerRuntimeConfig();
+
   return (
     <html lang="en" className={`${inter.variable} ${jetbrainsMono.variable}`} suppressHydrationWarning>
       <body className={`${inter.className} antialiased`}>
+        <Script
+          id="nexus-runtime-config-inline"
+          strategy="beforeInteractive"
+          dangerouslySetInnerHTML={{
+            __html: `window.__NEXUS_RUNTIME_CONFIG__=${JSON.stringify(runtimeConfig)};`,
+          }}
+        />
         <Script src="/runtime-config.js" strategy="beforeInteractive" />
         <ThemeProvider
           attribute="class"

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/config.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/config.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('getApiUrl public-origin fallback', () => {
+  const originalWindow = globalThis.window;
+  const envKeys = [
+    'NEXUS_API_URL',
+    'NEXT_PUBLIC_API_URL',
+    'NEXUS_ENV',
+    'NEXT_PUBLIC_NEXUS_ENV',
+  ] as const;
+  const originalEnv: Partial<Record<(typeof envKeys)[number], string | undefined>> = {};
+
+  beforeEach(() => {
+    vi.resetModules();
+    for (const key of envKeys) {
+      originalEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    delete (globalThis as { __NEXUS_RUNTIME_CONFIG__?: unknown }).__NEXUS_RUNTIME_CONFIG__;
+  });
+
+  afterEach(() => {
+    for (const key of envKeys) {
+      if (originalEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = originalEnv[key];
+      }
+    }
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: originalWindow,
+    });
+    delete (globalThis as { __NEXUS_RUNTIME_CONFIG__?: unknown }).__NEXUS_RUNTIME_CONFIG__;
+    vi.restoreAllMocks();
+  });
+
+  it('refuses localhost when the page origin is public and config is missing', async () => {
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {
+        location: {
+          hostname: 'zen.naas.ai',
+          origin: 'https://zen.naas.ai',
+          protocol: 'https:',
+        },
+        __NEXUS_RUNTIME_CONFIG__: undefined,
+      },
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { getApiUrl, getEnvironment } = await import('./config');
+
+    expect(getEnvironment()).toBe('cloudflare');
+    expect(getApiUrl()).toBe('https://api.zen.naas.ai');
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('prefers runtime-config apiUrl when present', async () => {
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {
+        location: {
+          hostname: 'zen.naas.ai',
+          origin: 'https://zen.naas.ai',
+          protocol: 'https:',
+        },
+        __NEXUS_RUNTIME_CONFIG__: {
+          apiUrl: 'https://api.zen.naas.ai',
+          env: 'cloudflare',
+        },
+      },
+    });
+
+    const { getApiUrl } = await import('./config');
+    expect(getApiUrl()).toBe('https://api.zen.naas.ai');
+  });
+
+  it('keeps localhost defaults for local browser origins', async () => {
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {
+        location: {
+          hostname: 'localhost',
+          origin: 'http://localhost:3000',
+          protocol: 'http:',
+        },
+        __NEXUS_RUNTIME_CONFIG__: undefined,
+      },
+    });
+
+    const { getApiUrl, getEnvironment } = await import('./config');
+    expect(getEnvironment()).toBe('local');
+    expect(getApiUrl()).toBe('http://localhost:9879');
+  });
+});

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/config.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/config.ts
@@ -56,8 +56,49 @@ function getRuntimeConfig() {
   return window.__NEXUS_RUNTIME_CONFIG__;
 }
 
+/** True when the page is served from a public host (not loopback / *.localhost). */
+function isBrowserPublicOrigin(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  const host = window.location.hostname;
+  return host !== 'localhost' && host !== '127.0.0.1' && !host.endsWith('.localhost');
+}
+
+/**
+ * Last-resort API URL when runtime-config and NEXT_PUBLIC_* are missing on a
+ * public origin. Matches Zen / Nexus hostname convention: api.<frontend-host>.
+ */
+function derivePublicApiUrl(): string {
+  const { protocol, hostname } = window.location;
+  return `${protocol}//api.${hostname}`;
+}
+
 function getResolvedApiUrl(defaultValue: string): string {
-  return getRuntimeConfig()?.apiUrl || process.env.NEXUS_API_URL || process.env.NEXT_PUBLIC_API_URL || defaultValue;
+  const runtimeUrl = getRuntimeConfig()?.apiUrl;
+  if (runtimeUrl) {
+    return runtimeUrl;
+  }
+
+  const envUrl = process.env.NEXUS_API_URL || process.env.NEXT_PUBLIC_API_URL;
+  if (envUrl) {
+    return envUrl;
+  }
+
+  // Next.js can evaluate client modules before /runtime-config.js runs. On a
+  // public origin, never use loopback or another product's baked default
+  // (e.g. api.nexus.naas.ai while serving zen.naas.ai).
+  if (isBrowserPublicOrigin()) {
+    const derived = derivePublicApiUrl();
+    if (defaultValue !== derived) {
+      console.warn(
+        `Nexus apiUrl missing at runtime on ${window.location.origin}; using ${derived} instead of ${defaultValue}.`
+      );
+    }
+    return derived;
+  }
+
+  return defaultValue;
 }
 
 function getResolvedWebsocketPath(defaultValue: string): string {
@@ -77,14 +118,22 @@ function getResolvedOllamaUrl(defaultValue: string): string {
  */
 export function getEnvironment(): Environment {
   const runtimeEnv = getRuntimeConfig()?.env;
-  const env = runtimeEnv || process.env.NEXT_PUBLIC_NEXUS_ENV || process.env.NEXUS_ENV || 'local';
-  
-  if (!['local', 'cloudflare', 'staging'].includes(env)) {
-    console.warn(`Unknown environment: ${env}, defaulting to 'local'`);
-    return 'local';
+  const env = runtimeEnv || process.env.NEXT_PUBLIC_NEXUS_ENV || process.env.NEXUS_ENV;
+
+  if (env && ['local', 'cloudflare', 'staging'].includes(env)) {
+    return env as Environment;
   }
-  
-  return env as Environment;
+
+  if (env) {
+    console.warn(`Unknown environment: ${env}, defaulting to 'local'`);
+  }
+
+  // Public hosts should not inherit the local defaults (localhost:9879 API).
+  if (isBrowserPublicOrigin()) {
+    return 'cloudflare';
+  }
+
+  return 'local';
 }
 
 /**


### PR DESCRIPTION
## Summary
- Next App Router can run async chunks before `/runtime-config.js`, so `getApiUrl()` fell back to `http://localhost:9879` on public hosts (blocked by Private Network Access).
- Inline server runtime config, bake `NEXT_PUBLIC_API_URL` / env in `Dockerfile.release`, and derive `api.<host>` when config is still missing on public origins.

## Test plan
- [x] `pnpm test -- src/lib/config.test.ts` in nexus web
- [ ] Zen GCP rebuild of nexus-web serves bundles without localhost fallback before runtime-config
- [ ] `curl -sS https://zen.naas.ai/runtime-config.js` still shows `https://api.zen.naas.ai`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every client resolves API and environment URLs in production; wrong bake-time or derived `api.<host>` could misroute traffic, but logic is defensive and covered by new tests.
> 
> **Overview**
> Fixes production Nexus web clients calling **`http://localhost:9879`** when async chunks run **`getApiUrl()`** before **`/runtime-config.js`** loads (Private Network Access failures on hosts like Zen).
> 
> **Root layout** now injects **`window.__NEXUS_RUNTIME_CONFIG__`** via a **`beforeInteractive`** inline script from server env (`NEXUS_*` / `NEXT_PUBLIC_*`), ahead of the external runtime-config script.
> 
> **`config.ts`** adds public-origin detection: if runtime and env URLs are missing on a non-loopback host, API URL falls back to **`api.<hostname>`** with a console warning, and **`getEnvironment()`** defaults to **`cloudflare`** instead of local. **`Dockerfile.release`** gains build args/env for **`NEXT_PUBLIC_API_URL`**, env, frontend URL, and WS path so release images bake the right client config.
> 
> **`config.test.ts`** covers public-origin derivation, runtime-config preference, and localhost behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba2b88c9b8831f4cf288dfeb97b2ad3a8a7b0ec4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->