### PR TITLE
Complete Gatekeeper GitHub flow: marketplace install + UX polish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ Core services live under `libs/naas-abi-core/naas_abi_core/services/`. Each has 
 | `cache` | Multi-tier (hot/cold) cache with decorator API | [services/cache/AGENTS.md](libs/naas-abi-core/naas_abi_core/services/cache/AGENTS.md) |
 | `email` | Transactional email sending (SMTP / SES / FS) | [services/email/AGENTS.md](libs/naas-abi-core/naas_abi_core/services/email/AGENTS.md) |
 | `event` | Durable typed event log + live pub/sub | [services/event/AGENTS.md](libs/naas-abi-core/naas_abi_core/services/event/AGENTS.md) |
+| `gatekeeper` | Tool mediation, observation log, derivation policy | [services/gatekeeper/AGENTS.md](libs/naas-abi-core/naas_abi_core/services/gatekeeper/AGENTS.md) |
 | `keyvalue` | Bytes-in/out KV store with TTL + atomic CAS/CAD | [services/keyvalue/AGENTS.md](libs/naas-abi-core/naas_abi_core/services/keyvalue/AGENTS.md) |
 | `model_registry` | Canonical-ID catalog of chat/embedding models | [services/model_registry/AGENTS.md](libs/naas-abi-core/naas_abi_core/services/model_registry/AGENTS.md) |
 | `object_storage` | S3-style blob storage (FS / S3 / Naas) | [services/object_storage/AGENTS.md](libs/naas-abi-core/naas_abi_core/services/object_storage/AGENTS.md) |

--- a/docs/adr/20260805_gatekeeper-observation-log.md
+++ b/docs/adr/20260805_gatekeeper-observation-log.md
@@ -1,0 +1,51 @@
+# ADR: Gatekeeper and Observation Log
+
+## Status
+
+Accepted — 2026-08-05
+
+## Context
+
+Cloudflare OS demonstrated that MCP tool lists alone are insufficient for enterprise agent governance. Agents can observe sensitive data through tool calls, and sharing conversations or exports can become an exfiltration path unless policy follows observed resources.
+
+Abi already has:
+
+- Nexus IAM (workspace roles, JWT scopes)
+- Agent event publishing (`AgentToolCalled`, etc.)
+- Marketplace integrations that call third-party APIs directly
+- Owner-scoped chat conversations
+
+What was missing: a mediation layer between agents and integrations that enforces default-deny for sensitive operations, records provenance, and applies derivation checks before export.
+
+## Decision
+
+Introduce a **Gatekeeper service** in `naas_abi_core.services.gatekeeper`:
+
+1. **Port + service** following the same pattern as `activity_log` and `event`.
+2. **SQLite adapter** for observations and per-chat session grants.
+3. **GitHub pilot policy** — secret-read and destructive repo tools require explicit session grants on `github.repo` resources.
+4. **Agent hook** in `Agent.call_tools` — evaluate before invoke, record after success.
+5. **Derivation check** in Nexus chat export — deny when sensitive observations exist and the viewer lacks export grants.
+6. **Process-wide accessor** via `get_default_gatekeeper_service()`, initialized on `Engine.load()`.
+
+## Consequences
+
+### Positive
+
+- Sensitive GitHub tools are blocked without explicit grants (Cloudflare OS “agents start with no access” for high-risk operations).
+- Every gated tool call leaves an observation tied to `chat_id` for audit and export policy.
+- Export path demonstrates “policy follows what the agent has seen.”
+- Hexagonal layout allows additional integration policies without changing Agent core.
+
+### Negative / follow-ups
+
+- No grant UI yet — grants are programmatic (`grant_resource`) until Nexus adds an approval flow.
+- Only GitHub is policy-wrapped; other marketplace integrations still call APIs directly.
+- Conversation **read** remains owner-scoped; cross-user shared threads need IAM + gatekeeper extension.
+- Gatekeeper is not yet wired into full Engine service configuration (uses default SQLite path).
+
+## References
+
+- https://blog.cloudflare.com/cloudflare-os/
+- GitHub issue #1171
+- `libs/naas-abi-core/naas_abi_core/services/gatekeeper/AGENTS.md`

--- a/libs/naas-abi-core/naas_abi_core/engine/Engine.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/Engine.py
@@ -1,6 +1,7 @@
 
 from naas_abi_core import logger
 from naas_abi_core.engine.context import (
+    init_default_gatekeeper_service,
     set_default_event_service,
     set_default_model_registry,
 )
@@ -123,6 +124,8 @@ class Engine(IEngine):
             set_default_model_registry(self.__services.model_registry)
         else:
             set_default_model_registry(None)
+
+        init_default_gatekeeper_service()
 
         logger.debug("Initializing engine")
         self.on_initialized()

--- a/libs/naas-abi-core/naas_abi_core/engine/context.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/context.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from naas_abi_core.services.event.EventService import EventService
+    from naas_abi_core.services.gatekeeper.GatekeeperService import GatekeeperService
     from naas_abi_core.services.model_registry.ModelRegistryPort import (
         IModelRegistry,
     )
