### PR TITLE
feat(deploy): make `admin` the default local admin password everywhere

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ NEXUS_API_URL=http://127.0.0.1:9879
 
 # Seeded by `abi dev` on first boot when auth_password_enabled is true.
 # NEXUS_USER_ADMIN_EXAMPLE_COM_EMAIL=admin@example.com
-# NEXUS_USER_ADMIN_EXAMPLE_COM_PASSWORD=
+# NEXUS_USER_ADMIN_EXAMPLE_COM_PASSWORD=admin
 
 # Optional: override Ollama endpoint (auto-detected by default).
 # ABI_OLLAMA_BASE_URL=http://127.0.0.1:11434

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,11 +216,11 @@ Default admin credentials:
 
 | Email | Password |
 |---|---|
-| `admin@example.com` | `Admin1234!` |
+| `admin@example.com` | `admin` |
 
 Password login is enabled via `auth_password_enabled: true` in `config.local.yaml`. Set it to `false` to switch back to magic link.
 
-**How the password is set:** On first boot, the seeder looks for `NEXUS_USER_ADMIN_EXAMPLE_COM_PASSWORD` in `.env`. If found, it uses that value. If missing, it generates a random password and writes it back to `.env`. The `.env` in this repo ships with `Admin1234!` pre-set, so all teammates get the same password as long as they don't delete that line.
+**How the password is set:** On first boot, the seeder looks for `NEXUS_USER_ADMIN_EXAMPLE_COM_PASSWORD` in `.env`. If found, it uses that value. If missing, it generates a random password and writes it back to `.env`. The `.env` in this repo ships with `admin` pre-set, so all teammates get the same password as long as they don't delete that line.
 
 If you see "Incorrect email or password":
 
@@ -234,10 +234,10 @@ abi stack start
 ```bash
 # 1. Add to .env if missing:
 echo "NEXUS_USER_ADMIN_EXAMPLE_COM_EMAIL=admin@example.com" >> .env
-echo "NEXUS_USER_ADMIN_EXAMPLE_COM_PASSWORD=Admin1234!" >> .env
+echo "NEXUS_USER_ADMIN_EXAMPLE_COM_PASSWORD=admin" >> .env
 
 # 2. Reset the hash in Postgres directly:
-HASH=$(docker exec abi-abi-1 python3 -c "import bcrypt; print(bcrypt.hashpw(b'Admin1234!', bcrypt.gensalt()).decode())")
+HASH=$(docker exec abi-abi-1 python3 -c "import bcrypt; print(bcrypt.hashpw(b'admin', bcrypt.gensalt()).decode())")
 docker exec abi-postgres-1 psql -U abi -d nexus -c "UPDATE users SET hashed_password='$HASH' WHERE email='admin@example.com';"
 docker compose restart abi
 ```
@@ -385,4 +385,4 @@ Non-obvious gotchas discovered during setup:
 - **For capable cloud models:** set `global_config.ai_mode: "cloud"`, uncomment a cloud provider module in `config.yaml`, replace `SECRET_REF` with a real Jinja secret, and add its key via Cursor Secrets / `.env`.
 - **First API boot is slow (~2-3 min):** the worker loads every module/ontology and runs Nexus SQLite migrations before serving. Watch `abi dev logs api`; it is ready when `/docs` returns 200 (`GET http://localhost:<api-port>/docs`).
 - **Ports are offset per worktree** (see `abi dev ports`), so they are not the config defaults. `abi dev` injects `OXIGRAPH_URL` into each service; the `config.yaml` default `:7878` is not the live port. To run a test that builds its own engine against the live triple store, pass `OXIGRAPH_URL=http://127.0.0.1:<oxigraph-port>`.
-- **Login:** `admin@example.com` / `admin` (the `abi dev` default; the Docker stack uses `Admin1234!`). Web UI is the `nexus-web` port.
+- **Login:** `admin@example.com` / `admin` — the same default for `abi dev up` and the Docker stack. Web UI is the `nexus-web` port.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ abi dev up
 
 ### Web UI
 
