### PR TITLE
feat(nexus): pass access token to app-html iframe embeds

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/apps/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/apps/page.tsx
@@ -10,7 +10,8 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { getApiUrl } from '@/lib/config';
-import { authFetch } from '@/stores/auth';
+import { appendAccessTokenToEmbedUrl } from '@/lib/embed-auth';
+import { authFetch, useAuthStore } from '@/stores/auth';
 import { useTenant } from '@/contexts/tenant-context';
 import Link from 'next/link';
 import { useWorkspaceStore } from '@/stores/workspace';
@@ -246,12 +247,14 @@ function AppDetailPanel({
   collapsed,
   onToggle,
   onSwitch,
+  embedUrl,
 }: {
   entry: AppEntry;
   apps: AppInfo[];
   collapsed: boolean;
   onToggle: () => void;
   onSwitch: (app: AppInfo) => void;
+  embedUrl: string;
 }) {
   const name = appEntryName(entry);
   const description = appEntryDescription(entry);
@@ -372,7 +375,7 @@ function AppDetailPanel({
 
             {/* Open in new tab */}
             <a
-              href={url}
+              href={embedUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="flex w-full items-center justify-center gap-2 py-2.5 text-sm font-semibold bg-workspace-accent text-white hover:bg-workspace-accent/90 transition-colors"
@@ -392,7 +395,12 @@ function AppDetailPanel({
 // ---------------------------------------------------------------------------
 
 function EmbedView({ entry, onBack }: { entry: AppEntry; onBack: () => void }) {
-  const url = appEntryUrl(entry);
+  const rawUrl = appEntryUrl(entry);
+  const token = useAuthStore((s) => s.token);
+  const embedUrl = useMemo(
+    () => appendAccessTokenToEmbedUrl(rawUrl, token),
+    [rawUrl, token],
+  );
   const name = appEntryName(entry);
   const [blocked, setBlocked] = useState(false);
   const [reloadKey, setReloadKey] = useState(0);
@@ -443,7 +451,7 @@ function EmbedView({ entry, onBack }: { entry: AppEntry; onBack: () => void }) {
           <RefreshCw size={13} />
         </button>
         <a
-          href={url}
+          href={embedUrl}
           target="_blank"
           rel="noopener noreferrer"
           title="Open in new tab"
@@ -472,7 +480,7 @@ function EmbedView({ entry, onBack }: { entry: AppEntry; onBack: () => void }) {
                 </p>
               </div>
               <a
-                href={url}
+                href={embedUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="flex items-center gap-2 px-4 py-2 text-sm font-semibold bg-workspace-accent text-white hover:bg-workspace-accent/90 transition-colors"
@@ -485,7 +493,7 @@ function EmbedView({ entry, onBack }: { entry: AppEntry; onBack: () => void }) {
             <iframe
               key={reloadKey}
               ref={iframeRef}
-              src={url}
+              src={embedUrl}
               title={name}
               onLoad={handleLoad}
               onLoadStart={() => { loadStartRef.current = Date.now(); }}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
@@ -20,6 +20,7 @@ import { TypingIndicator } from '@/components/typing-indicator';
 import { PdfViewer } from '@/components/files/pdf-viewer';
 
 import { getApiUrl, getOllamaUrl } from '@/lib/config';
+import { appendAccessTokenToEmbedUrl } from '@/lib/embed-auth';
 
 const getApiBase = () => getApiUrl();
 
@@ -155,6 +156,11 @@ const urlValidityCache = new Map<string, boolean>();
  *  panel and opens the URL in a new browser tab instead.
  */
 function PreviewPanel({ url, onClose, width }: { url: string; onClose: () => void; width: number }) {
+  const token = useAuthStore((s) => s.token);
+  const embedUrl = useMemo(
+    () => appendAccessTokenToEmbedUrl(url, token),
+    [url, token],
+  );
   const [reloadKey, setReloadKey] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -172,14 +178,14 @@ function PreviewPanel({ url, onClose, width }: { url: string; onClose: () => voi
       // A cross-origin page that loaded successfully throws SecurityError here instead.
       if (doc && (!doc.body || doc.body.innerHTML === '')) {
         onClose();
-        window.open(url, '_blank', 'noopener,noreferrer');
+        window.open(embedUrl, '_blank', 'noopener,noreferrer');
         return;
       }
     } catch {
       // SecurityError = cross-origin page loaded fine — keep the panel open.
     }
     setIsLoading(false);
-  }, [url, onClose]);
+  }, [embedUrl, onClose]);
 
   const handleReload = () => {
     setIsLoading(true);
@@ -192,7 +198,7 @@ function PreviewPanel({ url, onClose, width }: { url: string; onClose: () => voi
       <div className="flex items-center gap-1.5 border-b border-border px-3 py-2">
         <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">{domain}</span>
         <a
-          href={url}
+          href={embedUrl}
           target="_blank"
           rel="noopener noreferrer"
           className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
@@ -228,7 +234,7 @@ function PreviewPanel({ url, onClose, width }: { url: string; onClose: () => voi
         <iframe
           key={reloadKey}
           ref={iframeRef}
-          src={url}
+          src={embedUrl}
           title={domain}
           className="h-full w-full border-none"
           sandbox="allow-scripts allow-same-origin allow-forms allow-popups"

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/embed-auth.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/embed-auth.ts
@@ -2,7 +2,7 @@ import { getApiUrl } from '@/lib/config';
 
 /**
  * Append Nexus JWT to /app-html/ iframe URLs on the API origin so embedded
- * private apps (e.g. axi/docs) can authenticate via ?access_token=.
+ * private app-html embeds can authenticate via ?access_token=.
  */
 export function appendAccessTokenToEmbedUrl(url: string, token: string | null): string {
   if (!token) return url;

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/embed-auth.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/embed-auth.ts
@@ -1,0 +1,22 @@
+import { getApiUrl } from '@/lib/config';
+
+/**
+ * Append Nexus JWT to /app-html/ iframe URLs on the API origin so embedded
+ * private apps (e.g. axi/docs) can authenticate via ?access_token=.
+ */
+export function appendAccessTokenToEmbedUrl(url: string, token: string | null): string {
+  if (!token) return url;
+
+  try {
+    const parsed = new URL(url, typeof window !== 'undefined' ? window.location.href : undefined);
+    const apiOrigin = new URL(getApiUrl()).origin;
+
+    if (parsed.origin !== apiOrigin) return url;
+    if (!parsed.pathname.startsWith('/app-html/')) return url;
+
+    parsed.searchParams.set('access_token', token);
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}


### PR DESCRIPTION
Append JWT to same-origin /app-html/ URLs so private HTML apps can authenticate.