### PR TITLE
chore: remove Zen product coupling from ABI

### DIFF
--- a/libs/naas-abi-cli/README.md
+++ b/libs/naas-abi-cli/README.md
@@ -220,7 +220,7 @@ abi workspace list --org org-...
 abi workspace members list --workspace ws-...
 abi workspace members add --workspace ws-... --email someone@naas.ai --role member
 
-# Preferred on Zen (password signup off): create-on-invite + OTP/magic-link email
+# Preferred when password signup is off: create-on-invite + OTP/magic-link email
 abi user invite --email someone@gmail.com --name "Someone" \
   --org org-... --workspace ws-... --role member --workspace-role member
 abi org members invite --org org-... --email someone@gmail.com --workspace ws-...
@@ -242,11 +242,11 @@ Invite endpoints create the user when missing and email OTP / magic-link sign-in
 writes `secrets/NEXUS_USER_<EMAIL>.env` (mode 600). Pass `--show-password` only
 when you intentionally need stdout.
 
-**Break-glass Postgres** (Zen VM ops only, when invite email / browser auth is
+**Break-glass Postgres** (ops VM only, when invite email / browser auth is
 unavailable):
 
 ```bash
-export NEXUS_POSTGRES_COMPOSE_DIR=/opt/zen/zen
+export NEXUS_POSTGRES_COMPOSE_DIR=/opt/abi
 abi user create --via postgres --email someone@naas.ai --name "Someone" --org org-...
 abi workspace create --via postgres --name "..." --slug ... --org org-... --owner-id user-...
 ```

--- a/libs/naas-abi-cli/naas_abi_cli/cli/nexus_postgres.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/nexus_postgres.py
@@ -1,9 +1,9 @@
-"""Break-glass Postgres helpers for Nexus user/workspace ops (Zen VM SOP).
+"""Break-glass Postgres helpers for Nexus user/workspace ops (ops VM SOP).
 
 Preferred path is the authenticated Nexus HTTP API. Use this only when browser
-auth / password registration is unavailable, typically on `abi-naas-app` via:
+auth / password registration is unavailable, typically on an ops host via:
 
-  NEXUS_POSTGRES_COMPOSE_DIR=/opt/zen/zen
+  NEXUS_POSTGRES_COMPOSE_DIR=/opt/abi
   abi user create --via postgres --email ... --name ...
 
 Requires `bcrypt` at runtime for password hashing.
@@ -95,8 +95,8 @@ def run_postgres_sql(sql: str) -> str:
     compose_dir = os.getenv("NEXUS_POSTGRES_COMPOSE_DIR")
     if not compose_dir:
         raise RuntimeError(
-            "Set NEXUS_POSTGRES_COMPOSE_DIR to the Zen compose directory "
-            "(e.g. /opt/zen/zen) before using --via postgres."
+            "Set NEXUS_POSTGRES_COMPOSE_DIR to the deployment compose directory "
+            "(e.g. /opt/abi) before using --via postgres."
         )
     root = Path(compose_dir)
     gcp = root / "docker-compose.gcp.yml"

--- a/libs/naas-abi-cli/naas_abi_cli/cli/user.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/user.py
@@ -99,7 +99,7 @@ def user() -> None:
     type=click.Choice(["api", "postgres"], case_sensitive=False),
     default="api",
     show_default=True,
-    help="api: POST /api/auth/register. postgres: break-glass SQL (Zen ops only).",
+    help="api: POST /api/auth/register. postgres: break-glass SQL (ops VM only).",
 )
 @common_api_options
 def user_create(
@@ -122,7 +122,7 @@ def user_create(
     """Create a user.
 
     API path uses `/api/auth/register` (requires password auth enabled on the
-    Nexus instance). On production Zen where password auth is disabled, use
+    Nexus instance). On production deployments where password auth is disabled, use
     magic-link signup or `--via postgres` on the VM (documented break-glass).
     """
     password_value = user_password or secrets.token_urlsafe(18)

--- a/libs/naas-abi-cli/naas_abi_cli/cli/workspace.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/workspace.py
@@ -40,7 +40,7 @@ def workspace() -> None:
     type=click.Choice(["api", "postgres"], case_sensitive=False),
     default="api",
     show_default=True,
-    help="api: POST /api/workspaces. postgres: break-glass SQL (Zen ops only).",
+    help="api: POST /api/workspaces. postgres: break-glass SQL (ops VM only).",
 )
 @common_api_options
 def workspace_create(

--- a/libs/naas-abi-core/naas_abi_core/services/coding_environment/adapters/secondary/CoderAdapter_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/coding_environment/adapters/secondary/CoderAdapter_test.py
@@ -521,11 +521,11 @@ def test_get_workspace_ui_url_uses_access_url_owner_and_name() -> None:
 def test_build_workspace_ui_url() -> None:
     assert (
         CoderAdapter.build_workspace_ui_url(
-            access_url="https://coder.zen.naas.ai/",
+            access_url="https://coder.example.com/",
             owner="jeremy",
             name="slides-quest",
         )
-        == "https://coder.zen.naas.ai/@jeremy/slides-quest"
+        == "https://coder.example.com/@jeremy/slides-quest"
     )
 
 

--- a/libs/naas-abi/naas_abi/agents/tools/slides_tools_test.py
+++ b/libs/naas-abi/naas_abi/agents/tools/slides_tools_test.py
@@ -38,17 +38,15 @@ _SAMPLE = """<!DOCTYPE html>
 </body></html>
 """
 
-_TEMPLATE_CANDIDATES = (
+_TEMPLATE = (
     Path(__file__).resolve().parents[2]
     / "apps"
     / "nexus"
     / "assets"
     / "slides"
     / "templates"
-    / "minimal-light-v1.html",
-    Path("/Users/jrvmac/abi-naas/src/zen/assets/slides/templates/minimal-light-v1.html"),
+    / "minimal-light-v1.html"
 )
-_TEMPLATE = next((p for p in _TEMPLATE_CANDIDATES if p.is_file()), _TEMPLATE_CANDIDATES[0])
 
 
 def test_redact_data_urls_shrinks_payload_and_counts():

--- a/libs/naas-abi/naas_abi/apps/nexus/AGENTS.md
+++ b/libs/naas-abi/naas_abi/apps/nexus/AGENTS.md
@@ -115,7 +115,7 @@ These are distinct mental models. Do not conflate them in UI copy.
 | Lifetime | Long-lived | Often ephemeral |
 | Auth / access | Org RBAC | Repo tokens / SSH; tied to branches, folders, containers |
 
-Footer labels must say **Business workspace** and **Code workspace**. Canonical UX note (Zen): `docs/ux/business-vs-code-workspace.md`.
+Footer labels must say **Business workspace** and **Code workspace**. Canonical UX note: parent-app `docs/ux/business-vs-code-workspace.md` (or equivalent).
 
 ### Platform status footer
 
@@ -157,7 +157,7 @@ Each migrated route uses three files so structure, routing, and style stay separ
 
 Example: `src/app/account/api-keys/page.tsx` re-exports from `./api-keys`, which imports `./api-keys.css`.
 
-This yields reviewable diffs, cherry-pick friendly commits to upstream ABI (`integrate/zen-july` unpacks into small PRs to jupyter-naas/abi main), and clear ownership: routing vs component vs CSS.
+This yields reviewable diffs, cherry-pick friendly commits to upstream ABI (product integration branches unpack into small PRs to jupyter-naas/abi main), and clear ownership: routing vs component vs CSS.
 
 ### Why `{surface}-{region}-{element}` class names
 
@@ -353,7 +353,7 @@ Maps is a **dataset loader**, not the Knowledge Graph. Graph stays under `/graph
 
 **Ownership rule:** Nexus Maps owns situation-awareness Public layers as first-class product code under `apps/web/src/app/workspace/[workspaceId]/maps/` plus Maps API proxies under `apps/web/src/app/api/maps/`. Do **not** import from `naas_abi_marketplace/.../wsr`. World Situation Room is a legacy marketplace demo; do not couple Maps to it.
 
-The Maps sidebar mirrors Search sources: collapsible **Public / Private / Custom** groups with `active/total` counts, icon + label rows, and `org-border-radius` via `maps-*` CSS. Empty buckets (including Custom upstream) are hidden. Maps in ABI is generic: product-specific datasets (for example Zen World Organization Graph) are registered by the deployment through the Custom bucket contract below, never hard-coded into upstream ABI.
+The Maps sidebar mirrors Search sources: collapsible **Public / Private / Custom** groups with `active/total` counts, icon + label rows, and `org-border-radius` via `maps-*` CSS. Empty buckets (including Custom upstream) are hidden. Maps in ABI is generic: product-specific datasets (for example a parent-app World Organization Graph) are registered by the deployment through the Custom bucket contract below, never hard-coded into upstream ABI.
 
 | Bucket | Dataset | Route | Role |
 |---|---|---|---|

--- a/libs/naas-abi/naas_abi/apps/nexus/Dockerfile.release
+++ b/libs/naas-abi/naas_abi/apps/nexus/Dockerfile.release
@@ -11,7 +11,7 @@ COPY docker-entrypoint.sh ./docker-entrypoint.sh
 
 WORKDIR /app/apps/web
 
-# Deployments (e.g. Zen) bake public client config into the Next bundle.
+# Deployments bake public client config into the Next bundle.
 # NEXT_PUBLIC_* is inlined at build time; empty defaults keep upstream generic.
 # Baking API URL / env avoids a client race where async chunks call getApiUrl()
 # before /runtime-config.js runs and fall back to localhost:9879.

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/agents/adapters/primary/agents__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/agents/adapters/primary/agents__primary_adapter__FastAPI.py
@@ -139,10 +139,10 @@ def request_context(current_user: User) -> RequestContext:
 
 
 def _get_engine_default_agent_class_name() -> str | None:
-    """Resolve engine ``default_agent`` (e.g. ``zen ZenAgent``) to a registry key.
+    """Resolve engine ``default_agent`` (e.g. ``myapp MyAgent``) to a registry key.
 
     Registry keys are ``{python_module}/{ClassName}`` (for example
-    ``zen.agents.ZenAgent/ZenAgent``). The config form is ``{module} {AgentName}``,
+    ``myapp.agents.MyAgent/MyAgent``). The config form is ``{module} {AgentName}``,
     so we match by scanning the live class registry rather than inventing a path.
     """
     try:

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/slides/adapters/primary/slides__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/slides/adapters/primary/slides__primary_adapter__FastAPI.py
@@ -320,8 +320,8 @@ def _template_dirs() -> list[Path]:
     here = Path(__file__).resolve()
     dirs = [
         here.parents[7] / "assets" / "slides" / "templates",
-        Path("/app/src/zen/assets/slides/templates"),
-        Path("src/zen/assets/slides/templates"),
+        Path("/app/assets/slides/templates"),
+        Path("assets/slides/templates"),
     ]
     try:
         root = resources.files("naas_abi.apps.nexus.assets.slides.templates")
@@ -435,7 +435,7 @@ def _seed_template_meta(template_id: str) -> dict[str, str]:
     return {
         "id": template_id,
         "name": title,
-        "description": f"Zen deck seed ({template_id})",
+        "description": f"Deck seed ({template_id})",
         "preview_bg": "#f4f4f4",
         "preview_panel": "#ffffff",
         "preview_accent": "#0072ce",
@@ -1867,6 +1867,6 @@ async def list_seed_templates(
     workspace_id: str,
     current_user: User = Depends(get_current_user_required),
 ) -> list[SeedTemplateResponse]:
-    """List Zen/ABI seed templates available for New Presentation."""
+    """List Nexus seed templates available for New Presentation."""
     await require_workspace_access(current_user.id, workspace_id)
     return [SeedTemplateResponse(**row) for row in _list_seed_template_records()]

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/api/maps/_lib.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/api/maps/_lib.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 
 /** Maps-owned upstream identity (NWS and similar require a contactable UA). */
 export const MAPS_USER_AGENT =
-  'NexusMaps/1.0 (+https://zen.naas.ai; maps@naas.ai)';
+  'NexusMaps/1.0 (+https://naas.ai; maps@naas.ai)';
 
 export function mapsJson(
   body: unknown,

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/maps/lib/datasets.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/maps/lib/datasets.ts
@@ -218,7 +218,7 @@ const MAPS_BUILTIN_DATASETS: MapsDataset[] = [
   {
     id: 'presence',
     title: 'Here',
-    description: 'Your devices and the Zen GCP server on one map.',
+    description: 'Your devices and the deployment server on one map.',
     category: 'private',
     icon: 'Laptop',
     order: 0,

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/platform-status-footer.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/platform-status-footer.tsx
@@ -82,7 +82,7 @@ function Slot({
  * Left: User / Business workspace / Repo / Branch / Code workspace [/ dirty]
  * Right: Refresh + API health
  *
- * Terminology: see Zen docs/ux/business-vs-code-workspace.md
+ * Terminology: see parent-app docs/ux/business-vs-code-workspace.md
  */
 export function PlatformStatusFooter() {
   const pathname = usePathname() || '';

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/slides/slides-preview-fit.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/slides/slides-preview-fit.ts
@@ -1,9 +1,9 @@
-/** Canonical slide stage used by Zen / Nexus deck seeds. */
+/** Canonical slide stage used by Nexus deck seeds. */
 export const SLIDES_STAGE_WIDTH = 1280;
 export const SLIDES_STAGE_HEIGHT = 720;
 
 /** postMessage channel for sandboxed preview iframes (no allow-same-origin). */
-export const SLIDES_PREVIEW_MESSAGE_SOURCE = 'zen-slides-preview';
+export const SLIDES_PREVIEW_MESSAGE_SOURCE = 'nexus-slides-preview';
 
 export type SlidesPreviewToParentMessage =
   | {
@@ -40,8 +40,8 @@ export function computeSlidesPreviewScale(
 }
 
 /** CSS injected into preview srcDoc so fixed 1280x720 slides fill the stage cleanly. */
-export const SLIDES_PREVIEW_FIT_STYLE_ID = 'zen-slides-preview-fit';
-export const SLIDES_PREVIEW_BRIDGE_SCRIPT_ID = 'zen-slides-preview-bridge';
+export const SLIDES_PREVIEW_FIT_STYLE_ID = 'nexus-slides-preview-fit';
+export const SLIDES_PREVIEW_BRIDGE_SCRIPT_ID = 'nexus-slides-preview-bridge';
 
 const PREVIEW_BRIDGE_SCRIPT = `<script id="${SLIDES_PREVIEW_BRIDGE_SCRIPT_ID}">
 (function () {

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/config.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/config.test.ts
@@ -40,8 +40,8 @@ describe('getApiUrl public-origin fallback', () => {
       configurable: true,
       value: {
         location: {
-          hostname: 'zen.naas.ai',
-          origin: 'https://zen.naas.ai',
+          hostname: 'app.example.com',
+          origin: 'https://app.example.com',
           protocol: 'https:',
         },
         __NEXUS_RUNTIME_CONFIG__: undefined,
@@ -52,7 +52,7 @@ describe('getApiUrl public-origin fallback', () => {
     const { getApiUrl, getEnvironment } = await import('./config');
 
     expect(getEnvironment()).toBe('cloudflare');
-    expect(getApiUrl()).toBe('https://api.zen.naas.ai');
+    expect(getApiUrl()).toBe('https://api.app.example.com');
     expect(warn).toHaveBeenCalled();
   });
 
@@ -61,19 +61,19 @@ describe('getApiUrl public-origin fallback', () => {
       configurable: true,
       value: {
         location: {
-          hostname: 'zen.naas.ai',
-          origin: 'https://zen.naas.ai',
+          hostname: 'app.example.com',
+          origin: 'https://app.example.com',
           protocol: 'https:',
         },
         __NEXUS_RUNTIME_CONFIG__: {
-          apiUrl: 'https://api.zen.naas.ai',
+          apiUrl: 'https://api.app.example.com',
           env: 'cloudflare',
         },
       },
     });
 
     const { getApiUrl } = await import('./config');
-    expect(getApiUrl()).toBe('https://api.zen.naas.ai');
+    expect(getApiUrl()).toBe('https://api.app.example.com');
   });
 
   it('keeps localhost defaults for local browser origins', async () => {

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/config.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/config.ts
@@ -67,7 +67,7 @@ function isBrowserPublicOrigin(): boolean {
 
 /**
  * Last-resort API URL when runtime-config and NEXT_PUBLIC_* are missing on a
- * public origin. Matches Zen / Nexus hostname convention: api.<frontend-host>.
+ * public origin. Matches Nexus hostname convention: api.<frontend-host>.
  */
 function derivePublicApiUrl(): string {
   const { protocol, hostname } = window.location;
@@ -87,7 +87,7 @@ function getResolvedApiUrl(defaultValue: string): string {
 
   // Next.js can evaluate client modules before /runtime-config.js runs. On a
   // public origin, never use loopback or another product's baked default
-  // (e.g. api.nexus.naas.ai while serving zen.naas.ai).
+  // (e.g. api.other.example.com while serving app.example.com).
   if (isBrowserPublicOrigin()) {
     const derived = derivePublicApiUrl();
     if (defaultValue !== derived) {

--- a/libs/naas-abi/naas_abi/apps/nexus/assets/slides/templates/NOTICE.md
+++ b/libs/naas-abi/naas_abi/apps/nexus/assets/slides/templates/NOTICE.md
@@ -1,6 +1,6 @@
 # Third-party notices (Slides templates)
 
-Visual preset ideas (color mood, layout density) were adapted for the Zen
+Visual preset ideas (color mood, layout density) were adapted for the Nexus
 deck contract from the MIT-licensed Frontend Slides skill and style recipes:
 
 https://github.com/zarazhangrui/frontend-slides
@@ -25,5 +25,5 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-Zen does not vendor the Frontend Slides skill sources. Seeds here use the Zen
+ABI does not vendor the Frontend Slides skill sources. Seeds here use the Nexus
 HTML contract (`.deck` / `.slide`, menubar, `buildPptx()`).

--- a/libs/naas-abi/naas_abi/apps/nexus/assets/slides/templates/README.md
+++ b/libs/naas-abi/naas_abi/apps/nexus/assets/slides/templates/README.md
@@ -2,7 +2,7 @@
 
 Canonical seed decks for Nexus Slides (`/slides`).
 
-Mirrored for Zen deploys at `src/zen/assets/slides/templates/` in the Zen repo.
+Parent applications may mirror these seeds under their own assets tree if needed.
 
 | File | Catalog name | Notes |
 |---|---|---|
@@ -23,10 +23,10 @@ New Slides projects copy the chosen seed into Forgejo at `slides/<slug>/deck.htm
 
 ## How to add a template
 
-1. Copy an existing `*.html` seed and restyle under the Zen contract above.
+1. Copy an existing `*.html` seed and restyle under the Nexus contract above.
 2. Name the file `<kebab-id>.html` (e.g. `swiss-modern-v1.html`). The stem is the `template_id`.
 3. Register it in `catalog.json` with `id`, `name`, `description`, and `preview` colors (`bg`, `panel`, `accent`, `ink`) for the gallery CSS miniature.
-4. Mirror the same files into Zen `src/zen/assets/slides/templates/` when shipping on Zen.
+4. Optionally mirror the same files into the parent application assets tree when shipping a product deploy.
 5. Run API tests: `pytest …/slides__primary_adapter__FastAPI_test.py -k seed`.
 6. Optional: progressive style packs can be imported later by dropping more HTML + catalog rows; do not vendor external skill trees as source.
 

--- a/libs/naas-abi/naas_abi/apps/nexus/assets/slides/templates/executive-v1.html
+++ b/libs/naas-abi/naas_abi/apps/nexus/assets/slides/templates/executive-v1.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<meta name="zen-slides-template" content="executive-v1" />
+<meta name="nexus-slides-template" content="executive-v1" />
 <title>Presentation Title</title>
 <script src="https://code.iconify.design/iconify-icon/2.1.0/iconify-icon.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/pptxgenjs@3.12.0/dist/pptxgen.bundle.js"></script>
@@ -340,7 +340,7 @@ async function buildPptx() {
   });
 })();
 </script>
-<script>/* zen-slides-viewport-fit */
+<script>/* nexus-slides-viewport-fit */
 
 (function(){
   var STAGE_W = 1280, STAGE_H = 720;

--- a/libs/naas-abi/naas_abi/apps/nexus/assets/slides/templates/minimal-light-v1.html
+++ b/libs/naas-abi/naas_abi/apps/nexus/assets/slides/templates/minimal-light-v1.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<meta name="zen-slides-template" content="minimal-light-v1" />
+<meta name="nexus-slides-template" content="minimal-light-v1" />
 <title>Presentation Title</title>
 <script src="https://code.iconify.design/iconify-icon/2.1.0/iconify-icon.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/pptxgenjs@3.12.0/dist/pptxgen.bundle.js"></script>
@@ -340,7 +340,7 @@ async function buildPptx() {
   });
 })();
 </script>
-<script>/* zen-slides-viewport-fit */
+<script>/* nexus-slides-viewport-fit */
 
 (function(){
   var STAGE_W = 1280, STAGE_H = 720;

--- a/libs/naas-abi/naas_abi/apps/nexus/assets/slides/templates/pitch-dark-v1.html
+++ b/libs/naas-abi/naas_abi/apps/nexus/assets/slides/templates/pitch-dark-v1.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<meta name="zen-slides-template" content="pitch-dark-v1" />
+<meta name="nexus-slides-template" content="pitch-dark-v1" />
 <title>Presentation Title</title>
 <script src="https://code.iconify.design/iconify-icon/2.1.0/iconify-icon.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/pptxgenjs@3.12.0/dist/pptxgen.bundle.js"></script>
@@ -340,7 +340,7 @@ async function buildPptx() {
   });
 })();
 </script>
-<script>/* zen-slides-viewport-fit */
+<script>/* nexus-slides-viewport-fit */
 
 (function(){
   var STAGE_W = 1280, STAGE_H = 720;


### PR DESCRIPTION
## Summary
- Remove Zen-specific branding, hostnames (`zen.naas.ai`), paths (`/opt/zen/zen`, `src/zen/...`), and docs that treated ABI as the Zen product.
- Generalize CLI break-glass ops copy, Nexus slides/maps/config examples, seed template IDs (`nexus-slides-*`), and default-agent docstring examples to ABI / Nexus / parent-app language.
- Local junk `SCM_DIFF_TEST.md` was deleted and not committed; `dev/` left untracked.

## What was removed vs kept
**Removed / generalized (21 files):**
- CLI: `nexus_postgres`, `user`, `workspace` help text + README (`/opt/abi`, ops VM wording)
- Nexus slides: template dirs, seed descriptions, preview message/source IDs, HTML meta/comments, NOTICE/README
- Nexus web: Maps UA, Here dataset copy, platform footer comment, `config.ts` / `config.test.ts` hosts (`app.example.com`)
- Agents adapter docstring examples (`myapp MyAgent`)
- Coder adapter test URLs (`coder.example.com`)
- Nexus `AGENTS.md` / `Dockerfile.release` product references

**Intentionally kept (false positives / not product coupling):**
- `frozen=True`, `frozenset`, `frozen-lockfile`, `frozenlist` / `frozendict` lock entries
- Ontology terms: Citizen, Zenith, zenith; place name Natanz
- English "dozens"; package-lock integrity hashes containing `zen` substrings
- No changelog archaeology: no release-note rewrites needed for product Zen hits on `main`

**Remaining case-insensitive `zen` substring hits:** ~244 after excluding lockfiles/node_modules (almost all `frozen*` / Citizen / Zenith / Natanz / hashes). **Standalone `\bzen\b` / `\bZen\b` product hits on tracked sources: 0.**

## Test plan
- [ ] Spot-check CLI help: `abi user create --help`, `abi workspace create --help`
- [ ] Nexus web: `pnpm test -- src/lib/config.test.ts` and slides preview fit tests under `apps/nexus/apps/web`
- [ ] Confirm Maps UA still acceptable for NWS-style upstreams
- [ ] After merge only: bump parent Zen `.abi` submodule SHA (not part of this PR)