### PR TITLE
feat(cli): make the scaffolded default admin a superadmin

### DIFF
--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/config_template_test.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/config_template_test.py
@@ -30,6 +30,9 @@ _TEMPLATE = os.path.join(_TEMPLATES_DIR, "config.local.yaml")
 _DEFAULT_CHAT_MODEL = "gemma-4-26b-a4b-it"
 _DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small"
 _ALL_CONFIGS = ("config.yaml", "config.local.yaml", "config.remote.yaml")
+# config.remote.yaml seeds no users — it expects them to be created by an
+# operator, so only these two carry the bootstrap admin.
+_CONFIGS_SEEDING_USERS = ("config.yaml", "config.local.yaml")
 
 _BASE_VALUES = {
     "project_name": "Demo",
@@ -96,6 +99,24 @@ def test_model_registry_defaults_are_the_cheap_openrouter_pair(filename: str) ->
 
     assert registry["default_chat_model"] == _DEFAULT_CHAT_MODEL
     assert registry["default_embedding_model"] == _DEFAULT_EMBEDDING_MODEL
+
+
+@pytest.mark.parametrize("filename", _CONFIGS_SEEDING_USERS)
+def test_seeded_admin_is_a_superadmin(filename: str) -> None:
+    """The bootstrap admin owns the seeded org and workspace, but org/workspace
+    ownership does not grant platform-wide admin (admin console, live event
+    stream) — that is the separate ``is_superadmin`` flag, and without it a new
+    project has no account that can reach those screens."""
+    nexus_config = next(
+        m for m in _render(filename)["modules"] if m["module"] == "naas_abi"
+    )["config"]["nexus_config"]
+    users = nexus_config["users"]
+
+    assert users, f"{filename} seeds no users"
+    assert all(u["is_superadmin"] for u in users)
+    # The seeded admin is also the org/workspace owner; the two must not drift.
+    org = nexus_config["organizations"][0]
+    assert org["owner_email"] in {u["email"] for u in users}
 
 
 @pytest.mark.parametrize("filename", _ALL_CONFIGS)

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/project/config.local.yaml
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/project/config.local.yaml
@@ -86,6 +86,9 @@ modules:
         users:
           - email: "admin@example.com"
             name: "ABI Admin"
+            # Platform-wide admin (admin console, live event stream). Kept in
+            # config so it is reconciled on every boot — flip to false to demote.
+            is_superadmin: true
         organizations:
           - name: "ABI"
             slug: "abi"

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/project/config.yaml
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/project/config.yaml
@@ -45,6 +45,9 @@ modules:
         users:
           - email: "admin@example.com"
             name: "Dev Admin"
+            # Platform-wide admin (admin console, live event stream). Kept in
+            # config so it is reconciled on every boot — flip to false to demote.
+            is_superadmin: true
         organizations:
           - name: "Dev"
             slug: "dev"


### PR DESCRIPTION
## What

`abi new project` seeds `admin@example.com` as the org + workspace owner, but left `is_superadmin` at its default (`false`). Org/workspace ownership is a different axis from platform-wide admin — the admin console and live event stream gate on `is_superadmin` — so a freshly scaffolded project had **no account able to reach those screens**.

The repo-root dev `config.yaml` already sets `is_superadmin: true`; the scaffold templates had simply drifted from it. This brings them back in line.

## Changes

- `cli/new/templates/project/config.yaml` — `is_superadmin: true` on the seeded admin
- `cli/new/templates/project/config.local.yaml` — same
- `cli/new/config_template_test.py` — regression test asserting the flag, parametrized over the two configs that seed users

`config.remote.yaml` seeds no users (operator-provisioned), so it is unchanged.

## Notes

`org_seed` reconciles `is_superadmin` from config on **every** boot, so this also promotes the admin in existing projects that pick up the regenerated config — and flipping it back to `false` demotes, without recreating the account.

## Verification

- Rendered all three templates through Jinja + YAML and validated the users against `UserSeedConfig` (which is `extra="forbid"`): both seeding configs yield `admin@example.com → is_superadmin=True`.
- `config_template_test.py`: 13 passed (11 existing + 2 new).
- Pre-commit suite green on both commits: ruff, mypy, bandit, Nexus build.