-The main interface. Chat with Abi, switch agents, manage your workspace, and access your knowledge graph. Open [http://localhost:3042](http://localhost:3042) and log in with `admin@example.com` / `Admin1234!`.
+The main interface. Chat with Abi, switch agents, manage your workspace, and access your knowledge graph. Open [http://localhost:3042](http://localhost:3042) and log in with `admin@example.com` / `admin`.
 
 <div align="center">
   <img src="docs/site/static/abi/Screenshot_Local_WebUI.png" alt="ABI web UI" width="800">

--- a/config.local.yaml
+++ b/config.local.yaml
@@ -104,7 +104,7 @@ modules:
           login_footer_text: "© ABI AI Platform (Beta) | Naas.ai"
 
         # Q: Who gets an account created automatically on first boot?
-        # A: List seed users here. Password comes from NEXUS_USER_ADMIN_EXAMPLE_COM_PASSWORD in .env (default: Admin1234!)
+        # A: List seed users here. Password comes from NEXUS_USER_ADMIN_EXAMPLE_COM_PASSWORD in .env (default: admin)
         users:
           - email: "admin@example.com"
             name: "Local Admin"

--- a/docs/site/docs/capabilities/applications/nexus.md
+++ b/docs/site/docs/capabilities/applications/nexus.md
@@ -49,7 +49,7 @@ The local stack seeds a single admin account on first start. Default credentials
 
 | Email | Password |
 |---|---|
-| `admin@example.com` | `Admin1234!` |
+| `admin@example.com` | `admin` |
 
 The password is read from `.env` at seed time via `NEXUS_USER_ADMIN_EXAMPLE_COM_PASSWORD`. Change it there before sharing the stack with others.
 

--- a/docs/site/docs/get-started/quickstart.md
+++ b/docs/site/docs/get-started/quickstart.md
@@ -43,9 +43,9 @@ OPENROUTER_API_KEY=sk-or-...
 
 # Local admin login at http://localhost:3042/auth/login
 NEXUS_USER_ADMIN_EMAIL=admin@example.com
-NEXUS_USER_ADMIN_PASSWORD=Admin1234!
+NEXUS_USER_ADMIN_PASSWORD=admin
 NEXUS_USER_ADMIN_EXAMPLE_COM_EMAIL=admin@example.com
-NEXUS_USER_ADMIN_EXAMPLE_COM_PASSWORD=Admin1234!
+NEXUS_USER_ADMIN_EXAMPLE_COM_PASSWORD=admin
 ```
 
 For local mode (no internet, no API key required), set `ai_mode: "local"` in `config.yaml` and install Ollama.

--- a/libs/naas-abi-cli/naas_abi_cli/cli/deploy/local.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/deploy/local.py
@@ -39,7 +39,9 @@ DEFAULT_ENV_VALUES: dict[str, str] = {
     "NEXUS_WEB_TAG": "latest",
     "NEXUS_WEB_PORT": "3042",
     "NEXUS_USER_ADMIN_EMAIL": "admin@example.com",
-    "NEXUS_USER_ADMIN_PASSWORD": "Admin1234!",
+    # Local-only convenience credential, matching the `abi dev up` default
+    # (see DEFAULT_ADMIN_PASSWORD in cli/dev.py). Overridable via `.env`.
+    "NEXUS_USER_ADMIN_PASSWORD": "admin",  # nosec B105 - local-dev only
     "HEADSCALE_SERVER_URL": "headscale.localhost",
     "HEADSCALE_SERVER_PORT": "8083",
     "HEADSCALE_METRICS_PORT": "9090",

--- a/libs/naas-abi/naas_abi/apps/nexus/CONTRIBUTING.md
+++ b/libs/naas-abi/naas_abi/apps/nexus/CONTRIBUTING.md
@@ -50,7 +50,7 @@ make up
 
 Visit http://localhost:3000 and login with:
 - Email: `admin@example.com`
-- Password: `Admin1234!`
+- Password: `admin`
 
 ## Development Setup
 

--- a/libs/naas-abi/naas_abi/apps/nexus/README.md
+++ b/libs/naas-abi/naas_abi/apps/nexus/README.md
@@ -16,7 +16,7 @@ git clone https://github.com/jravenel/nexus.git && cd nexus
 make install && make db-up && make db-migrate && make up
 ```
 
-→ **http://localhost:3000/auth/login** · `admin@example.com` / `Admin1234!`
+→ **http://localhost:3000/auth/login** · `admin@example.com` / `admin`
 
 ## Features
 

--- a/libs/naas-abi/naas_abi/apps/nexus/docs/START.md
+++ b/libs/naas-abi/naas_abi/apps/nexus/docs/START.md
@@ -12,7 +12,7 @@ make up         # Start servers
 
 Visit http://localhost:3000
 
-**Login:** admin@example.com / Admin1234!
+**Login:** admin@example.com / admin
 
 ## What Is This?
 

--- a/libs/naas-abi/naas_abi/apps/nexus/docs/TROUBLESHOOTING.md
+++ b/libs/naas-abi/naas_abi/apps/nexus/docs/TROUBLESHOOTING.md
@@ -244,7 +244,7 @@ curl http://localhost:8000/docs
 # 5. Check specific endpoint
 curl -X POST http://localhost:8000/api/auth/login \
   -H "Content-Type: application/json" \
-  -d '{"email":"admin@example.com","password":"Admin1234!"}'
+  -d '{"email":"admin@example.com","password":"admin"}'
 ```
 
 ### CORS errors
@@ -417,12 +417,12 @@ docker exec nexus-postgres psql -U nexus -d nexus -c "SELECT email FROM users;"
 
 # 2. Check local admin credentials (set in .env)
 # Email: admin@example.com (NEXUS_USER_ADMIN_EMAIL)
-# Password: Admin1234!  (NEXUS_USER_ADMIN_PASSWORD)
+# Password: admin  (NEXUS_USER_ADMIN_PASSWORD)
 
 # 3. Check API login endpoint
 curl -X POST http://localhost:8000/api/auth/login \
   -H "Content-Type: application/json" \
-  -d '{"email":"admin@example.com","password":"Admin1234!"}'
+  -d '{"email":"admin@example.com","password":"admin"}'
 # Should return {"access_token": "...", "refresh_token": "..."}
 
 # 4. Check browser console for errors


### PR DESCRIPTION
## Why

Two different defaults for the same local login:

| Path | Default password |
|---|---|
| `abi dev up` (native) | `admin` |
| `abi deploy local` (Docker) | `Admin1234!` |

So which one you type depends on which stack you happened to boot. This aligns both on `admin`.

## Is this a downgrade?

No. `Admin1234!` is not a secret — it's printed in the README, AGENTS.md, the docs site, CONTRIBUTING, START.md and TROUBLESHOOTING of a **public** repo. Both values are equally guessable; only one of them is also annoying to type.

The change is local-only:

- `DEFAULT_ENV_VALUES` is read solely by `abi deploy local`. Remote deploys don't touch it.
- An existing `.env` value always wins — existing stacks are unaffected.
- Fuseki / Postgres / MinIO / RabbitMQ / Coder / Forgejo passwords stay randomly generated (`RANDOM_ENV_KEYS`, `secrets.token_urlsafe`). This only moves the seeded Nexus admin login.

## Why `admin` is accepted at all

The seeder in `org_seed.py` bcrypt-hashes the password directly, so it never passes through `UserCreate` (`min_length=8`). Login goes through `UserLogin`, which is `min_length=1`. That's why the native path could already use `admin` — this just makes the Docker path agree.

## Changes

- `deploy/local.py` — `NEXUS_USER_ADMIN_PASSWORD` default `Admin1234!` → `admin`
- `.env.example` — fill in the (still-commented) documented default
- 16 doc references updated across README, AGENTS.md, docs site, quickstart, Nexus README/CONTRIBUTING/START/TROUBLESHOOTING, `config.local.yaml`
- AGENTS.md no longer says "the Docker stack uses a different one"

## Verification

- `uvx ruff check ...` (exact Makefile line) — passed
- pre-commit gate (ruff + mypy across core/cli/abi) — passed
- `pytest deploy/local_test.py dev_test.py` — 38 passed, 1 failed
  - The failure is `test_setup_local_deploy_hardens_fuseki_for_reliability`, and it is **pre-existing**: I reverted `local.py` to `HEAD` and it fails identically. It asserts one `image:` line in the fuseki section while the template now also has a `curlimages/curl` sidecar. Unrelated to this change, not fixed here.
- e2e specs already defaulted to `admin` (`NEXUS_ADMIN_PASSWORD || 'admin'`), so they now match the Docker stack too.