### PR TITLE
fix(agent): stop the markdown formatting pass from erasing the answer

### DIFF
--- a/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
@@ -1027,7 +1027,11 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
         ]
 
         try:
-            formatted_response = self._chat_model_with_tools.invoke(prompt)
+            # Use the *unbound* model: this pass only reformats text, and a
+            # tool-bound model may answer a formatting prompt with a tool call
+            # and `content=''` (small local models do this readily), which used
+            # to wipe the real answer below.
+            formatted_response = self._chat_model.invoke(prompt)
             logger.debug(
                 f"Markdown pretty display response: {formatted_response.content}"
             )
@@ -1035,7 +1039,18 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
             if not isinstance(formatted_response.content, str):
                 return response
 
-            response.content = formatted_response.content.strip()
+            formatted = formatted_response.content.strip()
+            if not formatted:
+                # Never let a failed formatting pass destroy the answer. This
+                # surfaced as an agent that "replied" in the logs while the UI
+                # streamed nothing and sat on its placeholder forever.
+                logger.warning(
+                    f"Markdown pretty display returned empty content for agent "
+                    f"'{self._name}'; keeping the unformatted response."
+                )
+                return response
+
+            response.content = formatted
             return response
         except Exception as e:  # noqa: BLE001
             logger.warning(

--- a/libs/naas-abi-core/naas_abi_core/services/agent/Agent_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/Agent_test.py
@@ -586,3 +586,73 @@ def test_normalize_coerces_present_but_invalid_input_in_tooluse_block():
 
     assert normalized is not message
     assert normalized.content[0]["toolUse"]["input"] == {}
+
+
+def _pretty_display_stub(plain_output: str, tool_bound_output: str):
+    """Minimal ``self`` for calling ``_pretty_display_markdown`` unbound.
+
+    Gives the unbound and tool-bound models *different* replies so a test can
+    tell which one the formatting pass actually used.
+    """
+    from types import SimpleNamespace
+
+    from langchain_core.messages import AIMessage
+
+    class _Model:
+        def __init__(self, out):
+            self.out = out
+            self.calls = 0
+
+        def invoke(self, _prompt):
+            self.calls += 1
+            return AIMessage(content=self.out)
+
+    plain = _Model(plain_output)
+    tool_bound = _Model(tool_bound_output)
+    return (
+        SimpleNamespace(
+            _name="Tester",
+            _chat_model=plain,
+            _chat_model_with_tools=tool_bound,
+        ),
+        plain,
+        tool_bound,
+    )
+
+
+def test_pretty_display_keeps_answer_when_formatter_returns_empty():
+    """A formatting pass that comes back blank must not destroy the answer.
+
+    Regression guard: the formatter assigned its (empty) output straight onto
+    the response, so the agent logged a real reply while the chat stream
+    emitted nothing and the UI sat on its `▌` placeholder forever.
+    """
+    from langchain_core.messages import AIMessage
+    from naas_abi_core.services.agent.Agent import Agent
+
+    original = "I am Abi, the orchestrator Agent developed by NaasAI."
+    response = AIMessage(content=original)
+    stub, _, _ = _pretty_display_stub("   \n  ", "   \n  ")
+
+    result = Agent._pretty_display_markdown(stub, response)
+
+    assert result.content == original
+
+
+def test_pretty_display_formats_via_the_unbound_model():
+    """The pass must use the tool-free model.
+
+    A tool-bound model can answer a formatting prompt with a tool call and
+    ``content=''`` — which is exactly how the answer got wiped in practice.
+    """
+    from langchain_core.messages import AIMessage
+    from naas_abi_core.services.agent.Agent import Agent
+
+    response = AIMessage(content="hello there")
+    stub, plain, tool_bound = _pretty_display_stub("**Hello** there\n", "")
+
+    result = Agent._pretty_display_markdown(stub, response)
+
+    assert result.content == "**Hello** there"
+    assert plain.calls == 1
+    assert tool_bound.calls == 0

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
@@ -823,6 +823,7 @@ export function ChatInterface({
   const setSelectedAgent = useWorkspaceStore((s) => s.setSelectedAgent);
   const addMessage = useWorkspaceStore((s) => s.addMessage);
   const updateLastMessage = useWorkspaceStore((s) => s.updateLastMessage);
+  const updateMessageById = useWorkspaceStore((s) => s.updateMessageById);
   const getWorkspaceConversations = useWorkspaceStore((s) => s.getWorkspaceConversations);
   const currentWorkspaceId = useWorkspaceStore((s) => s.currentWorkspaceId);
   const loadConversationMessages = useWorkspaceStore((s) => s.loadConversationMessages);
@@ -1750,9 +1751,15 @@ export function ChatInterface({
     let effectiveAgent = agentOverride ?? selectedAgent;
     // Pane can hydrate with paneAgent="" before agents sync; resolve Abi/default
     // so stream has a real agent id (selector label may already show Abi).
-    if (!effectiveAgent) {
+    //
+    // On a freshly booted project the agents list can still be in flight when
+    // the first message is sent (the boot-time /api/ontology/* calls delay it
+    // by seconds). Sending then posts `agent: ""`, which the API rejects with
+    // 422 `string_too_short`, so wait briefly rather than firing a request that
+    // cannot succeed.
+    const resolveAgentId = () => {
       const agents = useAgentsStore.getState().agents.filter((a) => a.enabled);
-      const resolved =
+      return (
         (isPane
           ? agents.find(
               (a) =>
@@ -1762,7 +1769,16 @@ export function ChatInterface({
             )
           : null) ??
         agents.find((a) => a.isDefault) ??
-        agents[0];
+        agents[0]
+      );
+    };
+    if (!effectiveAgent) {
+      let resolved = resolveAgentId();
+      const waitUntil = Date.now() + 8000;
+      while (!resolved && Date.now() < waitUntil) {
+        await new Promise((r) => setTimeout(r, 150));
+        resolved = resolveAgentId();
+      }
       if (resolved) {
         effectiveAgent = resolved.id;
         if (isPane) {
@@ -1771,6 +1787,13 @@ export function ChatInterface({
           useWorkspaceStore.getState().setSelectedAgent(resolved.id);
         }
       }
+    }
+    if (!effectiveAgent) {
+      // Keep the composer contents so the message is not lost, and release the
+      // submit lock so the user can retry once agents finish loading.
+      isSubmittingRef.current = false;
+      setImageError('Agents are still loading — try again in a moment.');
+      return;
     }
 
     const latestActiveConversationId = readSurfaceConversationId();
@@ -1898,6 +1921,48 @@ export function ChatInterface({
     setRequestSentAt(Date.now());
     setIsLoading(true);
 
+    // Hoisted out of the streaming branch so the outer error handler can
+    // address the assistant placeholder by id. `isStreaming` (React state) is
+    // stale inside this closure, so branching on it there wrote the error to
+    // the wrong row and left the placeholder spinning on `▌` forever.
+    let assistantMessageIdRef: string | null = null;
+
+    // Single writer for the streaming assistant row. Targets it by id so a
+    // mid-turn message-list change (conversation sync, pane/tab switch) cannot
+    // redirect the write to whatever happens to be last.
+    const writeAssistantMessage = (
+      content: string,
+      thinkingDuration?: number,
+      sources?: string[],
+      activityLine?: string | null,
+      toolCalls?: ToolCall[] | null,
+      executionTime?: number,
+    ) => {
+      if (!conversationId) return;
+      if (assistantMessageIdRef) {
+        updateMessageById(
+          conversationId,
+          assistantMessageIdRef,
+          content,
+          thinkingDuration,
+          sources,
+          activityLine,
+          toolCalls,
+          executionTime,
+        );
+      } else {
+        updateLastMessage(
+          conversationId,
+          content,
+          thinkingDuration,
+          sources,
+          activityLine,
+          toolCalls,
+          executionTime,
+        );
+      }
+    };
+
     try {
       // Get provider for current agent
       const provider = getProviderForAgent(effectiveAgent);
@@ -1959,7 +2024,6 @@ export function ChatInterface({
         // variable AND in React state — the SSE handler runs inside the same
         // async function so it can't rely on the freshly-set state (closures
         // capture stale values).
-        let assistantMessageIdRef: string | null = null;
         {
           const convNow = useWorkspaceStore.getState().conversations.find(c => c.id === conversationId);
           const lastMsg = convNow?.messages[convNow.messages.length - 1];
@@ -2177,8 +2241,7 @@ export function ChatInterface({
             ? `${contentBody || '▌'}${contentBody ? '▌' : ''}`
             : `${contentBody}`;
 
-          updateLastMessage(
-            conversationId!,
+          writeAssistantMessage(
             assembled.trimEnd() || '▌',
             undefined,
             streamSources.length > 0 ? streamSources : undefined,
@@ -2313,7 +2376,7 @@ export function ChatInterface({
                 if (parsed.error) {
                   // Show error in current message and throw to trigger modal
                   fullContent = `Error: ${parsed.error}`;
-                  updateLastMessage(conversationId!, fullContent);
+                  writeAssistantMessage(fullContent);
                   throw new Error(parsed.error);
                 }
               } catch (parseError) {
@@ -2338,8 +2401,7 @@ export function ChatInterface({
         // Mark any still-running tool as done
         streamToolCalls.forEach((t) => { if (t.status === 'running') t.status = 'done'; });
         const finalToolCalls = streamToolCalls.length > 0 ? [...streamToolCalls] : undefined;
-        updateLastMessage(
-          conversationId!,
+        writeAssistantMessage(
           finalContent,
           thinkingDuration,
           streamSources.length > 0 ? streamSources : undefined,
@@ -2377,16 +2439,13 @@ export function ChatInterface({
             : responseContent;
           const finalContent = finalBody.trim();
           streamToolCalls.forEach((t) => { if (t.status === 'running') t.status = 'done'; });
-          if (conversationId) {
-            updateLastMessage(
-              conversationId,
-              finalContent,
-              undefined,
-              streamSources.length > 0 ? streamSources : undefined,
-              hasDetailedActivity ? streamActivityLine : null,
-              streamToolCalls.length > 0 ? [...streamToolCalls] : undefined,
-            );
-          }
+          writeAssistantMessage(
+            finalContent,
+            undefined,
+            streamSources.length > 0 ? streamSources : undefined,
+            hasDetailedActivity ? streamActivityLine : null,
+            streamToolCalls.length > 0 ? [...streamToolCalls] : undefined,
+          );
         } else {
           // Streaming-specific error - throw to outer catch for modal handling
           throw streamError as any;
@@ -2513,17 +2572,23 @@ export function ChatInterface({
       // } else {
       // For other errors, update the placeholder if it exists, otherwise add new message
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      const errorBody = `❌ Error: ${errorMessage}\n\nPlease try again or check your provider settings.`;
       if (conversationId) {
-          if (isStreaming) {
-            updateLastMessage(conversationId, `❌ Error: ${errorMessage}\n\nPlease try again or check your provider settings.`);
-          } else {
-            addMessage(conversationId, {
-              role: 'assistant',
-              content: `❌ Error: ${errorMessage}\n\nPlease try again or check your provider settings.`,
-              agent: effectiveAgent,
-            });
-          }
+        // Branch on whether a placeholder was actually created, not on the
+        // `isStreaming` React state — that const is captured at render time and
+        // is still `false` here even though `setIsStreaming(true)` ran earlier
+        // in this same call. Reading it stranded the placeholder on `▌` and
+        // appended a second bubble instead of replacing it.
+        if (assistantMessageIdRef) {
+          writeAssistantMessage(errorBody, undefined, undefined, null, null);
+        } else {
+          addMessage(conversationId, {
+            role: 'assistant',
+            content: errorBody,
+            agent: effectiveAgent,
+          });
         }
+      }
     } finally {
       setIsLoading(false);
       setIsStreaming(false);

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
@@ -277,6 +277,21 @@ interface WorkspaceState {
     toolCalls?: ToolCall[] | null,
     executionTime?: number,
   ) => void;
+  /** Update one message by id. Streaming must use this rather than
+   *  `updateLastMessage`: the assistant placeholder is not reliably the last
+   *  message for the whole turn (`loadConversationMessages` appends
+   *  server-unknown local messages after it), and a positional write then
+   *  lands on the wrong row, stranding the placeholder on its `▌` spinner. */
+  updateMessageById: (
+    conversationId: string,
+    messageId: string,
+    content: string,
+    thinkingDuration?: number,
+    sources?: string[],
+    activityLine?: string | null,
+    toolCalls?: ToolCall[] | null,
+    executionTime?: number,
+  ) => void;
   updateMessageFeedback: (
     conversationId: string,
     messageId: string,
@@ -619,6 +634,41 @@ export const useWorkspaceStore = create<WorkspaceState>()(
               ...conv,
               messages: conv.messages.map((msg, idx) =>
                 idx === conv.messages.length - 1
+                  ? {
+                      ...msg,
+                      content,
+                      ...(thinkingDuration !== undefined && { thinkingDuration }),
+                      ...(sources !== undefined && { sources }),
+                      ...(activityLine !== undefined && { activityLine: activityLine || undefined }),
+                      ...(toolCalls !== undefined && { toolCalls: toolCalls || undefined }),
+                      ...(executionTime !== undefined && { executionTime }),
+                    }
+                  : msg
+              ),
+              updatedAt: new Date(),
+            }
+          : conv
+      ),
+    }));
+  },
+
+  updateMessageById: (
+    conversationId,
+    messageId,
+    content,
+    thinkingDuration,
+    sources,
+    activityLine,
+    toolCalls,
+    executionTime,
+  ) => {
+    set((state) => ({
+      conversations: state.conversations.map((conv) =>
+        conv.id === conversationId
+          ? {
+              ...conv,
+              messages: conv.messages.map((msg) =>
+                msg.id === messageId
                   ? {
                       ...msg,
                       content,


### PR DESCRIPTION
## Symptom

On a fresh `abi dev up` project: you talk to Abi, the abi process logs show the
LLM answered, but the Nexus UI stays on **"Processing…"** forever — no error, no
warning. Reported by @Dr0p42.

## Root cause

`Agent._pretty_display_markdown` runs a *second* LLM call to reformat the reply,
then assigned the result onto the response unconditionally:

```python
response.content = formatted_response.content.strip()
```

When that second call comes back blank, the real answer is silently replaced
with `""`. Captured live on `abi dev up` (Ollama `qwen2.5:3b`):

```
18:03:56.404  Model response: content='I am Abi, the orchestrator Agent developed by NaasAI...'
18:03:56.431  Applying Markdown pretty display to response
18:04:08.475  Markdown pretty display response:          <- empty
18:04:39.977  stream_invoke:2259 - Response:             <- empty
```

With an empty final state, `stream_invoke` emits no `ai_message` events, the SSE
stream carries no `content` frames, the assistant row is persisted empty, and
the client never leaves its `▌` placeholder. Nothing raises, so no error is ever
shown — which is exactly why this looks like a hang rather than a failure.

Why it comes back blank: the pass used `_chat_model_with_tools`. A tool-bound
model can answer a formatting prompt with a tool call and `content=''` — small
local models do this readily.

## Fix

- Keep the original response when the formatting pass returns blank.
- Route the pass through the unbound `_chat_model`. A pure text-reformat step
  has no business offering tools.

## Client hardening (same visible symptom, separate paths)

Found while reproducing, each independently reproducible:

- **Positional writes.** Streaming updated the assistant row via
  `updateLastMessage` (last element) rather than by id. The placeholder is not
  reliably last for the whole turn — `loadConversationMessages` appends local
  messages the server doesn't know by id *after* the API's — so the write could
  land on the wrong row and strand the placeholder. Now uses `updateMessageById`.
- **Stale `isStreaming`.** The outer error handler branched on `isStreaming`, a
  closure copy of React state that is still `false` there even though
  `setIsStreaming(true)` ran earlier in the same call. It appended a second
  bubble instead of replacing the placeholder — leaving a spinner that only a
  reload cleared. (The file already documents this trap for `streamingMessageId`
  a few lines up; the same fix was never applied here.) Now branches on whether
  a placeholder actually exists.
- **422 race.** Sending before `/api/agents/` resolves posts `agent: ""`, which
  the API rejects with `422 string_too_short`. On a freshly booted project this
  window is seconds wide (boot-time `/api/ontology/*` calls delay the agents
  fetch). Now waits for the list and surfaces a notice instead of firing a
  request that cannot succeed.

## Verification

- Two regression tests in `Agent_test.py`. Both **fail on `main`** with exactly
  the data loss (`assert '' == 'I am Abi...'`) and pass here.
- `Agent_test.py`: 19 passed. `test_agent_stream_invoke` fails in a full-file run
  — confirmed **pre-existing**, it fails identically on `main` and passes in
  isolation on both (live-LLM flake).
- `uvx ruff check` clean; `mypy` clean on the changed file.
- Frontend `tsc --noEmit` clean; the client changes were exercised by driving the
  real UI headlessly against a live stack (reproduced the stuck placeholder
  before, and the 422 path).

## Note for reviewers

The client changes make the placeholder impossible to strand, but the answer-
erasing bug is the one that produced the reported symptom. I'd take the
`Agent.py` change even if the frontend ones are debated.

Worth a follow-up (not in scope here): this formatting pass doubles latency on
every reply (a full extra round-trip — 12s in the trace above), and the local
SQLite hit `database is locked` under concurrent stream writes during testing.
