### PR TITLE
feat(cli): report where `abi new project` landed and how to start it

### DIFF
--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/project.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/project.py
@@ -1,4 +1,5 @@
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -67,6 +68,38 @@ def _add_abi_submodule(project_path: str) -> bool:
     # A clone that succeeded but landed an unexpected layout is still unusable
     # as a dependency source, so check for the directory uv will be told about.
     return os.path.isdir(os.path.join(project_path, ABI_SUBMODULE_PATH, "libs"))
+
+
+def _cd_argument(project_path: str) -> str:
+    """The shortest `cd` target that gets the caller from their CWD to the project.
+
+    `abi` runs as a child process, so it cannot change the calling shell's
+    working directory — the best it can do is hand back a line to paste. A
+    relative path is what the caller would have typed themselves, so prefer it
+    when the project sits under the CWD; anything else (a sibling, an absolute
+    `project-path` argument) is clearer spelled out in full.
+    """
+    try:
+        relative = os.path.relpath(project_path, os.getcwd())
+    except ValueError:
+        # Windows: no relative path exists across drives.
+        return shlex.quote(project_path)
+
+    # `..`-prefixed paths are not more readable than the absolute one.
+    if relative == os.curdir or relative.startswith(os.pardir):
+        return shlex.quote(project_path)
+    return shlex.quote(relative)
+
+
+def _print_next_steps(project_path: str) -> None:
+    """Report where the project landed and how to start it."""
+    click.echo()
+    click.secho(f"✓ Project created at {project_path}", fg="green", bold=True)
+    click.echo()
+    click.secho("Next steps:", bold=True)
+    click.echo(f"  cd {_cd_argument(project_path)}")
+    click.echo("  uv run abi dev up")
+    click.echo()
 
 
 @new.command("project")
@@ -198,3 +231,5 @@ def new_project(
         cwd=project_path,
         check=True,
     )
+
+    _print_next_steps(project_path)

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/project.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/project.py
@@ -98,7 +98,7 @@ def _print_next_steps(project_path: str) -> None:
     click.echo()
     click.secho("Next steps:", bold=True)
     click.echo(f"  cd {_cd_argument(project_path)}")
-    click.echo("  uv run abi dev up")
+    click.echo("  abi dev up")
     click.echo()
 
 

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/project_test.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/project_test.py
@@ -124,6 +124,26 @@ def _run_new_project(tmp_path, monkeypatch, *extra_args, submodule_ok: bool):
     return tomllib.loads(generated), generated
 
 
+def _invoke_new_project(tmp_path, monkeypatch, *extra_args):
+    """Drive the command as above, but return the CLI result, not the manifest."""
+    from click.testing import CliRunner
+
+    monkeypatch.setattr(
+        project.subprocess,
+        "run",
+        lambda cmd, **_kwargs: subprocess.CompletedProcess(cmd, 0),
+    )
+    monkeypatch.setattr(project.shutil, "which", lambda _cmd: "/usr/bin/git")
+
+    result = CliRunner().invoke(
+        project.new_project,
+        ["demo", str(tmp_path), "--domain", "localhost", "--without-local-deploy",
+         "--without-abi-submodule", *extra_args],
+    )
+    assert result.exit_code == 0, result.output
+    return result
+
+
 def test_new_project_emits_live_sources(tmp_path, monkeypatch) -> None:
     doc, _ = _run_new_project(tmp_path, monkeypatch, submodule_ok=True)
 
@@ -152,4 +172,51 @@ def test_new_project_without_the_submodule_flag_uses_pypi(
     )
 
     assert "sources" not in doc["tool"]["uv"]
+
+
+# =============================================================================
+# Next steps.
+#
+# `abi` is a child process and cannot cd the calling shell, so the closing
+# report is the only thing telling the caller where the project went. It has to
+# name the absolute path and hand back a `cd` line that actually works from
+# where the caller stands.
+# =============================================================================
+
+def test_next_steps_report_the_project_path_and_how_to_start(
+    tmp_path, monkeypatch
+) -> None:
+    result = _invoke_new_project(tmp_path, monkeypatch)
+
+    assert str(tmp_path / "demo") in result.output
+    assert "cd " in result.output
+    assert "uv run abi dev up" in result.output
+
+
+def test_cd_target_is_relative_when_the_project_is_below_the_cwd(
+    tmp_path, monkeypatch
+) -> None:
+    """The caller asked for `demo` here; echoing an absolute path back is noise."""
+    monkeypatch.chdir(tmp_path)
+
+    assert project._cd_argument(str(tmp_path / "demo")) == "demo"
+
+
+def test_cd_target_is_absolute_when_the_project_is_outside_the_cwd(
+    tmp_path, monkeypatch
+) -> None:
+    """`../../..`-style paths are not more readable than the real location."""
+    elsewhere = tmp_path / "elsewhere"
+    (elsewhere / "nested").mkdir(parents=True)
+    monkeypatch.chdir(elsewhere / "nested")
+    target = str(tmp_path / "demo")
+
+    assert project._cd_argument(target) == target
+
+
+def test_cd_target_is_quoted_when_the_path_has_spaces(tmp_path, monkeypatch) -> None:
+    """The line is meant to be pasted into a shell, so it must survive one."""
+    monkeypatch.chdir(tmp_path)
+
+    assert project._cd_argument(str(tmp_path / "my demo")) == "'my demo'"
 

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/project_test.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/project_test.py
@@ -190,7 +190,7 @@ def test_next_steps_report_the_project_path_and_how_to_start(
 
     assert str(tmp_path / "demo") in result.output
     assert "cd " in result.output
-    assert "uv run abi dev up" in result.output
+    assert "  abi dev up" in result.output
 
 
 def test_cd_target_is_relative_when_the_project_is_below_the_cwd(


### PR DESCRIPTION
## What

`abi new project` now closes with a next-steps block:

```
✓ Project created at /Users/max/dev/my-proj

Next steps:
  cd my-proj
  abi dev up
```

## Why

The ask was "could `abi new project` automatically cd into the created directory". It can't — `abi` is a console script, i.e. a child process, and no child process can change its parent shell's working directory. The workarounds are a shell wrapper function (`abi shell-init`) or exec'ing a nested `$SHELL`; both were considered and deliberately declined in favour of the smallest thing that solves the real problem.

That problem was that the command printed **nothing** on success — after `uv add` and `abi config validate` scrolled past, there was no statement of where the project went or what to run next.

## Details

- `_print_next_steps` runs only after `uv add` and `abi config validate` succeed (both `check=True`, so a failure aborts before the block prints).
- `_cd_argument` picks the shortest target that works from the caller's CWD: relative when the project is below it, absolute for siblings/`..` paths and cross-drive cases, `shlex.quote`d so paths with spaces survive being pasted into a shell.

## Testing

- 4 new tests (output contents, relative/absolute/quoted `cd` targets); 53 passed, 3 skipped across `naas_abi_cli/cli/new`.
- `uvx ruff check` and `mypy -p naas_abi_cli` clean, run with the exact Makefile invocations.
