### PR TITLE
fix: pass json_schema_extra instead of the deprecated Field(example=)

### DIFF
--- a/libs/naas-abi-core/naas_abi_core/modules/templatablesparqlquery/workflows/TemplatableSparqlQueryLoader.py
+++ b/libs/naas-abi-core/naas_abi_core/modules/templatablesparqlquery/workflows/TemplatableSparqlQueryLoader.py
@@ -186,7 +186,11 @@ class TemplatableSparqlQueryLoader:
                                 description=str(arguments[argument]["description"]),
                                 pattern=str(arguments[argument]["validationPattern"]),
                                 # You could also add additional metadata from validationFormat if needed
-                                example=str(arguments[argument]["validationFormat"]),
+                                json_schema_extra={
+                                    "example": str(
+                                        arguments[argument]["validationFormat"]
+                                    )
+                                },
                             ),
                         )
                         for argument in query.get("hasArgument")

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/ai/gemini/workflows/ImageGenerationStorageWorkflow.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/ai/gemini/workflows/ImageGenerationStorageWorkflow.py
@@ -32,11 +32,13 @@ class ImageGenerationStorageWorkflowParameters(WorkflowParameters):
         Field(
             ...,
             description="Text prompt to generate the image from",
-            example="A beautiful sunset over mountains with a lake reflection",
+            json_schema_extra={
+                "example": "A beautiful sunset over mountains with a lake reflection"
+            },
         ),
     ]
-    file_name: Annotated[str, Field(description="Name for the generated image file", example="sunset_mountains.png")] | None = "generated_image.png"
-    folder_name: Annotated[str, Field(description="Subfolder name within the timestamped directory", example="images")] | None = "images"
+    file_name: Annotated[str, Field(description="Name for the generated image file", json_schema_extra={"example": "sunset_mountains.png"})] | None = "generated_image.png"
+    folder_name: Annotated[str, Field(description="Subfolder name within the timestamped directory", json_schema_extra={"example": "images"})] | None = "images"
 
 
 class ImageGenerationStorageWorkflow(Workflow):

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/sanax/pipelines/SanaxLinkedInSalesNavigatorExtractorPipeline.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/sanax/pipelines/SanaxLinkedInSalesNavigatorExtractorPipeline.py
@@ -52,7 +52,9 @@ class SanaxLinkedInSalesNavigatorExtractorPipelineParameters(PipelineParameters)
         str,
         Field(
             description="Path of the Excel file to process",
-            example="datastore/linkedin_sales_navigator/sanax_extractor/Example.xlsx",
+            json_schema_extra={
+                "example": "datastore/linkedin_sales_navigator/sanax_extractor/Example.xlsx"
+            },
         ),
     ]
     sheet_name: Annotated[str, Field(description="Name of the sheet to process")] = (

--- a/libs/naas-abi/naas_abi/pipelines/AddIndividualPipeline.py
+++ b/libs/naas-abi/naas_abi/pipelines/AddIndividualPipeline.py
@@ -39,14 +39,17 @@ class AddIndividualPipelineParameters(PipelineParameters):
     individual_label: Annotated[
         str,
         Field(
-            description="Individual label to add to the ontology.", example="Naas.ai"
+            description="Individual label to add to the ontology.",
+            json_schema_extra={"example": "Naas.ai"},
         ),
     ]
     class_uri: Annotated[
         str,
         Field(
             description="Class URI to add the individual to. Use tool `search_class` to search for a class URI in the ontology.",
-            example="https://www.commoncoreontologies.org/ont00000443",
+            json_schema_extra={
+                "example": "https://www.commoncoreontologies.org/ont00000443"
+            },
         ),
     ]
     threshold: Annotated[

--- a/libs/naas-abi/naas_abi/workflows/GetSubjectGraphWorkflow.py
+++ b/libs/naas-abi/naas_abi/workflows/GetSubjectGraphWorkflow.py
@@ -26,7 +26,9 @@ class GetSubjectGraphWorkflowParameters(WorkflowParameters):
         Field(
             ...,
             description="URI of the individual/instance to get the subject graph of.",
-            example="http://ontology.naas.ai/abi/a25ef0cc-56cf-458a-88c0-fabccb69e9b7",
+            json_schema_extra={
+                "example": "http://ontology.naas.ai/abi/a25ef0cc-56cf-458a-88c0-fabccb69e9b7"
+            },
             pattern=URI_REGEX,
         ),
     ]
@@ -35,7 +37,7 @@ class GetSubjectGraphWorkflowParameters(WorkflowParameters):
         Field(
             2,
             description="Depth of the subject graph to get. 1 means the individual and its direct properties, 2 means the individual and its direct properties and the properties of the properties, etc.",
-            example=2,
+            json_schema_extra={"example": 2},
         ),
     ] = 2
 