@@ -148,3 +149,53 @@ def with_model_registry_override(
         yield
     finally:
         _model_registry_override.reset(token)
+
+
+# --------------------------------------------------------------------------- #
+# GatekeeperService                                                            #
+# --------------------------------------------------------------------------- #
+
+
+_default_gatekeeper_service: GatekeeperService | None = None
+_gatekeeper_service_override: ContextVar[GatekeeperService | None] = ContextVar(
+    "gatekeeper_service_override", default=None
+)
+
+
+def set_default_gatekeeper_service(service: GatekeeperService | None) -> None:
+    """Bind the process-wide GatekeeperService. Called by ``Engine.load()``."""
+    global _default_gatekeeper_service
+    _default_gatekeeper_service = service
+
+
+def get_default_gatekeeper_service() -> GatekeeperService | None:
+    """Return the GatekeeperService to use right now, or ``None`` if not configured."""
+    return _gatekeeper_service_override.get() or _default_gatekeeper_service
+
+
+@contextmanager
+def with_gatekeeper_service_override(
+    service: GatekeeperService | None,
+) -> Iterator[None]:
+    """Temporarily swap the GatekeeperService within this context (and async task)."""
+    token = _gatekeeper_service_override.set(service)
+    try:
+        yield
+    finally:
+        _gatekeeper_service_override.reset(token)
+
+
+def init_default_gatekeeper_service(
+    data_dir: str = "storage/gatekeeper",
+) -> GatekeeperService:
+    """Create and bind the default SQLite-backed gatekeeper (idempotent)."""
+    global _default_gatekeeper_service
+    if _default_gatekeeper_service is None:
+        from naas_abi_core.services.gatekeeper.GatekeeperFactory import (
+            GatekeeperFactory,
+        )
+
+        _default_gatekeeper_service = GatekeeperFactory.GatekeeperServiceSqlite(
+            data_dir=data_dir
+        )
+    return _default_gatekeeper_service

--- a/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
@@ -75,7 +75,10 @@ from naas_abi_core.services.agent.ontologies.modules.AgentEventOntology import (
 )
 from naas_abi_core.services.cache.CacheFactory import CacheFactory
 from naas_abi_core.services.cache.CachePort import DataType
-from naas_abi_core.services.gatekeeper.GatekeeperPort import GatekeeperSubject
+from naas_abi_core.services.gatekeeper.GatekeeperPort import (
+    GatekeeperSubject,
+    parse_missing_grant_reason,
+)
 from sse_starlette.sse import EventSourceResponse
 
 from .tools.default_tools import default_tools
@@ -329,6 +332,15 @@ class CallModelEvent(Event):
 @dataclass
 class AgentRoutingEvent(Event):
     agent_name: str
+
+
+@dataclass
+class GatekeeperDeniedEvent(Event):
+    tool_name: str
+    reason: str
+    resource_type: str | None = None
+    resource_id: str | None = None
+    action: str | None = None
 
 
 @dataclass
@@ -1584,6 +1596,17 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
                         logger.warning(
                             f"🚫 Gatekeeper denied tool '{tool_name}': {decision.reason}"
                         )
+                        parsed = parse_missing_grant_reason(decision.reason)
+                        self._event_queue.put(
+                            GatekeeperDeniedEvent(
+                                payload=None,
+                                tool_name=tool_name,
+                                reason=decision.reason,
+                                resource_type=parsed[0] if parsed else None,
+                                resource_id=parsed[1] if parsed else None,
+                                action=parsed[2] if parsed else None,
+                            )
+                        )
                         had_tool_error = True
                         results.append(
                             Command(
@@ -2306,6 +2329,19 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
                     yield {
                         "event": "agent_routing",
                         "data": str(message.payload),
+                    }
+                elif isinstance(message, GatekeeperDeniedEvent):
+                    yield {
+                        "event": "gatekeeper_denied",
+                        "data": json.dumps(
+                            {
+                                "tool": message.tool_name,
+                                "reason": message.reason,
+                                "resource_type": message.resource_type,
+                                "resource_id": message.resource_id,
+                                "action": message.action,
+                            }
+                        ),
                     }
                 elif isinstance(message, FinalStateEvent):
                     final_state = message.payload

--- a/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
@@ -54,7 +54,10 @@ from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import START, StateGraph
 from langgraph.graph.message import MessagesState
 from langgraph.types import Command
-from naas_abi_core.engine.context import get_default_event_service
+from naas_abi_core.engine.context import (
+    get_default_event_service,
+    get_default_gatekeeper_service,
+)
 from naas_abi_core.services.agent.context import (
     agent_chat_id,
     agent_user_id,
@@ -72,6 +75,7 @@ from naas_abi_core.services.agent.ontologies.modules.AgentEventOntology import (
 )
 from naas_abi_core.services.cache.CacheFactory import CacheFactory
 from naas_abi_core.services.cache.CachePort import DataType
+from naas_abi_core.services.gatekeeper.GatekeeperPort import GatekeeperSubject
 from sse_starlette.sse import EventSourceResponse
 
 from .tools.default_tools import default_tools
@@ -1555,6 +1559,51 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
 
             # Check if tool is a handoff tool
             is_handoff = tool_call["name"].startswith("transfer_to_")
+
+            if not is_handoff:
+                gatekeeper = get_default_gatekeeper_service()
+                if gatekeeper is not None:
+                    tool_args = (
+                        tool_call.get("args")
+                        if isinstance(tool_call, dict)
+                        else getattr(tool_call, "args", None)
+                    )
+                    if not isinstance(tool_args, dict):
+                        tool_args = {}
+                    subject = GatekeeperSubject(
+                        user_id=agent_user_id.get(),
+                        workspace_id=agent_workspace_id.get(),
+                        chat_id=agent_chat_id.get() or self._state.thread_id,
+                    )
+                    decision = gatekeeper.evaluate_tool_call(
+                        subject,
+                        tool_name,
+                        tool_args,
+                    )
+                    if not decision.allowed:
+                        logger.warning(
+                            f"🚫 Gatekeeper denied tool '{tool_name}': {decision.reason}"
+                        )
+                        had_tool_error = True
+                        results.append(
+                            Command(
+                                update={
+                                    "messages": [
+                                        ToolMessage(
+                                            content=(
+                                                f"Access denied by gatekeeper: "
+                                                f"{decision.reason}. Grant access to "
+                                                f"the required resource for this chat "
+                                                f"session before retrying."
+                                            ),
+                                            name=tool_name,
+                                            tool_call_id=tool_call["id"],
+                                        )
+                                    ]
+                                },
+                            )
+                        )
+                        continue
             if is_handoff is True:
                 args = {"state": state, "tool_call": {**tool_call, "role": "tool_call"}}
 
@@ -1565,6 +1614,25 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
                 logger.debug(
                     f"📦 Tool response: {tool_response.content if hasattr(tool_response, 'content') else tool_response}"
                 )
+                if not is_handoff:
+                    gatekeeper = get_default_gatekeeper_service()
+                    if gatekeeper is not None:
+                        tool_args = (
+                            tool_call.get("args")
+                            if isinstance(tool_call, dict)
+                            else getattr(tool_call, "args", None)
+                        )
+                        if not isinstance(tool_args, dict):
+                            tool_args = {}
+                        gatekeeper.record_tool_observation(
+                            GatekeeperSubject(
+                                user_id=agent_user_id.get(),
+                                workspace_id=agent_workspace_id.get(),
+                                chat_id=agent_chat_id.get() or self._state.thread_id,
+                            ),
+                            tool_name,
+                            tool_args,
+                        )
                 if (
                     tool_response is not None
                     and hasattr(tool_response, "name")

--- a/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
@@ -344,6 +344,17 @@ class GatekeeperDeniedEvent(Event):
 
 
 @dataclass
+class GatekeeperRequestEvent(Event):
+    """Emitted when a tool call needs user approval before execution."""
+
+    tool_name: str
+    reason: str
+    resource_type: str | None = None
+    resource_id: str | None = None
+    action: str | None = None
+
+
+@dataclass
 class AgentConfiguration:
     on_tool_usage: Callable[[AnyMessage], None] = field(
         default_factory=lambda: lambda _: None
@@ -1608,16 +1619,21 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
                             )
                         )
                         had_tool_error = True
+                        resource_hint = (
+                            f"{parsed[1]} ({parsed[0]})"
+                            if parsed
+                            else "the requested resource"
+                        )
                         results.append(
                             Command(
                                 update={
                                     "messages": [
                                         ToolMessage(
                                             content=(
-                                                f"Access denied by gatekeeper: "
-                                                f"{decision.reason}. Grant access to "
-                                                f"the required resource for this chat "
-                                                f"session before retrying."
+                                                "Gatekeeper approval required: "
+                                                f"{decision.reason}. Waiting for the "
+                                                f"user to approve access to "
+                                                f"{resource_hint} in the chat UI."
                                             ),
                                             name=tool_name,
                                             tool_call_id=tool_call["id"],
@@ -1805,7 +1821,56 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
         except Exception:  # noqa: BLE001
             return str(value)
 
+    def _emit_gatekeeper_approval_event(
+        self,
+        tool_name: str,
+        reason: str,
+        tool_args: dict[str, Any],
+    ) -> None:
+        parsed = parse_missing_grant_reason(reason)
+        event = GatekeeperRequestEvent(
+            payload=None,
+            tool_name=tool_name,
+            reason=reason,
+            resource_type=parsed[0] if parsed else None,
+            resource_id=parsed[1] if parsed else None,
+            action=parsed[2] if parsed else None,
+        )
+        self._event_queue.put(event)
+
     def _notify_tool_usage(self, message: AnyMessage):
+        identity_subject = GatekeeperSubject(
+            user_id=agent_user_id.get(),
+            workspace_id=agent_workspace_id.get(),
+            chat_id=agent_chat_id.get() or self._state.thread_id,
+        )
+        gatekeeper = get_default_gatekeeper_service()
+        for call in getattr(message, "tool_calls", []) or []:
+            tool_name = (
+                call.get("name")
+                if isinstance(call, dict)
+                else getattr(call, "name", None)
+            )
+            if not tool_name or tool_name.startswith("transfer_to_"):
+                continue
+            tool_args = (
+                call.get("args")
+                if isinstance(call, dict)
+                else getattr(call, "args", None)
+            )
+            if not isinstance(tool_args, dict):
+                tool_args = {}
+            if gatekeeper is not None:
+                decision = gatekeeper.evaluate_tool_call(
+                    identity_subject,
+                    tool_name,
+                    tool_args,
+                )
+                if not decision.allowed:
+                    self._emit_gatekeeper_approval_event(
+                        tool_name, decision.reason, tool_args
+                    )
+
         self._event_queue.put(ToolUsageEvent(payload=message))
         self._on_tool_usage(message)
         identity = self._identity()
@@ -2329,6 +2394,19 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
                     yield {
                         "event": "agent_routing",
                         "data": str(message.payload),
+                    }
+                elif isinstance(message, GatekeeperRequestEvent):
+                    yield {
+                        "event": "gatekeeper_request",
+                        "data": json.dumps(
+                            {
+                                "tool": message.tool_name,
+                                "reason": message.reason,
+                                "resource_type": message.resource_type,
+                                "resource_id": message.resource_id,
+                                "action": message.action,
+                            }
+                        ),
                     }
                 elif isinstance(message, GatekeeperDeniedEvent):
                     yield {

--- a/libs/naas-abi-core/naas_abi_core/services/gatekeeper/AGENTS.md
+++ b/libs/naas-abi-core/naas_abi_core/services/gatekeeper/AGENTS.md
@@ -1,0 +1,64 @@
+# Gatekeeper Service — AGENTS.md
+
+> Scope: `libs/naas-abi-core/naas_abi_core/services/gatekeeper/`. Canonical reference for agents.
+
+## Purpose
+
+Mediate agent tool access to external systems, record observations for provenance, and enforce derivation policy when conversations or exports are shared.
+
+Inspired by Cloudflare OS Gatekeepers: agents start without broad integration access; sensitive operations require explicit session grants; policy follows observed data.
+
+## Files
+
+```
+gatekeeper/
+├── GatekeeperPort.py              # DTOs + IObservationStore / IGrantStore / IGatekeeperDomain
+├── GatekeeperService.py           # evaluate_tool_call, record_tool_observation, export policy
+├── GatekeeperFactory.py
+├── policies/
+│   └── GitHubGatekeeperPolicy.py  # Pilot: GitHub secret + delete-repo tools
+├── adapters/secondary/
+│   └── GatekeeperSqliteAdapter.py
+└── GatekeeperService_test.py
+```
+
+## Port
+
+```python
+evaluate_tool_call(subject, tool_name, tool_args) -> GatekeeperDecision
+record_tool_observation(subject, tool_name, tool_args) -> ObservationRecord | None
+grant_resource(chat_id, resource, actions) -> ResourceGrant
+evaluate_conversation_export(subject, conversation_id) -> GatekeeperDecision
+list_observations(chat_id) -> list[ObservationRecord]
+```
+
+## Pilot policy (GitHub)
+
+Sensitive tools (require session grant on `github.repo`):
+
+- `github_list_repository_secrets`
+- `github_get_repository_secret`
+- `github_create_or_update_repository_secret`
+- `github_delete_repository_secret`
+- `github_delete_organization_repository`
+
+## Integration points
+
+| Consumer | Hook |
+|---|---|
+| `Agent.call_tools` | Pre-invoke `evaluate_tool_call`; post-success `record_tool_observation` |
+| `ChatService` export | `evaluate_conversation_export` before returning transcript |
+| Process-wide accessor | `engine/context.py` → `get_default_gatekeeper_service()` |
+
+## Tests
+
+```bash
+uv run pytest libs/naas-abi-core/naas_abi_core/services/gatekeeper/GatekeeperService_test.py -v
+```
+
+## Adding a new integration policy
+
+1. Implement `IGatekeeperPolicy` under `policies/`.
+2. Register it in `GatekeeperService.__init__(policies=[...])`.
+3. Define sensitive tools, resource extraction, and required grant actions.
+4. Add tests mirroring `GatekeeperService_test.py`.

--- a/libs/naas-abi-core/naas_abi_core/services/gatekeeper/AGENTS.md
+++ b/libs/naas-abi-core/naas_abi_core/services/gatekeeper/AGENTS.md
@@ -34,6 +34,8 @@ list_observations(chat_id) -> list[ObservationRecord]
 
 ## Pilot policy (GitHub)
 
+**Prerequisites:** GitHub must be enabled in `config.yaml` and `GITHUB_ACCESS_TOKEN` must be set in `.env`. Use Marketplace → Install on the GitHub application module, or uncomment the block in `config.yaml`, then restart the API. Gatekeeper does not auto-enable integrations.
+
 Sensitive tools (require session grant on `github.repo`):
 
 - `github_list_repository_secrets`

--- a/libs/naas-abi-core/naas_abi_core/services/gatekeeper/GatekeeperFactory.py
+++ b/libs/naas-abi-core/naas_abi_core/services/gatekeeper/GatekeeperFactory.py
@@ -1,0 +1,20 @@
+import os
+
+from naas_abi_core.services.gatekeeper.adapters.secondary.GatekeeperSqliteAdapter import (
+    GatekeeperSqliteAdapter,
+)
+from naas_abi_core.services.gatekeeper.GatekeeperService import GatekeeperService
+
+
+class GatekeeperFactory:
+    @staticmethod
+    def GatekeeperServiceSqlite(
+        data_dir: str = "storage/gatekeeper",
+        db_name: str = "gatekeeper.sqlite",
+    ) -> GatekeeperService:
+        os.makedirs(data_dir, exist_ok=True)
+        adapter = GatekeeperSqliteAdapter(db_path=os.path.join(data_dir, db_name))
+        return GatekeeperService(
+            observation_store=adapter,
+            grant_store=adapter,
+        )

--- a/libs/naas-abi-core/naas_abi_core/services/gatekeeper/GatekeeperPort.py
+++ b/libs/naas-abi-core/naas_abi_core/services/gatekeeper/GatekeeperPort.py
@@ -143,6 +143,10 @@ class IGatekeeperDomain(ABC):
         raise NotImplementedError()
 
     @abstractmethod
+    def list_grants(self, chat_id: str) -> list[ResourceGrant]:
+        raise NotImplementedError()
+
+    @abstractmethod
     def list_observations(self, chat_id: str) -> list[ObservationRecord]:
         raise NotImplementedError()
 
@@ -157,3 +161,17 @@ def new_observation_id() -> str:
 
 def utc_now() -> datetime:
     return datetime.now(UTC)
+
+
+def parse_missing_grant_reason(reason: str) -> tuple[str, str, str] | None:
+    """Parse ``missing_grant:{type}:{id}:{action}`` gatekeeper denial reasons."""
+    prefix = "missing_grant:"
+    if not reason.startswith(prefix):
+        return None
+    parts = reason[len(prefix) :].split(":", 2)
+    if len(parts) != 3:
+        return None
+    resource_type, resource_id, action = parts
+    if not resource_type or not resource_id or not action:
+        return None
+    return resource_type, resource_id, action

--- a/libs/naas-abi-core/naas_abi_core/services/gatekeeper/GatekeeperPort.py
+++ b/libs/naas-abi-core/naas_abi_core/services/gatekeeper/GatekeeperPort.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal
+from uuid import uuid4
+
+Sensitivity = Literal["normal", "sensitive"]
+
+
+@dataclass(frozen=True)
+class GatekeeperSubject:
+    user_id: str | None
+    workspace_id: str | None
+    chat_id: str | None
+
+
+@dataclass(frozen=True)
+class GatekeeperResource:
+    type: str
+    id: str
+
+
+@dataclass(frozen=True)
+class GatekeeperDecision:
+    allowed: bool
+    reason: str
+    observation_id: str | None = None
+
+
+@dataclass(frozen=True)
+class ResourceGrant:
+    chat_id: str
+    resource_type: str
+    resource_id: str
+    actions: frozenset[str]
+    granted_at: datetime
+
+
+@dataclass(frozen=True)
+class ObservationRecord:
+    id: str
+    chat_id: str
+    user_id: str | None
+    workspace_id: str | None
+    tool_name: str
+    resource_type: str
+    resource_id: str
+    sensitivity: Sensitivity
+    observed_at: datetime
+    tool_args: dict[str, Any] = field(default_factory=dict)
+
+
+class IObservationStore(ABC):
+    @abstractmethod
+    def record(self, observation: ObservationRecord) -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def list_observations(self, chat_id: str) -> list[ObservationRecord]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def shutdown(self) -> None:
+        raise NotImplementedError()
+
+
+class IGrantStore(ABC):
+    @abstractmethod
+    def grant(self, grant: ResourceGrant) -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def list_grants(self, chat_id: str) -> list[ResourceGrant]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def has_grant(
+        self,
+        chat_id: str,
+        resource_type: str,
+        resource_id: str,
+        action: str,
+    ) -> bool:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def shutdown(self) -> None:
+        raise NotImplementedError()
+
+
+class IGatekeeperPolicy(ABC):
+    @abstractmethod
+    def classify_tool(self, tool_name: str) -> Sensitivity:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def extract_resources(
+        self, tool_name: str, tool_args: dict[str, Any]
+    ) -> list[GatekeeperResource]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def required_action(self, tool_name: str) -> str:
+        raise NotImplementedError()
+
+
+class IGatekeeperDomain(ABC):
+    @abstractmethod
+    def evaluate_tool_call(
+        self,
+        subject: GatekeeperSubject,
+        tool_name: str,
+        tool_args: dict[str, Any] | None = None,
+    ) -> GatekeeperDecision:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def record_tool_observation(
+        self,
+        subject: GatekeeperSubject,
+        tool_name: str,
+        tool_args: dict[str, Any] | None = None,
+    ) -> ObservationRecord | None:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def grant_resource(
+        self,
+        chat_id: str,
+        resource: GatekeeperResource,
+        actions: frozenset[str],
+    ) -> ResourceGrant:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def evaluate_conversation_export(
+        self,
+        subject: GatekeeperSubject,
+        conversation_id: str,
+    ) -> GatekeeperDecision:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def list_observations(self, chat_id: str) -> list[ObservationRecord]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def shutdown(self) -> None:
+        raise NotImplementedError()
+
+
+def new_observation_id() -> str:
+    return str(uuid4())
+
+
+def utc_now() -> datetime:
+    return datetime.now(UTC)

--- a/libs/naas-abi-core/naas_abi_core/services/gatekeeper/GatekeeperService.py
+++ b/libs/naas-abi-core/naas_abi_core/services/gatekeeper/GatekeeperService.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+from typing import Any
+
+from naas_abi_core.services.activity_log.ActivityLogPort import ActivityEvent
+from naas_abi_core.services.activity_log.ActivityLogService import ActivityLogService
+from naas_abi_core.services.gatekeeper.GatekeeperPort import (
+    GatekeeperDecision,
+    GatekeeperResource,
+    GatekeeperSubject,
+    IGatekeeperDomain,
+    IGatekeeperPolicy,
+    IGrantStore,
+    IObservationStore,
+    ObservationRecord,
+    ResourceGrant,
+    new_observation_id,
+    utc_now,
+)
+from naas_abi_core.services.gatekeeper.policies.GitHubGatekeeperPolicy import (
+    GITHUB_TOOL_PREFIX,
+    GitHubGatekeeperPolicy,
+)
+from naas_abi_core.services.ServiceBase import ServiceBase
+
+
+class GatekeeperService(ServiceBase, IGatekeeperDomain):
+    """Mediate tool access, record observations, and enforce derivation policy."""
+
+    def __init__(
+        self,
+        observation_store: IObservationStore,
+        grant_store: IGrantStore,
+        policies: list[IGatekeeperPolicy] | None = None,
+        activity_log: ActivityLogService | None = None,
+    ) -> None:
+        super().__init__()
+        self._observations = observation_store
+        self._grants = grant_store
+        self._policies = policies or [GitHubGatekeeperPolicy()]
+        self._activity_log = activity_log
+
+    def evaluate_tool_call(
+        self,
+        subject: GatekeeperSubject,
+        tool_name: str,
+        tool_args: dict[str, Any] | None = None,
+    ) -> GatekeeperDecision:
+        args = tool_args or {}
+        policy = self._policy_for_tool(tool_name)
+        if policy is None:
+            return GatekeeperDecision(allowed=True, reason="no_policy")
+
+        sensitivity = policy.classify_tool(tool_name)
+        if sensitivity != "sensitive":
+            return GatekeeperDecision(allowed=True, reason="not_sensitive")
+
+        chat_id = subject.chat_id
+        if not chat_id:
+            decision = GatekeeperDecision(
+                allowed=False,
+                reason="sensitive_tool_requires_chat_session",
+            )
+            self._audit(subject, "gatekeeper.tool.denied", tool_name, decision.reason)
+            return decision
+
+        resources = policy.extract_resources(tool_name, args)
+        if not resources:
+            decision = GatekeeperDecision(
+                allowed=False,
+                reason="sensitive_tool_missing_resource_scope",
+            )
+            self._audit(subject, "gatekeeper.tool.denied", tool_name, decision.reason)
+            return decision
+
+        action = policy.required_action(tool_name)
+        for resource in resources:
+            if not self._grants.has_grant(chat_id, resource.type, resource.id, action):
+                decision = GatekeeperDecision(
+                    allowed=False,
+                    reason=(f"missing_grant:{resource.type}:{resource.id}:{action}"),
+                )
+                self._audit(
+                    subject, "gatekeeper.tool.denied", tool_name, decision.reason
+                )
+                return decision
+
+        decision = GatekeeperDecision(allowed=True, reason="granted")
+        self._audit(subject, "gatekeeper.tool.allowed", tool_name, decision.reason)
+        return decision
+
+    def record_tool_observation(
+        self,
+        subject: GatekeeperSubject,
+        tool_name: str,
+        tool_args: dict[str, Any] | None = None,
+    ) -> ObservationRecord | None:
+        args = tool_args or {}
+        policy = self._policy_for_tool(tool_name)
+        if policy is None or not subject.chat_id:
+            return None
+
+        resources = policy.extract_resources(tool_name, args)
+        if not resources:
+            resources = [GatekeeperResource(type="tool", id=tool_name)]
+
+        sensitivity = policy.classify_tool(tool_name)
+        observation = ObservationRecord(
+            id=new_observation_id(),
+            chat_id=subject.chat_id,
+            user_id=subject.user_id,
+            workspace_id=subject.workspace_id,
+            tool_name=tool_name,
+            resource_type=resources[0].type,
+            resource_id=resources[0].id,
+            sensitivity=sensitivity,
+            observed_at=utc_now(),
+            tool_args=args,
+        )
+        try:
+            self._observations.record(observation)
+        except Exception as exc:  # noqa: BLE001
+            from naas_abi_core import logger
+
+            logger.warning(f"gatekeeper.record_observation failed: {exc}")
+            return None
+
+        if sensitivity == "sensitive":
+            for resource in resources:
+                self.grant_resource(
+                    subject.chat_id,
+                    resource,
+                    frozenset({"export"}),
+                )
+
+        self._audit(
+            subject,
+            "gatekeeper.observation.recorded",
+            tool_name,
+            f"{observation.resource_type}:{observation.resource_id}",
+        )
+        return observation
+
+    def grant_resource(
+        self,
+        chat_id: str,
+        resource: GatekeeperResource,
+        actions: frozenset[str],
+    ) -> ResourceGrant:
+        grant = ResourceGrant(
+            chat_id=chat_id,
+            resource_type=resource.type,
+            resource_id=resource.id,
+            actions=actions,
+            granted_at=utc_now(),
+        )
+        self._grants.grant(grant)
+        return grant
+
+    def evaluate_conversation_export(
+        self,
+        subject: GatekeeperSubject,
+        conversation_id: str,
+    ) -> GatekeeperDecision:
+        sensitive = [
+            obs
+            for obs in self._observations.list_observations(conversation_id)
+            if obs.sensitivity == "sensitive"
+        ]
+        if not sensitive:
+            return GatekeeperDecision(allowed=True, reason="no_sensitive_observations")
+
+        for obs in sensitive:
+            if subject.user_id != obs.user_id:
+                decision = GatekeeperDecision(
+                    allowed=False,
+                    reason=(
+                        "export_denied:viewer_lacks_access_to_observed_resource:"
+                        f"{obs.resource_type}:{obs.resource_id}"
+                    ),
+                )
+                self._audit(
+                    subject,
+                    "gatekeeper.export.denied",
+                    conversation_id,
+                    decision.reason,
+                )
+                return decision
+
+            if not self._grants.has_grant(
+                conversation_id, obs.resource_type, obs.resource_id, "export"
+            ) and not self._grants.has_grant(
+                conversation_id, obs.resource_type, obs.resource_id, "*"
+            ):
+                decision = GatekeeperDecision(
+                    allowed=False,
+                    reason=(
+                        "export_denied:sensitive_observations_require_export_grant:"
+                        f"{obs.resource_type}:{obs.resource_id}"
+                    ),
+                )
+                self._audit(
+                    subject,
+                    "gatekeeper.export.denied",
+                    conversation_id,
+                    decision.reason,
+                )
+                return decision
+
+        return GatekeeperDecision(allowed=True, reason="export_granted")
+
+    def list_observations(self, chat_id: str) -> list[ObservationRecord]:
+        return self._observations.list_observations(chat_id)
+
+    def shutdown(self) -> None:
+        self._observations.shutdown()
+        self._grants.shutdown()
+
+    def _policy_for_tool(self, tool_name: str) -> IGatekeeperPolicy | None:
+        if not tool_name.startswith(GITHUB_TOOL_PREFIX):
+            return None
+        for policy in self._policies:
+            if isinstance(policy, GitHubGatekeeperPolicy):
+                return policy
+        return self._policies[0] if self._policies else None
+
+    def _audit(
+        self,
+        subject: GatekeeperSubject,
+        event_type: str,
+        tool_name: str,
+        reason: str,
+    ) -> None:
+        if self._activity_log is None:
+            return
+        actor_id = f"user:{subject.user_id}" if subject.user_id else "anonymous"
+        self._activity_log.record(
+            ActivityEvent(
+                actor_id=actor_id,
+                event_type=event_type,
+                correlation_id=subject.chat_id,
+                attributes={
+                    "tool_name": tool_name,
+                    "reason": reason,
+                    "workspace_id": subject.workspace_id,
+                },
+            )
+        )

--- a/libs/naas-abi-core/naas_abi_core/services/gatekeeper/GatekeeperService.py
+++ b/libs/naas-abi-core/naas_abi_core/services/gatekeeper/GatekeeperService.py
@@ -209,6 +209,9 @@ class GatekeeperService(ServiceBase, IGatekeeperDomain):
 
         return GatekeeperDecision(allowed=True, reason="export_granted")
 
+    def list_grants(self, chat_id: str) -> list[ResourceGrant]:
+        return self._grants.list_grants(chat_id)
+
     def list_observations(self, chat_id: str) -> list[ObservationRecord]:
         return self._observations.list_observations(chat_id)
 

--- a/libs/naas-abi-core/naas_abi_core/services/gatekeeper/GatekeeperService_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/gatekeeper/GatekeeperService_test.py
@@ -7,6 +7,7 @@ from naas_abi_core.services.gatekeeper.GatekeeperFactory import GatekeeperFactor
 from naas_abi_core.services.gatekeeper.GatekeeperPort import (
     GatekeeperResource,
     GatekeeperSubject,
+    parse_missing_grant_reason,
 )
 
 
@@ -109,6 +110,24 @@ def test_export_denied_for_viewer_without_grants(gatekeeper) -> None:
     decision = gatekeeper.evaluate_conversation_export(viewer, chat_id)
     assert decision.allowed is False
     assert "viewer_lacks_access" in decision.reason
+
+
+def test_list_grants_after_grant(gatekeeper) -> None:
+    chat_id = "chat-grants"
+    gatekeeper.grant_resource(
+        chat_id,
+        GatekeeperResource(type="github.repo", id="org/repo"),
+        frozenset({"read_secrets"}),
+    )
+    grants = gatekeeper.list_grants(chat_id)
+    assert len(grants) == 1
+    assert grants[0].resource_id == "org/repo"
+
+
+def test_parse_missing_grant_reason() -> None:
+    parsed = parse_missing_grant_reason("missing_grant:github.repo:org/x:read_secrets")
+    assert parsed == ("github.repo", "org/x", "read_secrets")
+    assert parse_missing_grant_reason("other") is None
 
 
 def test_export_allowed_for_observer_with_auto_export_grant(gatekeeper) -> None:

--- a/libs/naas-abi-core/naas_abi_core/services/gatekeeper/GatekeeperService_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/gatekeeper/GatekeeperService_test.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import tempfile
+
+import pytest
+from naas_abi_core.services.gatekeeper.GatekeeperFactory import GatekeeperFactory
+from naas_abi_core.services.gatekeeper.GatekeeperPort import (
+    GatekeeperResource,
+    GatekeeperSubject,
+)
+
+
+@pytest.fixture
+def gatekeeper():
+    with tempfile.TemporaryDirectory() as tmp:
+        service = GatekeeperFactory.GatekeeperServiceSqlite(data_dir=tmp)
+        yield service
+        service.shutdown()
+
+
+def test_sensitive_github_tool_denied_without_grant(gatekeeper) -> None:
+    subject = GatekeeperSubject(
+        user_id="user-1",
+        workspace_id="ws-1",
+        chat_id="chat-1",
+    )
+    decision = gatekeeper.evaluate_tool_call(
+        subject,
+        "github_list_repository_secrets",
+        {"repo_name": "org/private-repo"},
+    )
+    assert decision.allowed is False
+    assert "missing_grant" in decision.reason
+
+
+def test_sensitive_github_tool_allowed_with_grant(gatekeeper) -> None:
+    chat_id = "chat-2"
+    gatekeeper.grant_resource(
+        chat_id,
+        GatekeeperResource(type="github.repo", id="org/private-repo"),
+        frozenset({"read_secrets"}),
+    )
+    subject = GatekeeperSubject(
+        user_id="user-1",
+        workspace_id="ws-1",
+        chat_id=chat_id,
+    )
+    decision = gatekeeper.evaluate_tool_call(
+        subject,
+        "github_list_repository_secrets",
+        {"repo_name": "org/private-repo"},
+    )
+    assert decision.allowed is True
+
+
+def test_non_sensitive_github_tool_allowed_without_grant(gatekeeper) -> None:
+    subject = GatekeeperSubject(
+        user_id="user-1",
+        workspace_id="ws-1",
+        chat_id="chat-3",
+    )
+    decision = gatekeeper.evaluate_tool_call(
+        subject,
+        "github_get_issue",
+        {"repo_name": "org/repo", "issue_number": 1},
+    )
+    assert decision.allowed is True
+
+
+def test_observation_recorded_after_tool_use(gatekeeper) -> None:
+    subject = GatekeeperSubject(
+        user_id="user-1",
+        workspace_id="ws-1",
+        chat_id="chat-4",
+    )
+    gatekeeper.grant_resource(
+        "chat-4",
+        GatekeeperResource(type="github.repo", id="org/repo"),
+        frozenset({"read_secrets"}),
+    )
+    gatekeeper.record_tool_observation(
+        subject,
+        "github_get_repository_secret",
+        {"repo_name": "org/repo", "secret_name": "API_KEY"},
+    )
+    observations = gatekeeper.list_observations("chat-4")
+    assert len(observations) == 1
+    assert observations[0].sensitivity == "sensitive"
+    assert observations[0].tool_name == "github_get_repository_secret"
+
+
+def test_export_denied_for_viewer_without_grants(gatekeeper) -> None:
+    chat_id = "chat-5"
+    observer = GatekeeperSubject(user_id="owner", workspace_id="ws-1", chat_id=chat_id)
+    gatekeeper.grant_resource(
+        chat_id,
+        GatekeeperResource(type="github.repo", id="org/secret-repo"),
+        frozenset({"read_secrets"}),
+    )
+    gatekeeper.record_tool_observation(
+        observer,
+        "github_list_repository_secrets",
+        {"repo_name": "org/secret-repo"},
+    )
+
+    viewer = GatekeeperSubject(
+        user_id="other-user", workspace_id="ws-1", chat_id=chat_id
+    )
+    decision = gatekeeper.evaluate_conversation_export(viewer, chat_id)
+    assert decision.allowed is False
+    assert "viewer_lacks_access" in decision.reason
+
+
+def test_export_allowed_for_observer_with_auto_export_grant(gatekeeper) -> None:
+    chat_id = "chat-6"
+    observer = GatekeeperSubject(user_id="owner", workspace_id="ws-1", chat_id=chat_id)
+    gatekeeper.grant_resource(
+        chat_id,
+        GatekeeperResource(type="github.repo", id="org/secret-repo"),
+        frozenset({"read_secrets"}),
+    )
+    gatekeeper.record_tool_observation(
+        observer,
+        "github_list_repository_secrets",
+        {"repo_name": "org/secret-repo"},
+    )
+
+    decision = gatekeeper.evaluate_conversation_export(observer, chat_id)
+    assert decision.allowed is True

--- a/libs/naas-abi-core/naas_abi_core/services/gatekeeper/adapters/secondary/GatekeeperSqliteAdapter.py
+++ b/libs/naas-abi-core/naas_abi_core/services/gatekeeper/adapters/secondary/GatekeeperSqliteAdapter.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import threading
+from datetime import datetime
+from typing import Any
+
+from naas_abi_core.services.gatekeeper.GatekeeperPort import (
+    IGrantStore,
+    IObservationStore,
+    ObservationRecord,
+    ResourceGrant,
+)
+
+
+class GatekeeperSqliteAdapter(IObservationStore, IGrantStore):
+    """Single SQLite database for observations and session grants."""
+
+    def __init__(
+        self,
+        db_path: str,
+        synchronous: str = "NORMAL",
+        journal_mode: str = "WAL",
+        busy_timeout_ms: int = 5000,
+    ) -> None:
+        os.makedirs(os.path.dirname(db_path) or ".", exist_ok=True)
+        self._db_path = db_path
+        self._lock = threading.Lock()
+        self._conn = sqlite3.connect(db_path, check_same_thread=False)
+        self._conn.execute(f"PRAGMA journal_mode={journal_mode}")
+        self._conn.execute(f"PRAGMA synchronous={synchronous}")
+        self._conn.execute(f"PRAGMA busy_timeout={busy_timeout_ms}")
+        self._init_schema()
+
+    def _init_schema(self) -> None:
+        with self._lock:
+            self._conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS observations (
+                    id TEXT PRIMARY KEY,
+                    chat_id TEXT NOT NULL,
+                    user_id TEXT,
+                    workspace_id TEXT,
+                    tool_name TEXT NOT NULL,
+                    resource_type TEXT NOT NULL,
+                    resource_id TEXT NOT NULL,
+                    sensitivity TEXT NOT NULL,
+                    observed_at TEXT NOT NULL,
+                    tool_args_json TEXT NOT NULL
+                );
+                CREATE INDEX IF NOT EXISTS idx_observations_chat_id
+                    ON observations(chat_id);
+
+                CREATE TABLE IF NOT EXISTS grants (
+                    chat_id TEXT NOT NULL,
+                    resource_type TEXT NOT NULL,
+                    resource_id TEXT NOT NULL,
+                    actions_json TEXT NOT NULL,
+                    granted_at TEXT NOT NULL,
+                    PRIMARY KEY (chat_id, resource_type, resource_id)
+                );
+                """
+            )
+            self._conn.commit()
+
+    def record(self, observation: ObservationRecord) -> None:
+        with self._lock:
+            self._conn.execute(
+                """
+                INSERT INTO observations (
+                    id, chat_id, user_id, workspace_id, tool_name,
+                    resource_type, resource_id, sensitivity, observed_at, tool_args_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    observation.id,
+                    observation.chat_id,
+                    observation.user_id,
+                    observation.workspace_id,
+                    observation.tool_name,
+                    observation.resource_type,
+                    observation.resource_id,
+                    observation.sensitivity,
+                    observation.observed_at.isoformat(),
+                    json.dumps(observation.tool_args, default=str),
+                ),
+            )
+            self._conn.commit()
+
+    def list_observations(self, chat_id: str) -> list[ObservationRecord]:
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT id, chat_id, user_id, workspace_id, tool_name,
+                       resource_type, resource_id, sensitivity, observed_at, tool_args_json
+                FROM observations
+                WHERE chat_id = ?
+                ORDER BY observed_at ASC
+                """,
+                (chat_id,),
+            ).fetchall()
+        return [self._row_to_observation(row) for row in rows]
+
+    def grant(self, grant: ResourceGrant) -> None:
+        with self._lock:
+            self._conn.execute(
+                """
+                INSERT INTO grants (chat_id, resource_type, resource_id, actions_json, granted_at)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(chat_id, resource_type, resource_id) DO UPDATE SET
+                    actions_json = excluded.actions_json,
+                    granted_at = excluded.granted_at
+                """,
+                (
+                    grant.chat_id,
+                    grant.resource_type,
+                    grant.resource_id,
+                    json.dumps(sorted(grant.actions)),
+                    grant.granted_at.isoformat(),
+                ),
+            )
+            self._conn.commit()
+
+    def list_grants(self, chat_id: str) -> list[ResourceGrant]:
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT chat_id, resource_type, resource_id, actions_json, granted_at
+                FROM grants
+                WHERE chat_id = ?
+                ORDER BY granted_at ASC
+                """,
+                (chat_id,),
+            ).fetchall()
+        return [self._row_to_grant(row) for row in rows]
+
+    def has_grant(
+        self,
+        chat_id: str,
+        resource_type: str,
+        resource_id: str,
+        action: str,
+    ) -> bool:
+        with self._lock:
+            row = self._conn.execute(
+                """
+                SELECT actions_json FROM grants
+                WHERE chat_id = ? AND resource_type = ? AND resource_id = ?
+                """,
+                (chat_id, resource_type, resource_id),
+            ).fetchone()
+        if row is None:
+            return False
+        actions = json.loads(row[0])
+        return action in actions or "*" in actions
+
+    def shutdown(self) -> None:
+        with self._lock:
+            self._conn.close()
+
+    @staticmethod
+    def _row_to_observation(row: tuple[Any, ...]) -> ObservationRecord:
+        return ObservationRecord(
+            id=row[0],
+            chat_id=row[1],
+            user_id=row[2],
+            workspace_id=row[3],
+            tool_name=row[4],
+            resource_type=row[5],
+            resource_id=row[6],
+            sensitivity=row[7],  # type: ignore[arg-type]
+            observed_at=datetime.fromisoformat(row[8]),
+            tool_args=json.loads(row[9]),
+        )
+
+    @staticmethod
+    def _row_to_grant(row: tuple[Any, ...]) -> ResourceGrant:
+        return ResourceGrant(
+            chat_id=row[0],
+            resource_type=row[1],
+            resource_id=row[2],
+            actions=frozenset(json.loads(row[3])),
+            granted_at=datetime.fromisoformat(row[4]),
+        )

--- a/libs/naas-abi-core/naas_abi_core/services/gatekeeper/policies/GitHubGatekeeperPolicy.py
+++ b/libs/naas-abi-core/naas_abi_core/services/gatekeeper/policies/GitHubGatekeeperPolicy.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import Any
+
+from naas_abi_core.services.gatekeeper.GatekeeperPort import (
+    GatekeeperResource,
+    IGatekeeperPolicy,
+    Sensitivity,
+)
+
+GITHUB_TOOL_PREFIX = "github_"
+
+SENSITIVE_GITHUB_TOOLS: frozenset[str] = frozenset(
+    {
+        "github_list_repository_secrets",
+        "github_get_repository_secret",
+        "github_create_or_update_repository_secret",
+        "github_delete_repository_secret",
+        "github_delete_organization_repository",
+    }
+)
+
+
+class GitHubGatekeeperPolicy(IGatekeeperPolicy):
+    """Pilot policy: sensitive GitHub tools require an explicit session grant."""
+
+    def classify_tool(self, tool_name: str) -> Sensitivity:
+        if tool_name in SENSITIVE_GITHUB_TOOLS:
+            return "sensitive"
+        return "normal"
+
+    def extract_resources(
+        self, tool_name: str, tool_args: dict[str, Any]
+    ) -> list[GatekeeperResource]:
+        if not tool_name.startswith(GITHUB_TOOL_PREFIX):
+            return []
+
+        repo_name = tool_args.get("repo_name")
+        if isinstance(repo_name, str) and repo_name.strip():
+            return [
+                GatekeeperResource(type="github.repo", id=repo_name.strip()),
+            ]
+
+        org = tool_args.get("org")
+        if isinstance(org, str) and org.strip():
+            return [
+                GatekeeperResource(type="github.org", id=org.strip()),
+            ]
+
+        return []
+
+    def required_action(self, tool_name: str) -> str:
+        if tool_name in SENSITIVE_GITHUB_TOOLS:
+            if "secret" in tool_name:
+                return "read_secrets"
+            if tool_name == "github_delete_organization_repository":
+                return "delete_repo"
+        if tool_name.startswith(GITHUB_TOOL_PREFIX):
+            return "invoke"
+        return "invoke"

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/api/router.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/api/router.py
@@ -29,6 +29,9 @@ from naas_abi.apps.nexus.apps.api.app.services.coding_environment.handlers impor
     router as coding_environment_router,
 )
 from naas_abi.apps.nexus.apps.api.app.services.files.handlers import router as files_router
+from naas_abi.apps.nexus.apps.api.app.services.gatekeeper.handlers import (
+    router as gatekeeper_router,
+)
 from naas_abi.apps.nexus.apps.api.app.services.modules.handlers import router as modules_router
 from naas_abi.apps.nexus.apps.api.app.services.openai_gateway.handlers import (
     router as openai_gateway_router,
@@ -66,6 +69,7 @@ api_router.include_router(graph.router, prefix="/graph", tags=["graph"])
 api_router.include_router(view.router, prefix="/view", tags=["view"])
 api_router.include_router(agents_router, prefix="/agents", tags=["agents"])
 api_router.include_router(skills_router, prefix="/skills", tags=["skills"])
+api_router.include_router(gatekeeper_router, prefix="/gatekeeper", tags=["gatekeeper"])
 api_router.include_router(modules_router, prefix="/modules", tags=["modules"])
 api_router.include_router(apps_router, prefix="/apps", tags=["apps"])
 api_router.include_router(files_router, prefix="/files", tags=["files"])

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__FastAPI.py
@@ -475,6 +475,15 @@ async def export_conversation(
     if not conv:
         raise HTTPException(status_code=404, detail="Conversation not found")
 
+    try:
+        registry.chat.ensure_conversation_export_allowed(
+            context=request_context(current_user),
+            conversation_id=conversation_id,
+            workspace_id=conv.workspace_id,
+        )
+    except PermissionError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+
     await require_workspace_access(current_user.id, conv.workspace_id)
     logger.info(
         "📥 EXPORT: user=%s, conversation=%s, format=%s, messages=%s, workspace=%s",

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/service.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/service.py
@@ -531,6 +531,31 @@ class ChatService:
             context.actor_user_id,
         )
 
+    def ensure_conversation_export_allowed(
+        self,
+        context: RequestContext,
+        conversation_id: str,
+        workspace_id: str | None = None,
+    ) -> None:
+        """Enforce derivation policy before exporting a conversation transcript."""
+        from naas_abi_core.engine.context import get_default_gatekeeper_service
+        from naas_abi_core.services.gatekeeper.GatekeeperPort import GatekeeperSubject
+
+        gatekeeper = get_default_gatekeeper_service()
+        if gatekeeper is None:
+            return
+
+        decision = gatekeeper.evaluate_conversation_export(
+            GatekeeperSubject(
+                user_id=context.actor_user_id,
+                workspace_id=workspace_id,
+                chat_id=conversation_id,
+            ),
+            conversation_id,
+        )
+        if not decision.allowed:
+            raise PermissionError(decision.reason)
+
     def _ensure_scope(
         self,
         context: RequestContext,

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/gatekeeper/__init__.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/gatekeeper/__init__.py
@@ -1,0 +1,13 @@
+from naas_abi.apps.nexus.apps.api.app.services.gatekeeper.port import (
+    GatekeeperGrantCreateInput,
+    GatekeeperGrantRecord,
+)
+from naas_abi.apps.nexus.apps.api.app.services.gatekeeper.service import (
+    GatekeeperNexusService,
+)
+
+__all__ = [
+    "GatekeeperGrantCreateInput",
+    "GatekeeperGrantRecord",
+    "GatekeeperNexusService",
+]

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/gatekeeper/adapters/primary/__init__.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/gatekeeper/adapters/primary/__init__.py
@@ -1,0 +1,5 @@
+from naas_abi.apps.nexus.apps.api.app.services.gatekeeper.adapters.primary.gatekeeper__primary_adapter__FastAPI import (
+    router,
+)
+
+__all__ = ["router"]

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/gatekeeper/adapters/primary/gatekeeper__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/gatekeeper/adapters/primary/gatekeeper__primary_adapter__FastAPI.py
@@ -1,0 +1,114 @@
+"""Gatekeeper FastAPI primary adapter."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException
+from naas_abi.apps.nexus.apps.api.app.api.endpoints.auth import (
+    User,
+    get_current_user_required,
+)
+from naas_abi.apps.nexus.apps.api.app.services.gatekeeper.port import (
+    GatekeeperGrantCreateInput,
+    GatekeeperGrantRecord,
+)
+from naas_abi.apps.nexus.apps.api.app.services.gatekeeper.service import (
+    GatekeeperNexusService,
+    GatekeeperUnavailableError,
+)
+from naas_abi.apps.nexus.apps.api.app.services.iam.port import RequestContext, TokenData
+from naas_abi.apps.nexus.apps.api.app.services.registry import (
+    ServiceRegistry,
+    get_service_registry,
+)
+from pydantic import BaseModel, Field
+
+router = APIRouter(dependencies=[Depends(get_current_user_required)])
+
+
+class GatekeeperFastAPIPrimaryAdapter:
+    def __init__(self) -> None:
+        self.router = router
+
+
+def get_gatekeeper_service(
+    registry: ServiceRegistry = Depends(get_service_registry),
+) -> GatekeeperNexusService:
+    return registry.gatekeeper
+
+
+def request_context(current_user: User) -> RequestContext:
+    return RequestContext(
+        token_data=TokenData(user_id=current_user.id, scopes={"*"}, is_authenticated=True)
+    )
+
+
+class GatekeeperGrantBody(BaseModel):
+    resource_type: str = Field(..., min_length=1, max_length=200)
+    resource_id: str = Field(..., min_length=1, max_length=500)
+    actions: list[str] = Field(..., min_length=1)
+
+
+class GatekeeperGrantResponse(BaseModel):
+    chat_id: str
+    resource_type: str
+    resource_id: str
+    actions: list[str]
+    granted_at: datetime
+
+
+def _to_response(record: GatekeeperGrantRecord) -> GatekeeperGrantResponse:
+    return GatekeeperGrantResponse(
+        chat_id=record.chat_id,
+        resource_type=record.resource_type,
+        resource_id=record.resource_id,
+        actions=list(record.actions),
+        granted_at=record.granted_at,
+    )
+
+
+@router.get("/conversations/{conversation_id}/grants")
+async def list_conversation_grants(
+    conversation_id: str,
+    workspace_id: str,
+    current_user: User = Depends(get_current_user_required),
+    gatekeeper_service: GatekeeperNexusService = Depends(get_gatekeeper_service),
+) -> list[GatekeeperGrantResponse]:
+    try:
+        grants = await gatekeeper_service.list_grants(
+            context=request_context(current_user),
+            workspace_id=workspace_id,
+            conversation_id=conversation_id,
+        )
+    except PermissionError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except GatekeeperUnavailableError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    return [_to_response(grant) for grant in grants]
+
+
+@router.post("/conversations/{conversation_id}/grants")
+async def create_conversation_grant(
+    conversation_id: str,
+    workspace_id: str,
+    body: GatekeeperGrantBody,
+    current_user: User = Depends(get_current_user_required),
+    gatekeeper_service: GatekeeperNexusService = Depends(get_gatekeeper_service),
+) -> GatekeeperGrantResponse:
+    try:
+        grant = await gatekeeper_service.grant_resource(
+            context=request_context(current_user),
+            workspace_id=workspace_id,
+            conversation_id=conversation_id,
+            data=GatekeeperGrantCreateInput(
+                resource_type=body.resource_type,
+                resource_id=body.resource_id,
+                actions=tuple(body.actions),
+            ),
+        )
+    except PermissionError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except GatekeeperUnavailableError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    return _to_response(grant)

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/gatekeeper/handlers/__init__.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/gatekeeper/handlers/__init__.py
@@ -1,0 +1,5 @@
+from naas_abi.apps.nexus.apps.api.app.services.gatekeeper.handlers.gatekeeper__http_handler import (
+    router,
+)
+
+__all__ = ["router"]

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/gatekeeper/handlers/gatekeeper__http_handler.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/gatekeeper/handlers/gatekeeper__http_handler.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from naas_abi.apps.nexus.apps.api.app.services.gatekeeper.adapters.primary.gatekeeper__primary_adapter__FastAPI import (
+    router,
+)
+
+__all__ = ["router"]

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/gatekeeper/port.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/gatekeeper/port.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass(frozen=True)
+class GatekeeperGrantRecord:
+    chat_id: str
+    resource_type: str
+    resource_id: str
+    actions: tuple[str, ...]
+    granted_at: datetime
+
+
+@dataclass(frozen=True)
+class GatekeeperGrantCreateInput:
+    resource_type: str
+    resource_id: str
+    actions: tuple[str, ...]

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/gatekeeper/service.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/gatekeeper/service.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from naas_abi.apps.nexus.apps.api.app.services.chat.service import ChatService
+from naas_abi.apps.nexus.apps.api.app.services.gatekeeper.port import (
+    GatekeeperGrantCreateInput,
+    GatekeeperGrantRecord,
+)
+from naas_abi.apps.nexus.apps.api.app.services.iam.port import RequestContext
+from naas_abi_core.engine.context import get_default_gatekeeper_service
+from naas_abi_core.services.gatekeeper.GatekeeperPort import GatekeeperResource
+
+
+class GatekeeperUnavailableError(RuntimeError):
+    pass
+
+
+class GatekeeperNexusService:
+    def __init__(self, chat_service: ChatService) -> None:
+        self._chat = chat_service
+
+    async def _ensure_conversation_access(
+        self,
+        context: RequestContext,
+        workspace_id: str,
+        conversation_id: str,
+    ) -> None:
+        await self._chat._ensure_workspace_access(
+            context=context,
+            workspace_id=workspace_id,
+            action="chat.conversation.read",
+        )
+        conversation = await self._chat.get_conversation_for_user(
+            context=context,
+            conversation_id=conversation_id,
+        )
+        if conversation is None or conversation.workspace_id != workspace_id:
+            raise PermissionError("Conversation not found")
+
+    def _core(self):
+        gatekeeper = get_default_gatekeeper_service()
+        if gatekeeper is None:
+            raise GatekeeperUnavailableError("Gatekeeper service is not configured")
+        return gatekeeper
+
+    async def list_grants(
+        self,
+        context: RequestContext,
+        workspace_id: str,
+        conversation_id: str,
+    ) -> list[GatekeeperGrantRecord]:
+        await self._ensure_conversation_access(context, workspace_id, conversation_id)
+        grants = self._core().list_grants(conversation_id)
+        return [
+            GatekeeperGrantRecord(
+                chat_id=grant.chat_id,
+                resource_type=grant.resource_type,
+                resource_id=grant.resource_id,
+                actions=tuple(sorted(grant.actions)),
+                granted_at=grant.granted_at,
+            )
+            for grant in grants
+        ]
+
+    async def grant_resource(
+        self,
+        context: RequestContext,
+        workspace_id: str,
+        conversation_id: str,
+        data: GatekeeperGrantCreateInput,
+    ) -> GatekeeperGrantRecord:
+        await self._ensure_conversation_access(context, workspace_id, conversation_id)
+        grant = self._core().grant_resource(
+            conversation_id,
+            GatekeeperResource(type=data.resource_type, id=data.resource_id),
+            frozenset(data.actions),
+        )
+        return GatekeeperGrantRecord(
+            chat_id=grant.chat_id,
+            resource_type=grant.resource_type,
+            resource_id=grant.resource_id,
+            actions=tuple(sorted(grant.actions)),
+            granted_at=grant.granted_at,
+        )

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/modules/handlers.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/modules/handlers.py
@@ -1,9 +1,10 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from naas_abi.apps.nexus.apps.api.app.api.endpoints.auth import (
     get_current_user_required,
 )
 from naas_abi.apps.nexus.apps.api.app.core.config import get_settings
 from naas_abi.apps.nexus.apps.api.app.services.modules.schema import (
+    InstallModuleResponse,
     MarketplaceConfigResponse,
     ModulesResponse,
 )
@@ -16,6 +17,21 @@ router = APIRouter(dependencies=[Depends(get_current_user_required)])
 async def list_modules() -> ModulesResponse:
     """Return installed modules and the full marketplace catalog."""
     return await ModulesService.list_modules()
+
+
+@router.post("/install/{module_path:path}", response_model=InstallModuleResponse)
+async def install_module(module_path: str) -> InstallModuleResponse:
+    """
+    Enable a marketplace module in config.yaml.
+
+    Requires an API restart before tools/agents from the module are available.
+    """
+    try:
+        return await ModulesService.install_module(module_path)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
 @router.get("/config", response_model=MarketplaceConfigResponse)

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/modules/schema.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/modules/schema.py
@@ -31,3 +31,13 @@ class ModulesResponse(BaseModel):
 class MarketplaceConfigResponse(BaseModel):
     """Full marketplace configuration returned by GET /api/modules/config."""
     config: MarketplaceConfig
+
+
+class InstallModuleResponse(BaseModel):
+    module_path: str
+    config_file: str
+    created: bool
+    restart_required: bool = True
+    secrets_required: list[str] = []
+    message: str
+    already_installed: bool = False

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/modules/service.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/modules/service.py
@@ -14,6 +14,7 @@ from functools import lru_cache
 from pathlib import Path
 
 from naas_abi.apps.nexus.apps.api.app.services.modules.schema import (
+    InstallModuleResponse,
     ModuleInfo,
     ModulesResponse,
 )
@@ -263,6 +264,40 @@ def _agent_meta(agent_cls: type) -> tuple[str | None, str | None, str | None]:
 
 
 class ModulesService:
+    @staticmethod
+    async def install_module(module_path: str) -> InstallModuleResponse:
+        from naas_abi.config.module_enable import enable_module_in_config
+
+        catalog = _build_catalog()
+        known = {m.module_path for m in catalog}
+        if module_path not in known:
+            raise ValueError(f"Unknown marketplace module: {module_path}")
+
+        from naas_abi import ABIModule
+
+        engine = ABIModule.get_instance().engine
+        if module_path in engine.modules:
+            return InstallModuleResponse(
+                module_path=module_path,
+                config_file="",
+                created=False,
+                restart_required=False,
+                secrets_required=[],
+                message=f"Module '{module_path}' is already loaded.",
+                already_installed=True,
+            )
+
+        result = enable_module_in_config(module_path)
+        return InstallModuleResponse(
+            module_path=result.module_path,
+            config_file=result.config_file,
+            created=result.created,
+            restart_required=result.restart_required,
+            secrets_required=result.secrets_required,
+            message=result.message,
+            already_installed=False,
+        )
+
     @staticmethod
     async def list_modules() -> ModulesResponse:
         from naas_abi import ABIModule

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/provider_runtime.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/provider_runtime.py
@@ -1518,6 +1518,13 @@ async def stream_with_abi_inprocess(
                 yield {"event": "call_model", "agent": text}
             elif event_name == "agent_routing" and text.strip():
                 yield {"event": "agent_routing", "agent": text}
+            elif event_name == "gatekeeper_request" and text.strip():
+                try:
+                    payload = json.loads(text)
+                except Exception:
+                    payload = {"reason": text}
+                if isinstance(payload, dict):
+                    yield {"event": "gatekeeper_request", **payload}
             elif event_name == "gatekeeper_denied" and text.strip():
                 try:
                     payload = json.loads(text)

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/provider_runtime.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/provider_runtime.py
@@ -1518,5 +1518,12 @@ async def stream_with_abi_inprocess(
                 yield {"event": "call_model", "agent": text}
             elif event_name == "agent_routing" and text.strip():
                 yield {"event": "agent_routing", "agent": text}
+            elif event_name == "gatekeeper_denied" and text.strip():
+                try:
+                    payload = json.loads(text)
+                except Exception:
+                    payload = {"reason": text}
+                if isinstance(payload, dict):
+                    yield {"event": "gatekeeper_denied", **payload}
         elif isinstance(event, str) and event.strip():
             yield event

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/registry.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/registry.py
@@ -15,6 +15,9 @@ if TYPE_CHECKING:
     from naas_abi.apps.nexus.apps.api.app.services.agents.service import AgentService
     from naas_abi.apps.nexus.apps.api.app.services.apps.service import AppsService
     from naas_abi.apps.nexus.apps.api.app.services.chat.service import ChatService
+    from naas_abi.apps.nexus.apps.api.app.services.gatekeeper.service import (
+        GatekeeperNexusService,
+    )
     from naas_abi.apps.nexus.apps.api.app.services.graph.service import GraphService
     from naas_abi.apps.nexus.apps.api.app.services.iam.service import IAMService
     from naas_abi.apps.nexus.apps.api.app.services.ontology.service import OntologyService
@@ -31,6 +34,7 @@ class RegistryServices:
     search: SearchService
     agents: AgentService
     skills: SkillService
+    gatekeeper: GatekeeperNexusService
     apps: AppsService
     workspaces: WorkspaceService
     organizations: OrganizationService
@@ -70,6 +74,10 @@ class ServiceRegistry:
     @property
     def skills(self) -> SkillService:
         return self._services.skills
+
+    @property
+    def gatekeeper(self) -> GatekeeperNexusService:
+        return self._services.gatekeeper
 
     @property
     def apps(self) -> AppsService:

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/registry_bootstrap.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/registry_bootstrap.py
@@ -18,6 +18,7 @@ from naas_abi.apps.nexus.apps.api.app.services.chat.adapters.secondary.postgres 
     ChatSecondaryAdapterPostgres,
 )
 from naas_abi.apps.nexus.apps.api.app.services.chat.service import ChatService
+from naas_abi.apps.nexus.apps.api.app.services.gatekeeper.service import GatekeeperNexusService
 from naas_abi.apps.nexus.apps.api.app.services.graph.service import GraphService
 from naas_abi.apps.nexus.apps.api.app.services.iam.adapters.secondary.postgres import (
     IAMSecondaryAdapterPostgres,
@@ -67,6 +68,7 @@ def initialize_nexus_service_registry() -> ServiceRegistry:
         auth_adapter=AuthSecondaryAdapterPostgres(db_getter=db_getter),
         skills_service=skills_service,
     )
+    gatekeeper_service = GatekeeperNexusService(chat_service=chat_service)
     search_service = SearchService()
     agents_service = AgentService(
         AgentSecondaryAdapterPostgres(db_getter=db_getter),
@@ -83,6 +85,7 @@ def initialize_nexus_service_registry() -> ServiceRegistry:
             search=search_service,
             agents=agents_service,
             skills=skills_service,
+            gatekeeper=gatekeeper_service,
             apps=apps_service,
             workspaces=workspace_service,
             organizations=organization_service,

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/chat/components/gatekeeper-grant-banner.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/chat/components/gatekeeper-grant-banner.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { Check, Loader2, ShieldAlert } from 'lucide-react';
+
+import {
+  describeGatekeeperAction,
+  describeGatekeeperResource,
+  extractGatekeeperDenialFromToolCalls,
+  type GatekeeperDenial,
+} from '@/lib/gatekeeper';
+import { useGatekeeperStore } from '@/stores/gatekeeper';
+import type { ToolCall } from '@/stores/workspace';
+
+type GrantState = 'idle' | 'granting' | 'granted' | 'error';
+
+interface GatekeeperGrantBannerProps {
+  conversationId: string;
+  workspaceId: string | null;
+  toolCalls?: ToolCall[];
+  liveDenial?: GatekeeperDenial | null;
+}
+
+export function GatekeeperGrantBanner({
+  conversationId,
+  workspaceId,
+  toolCalls,
+  liveDenial,
+}: GatekeeperGrantBannerProps) {
+  const grantConversation = useGatekeeperStore((s) => s.grantConversation);
+  const hasGrant = useGatekeeperStore((s) => s.hasGrant);
+  const fetchGrants = useGatekeeperStore((s) => s.fetchGrants);
+
+  const denial = useMemo(() => {
+    if (liveDenial) return liveDenial;
+    return extractGatekeeperDenialFromToolCalls(toolCalls);
+  }, [liveDenial, toolCalls]);
+
+  const [grantState, setGrantState] = useState<GrantState>('idle');
+  const [grantError, setGrantError] = useState<string | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    if (!workspaceId || !conversationId) return;
+    fetchGrants(workspaceId, conversationId).catch(() => {
+      /* grants are optional until user interacts */
+    });
+  }, [workspaceId, conversationId, fetchGrants]);
+
+  useEffect(() => {
+    setDismissed(false);
+    setGrantState('idle');
+    setGrantError(null);
+  }, [denial?.resourceType, denial?.resourceId, denial?.action, conversationId]);
+
+  if (!denial || dismissed || !workspaceId) {
+    return null;
+  }
+
+  const alreadyGranted = hasGrant(
+    conversationId,
+    denial.resourceType,
+    denial.resourceId,
+    denial.action,
+  );
+
+  if (alreadyGranted || grantState === 'granted') {
+    return (
+      <div className="mb-3 rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-xs text-emerald-800 dark:text-emerald-200">
+        <div className="flex items-center gap-2">
+          <Check size={14} />
+          <span>
+            Access granted for{' '}
+            {describeGatekeeperResource(denial.resourceType, denial.resourceId)}. Retry your
+            message to continue.
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  const handleGrant = async () => {
+    setGrantState('granting');
+    setGrantError(null);
+    try {
+      await grantConversation(workspaceId, conversationId, {
+        resourceType: denial.resourceType,
+        resourceId: denial.resourceId,
+        actions: [denial.action],
+      });
+      setGrantState('granted');
+    } catch (err) {
+      setGrantError(err instanceof Error ? err.message : 'Failed to grant access');
+      setGrantState('error');
+    }
+  };
+
+  return (
+    <div className="mb-3 rounded-lg border border-amber-500/50 bg-amber-500/10 px-3 py-3 text-xs text-foreground">
+      <div className="flex items-start gap-2">
+        <ShieldAlert size={16} className="mt-0.5 shrink-0 text-amber-600 dark:text-amber-400" />
+        <div className="min-w-0 flex-1 space-y-2">
+          <p className="text-sm font-medium">Agent access blocked</p>
+          <p className="text-muted-foreground">
+            The agent tried to use <span className="font-mono">{denial.toolName}</span> but needs
+            permission to {describeGatekeeperAction(denial.action)} on{' '}
+            {describeGatekeeperResource(denial.resourceType, denial.resourceId)} for this chat.
+          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={handleGrant}
+              disabled={grantState === 'granting'}
+              className="rounded-md bg-workspace-accent px-3 py-1.5 text-xs font-medium text-white hover:opacity-90 disabled:opacity-60"
+            >
+              {grantState === 'granting' ? (
+                <span className="inline-flex items-center gap-1">
+                  <Loader2 size={12} className="animate-spin" />
+                  Granting…
+                </span>
+              ) : (
+                'Grant access'
+              )}
+            </button>
+            <button
+              type="button"
+              onClick={() => setDismissed(true)}
+              className="rounded-md border border-border px-3 py-1.5 text-xs text-muted-foreground hover:bg-muted/50"
+            >
+              Dismiss
+            </button>
+          </div>
+          {grantError ? (
+            <p className="text-destructive">{grantError}</p>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/chat/components/gatekeeper-grant-banner.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/chat/components/gatekeeper-grant-banner.tsx
@@ -12,13 +12,14 @@ import {
 import { useGatekeeperStore } from '@/stores/gatekeeper';
 import type { ToolCall } from '@/stores/workspace';
 
-type GrantState = 'idle' | 'granting' | 'granted' | 'error';
+type GrantState = 'idle' | 'granting' | 'granted' | 'continuing' | 'error';
 
 interface GatekeeperGrantBannerProps {
   conversationId: string;
   workspaceId: string | null;
   toolCalls?: ToolCall[];
   liveDenial?: GatekeeperDenial | null;
+  onContinueAfterGrant?: (conversationId: string) => void | Promise<void>;
 }
 
 export function GatekeeperGrantBanner({
@@ -26,6 +27,7 @@ export function GatekeeperGrantBanner({
   workspaceId,
   toolCalls,
   liveDenial,
+  onContinueAfterGrant,
 }: GatekeeperGrantBannerProps) {
   const grantConversation = useGatekeeperStore((s) => s.grantConversation);
   const hasGrant = useGatekeeperStore((s) => s.hasGrant);
@@ -64,15 +66,20 @@ export function GatekeeperGrantBanner({
     denial.action,
   );
 
-  if (alreadyGranted || grantState === 'granted') {
+  if (alreadyGranted || grantState === 'granted' || grantState === 'continuing') {
+    const continuing = grantState === 'continuing';
     return (
       <div className="mb-3 rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-xs text-emerald-800 dark:text-emerald-200">
         <div className="flex items-center gap-2">
-          <Check size={14} />
+          {continuing ? (
+            <Loader2 size={14} className="animate-spin" />
+          ) : (
+            <Check size={14} />
+          )}
           <span>
-            Access granted for{' '}
-            {describeGatekeeperResource(denial.resourceType, denial.resourceId)}. Retry your
-            message to continue.
+            {continuing
+              ? 'Access granted — continuing with your request…'
+              : `Access granted for ${describeGatekeeperResource(denial.resourceType, denial.resourceId)}.`}
           </span>
         </div>
       </div>
@@ -89,6 +96,10 @@ export function GatekeeperGrantBanner({
         actions: [denial.action],
       });
       setGrantState('granted');
+      if (onContinueAfterGrant) {
+        setGrantState('continuing');
+        await onContinueAfterGrant(conversationId);
+      }
     } catch (err) {
       setGrantError(err instanceof Error ? err.message : 'Failed to grant access');
       setGrantState('error');
@@ -100,16 +111,26 @@ export function GatekeeperGrantBanner({
       <div className="flex items-start gap-2">
         <ShieldAlert size={16} className="mt-0.5 shrink-0 text-amber-600 dark:text-amber-400" />
         <div className="min-w-0 flex-1 space-y-2">
-          <p className="text-sm font-medium">Agent access blocked</p>
+          <p className="text-sm font-medium">Approval required</p>
           <p className="text-muted-foreground">
-            The agent tried to use <span className="font-mono">{denial.toolName}</span> but needs
-            permission to {describeGatekeeperAction(denial.action)} on{' '}
-            {describeGatekeeperResource(denial.resourceType, denial.resourceId)} for this chat.
+            To continue, the agent needs permission to{' '}
+            {describeGatekeeperAction(denial.action)} on{' '}
+            {describeGatekeeperResource(denial.resourceType, denial.resourceId)}.
+            {denial.toolName ? (
+              <>
+                {' '}
+                This applies to{' '}
+                <span className="font-mono text-foreground/80">{denial.toolName}</span>.
+              </>
+            ) : null}
+          </p>
+          <p className="text-muted-foreground/80">
+            Grant access for this chat only — the agent will pick up where it left off.
           </p>
           <div className="flex flex-wrap items-center gap-2">
             <button
               type="button"
-              onClick={handleGrant}
+              onClick={() => void handleGrant()}
               disabled={grantState === 'granting'}
               className="rounded-md bg-workspace-accent px-3 py-1.5 text-xs font-medium text-white hover:opacity-90 disabled:opacity-60"
             >
@@ -119,7 +140,7 @@ export function GatekeeperGrantBanner({
                   Granting…
                 </span>
               ) : (
-                'Grant access'
+                'Grant access & continue'
               )}
             </button>
             <button
@@ -127,12 +148,10 @@ export function GatekeeperGrantBanner({
               onClick={() => setDismissed(true)}
               className="rounded-md border border-border px-3 py-1.5 text-xs text-muted-foreground hover:bg-muted/50"
             >
-              Dismiss
+              Not now
             </button>
           </div>
-          {grantError ? (
-            <p className="text-destructive">{grantError}</p>
-          ) : null}
+          {grantError ? <p className="text-destructive">{grantError}</p> : null}
         </div>
       </div>
     </div>

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/marketplace/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/marketplace/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, useCallback } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { Header } from '@/components/shell/header';
 import {
@@ -40,6 +40,16 @@ interface ModuleInfo {
 interface ModulesResponse {
   installed: ModuleInfo[];
   available: ModuleInfo[];
+}
+
+interface InstallModuleResponse {
+  module_path: string;
+  config_file: string;
+  created: boolean;
+  restart_required: boolean;
+  secrets_required: string[];
+  message: string;
+  already_installed: boolean;
 }
 
 // Marketplace config shapes (mirrors backend Pydantic models)
@@ -393,7 +403,19 @@ function ModuleAvatar({ mod, className, imgClassName }: { mod: ModuleInfo; class
 // Module card
 // ---------------------------------------------------------------------------
 
-function ModuleCard({ mod, onClick, cfg }: { mod: ModuleInfo; onClick: () => void; cfg: MarketplaceConfig }) {
+function ModuleCard({
+  mod,
+  onClick,
+  cfg,
+  onInstall,
+  installing,
+}: {
+  mod: ModuleInfo;
+  onClick: () => void;
+  cfg: MarketplaceConfig;
+  onInstall?: (mod: ModuleInfo) => void;
+  installing?: boolean;
+}) {
   const isPortrait = mod.category === 'domain';
   const pricing = getModulePricing(mod, cfg);
 
@@ -441,15 +463,20 @@ function ModuleCard({ mod, onClick, cfg }: { mod: ModuleInfo; onClick: () => voi
             </a>
           ) : (
             <button
-              disabled={pricing.ctaDisabled}
-              onClick={(e) => e.stopPropagation()}
+              disabled={pricing.ctaDisabled || installing}
+              onClick={(e) => {
+                e.stopPropagation();
+                if (!pricing.ctaDisabled && pricing.cta === 'Install' && onInstall) {
+                  onInstall(mod);
+                }
+              }}
               className={cn(
                 'flex items-center gap-1 px-3 py-1 text-xs font-semibold transition-colors',
                 pricing.ctaStyle,
               )}
             >
-              {!pricing.ctaDisabled && <Download size={11} />}
-              {pricing.cta}
+              {!pricing.ctaDisabled && !installing && <Download size={11} />}
+              {installing ? 'Installing…' : pricing.cta}
             </button>
           )}
         </div>
@@ -526,7 +553,23 @@ function ExternalAppCard({ app }: { app: { name: string; url: string; descriptio
 // Agent ID Card panel
 // ---------------------------------------------------------------------------
 
-function AgentIdCard({ mod, onClose, cfg, workspaceId }: { mod: ModuleInfo; onClose: () => void; cfg: MarketplaceConfig; workspaceId: string | null }) {
+function AgentIdCard({
+  mod,
+  onClose,
+  cfg,
+  workspaceId,
+  onInstall,
+  installing,
+  installNotice,
+}: {
+  mod: ModuleInfo;
+  onClose: () => void;
+  cfg: MarketplaceConfig;
+  workspaceId: string | null;
+  onInstall?: (mod: ModuleInfo) => void;
+  installing?: boolean;
+  installNotice?: string | null;
+}) {
   const isPortrait = mod.category === 'domain';
   const pricing = getModulePricing(mod, cfg);
 
@@ -607,6 +650,11 @@ function AgentIdCard({ mod, onClose, cfg, workspaceId }: { mod: ModuleInfo; onCl
             </div>
 
             {/* CTA */}
+            {installNotice ? (
+              <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-foreground">
+                {installNotice}
+              </div>
+            ) : null}
             {pricing.ctaUrl && !pricing.ctaDisabled ? (
               <a
                 href={pricing.ctaUrl}
@@ -619,11 +667,16 @@ function AgentIdCard({ mod, onClose, cfg, workspaceId }: { mod: ModuleInfo; onCl
               </a>
             ) : (
               <button
-                disabled={pricing.ctaDisabled}
+                disabled={pricing.ctaDisabled || installing}
+                onClick={() => {
+                  if (!pricing.ctaDisabled && pricing.cta === 'Install' && onInstall) {
+                    onInstall(mod);
+                  }
+                }}
                 className={cn('w-full py-2.5 text-sm font-semibold transition-colors flex items-center justify-center gap-2', pricing.ctaStyle)}
               >
-                {!pricing.ctaDisabled && <Download size={14} />}
-                {pricing.cta}
+                {!pricing.ctaDisabled && !installing && <Download size={14} />}
+                {installing ? 'Installing…' : pricing.cta}
               </button>
             )}
 
@@ -666,6 +719,47 @@ export default function MarketplacePage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedMod, setSelectedMod] = useState<ModuleInfo | null>(null);
+  const [installingPath, setInstallingPath] = useState<string | null>(null);
+  const [installNotice, setInstallNotice] = useState<string | null>(null);
+
+  const reloadModules = useCallback(async () => {
+    const apiBase = getApiUrl();
+    const modules = await authFetch(`${apiBase}/api/modules/`).then((r) =>
+      r.ok ? r.json() : Promise.reject(r.statusText),
+    );
+    setData(modules as ModulesResponse);
+  }, []);
+
+  const handleInstallModule = useCallback(
+    async (mod: ModuleInfo) => {
+      setInstallingPath(mod.module_path);
+      setInstallNotice(null);
+      setError(null);
+      try {
+        const apiBase = getApiUrl();
+        const response = await authFetch(
+          `${apiBase}/api/modules/install/${encodeURIComponent(mod.module_path)}`,
+          { method: 'POST' },
+        );
+        const body = (await response.json()) as InstallModuleResponse & { detail?: string };
+        if (!response.ok) {
+          throw new Error(body.detail || body.message || 'Install failed');
+        }
+        setInstallNotice(body.message);
+        await reloadModules();
+        setSelectedMod((current) =>
+          current?.module_path === mod.module_path
+            ? { ...current, installed: body.already_installed || body.restart_required }
+            : current,
+        );
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Install failed');
+      } finally {
+        setInstallingPath(null);
+      }
+    },
+    [reloadModules],
+  );
 
   useEffect(() => {
     const t = searchParams?.get('type') as ArtifactType | null;
@@ -857,7 +951,14 @@ export default function MarketplacePage() {
                     )}
                     <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
                       {mods.map((mod) => (
-                        <ModuleCard key={mod.module_path} mod={mod} onClick={() => setSelectedMod(mod)} cfg={mktCfg} />
+                        <ModuleCard
+                          key={mod.module_path}
+                          mod={mod}
+                          onClick={() => setSelectedMod(mod)}
+                          cfg={mktCfg}
+                          onInstall={handleInstallModule}
+                          installing={installingPath === mod.module_path}
+                        />
                       ))}
                     </div>
                   </section>
@@ -891,7 +992,18 @@ export default function MarketplacePage() {
       </div>
 
       {selectedMod && (
-        <AgentIdCard mod={selectedMod} onClose={() => setSelectedMod(null)} cfg={mktCfg} workspaceId={currentWorkspaceId} />
+        <AgentIdCard
+          mod={selectedMod}
+          onClose={() => {
+            setSelectedMod(null);
+            setInstallNotice(null);
+          }}
+          cfg={mktCfg}
+          workspaceId={currentWorkspaceId}
+          onInstall={handleInstallModule}
+          installing={installingPath === selectedMod.module_path}
+          installNotice={installNotice}
+        />
       )}
     </div>
   );

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useRef, useEffect, useMemo, useCallback, useLayoutEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { Send, Plus, Bot, User, AlertCircle, Brain, ChevronDown, X, ArrowUp, ExternalLink, HardDrive, RefreshCw, Mic, Check, Loader2, Wrench, Copy, FileText, ThumbsUp, ThumbsDown, Volume2, Square, Columns2 } from 'lucide-react';
+import { Send, Plus, Bot, User, AlertCircle, Brain, ChevronDown, X, ArrowUp, ExternalLink, HardDrive, RefreshCw, Mic, Check, Loader2, Wrench, Copy, FileText, ThumbsUp, ThumbsDown, Volume2, Square, Columns2, ShieldAlert } from 'lucide-react';
 import Image from 'next/image';
 import { usePathname, useRouter } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
@@ -21,7 +21,8 @@ import { useTenant } from '@/contexts/tenant-context';
 import { ChatAgentSelector } from '@/app/workspace/[workspaceId]/chat/components/chat-agent-selector';
 import { GatekeeperGrantBanner } from '@/app/workspace/[workspaceId]/chat/components/gatekeeper-grant-banner';
 import '@/app/workspace/[workspaceId]/chat/components/chat-agent-selector.css';
-import { type GatekeeperDenial, parseGatekeeperDenialFromOutput } from '@/lib/gatekeeper';
+import { type GatekeeperDenial, parseGatekeeperDenialFromOutput, parseGatekeeperRequestPayload } from '@/lib/gatekeeper';
+import { useGatekeeperStore } from '@/stores/gatekeeper';
 import { TypingIndicator } from '@/components/typing-indicator';
 import { PdfViewer } from '@/components/files/pdf-viewer';
 
@@ -827,6 +828,7 @@ export function ChatInterface({
   const setSelectedAgent = useWorkspaceStore((s) => s.setSelectedAgent);
   const addMessage = useWorkspaceStore((s) => s.addMessage);
   const updateLastMessage = useWorkspaceStore((s) => s.updateLastMessage);
+  const removeLastAssistantMessage = useWorkspaceStore((s) => s.removeLastAssistantMessage);
   const getWorkspaceConversations = useWorkspaceStore((s) => s.getWorkspaceConversations);
   const currentWorkspaceId = useWorkspaceStore((s) => s.currentWorkspaceId);
   const loadConversationMessages = useWorkspaceStore((s) => s.loadConversationMessages);
@@ -1744,7 +1746,8 @@ export function ChatInterface({
     e?: React.FormEvent,
     messageOverride?: string,
     agentOverride?: string,
-    conversationIdOverride?: string
+    conversationIdOverride?: string,
+    options?: { skipUserMessage?: boolean },
   ) => {
     e?.preventDefault();
     if (isSubmittingRef.current) return;
@@ -1878,26 +1881,34 @@ export function ChatInterface({
       // normal send flow below, unmodified.
     }
 
-    const currentImages = [...attachedImages]; // Copy before clearing
-    const currentFileAttachments = [...pendingFileAttachments]; // Copy before clearing
+    const currentImages = options?.skipUserMessage ? [] : [...attachedImages];
+    const currentFileAttachments = options?.skipUserMessage
+      ? []
+      : [...pendingFileAttachments];
 
-    // Add user message with images and file attachments
-    addMessage(conversationId, {
-      role: 'user',
-      content: sourceText.trim() || (attachedImages.length > 0 ? 'What is in this image?' : ''),
-      images: currentImages.length > 0 ? currentImages : undefined,
-      fileAttachments: currentFileAttachments.length > 0 ? currentFileAttachments : undefined,
-    });
-
-    const userMessage = sourceText.trim() || (currentImages.length > 0 ? 'What is in this image?' : '');
-    // Only clear the input field if the message came from the input
-    if (messageOverride === undefined) {
-      handleInputChange('');
-    } else {
-      setInput('');
+    if (!options?.skipUserMessage) {
+      // Add user message with images and file attachments
+      addMessage(conversationId, {
+        role: 'user',
+        content: sourceText.trim() || (attachedImages.length > 0 ? 'What is in this image?' : ''),
+        images: currentImages.length > 0 ? currentImages : undefined,
+        fileAttachments: currentFileAttachments.length > 0 ? currentFileAttachments : undefined,
+      });
     }
-    setAttachedImages([]); // Clear attached images after adding to message
-    setPendingFileAttachments([]); // Clear file attachments after adding to message
+
+    const userMessage =
+      sourceText.trim() ||
+      (currentImages.length > 0 ? 'What is in this image?' : '');
+    // Only clear the input field if the message came from the input
+    if (!options?.skipUserMessage) {
+      if (messageOverride === undefined) {
+        handleInputChange('');
+      } else {
+        setInput('');
+      }
+      setAttachedImages([]); // Clear attached images after adding to message
+      setPendingFileAttachments([]); // Clear file attachments after adding to message
+    }
     setImageError(null);
     // setSearchEnabled(false); // Reset search toggle after sending
     setRequestSentAt(Date.now());
@@ -1988,6 +1999,40 @@ export function ChatInterface({
         let firstCallModelSeen = false;
         let lastEventWasToolResponse = false;
 
+        const recordGatekeeperPendingRetry = () => {
+          useGatekeeperStore.getState().setPendingRetry(conversationId!, {
+            userMessage,
+            agent: effectiveAgent,
+            images: currentImages.length > 0 ? currentImages : undefined,
+            fileAttachments:
+              currentFileAttachments.length > 0 ? currentFileAttachments : undefined,
+          });
+        };
+
+        const markToolAwaitingApproval = (rawTool?: string) => {
+          const reversed = [...streamToolCalls].reverse();
+          const runningReverseIndex = reversed.findIndex(
+            (call) => call.prefix === 'Tool' && call.status === 'running',
+          );
+          if (runningReverseIndex !== -1) {
+            const targetIndex = streamToolCalls.length - 1 - runningReverseIndex;
+            streamToolCalls[targetIndex].status = 'awaiting_approval';
+            streamActivityLine = `${streamToolCalls[targetIndex].toolName} — awaiting approval`;
+            return;
+          }
+          if (!rawTool) return;
+          const { prefix, name } = formatToolLabel(rawTool);
+          streamToolCalls.push({
+            id: `tc-${Date.now()}-${streamToolCalls.length}`,
+            toolName: name,
+            prefix,
+            rawName: rawTool,
+            status: 'awaiting_approval',
+          });
+          hasDetailedActivity = true;
+          streamActivityLine = `${name} — awaiting approval`;
+        };
+
         const singleLine = (value: string) => value.replace(/\s+/g, ' ').trim();
         const truncateLine = (value: string, max = 140) =>
           value.length > max ? `${value.slice(0, max - 1)}…` : value;
@@ -2057,6 +2102,8 @@ export function ChatInterface({
           );
           if (gatekeeperDenial) {
             setStreamingGatekeeperDenial(gatekeeperDenial);
+            target.status = 'awaiting_approval';
+            recordGatekeeperPendingRetry();
           }
 
           // After Abi writes a Slides deck, nudge the open preview to reload.
@@ -2138,20 +2185,13 @@ export function ChatInterface({
               lastEventWasToolResponse = true;
               return true;
             }
-            case 'gatekeeper_denied': {
-              const tool = getStringValue(payload.tool);
-              const reason = getStringValue(payload.reason);
-              const resourceType = getStringValue(payload.resource_type);
-              const resourceId = getStringValue(payload.resource_id);
-              const action = getStringValue(payload.action);
-              if (resourceType && resourceId && action) {
-                setStreamingGatekeeperDenial({
-                  toolName: tool || 'tool',
-                  reason,
-                  resourceType,
-                  resourceId,
-                  action,
-                });
+            case 'gatekeeper_denied':
+            case 'gatekeeper_request': {
+              const denial = parseGatekeeperRequestPayload(payload);
+              if (denial) {
+                setStreamingGatekeeperDenial(denial);
+                recordGatekeeperPendingRetry();
+                markToolAwaitingApproval(denial.toolName !== 'tool' ? denial.toolName : undefined);
               }
               return true;
             }
@@ -2365,8 +2405,10 @@ export function ChatInterface({
           ? `<think>${thinkingContent}</think>\n\n${responseContent}`
           : responseContent;
         const finalContent = finalBody.trim();
-        // Mark any still-running tool as done
-        streamToolCalls.forEach((t) => { if (t.status === 'running') t.status = 'done'; });
+        // Mark any still-running tool as done (awaiting_approval stays as-is)
+        streamToolCalls.forEach((t) => {
+          if (t.status === 'running') t.status = 'done';
+        });
         const finalToolCalls = streamToolCalls.length > 0 ? [...streamToolCalls] : undefined;
         updateLastMessage(
           conversationId!,
@@ -2406,7 +2448,9 @@ export function ChatInterface({
             ? `<think>${thinkingContent}</think>\n\n${responseContent}`
             : responseContent;
           const finalContent = finalBody.trim();
-          streamToolCalls.forEach((t) => { if (t.status === 'running') t.status = 'done'; });
+          streamToolCalls.forEach((t) => {
+            if (t.status === 'running') t.status = 'done';
+          });
           if (conversationId) {
             updateLastMessage(
               conversationId,
@@ -2564,6 +2608,34 @@ export function ChatInterface({
   const handleSubmitRef = useRef(handleSubmit);
   handleSubmitRef.current = handleSubmit;
 
+  const handleContinueAfterGrant = useCallback(
+    async (conversationId: string) => {
+      let retry = useGatekeeperStore.getState().getPendingRetry(conversationId);
+      if (!retry) {
+        const conv = useWorkspaceStore.getState().conversations.find(
+          (c) => c.id === conversationId,
+        );
+        const lastUser = conv?.messages.filter((m) => m.role === 'user').at(-1);
+        if (lastUser?.content) {
+          retry = {
+            userMessage: lastUser.content,
+            agent: lastUser.agent ?? conv?.agent ?? selectedAgent,
+            images: lastUser.images,
+            fileAttachments: lastUser.fileAttachments,
+          };
+        }
+      }
+      if (!retry) return;
+      useGatekeeperStore.getState().clearPendingRetry(conversationId);
+      removeLastAssistantMessage(conversationId);
+      setStreamingGatekeeperDenial(null);
+      await handleSubmitRef.current(undefined, retry.userMessage, retry.agent, conversationId, {
+        skipUserMessage: true,
+      });
+    },
+    [removeLastAssistantMessage, selectedAgent],
+  );
+
   // Compare mode: both surfaces listen and submit the shared prompt.
   useEffect(() => {
     const onCompareSend = (event: Event) => {
@@ -2611,6 +2683,7 @@ export function ChatInterface({
                 liveGatekeeperDenial={
                   message.id === streamingMessageId ? streamingGatekeeperDenial : null
                 }
+                onContinueAfterGrant={handleContinueAfterGrant}
                 currentSelectedAgent={selectedAgent}
                 showConnecting={showConnecting}
                 showStop={Boolean(streamingMessageId)}
@@ -3447,11 +3520,15 @@ function ToolCallRow({ tool }: { tool: ToolCall }) {
       >
         {tool.status === 'running' ? (
           <Loader2 size={11} className="shrink-0 animate-spin text-workspace-accent" />
+        ) : tool.status === 'awaiting_approval' ? (
+          <ShieldAlert size={11} className="shrink-0 text-amber-600 dark:text-amber-400" />
         ) : (
           <Check size={11} className="shrink-0 text-green-500 dark:text-green-400" />
         )}
         <span className="flex-1 text-left font-medium text-foreground/80">
-          {formatToolCallLabel(tool.prefix, tool.toolName)}
+          {tool.status === 'awaiting_approval'
+            ? `${formatToolCallLabel(tool.prefix, tool.toolName)} — awaiting approval`
+            : formatToolCallLabel(tool.prefix, tool.toolName)}
         </span>
         {hasDetails && (
           <ChevronDown size={10} className={cn('shrink-0 transition-transform', expanded && 'rotate-180')} />
@@ -3504,6 +3581,7 @@ const MessageBubble = React.memo(function MessageBubble({
   conversationId,
   workspaceId,
   liveGatekeeperDenial,
+  onContinueAfterGrant,
   currentSelectedAgent,
   showConnecting,
   showStop,
@@ -3515,6 +3593,7 @@ const MessageBubble = React.memo(function MessageBubble({
   conversationId: string;
   workspaceId: string;
   liveGatekeeperDenial?: GatekeeperDenial | null;
+  onContinueAfterGrant?: (conversationId: string) => void | Promise<void>;
   currentSelectedAgent: string;
   showConnecting: boolean;
   showStop: boolean;
@@ -4034,6 +4113,7 @@ const MessageBubble = React.memo(function MessageBubble({
               workspaceId={workspaceId}
               toolCalls={message.toolCalls}
               liveDenial={liveGatekeeperDenial}
+              onContinueAfterGrant={onContinueAfterGrant}
             />
           )}
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
@@ -19,7 +19,9 @@ import { useAuthStore, authFetch } from '@/stores/auth';
 import { useWebSocket } from '@/contexts/websocket-context';
 import { useTenant } from '@/contexts/tenant-context';
 import { ChatAgentSelector } from '@/app/workspace/[workspaceId]/chat/components/chat-agent-selector';
+import { GatekeeperGrantBanner } from '@/app/workspace/[workspaceId]/chat/components/gatekeeper-grant-banner';
 import '@/app/workspace/[workspaceId]/chat/components/chat-agent-selector.css';
+import { type GatekeeperDenial, parseGatekeeperDenialFromOutput } from '@/lib/gatekeeper';
 import { TypingIndicator } from '@/components/typing-indicator';
 import { PdfViewer } from '@/components/files/pdf-viewer';
 
@@ -734,6 +736,8 @@ export function ChatInterface({
   const [isStreaming, setIsStreaming] = useState(false);
   const streamControllerRef = useRef<AbortController | null>(null);
   const [streamingMessageId, setStreamingMessageId] = useState<string | null>(null);
+  const [streamingGatekeeperDenial, setStreamingGatekeeperDenial] =
+    useState<GatekeeperDenial | null>(null);
   const [showConnecting, setShowConnecting] = useState(false);
   const gotFirstTokenRef = useRef(false);
   const connectingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -1747,6 +1751,7 @@ export function ChatInterface({
     const sourceText = messageOverride !== undefined ? messageOverride : input;
     if ((!sourceText.trim() && attachedImages.length === 0 && pendingFileAttachments.length === 0) || isLoading) return;
     isSubmittingRef.current = true;
+    setStreamingGatekeeperDenial(null);
     let effectiveAgent = agentOverride ?? selectedAgent;
     // Pane can hydrate with paneAgent="" before agents sync; resolve Abi/default
     // so stream has a real agent id (selector label may already show Abi).
@@ -2046,6 +2051,14 @@ export function ChatInterface({
           target.status = 'done';
           target.output = output;
 
+          const gatekeeperDenial = parseGatekeeperDenialFromOutput(
+            output,
+            target.rawName || target.toolName,
+          );
+          if (gatekeeperDenial) {
+            setStreamingGatekeeperDenial(gatekeeperDenial);
+          }
+
           // After Abi writes a Slides deck, nudge the open preview to reload.
           const raw = (target.rawName || target.toolName || '').toLowerCase();
           if (
@@ -2123,6 +2136,23 @@ export function ChatInterface({
               const output = getStringValue(payload.output, payload.content, payload.data);
               handleToolResponseEvent(output);
               lastEventWasToolResponse = true;
+              return true;
+            }
+            case 'gatekeeper_denied': {
+              const tool = getStringValue(payload.tool);
+              const reason = getStringValue(payload.reason);
+              const resourceType = getStringValue(payload.resource_type);
+              const resourceId = getStringValue(payload.resource_id);
+              const action = getStringValue(payload.action);
+              if (resourceType && resourceId && action) {
+                setStreamingGatekeeperDenial({
+                  toolName: tool || 'tool',
+                  reason,
+                  resourceType,
+                  resourceId,
+                  action,
+                });
+              }
               return true;
             }
             case 'agent.question': {
@@ -2576,6 +2606,11 @@ export function ChatInterface({
               <MessageBubble
                 key={message.id}
                 message={message}
+                conversationId={activeConversation.id}
+                workspaceId={activeConversation.workspaceId}
+                liveGatekeeperDenial={
+                  message.id === streamingMessageId ? streamingGatekeeperDenial : null
+                }
                 currentSelectedAgent={selectedAgent}
                 showConnecting={showConnecting}
                 showStop={Boolean(streamingMessageId)}
@@ -3466,6 +3501,9 @@ const NOT_FOUND_TITLE_RE = /\b(404|not found|page not found|introuvable|doesn.t 
 
 const MessageBubble = React.memo(function MessageBubble({
   message,
+  conversationId,
+  workspaceId,
+  liveGatekeeperDenial,
   currentSelectedAgent,
   showConnecting,
   showStop,
@@ -3474,6 +3512,9 @@ const MessageBubble = React.memo(function MessageBubble({
   requestSentAt,
 }: {
   message: Message;
+  conversationId: string;
+  workspaceId: string;
+  liveGatekeeperDenial?: GatekeeperDenial | null;
   currentSelectedAgent: string;
   showConnecting: boolean;
   showStop: boolean;
@@ -3986,6 +4027,15 @@ const MessageBubble = React.memo(function MessageBubble({
               )} */}
             </div>
           </div>
+
+          {!isUser && (
+            <GatekeeperGrantBanner
+              conversationId={conversationId}
+              workspaceId={workspaceId}
+              toolCalls={message.toolCalls}
+              liveDenial={liveGatekeeperDenial}
+            />
+          )}
 
           {!isUser && message.toolCalls && message.toolCalls.length > 0 && (
             <ToolCallsDropdown

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/gatekeeper.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/gatekeeper.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  parseGatekeeperDenialFromOutput,
+  parseGatekeeperRequestPayload,
+  parseMissingGrantReason,
+} from './gatekeeper';
+
+describe('gatekeeper parsing', () => {
+  it('parses missing_grant reason tokens', () => {
+    expect(
+      parseMissingGrantReason('missing_grant:github.repo:acme/app:read_secrets'),
+    ).toEqual({
+      reason: 'missing_grant:github.repo:acme/app:read_secrets',
+      resourceType: 'github.repo',
+      resourceId: 'acme/app',
+      action: 'read_secrets',
+    });
+  });
+
+  it('parses approval-required tool output', () => {
+    const output =
+      'Gatekeeper approval required: missing_grant:github.repo:acme/app:read_secrets. Waiting for the user to approve access.';
+    expect(parseGatekeeperDenialFromOutput(output, 'github_list_repo_secrets')).toEqual({
+      toolName: 'github_list_repo_secrets',
+      reason: 'missing_grant:github.repo:acme/app:read_secrets',
+      resourceType: 'github.repo',
+      resourceId: 'acme/app',
+      action: 'read_secrets',
+    });
+  });
+
+  it('parses legacy access-denied tool output', () => {
+    const output =
+      'Access denied by gatekeeper: missing_grant:github.repo:acme/app:delete_repo.';
+    expect(parseGatekeeperDenialFromOutput(output, 'github_delete_organization_repository')).toEqual({
+      toolName: 'github_delete_organization_repository',
+      reason: 'missing_grant:github.repo:acme/app:delete_repo',
+      resourceType: 'github.repo',
+      resourceId: 'acme/app',
+      action: 'delete_repo',
+    });
+  });
+
+  it('parses gatekeeper_request SSE payload', () => {
+    expect(
+      parseGatekeeperRequestPayload({
+        tool: 'github_list_repo_secrets',
+        reason: 'missing_grant:github.repo:acme/app:read_secrets',
+        resource_type: 'github.repo',
+        resource_id: 'acme/app',
+        action: 'read_secrets',
+      }),
+    ).toEqual({
+      toolName: 'github_list_repo_secrets',
+      reason: 'missing_grant:github.repo:acme/app:read_secrets',
+      resourceType: 'github.repo',
+      resourceId: 'acme/app',
+      action: 'read_secrets',
+    });
+  });
+});

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/gatekeeper.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/gatekeeper.ts
@@ -10,19 +10,41 @@ export interface GatekeeperDenial {
   action: string;
 }
 
+const GATEKEEPER_APPROVAL_RE =
+  /Gatekeeper approval required:\s*(?<reason>[^.]+)\./i;
+
 const GATEKEEPER_DENIAL_RE =
   /Access denied by gatekeeper:\s*(?<reason>[^.]+)\./i;
 
 const MISSING_GRANT_RE =
   /^missing_grant:(?<type>[^:]+):(?<id>[^:]+):(?<action>.+)$/;
 
-export function parseMissingGrantReason(reason: string): Omit<GatekeeperDenial, 'toolName'> | null {
-  const match = reason.trim().match(MISSING_GRANT_RE);
+const MISSING_GRANT_INLINE_RE =
+  /missing_grant:(?<type>[^:]+):(?<id>[^:]+):(?<action>[a-z0-9_*]+)/i;
+
+export function parseMissingGrantReason(
+  reason: string,
+): Omit<GatekeeperDenial, 'toolName'> | null {
+  const trimmed = reason.trim();
+  const inline = trimmed.match(MISSING_GRANT_INLINE_RE);
+  if (inline?.groups) {
+    const { type, id, action } = inline.groups;
+    if (type && id && action) {
+      return {
+        reason: inline[0],
+        resourceType: type,
+        resourceId: id,
+        action,
+      };
+    }
+  }
+
+  const match = trimmed.match(MISSING_GRANT_RE);
   if (!match?.groups) return null;
   const { type, id, action } = match.groups;
   if (!type || !id || !action) return null;
   return {
-    reason,
+    reason: trimmed,
     resourceType: type,
     resourceId: id,
     action,
@@ -33,7 +55,16 @@ export function parseGatekeeperDenialFromOutput(
   output: string,
   toolName?: string,
 ): GatekeeperDenial | null {
-  const match = output.match(GATEKEEPER_DENIAL_RE);
+  const inline = output.match(MISSING_GRANT_INLINE_RE);
+  if (inline) {
+    const parsed = parseMissingGrantReason(inline[0]);
+    if (parsed) {
+      return { toolName: toolName ?? 'tool', ...parsed };
+    }
+  }
+
+  const match =
+    output.match(GATEKEEPER_APPROVAL_RE) ?? output.match(GATEKEEPER_DENIAL_RE);
   if (!match?.groups?.reason) return null;
   const parsed = parseMissingGrantReason(match.groups.reason);
   if (!parsed) return null;
@@ -41,6 +72,37 @@ export function parseGatekeeperDenialFromOutput(
     toolName: toolName ?? 'tool',
     ...parsed,
   };
+}
+
+export function parseGatekeeperRequestPayload(
+  payload: Record<string, unknown>,
+): GatekeeperDenial | null {
+  const tool = typeof payload.tool === 'string' ? payload.tool.trim() : '';
+  const reason = typeof payload.reason === 'string' ? payload.reason.trim() : '';
+  const resourceType =
+    typeof payload.resource_type === 'string' ? payload.resource_type.trim() : '';
+  const resourceId =
+    typeof payload.resource_id === 'string' ? payload.resource_id.trim() : '';
+  const action = typeof payload.action === 'string' ? payload.action.trim() : '';
+
+  if (resourceType && resourceId && action) {
+    return {
+      toolName: tool || 'tool',
+      reason: reason || `missing_grant:${resourceType}:${resourceId}:${action}`,
+      resourceType,
+      resourceId,
+      action,
+    };
+  }
+
+  if (reason) {
+    const parsed = parseMissingGrantReason(reason);
+    if (parsed) {
+      return { toolName: tool || 'tool', ...parsed };
+    }
+  }
+
+  return null;
 }
 
 export function extractGatekeeperDenialFromToolCalls(

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/gatekeeper.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/gatekeeper.ts
@@ -1,0 +1,83 @@
+/** Gatekeeper grant utilities for chat UI. */
+
+import type { ToolCall } from '@/stores/workspace';
+
+export interface GatekeeperDenial {
+  toolName: string;
+  reason: string;
+  resourceType: string;
+  resourceId: string;
+  action: string;
+}
+
+const GATEKEEPER_DENIAL_RE =
+  /Access denied by gatekeeper:\s*(?<reason>[^.]+)\./i;
+
+const MISSING_GRANT_RE =
+  /^missing_grant:(?<type>[^:]+):(?<id>[^:]+):(?<action>.+)$/;
+
+export function parseMissingGrantReason(reason: string): Omit<GatekeeperDenial, 'toolName'> | null {
+  const match = reason.trim().match(MISSING_GRANT_RE);
+  if (!match?.groups) return null;
+  const { type, id, action } = match.groups;
+  if (!type || !id || !action) return null;
+  return {
+    reason,
+    resourceType: type,
+    resourceId: id,
+    action,
+  };
+}
+
+export function parseGatekeeperDenialFromOutput(
+  output: string,
+  toolName?: string,
+): GatekeeperDenial | null {
+  const match = output.match(GATEKEEPER_DENIAL_RE);
+  if (!match?.groups?.reason) return null;
+  const parsed = parseMissingGrantReason(match.groups.reason);
+  if (!parsed) return null;
+  return {
+    toolName: toolName ?? 'tool',
+    ...parsed,
+  };
+}
+
+export function extractGatekeeperDenialFromToolCalls(
+  toolCalls: ToolCall[] | undefined,
+): GatekeeperDenial | null {
+  if (!toolCalls?.length) return null;
+  for (let i = toolCalls.length - 1; i >= 0; i -= 1) {
+    const call = toolCalls[i];
+    if (!call.output) continue;
+    const denial = parseGatekeeperDenialFromOutput(
+      call.output,
+      call.rawName || call.toolName,
+    );
+    if (denial) return denial;
+  }
+  return null;
+}
+
+export function describeGatekeeperAction(action: string): string {
+  switch (action) {
+    case 'read_secrets':
+      return 'read repository secrets';
+    case 'delete_repo':
+      return 'delete repositories';
+    case 'export':
+      return 'export conversations containing sensitive data';
+    default:
+      return action.replace(/_/g, ' ');
+  }
+}
+
+export function describeGatekeeperResource(type: string, id: string): string {
+  if (type === 'github.repo') {
+    return `GitHub repository ${id}`;
+  }
+  if (type === 'github.org') {
+    return `GitHub organization ${id}`;
+  }
+  return `${type} ${id}`;
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/gatekeeper.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/gatekeeper.ts
@@ -1,0 +1,132 @@
+import { create } from 'zustand';
+
+export interface ResourceGrant {
+  chatId: string;
+  resourceType: string;
+  resourceId: string;
+  actions: string[];
+  grantedAt: string;
+}
+
+export interface GrantResourceInput {
+  resourceType: string;
+  resourceId: string;
+  actions: string[];
+}
+
+interface GatekeeperState {
+  grantsByConversation: Record<string, ResourceGrant[]>;
+  grantConversation: (
+    workspaceId: string,
+    conversationId: string,
+    input: GrantResourceInput,
+  ) => Promise<ResourceGrant>;
+  fetchGrants: (
+    workspaceId: string,
+    conversationId: string,
+    force?: boolean,
+  ) => Promise<ResourceGrant[]>;
+  hasGrant: (
+    conversationId: string,
+    resourceType: string,
+    resourceId: string,
+    action: string,
+  ) => boolean;
+}
+
+const mapApiGrant = (g: Record<string, unknown>): ResourceGrant => ({
+  chatId: String(g.chat_id ?? ''),
+  resourceType: String(g.resource_type ?? ''),
+  resourceId: String(g.resource_id ?? ''),
+  actions: Array.isArray(g.actions) ? g.actions.map(String) : [],
+  grantedAt: String(g.granted_at ?? ''),
+});
+
+const apiHelpers = async () => {
+  const { authFetch } = await import('./auth');
+  const { getApiUrl } = await import('@/lib/config');
+  return { authFetch, API_BASE: getApiUrl() };
+};
+
+const readDetail = async (response: Response, fallback: string): Promise<string> => {
+  try {
+    const body = await response.json();
+    return body?.detail || fallback;
+  } catch {
+    return fallback;
+  }
+};
+
+export const useGatekeeperStore = create<GatekeeperState>()((set, get) => ({
+  grantsByConversation: {},
+
+  fetchGrants: async (workspaceId, conversationId, force = false) => {
+    const cached = get().grantsByConversation[conversationId];
+    if (!force && cached) return cached;
+
+    const { authFetch, API_BASE } = await apiHelpers();
+    const url =
+      `${API_BASE}/api/gatekeeper/conversations/${encodeURIComponent(conversationId)}/grants` +
+      `?workspace_id=${encodeURIComponent(workspaceId)}`;
+    const response = await authFetch(url);
+    if (!response.ok) {
+      throw new Error(await readDetail(response, 'Failed to load gatekeeper grants'));
+    }
+    const data = await response.json();
+    const grants = Array.isArray(data) ? data.map(mapApiGrant) : [];
+    set((state) => ({
+      grantsByConversation: {
+        ...state.grantsByConversation,
+        [conversationId]: grants,
+      },
+    }));
+    return grants;
+  },
+
+  grantConversation: async (workspaceId, conversationId, input) => {
+    const { authFetch, API_BASE } = await apiHelpers();
+    const url =
+      `${API_BASE}/api/gatekeeper/conversations/${encodeURIComponent(conversationId)}/grants` +
+      `?workspace_id=${encodeURIComponent(workspaceId)}`;
+    const response = await authFetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        resource_type: input.resourceType,
+        resource_id: input.resourceId,
+        actions: input.actions,
+      }),
+    });
+    if (!response.ok) {
+      throw new Error(await readDetail(response, 'Failed to grant access'));
+    }
+    const grant = mapApiGrant(await response.json());
+    set((state) => {
+      const existing = state.grantsByConversation[conversationId] ?? [];
+      const filtered = existing.filter(
+        (g) =>
+          !(
+            g.resourceType === grant.resourceType &&
+            g.resourceId === grant.resourceId
+          ),
+      );
+      return {
+        grantsByConversation: {
+          ...state.grantsByConversation,
+          [conversationId]: [...filtered, grant],
+        },
+      };
+    });
+    return grant;
+  },
+
+  hasGrant: (conversationId, resourceType, resourceId, action) => {
+    const grants = get().grantsByConversation[conversationId] ?? [];
+    return grants.some(
+      (grant) =>
+        grant.resourceType === resourceType &&
+        grant.resourceId === resourceId &&
+        (grant.actions.includes(action) || grant.actions.includes('*')),
+    );
+  },
+}));

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/gatekeeper.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/gatekeeper.ts
@@ -14,8 +14,16 @@ export interface GrantResourceInput {
   actions: string[];
 }
 
+export interface GatekeeperPendingRetry {
+  userMessage: string;
+  agent: string;
+  images?: string[];
+  fileAttachments?: string[];
+}
+
 interface GatekeeperState {
   grantsByConversation: Record<string, ResourceGrant[]>;
+  pendingRetryByConversation: Record<string, GatekeeperPendingRetry>;
   grantConversation: (
     workspaceId: string,
     conversationId: string,
@@ -32,6 +40,9 @@ interface GatekeeperState {
     resourceId: string,
     action: string,
   ) => boolean;
+  setPendingRetry: (conversationId: string, retry: GatekeeperPendingRetry) => void;
+  getPendingRetry: (conversationId: string) => GatekeeperPendingRetry | null;
+  clearPendingRetry: (conversationId: string) => void;
 }
 
 const mapApiGrant = (g: Record<string, unknown>): ResourceGrant => ({
@@ -59,6 +70,7 @@ const readDetail = async (response: Response, fallback: string): Promise<string>
 
 export const useGatekeeperStore = create<GatekeeperState>()((set, get) => ({
   grantsByConversation: {},
+  pendingRetryByConversation: {},
 
   fetchGrants: async (workspaceId, conversationId, force = false) => {
     const cached = get().grantsByConversation[conversationId];
@@ -128,5 +140,26 @@ export const useGatekeeperStore = create<GatekeeperState>()((set, get) => ({
         grant.resourceId === resourceId &&
         (grant.actions.includes(action) || grant.actions.includes('*')),
     );
+  },
+
+  setPendingRetry: (conversationId, retry) => {
+    set((state) => ({
+      pendingRetryByConversation: {
+        ...state.pendingRetryByConversation,
+        [conversationId]: retry,
+      },
+    }));
+  },
+
+  getPendingRetry: (conversationId) =>
+    get().pendingRetryByConversation[conversationId] ?? null,
+
+  clearPendingRetry: (conversationId) => {
+    set((state) => {
+      if (!state.pendingRetryByConversation[conversationId]) return state;
+      const next = { ...state.pendingRetryByConversation };
+      delete next[conversationId];
+      return { pendingRetryByConversation: next };
+    });
   },
 }));

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
@@ -53,7 +53,7 @@ export interface ToolCall {
   toolName: string;
   prefix: 'Tool' | 'Agent' | 'Handoff to' | 'Routing to';
   rawName: string;
-  status: 'running' | 'done';
+  status: 'running' | 'done' | 'awaiting_approval';
   input?: string;
   output?: string;
 }
@@ -288,6 +288,7 @@ interface WorkspaceState {
     oldMessageId: string,
     newMessageId: string,
   ) => void;
+  removeLastAssistantMessage: (conversationId: string) => void;
   togglePinConversation: (id: string) => void;
   toggleArchiveConversation: (id: string) => void;
   renameConversation: (id: string, newTitle: string) => void;
@@ -375,7 +376,12 @@ const mapApiMessage = (message: ApiChatMessage): Message => {
           const record = step as Record<string, unknown>;
           const toolName = typeof record.tool_name === 'string' ? record.tool_name : '';
           const prefix = typeof record.prefix === 'string' ? record.prefix : 'Tool';
-          const status = record.status === 'running' ? 'running' : 'done';
+          const status =
+            record.status === 'running'
+              ? 'running'
+              : record.status === 'awaiting_approval'
+                ? 'awaiting_approval'
+                : 'done';
           if (!toolName) return null;
           return {
             id: `${message.id}-step-${toolName}`,
@@ -633,6 +639,29 @@ export const useWorkspaceStore = create<WorkspaceState>()(
               updatedAt: new Date(),
             }
           : conv
+      ),
+    }));
+  },
+
+  removeLastAssistantMessage: (conversationId) => {
+    set((state) => ({
+      conversations: state.conversations.map((conv) =>
+        conv.id === conversationId
+          ? {
+              ...conv,
+              messages: (() => {
+                const next = [...conv.messages];
+                for (let i = next.length - 1; i >= 0; i -= 1) {
+                  if (next[i].role === 'assistant') {
+                    next.splice(i, 1);
+                    break;
+                  }
+                }
+                return next;
+              })(),
+              updatedAt: new Date(),
+            }
+          : conv,
       ),
     }));
   },

--- a/libs/naas-abi/naas_abi/cli.py
+++ b/libs/naas-abi/naas_abi/cli.py
@@ -8,7 +8,6 @@ import os
 import re
 import shutil
 
-import yaml
 from rich.console import Console
 from rich.prompt import Prompt
 
@@ -92,103 +91,33 @@ def get_component_selection():
 
 def enable_module_in_config(module_path: str):
     """Enable the module in config files if they exist."""
+    from naas_abi.config.module_enable import (
+        enable_module_in_config as _enable,
+    )
+    from naas_abi.config.module_enable import (
+        resolve_config_file,
+    )
 
-    def _resolve_env() -> str | None:
-        env = os.getenv("ENV")
-        if env:
-            return env
-
-        if not os.path.exists("config.yaml"):
-            return None
-
-        with open("config.yaml", "r", encoding="utf-8") as file:
-            config = yaml.safe_load(file) or {}
-
-        services = config.get("services")
-        if not isinstance(services, dict):
-            return None
-
-        secret = services.get("secret")
-        if not isinstance(secret, dict):
-            return None
-
-        secret_adapters = secret.get("secret_adapters")
-        if not isinstance(secret_adapters, list):
-            return None
-
-        for secret_adapter in secret_adapters:
-            if not isinstance(secret_adapter, dict):
-                continue
-            if secret_adapter.get("adapter") != "dotenv":
-                continue
-
-            secret_config = secret_adapter.get("config")
-            if not isinstance(secret_config, dict):
-                secret_config = {}
-
-            path = secret_config.get("path", ".env")
-            if not isinstance(path, str) or path.strip() == "":
-                raise ValueError(
-                    "Invalid dotenv secret adapter path in configuration. "
-                    "Expected a non-empty string at services.secret.secret_adapters[].config.path."
-                )
-
-            from naas_abi_core.services.secret.adaptors.secondary.dotenv_secret_secondaryadaptor import (
-                DotenvSecretSecondaryAdaptor,
-            )
-
-            value = DotenvSecretSecondaryAdaptor(path=path).get("ENV")
-            if value is not None:
-                return str(value)
-
-            return None
-
-        return None
-
-    env = _resolve_env()
-
-    config_file = f"config.{env}.yaml" if env else "config.yaml"
+    config_file = resolve_config_file()
     if not os.path.exists(config_file):
         config_file = "config.yaml"
 
     config_files = [config_file]
 
-    for config_file in config_files:
-        if os.path.exists(config_file):
+    for cfg in config_files:
+        if os.path.exists(cfg):
             try:
-                console.print(f"📝 Updating {config_file}...", style="yellow")
-
-                with open(config_file, "r", encoding="utf-8") as f:
-                    config = yaml.safe_load(f) or {}
-
-                # Ensure modules section exists
-                if "modules" not in config:
-                    config["modules"] = []
-
-                # Check if module already exists
-                module_exists = False
-                for module in config["modules"]:
-                    if module.get("path") == module_path:
-                        module["enabled"] = True
-                        module_exists = True
-                        break
-
-                # Add module if it doesn't exist
-                if not module_exists:
-                    config["modules"].append({"path": module_path, "enabled": True})
-
-                # Sort modules by path for consistency
-                config["modules"] = sorted(
-                    config["modules"], key=lambda x: x.get("path", "")
-                )
-
-                with open(config_file, "w", encoding="utf-8") as f:
-                    yaml.dump(config, f, default_flow_style=False, sort_keys=False)
-
-                console.print(f"✅ Module enabled in {config_file}", style="green")
-
+                console.print(f"📝 Updating {cfg}...", style="yellow")
+                result = _enable(module_path, config_file=cfg)
+                console.print(f"✅ Module enabled in {cfg}", style="green")
+                if result.secrets_required:
+                    console.print(
+                        f"🔑 Add secrets to .env: {', '.join(result.secrets_required)}",
+                        style="yellow",
+                    )
+                console.print("↻ Restart the API to load the module.", style="yellow")
             except Exception as e:  # noqa: BLE001
-                console.print(f"⚠️ Could not update {config_file}: {e}", style="yellow")
+                console.print(f"⚠️ Could not update {cfg}: {e}", style="yellow")
 
 
 def create_new_module():

--- a/libs/naas-abi/naas_abi/config/module_enable.py
+++ b/libs/naas-abi/naas_abi/config/module_enable.py
@@ -1,0 +1,155 @@
+"""Enable marketplace modules in config.yaml (shared by CLI and Nexus API)."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+import yaml
+
+# Default config blocks for known marketplace modules. Secrets use Jinja so the
+# engine resolves them from .env at boot — never hard-code tokens here.
+KNOWN_MODULE_DEFAULTS: dict[str, dict[str, Any]] = {
+    "naas_abi_marketplace.applications.github": {
+        "config": {
+            "github_access_token": "{{ secret.GITHUB_ACCESS_TOKEN }}",
+        },
+        "secrets": ["GITHUB_ACCESS_TOKEN"],
+    },
+}
+
+
+@dataclass(frozen=True)
+class ModuleEnableResult:
+    module_path: str
+    config_file: str
+    created: bool
+    secrets_required: list[str] = field(default_factory=list)
+    restart_required: bool = True
+
+    @property
+    def message(self) -> str:
+        parts = [
+            f"Module '{self.module_path}' enabled in {self.config_file}.",
+        ]
+        if self.secrets_required:
+            parts.append(
+                "Add to .env: "
+                + ", ".join(self.secrets_required)
+                + " (then restart the API)."
+            )
+        elif self.restart_required:
+            parts.append("Restart the API to load the module.")
+        return " ".join(parts)
+
+
+def resolve_config_file() -> str:
+    """Pick config.yaml or config.{ENV}.yaml using the same rules as the CLI."""
+    env = os.getenv("ENV")
+    if not env and os.path.exists("config.yaml"):
+        try:
+            with open("config.yaml", encoding="utf-8") as file:
+                config = yaml.safe_load(file) or {}
+            services = config.get("services")
+            if isinstance(services, dict):
+                secret = services.get("secret")
+                if isinstance(secret, dict):
+                    adapters = secret.get("secret_adapters")
+                    if isinstance(adapters, list):
+                        for adapter in adapters:
+                            if not isinstance(adapter, dict):
+                                continue
+                            if adapter.get("adapter") != "dotenv":
+                                continue
+                            secret_config = adapter.get("config")
+                            if not isinstance(secret_config, dict):
+                                secret_config = {}
+                            path = secret_config.get("path", ".env")
+                            if isinstance(path, str) and path.strip():
+                                from naas_abi_core.services.secret.adaptors.secondary.dotenv_secret_secondaryadaptor import (
+                                    DotenvSecretSecondaryAdaptor,
+                                )
+
+                                value = DotenvSecretSecondaryAdaptor(path=path).get("ENV")
+                                if value is not None:
+                                    env = str(value)
+                                break
+        except OSError:
+            pass
+
+    if env and os.path.exists(f"config.{env}.yaml"):
+        return f"config.{env}.yaml"
+    return "config.yaml"
+
+
+def _module_entry_key(entry: dict[str, Any]) -> str | None:
+    value = entry.get("module") or entry.get("path")
+    return str(value) if value else None
+
+
+def enable_module_in_config(
+    module_path: str,
+    *,
+    config_file: str | None = None,
+) -> ModuleEnableResult:
+    """
+    Enable a module in config.yaml. Idempotent.
+
+    Uses the ``module`` key (Engine loader expects ``module_config.module``).
+    Merges known default config/secrets for marketplace integrations.
+    """
+    target = config_file or resolve_config_file()
+    if not os.path.exists(target):
+        raise FileNotFoundError(f"Configuration file not found: {target}")
+
+    with open(target, encoding="utf-8") as handle:
+        config = yaml.safe_load(handle) or {}
+
+    if "modules" not in config or not isinstance(config["modules"], list):
+        config["modules"] = []
+
+    defaults = KNOWN_MODULE_DEFAULTS.get(module_path, {})
+    default_config = defaults.get("config", {})
+    secrets_required = list(defaults.get("secrets", []))
+
+    created = False
+    for entry in config["modules"]:
+        if not isinstance(entry, dict):
+            continue
+        if _module_entry_key(entry) == module_path:
+            entry["enabled"] = True
+            entry.setdefault("module", module_path)
+            entry.pop("path", None)
+            if default_config:
+                existing = entry.get("config")
+                if not isinstance(existing, dict):
+                    existing = {}
+                merged = {**default_config, **existing}
+                entry["config"] = merged
+            break
+    else:
+        created = True
+        new_entry: dict[str, Any] = {
+            "module": module_path,
+            "enabled": True,
+        }
+        if default_config:
+            new_entry["config"] = dict(default_config)
+        config["modules"].append(new_entry)
+
+    config["modules"] = sorted(
+        config["modules"],
+        key=lambda item: (_module_entry_key(item) or "") if isinstance(item, dict) else "",
+    )
+
+    with open(target, "w", encoding="utf-8") as handle:
+        yaml.dump(config, handle, default_flow_style=False, sort_keys=False)
+
+    return ModuleEnableResult(
+        module_path=module_path,
+        config_file=target,
+        created=created,
+        secrets_required=secrets_required,
+        restart_required=True,
+    )

--- a/libs/naas-abi/naas_abi/config/module_enable_test.py
+++ b/libs/naas-abi/naas_abi/config/module_enable_test.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from naas_abi.config.module_enable import enable_module_in_config
+
+
+def test_enable_github_module_writes_module_key_and_config(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.dump({"modules": [{"module": "naas_abi", "enabled": True}]}),
+        encoding="utf-8",
+    )
+
+    result = enable_module_in_config(
+        "naas_abi_marketplace.applications.github",
+        config_file=str(config_path),
+    )
+
+    assert result.created is True
+    assert result.secrets_required == ["GITHUB_ACCESS_TOKEN"]
+
+    data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    github = next(
+        m
+        for m in data["modules"]
+        if m.get("module") == "naas_abi_marketplace.applications.github"
+    )
+    assert github["enabled"] is True
+    assert github["config"]["github_access_token"] == "{{ secret.GITHUB_ACCESS_TOKEN }}"
+
+
+def test_enable_module_is_idempotent(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.dump(
+            {
+                "modules": [
+                    {
+                        "module": "naas_abi_marketplace.applications.github",
+                        "enabled": False,
+                        "config": {"github_access_token": "{{ secret.GITHUB_ACCESS_TOKEN }}"},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = enable_module_in_config(
+        "naas_abi_marketplace.applications.github",
+        config_file=str(config_path),
+    )
+
+    assert result.created is False
+    data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert data["modules"][0]["enabled"] is True

--- a/uv.lock
+++ b/uv.lock
@@ -3786,7 +3786,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-marketplace"
-version = "3.33.3"
+version = "3.33.5"
 source = { editable = "libs/naas-abi-marketplace" }
 dependencies = [
     { name = "ijson" },
@@ -6088,8 +6088,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes the gap between Gatekeeper approval UX and actually having GitHub tools available. Gatekeeper never auto-adds integrations — this PR wires the missing **install → secrets → restart → chat → grant → continue** path.

### Module install (new)
- **`POST /api/modules/install/{module_path}`** — enables a marketplace module in `config.yaml`
- Shared **`naas_abi.config.module_enable`** used by CLI + Nexus API (fixes old CLI bug that wrote `path` instead of `module`)
- GitHub install preset: `github_access_token: "{{ secret.GITHUB_ACCESS_TOKEN }}"` + secrets hint
- **Marketplace → Install** button now works for community modules

### Gatekeeper UX polish (from #1172)
- Pre-emptive `gatekeeper_request` SSE + approval banner
- **Grant access & continue** auto-retries the user's message
- Tool steps show `awaiting_approval` with shield icon
- Parsing fixes for `github.repo` resource IDs

### Full flow (after merge)

1. Marketplace → **GitHub** → **Install**
2. Add `GITHUB_ACCESS_TOKEN=...` to `.env`
3. Restart API (`abi dev` restart or stack restart)
4. Chat: ask for repo secrets → **Approval required** banner
5. **Grant access & continue** → agent completes the action

### Tests
- `module_enable_test.py` (2)
- `gatekeeper.test.ts` (4)
- `GatekeeperService_test.py` (8)

Related: #1171, builds on #1172
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd389-ec60-73dd-97c5-c667dc723209?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd389-ec60-73dd-97c5-c667dc723209&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