--- a/libs/naas-abi/naas_abi/workflows/SearchIndividualWorkflow.py
+++ b/libs/naas-abi/naas_abi/workflows/SearchIndividualWorkflow.py
@@ -28,10 +28,10 @@ class SearchIndividualWorkflowParameters(WorkflowParameters):
         Field(
             ...,
             description="Individual label to search for in the ontology schema.",
-            example="Naas.ai",
+            json_schema_extra={"example": "Naas.ai"},
         ),
     ]
-    class_uri: Annotated[str, Field(..., description="Class URI to use to search for individuals.", example="https://www.commoncoreontologies.org/ont00000443")] | None = None
+    class_uri: Annotated[str, Field(..., description="Class URI to use to search for individuals.", json_schema_extra={"example": "https://www.commoncoreontologies.org/ont00000443"})] | None = None
     limit: Annotated[int, Field(description="Maximum number of results to return.", ge=1, le=100)] | None = 10
     query: Annotated[str, Field(description="Custom SPARQL query to use to search for individuals.")] | None = None
 


### PR DESCRIPTION
## What

Pydantic deprecated extra keyword arguments on `Field`, so every model using
`example=` warns — on import for the static ones, and on every
`load_workflows()` call for the templatable SPARQL loader, which is why it shows
up in the console on a plain `Engine().load()`:

```
PydanticDeprecatedSince20: Using extra keyword arguments on `Field` is
deprecated and will be removed. Use `json_schema_extra` instead.
(Extra keys: 'example')
```

Converted all 11 call sites to `json_schema_extra={"example": ...}` — the
substitution Pydantic itself recommends.

**The emitted schema is unchanged.** The key stays `example`, which matters
because these models become LLM tool schemas:

```
old: {"description": "d", "example": "a", "title": "X", "type": "string"}
new: {"description": "d", "example": "a", "title": "X", "type": "string"}
```

`examples=` (plural) is deliberately left alone — it is a real Pydantic v2
parameter, not an extra kwarg, and does not warn.

## Sites

| package | file |
|---|---|
| naas-abi-core | `modules/templatablesparqlquery/workflows/TemplatableSparqlQueryLoader.py` |
| naas-abi | `workflows/SearchIndividualWorkflow.py` (2), `workflows/GetSubjectGraphWorkflow.py` (2), `pipelines/AddIndividualPipeline.py` (2) |
| naas-abi-marketplace | `ai/gemini/workflows/ImageGenerationStorageWorkflow.py` (3), `applications/sanax/pipelines/SanaxLinkedInSalesNavigatorExtractorPipeline.py` |

## Verification

Exercised the loader's `create_model` call under `warnings.simplefilter("error")`
so any deprecation becomes an exception — it now runs clean, and the old shape
still raises under the same harness (the control that makes the test meaningful):

```
workflows built: 0        # patched loader gets past create_model
--- control: the OLD code shape under the same harness ---
old shape raises as expected: PydanticDeprecatedSince20 ...
```

Also imported the edited `naas_abi` modules with deprecations-as-errors and
asserted the schema still carries `"example": "Naas.ai"`.

An AST scan confirms zero remaining `Field(..., example=...)` calls in `libs/`.
`uvx ruff check` clean, `mypy -p naas_abi_core` clean.

## Not in scope

The same run also emits two warnings from **third-party** code, which no ABI
change can fix — there is no ABI-side call to pass a value to:

- `LangChainPendingDeprecationWarning: allowed_objects` — `langgraph-checkpoint`
  3.0.1 does `LC_REVIVER = Reviver()` at module scope
  (`langgraph/checkpoint/serde/jsonplus.py:36`), firing on import. Fixed upstream
  in `langgraph-checkpoint` 4.1.1 (`Reviver(allowed_objects="core")`).
- `LangGraphDeprecatedSinceV10: AgentStatePydantic has been moved` — emitted by
  `langgraph.prebuilt` about its own class.

Both clear once the framework moves to LangGraph 1.2 / LangChain 1.x, which is a
separate dependency migration (262 files in `libs/` import langchain*/langgraph)
and is intentionally deferred.