### PR TITLE
fix(app-html): secure /app-html/ access with ABI API key and scoped JWTs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,7 @@ services:
       - NEXUS_INTERNAL_API_URL=http://abi:9879
       - NEXT_PUBLIC_SITE_URL=https://${PUBLIC_WEB_HOST}
       - NEXT_PUBLIC_WS_PATH=/ws/socket.io
+      - ABI_API_KEY=${ABI_API_KEY}
     networks:
       - abi-network
 
@@ -122,6 +123,7 @@ services:
       - PUBLIC_API_HOST=${PUBLIC_API_HOST:-api.localhost}
 
       - HEADSCALE_SERVER_URL=${HEADSCALE_SERVER_URL:-headscale.localhost}
+      - ABI_API_KEY=${ABI_API_KEY}
 
     volumes:
       - ./.deploy/docker/Caddyfile:/etc/caddy/Caddyfile:ro

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -1,4 +1,6 @@
 {$PUBLIC_WEB_HOST:localhost} {
+    # Same-origin /app-html/ → ABI without forging ABI_API_KEY (anonymous
+    # browsers must present a scoped JWT / cookie / user Bearer).
     handle /app-html/* {
         reverse_proxy abi:9879 {
             header_up X-Forwarded-Proto {scheme}

--- a/libs/naas-abi-cli/naas_abi_cli/cli/deploy/templates/local/docker/Caddyfile
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/deploy/templates/local/docker/Caddyfile
@@ -1,4 +1,6 @@
 {$PUBLIC_WEB_HOST:localhost} {
+    # Same-origin /app-html/ → ABI without forging ABI_API_KEY (anonymous
+    # browsers must present a scoped JWT / cookie / user Bearer).
     handle /app-html/* {
         reverse_proxy abi:9879 {
             header_up X-Forwarded-Proto {scheme}

--- a/libs/naas-abi-cli/uv.lock
+++ b/libs/naas-abi-cli/uv.lock
@@ -2615,7 +2615,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-marketplace"
-version = "3.33.5"
+version = "3.33.6"
 source = { editable = "../naas-abi-marketplace" }
 dependencies = [
     { name = "ijson" },

--- a/libs/naas-abi-core/naas_abi_core/apps/api/abi_api_key_auth.py
+++ b/libs/naas-abi-core/naas_abi_core/apps/api/abi_api_key_auth.py
@@ -1,0 +1,152 @@
+"""Shared ABI API key (+ optional JWT) checks for ``/app-html/`` assets."""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Callable
+
+from fastapi import HTTPException, status
+from fastapi.security.utils import get_authorization_scheme_param
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+logger = logging.getLogger(__name__)
+
+# Cookie stamped when a scoped ``?token=`` JWT opens ``/app-html/`` so SPA
+# asset / soft-nav requests keep working without re-attaching the query param.
+APP_HTML_TOKEN_COOKIE = "abi_app_html_token"
+# Email share links use 24h JWTs; cookie lifetime matches that ceiling.
+APP_HTML_TOKEN_COOKIE_MAX_AGE = 24 * 60 * 60
+
+# Extra validators (e.g. Nexus JWT) registered at startup. Signature:
+# ``(token, request) -> bool``.
+_EXTRA_APP_HTML_TOKEN_VALIDATORS: list[Callable[[str, Request], bool]] = []
+
+
+def register_app_html_token_validator(validator: Callable[[str, Request], bool]) -> None:
+    """Register an additional ``/app-html/`` token checker (Nexus JWT, etc.)."""
+    _EXTRA_APP_HTML_TOKEN_VALIDATORS.append(validator)
+
+
+def clear_app_html_token_validators() -> None:
+    """Test helper — wipe registered validators."""
+    _EXTRA_APP_HTML_TOKEN_VALIDATORS.clear()
+
+
+def extract_abi_api_token(request: Request) -> str | None:
+    """Return bearer / ``?token=`` / scoped cookie credential (agent parity)."""
+    authorization = request.headers.get("Authorization")
+    if authorization:
+        scheme, header_token = get_authorization_scheme_param(authorization)
+        if scheme.lower() == "bearer" and header_token:
+            return header_token
+
+    query_token = request.query_params.get("token")
+    if query_token:
+        return query_token
+
+    cookie_token = request.cookies.get(APP_HTML_TOKEN_COOKIE)
+    if cookie_token:
+        return cookie_token
+    return None
+
+
+def expected_abi_api_key() -> str | None:
+    return os.environ.get("ABI_API_KEY")
+
+
+def is_abi_api_token_valid(token: str | None) -> bool:
+    expected = expected_abi_api_key()
+    return bool(expected) and token == expected
+
+
+def is_app_html_request_authorized(request: Request) -> bool:
+    """True when ``ABI_API_KEY`` matches or any registered JWT validator accepts."""
+    token = extract_abi_api_token(request)
+    if is_abi_api_token_valid(token):
+        return True
+    if not token:
+        return False
+    for validator in tuple(_EXTRA_APP_HTML_TOKEN_VALIDATORS):
+        try:
+            if validator(token, request):
+                return True
+        except Exception as exc:  # noqa: BLE001 — never fail open on validator bugs
+            logger.debug("app-html token validator error: %s", exc)
+    return False
+
+
+def require_abi_api_token(request: Request) -> None:
+    """Raise ``401`` when the request is missing a valid app-html credential."""
+    if not is_app_html_request_authorized(request):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authentication credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+
+def _should_stamp_app_html_cookie(request: Request, token: str | None) -> bool:
+    """Stamp cookie only for scoped JWTs arriving via ``?token=`` (not API keys)."""
+    if not token:
+        return False
+    if is_abi_api_token_valid(token):
+        return False
+    if request.query_params.get("token") != token:
+        return False
+    # Must be accepted by a registered JWT validator (not a random string).
+    for validator in tuple(_EXTRA_APP_HTML_TOKEN_VALIDATORS):
+        try:
+            if validator(token, request):
+                return True
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("app-html cookie stamp validator error: %s", exc)
+    return False
+
+
+def _stamp_app_html_token_cookie(
+    response: Response,
+    *,
+    token: str,
+    request: Request,
+) -> None:
+    response.set_cookie(
+        key=APP_HTML_TOKEN_COOKIE,
+        value=token,
+        max_age=APP_HTML_TOKEN_COOKIE_MAX_AGE,
+        path="/app-html/",
+        httponly=True,
+        samesite="lax",
+        secure=request.url.scheme == "https",
+    )
+
+
+class AppHtmlAbiKeyMiddleware(BaseHTTPMiddleware):
+    """Require auth for every ``/app-html/`` request.
+
+    Accepted credentials (same channels as ``/agents``):
+    * ``Authorization: Bearer <ABI_API_KEY>`` or ``?token=<ABI_API_KEY>``
+    * A registered validator (Nexus user JWT / short-lived ``scope=app-html`` JWT)
+    * HttpOnly cookie ``abi_app_html_token`` stamped from a prior ``?token=`` JWT
+
+    CORS preflight (``OPTIONS``) is allowed through.
+    """
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        path = request.url.path
+        if path.startswith("/app-html/") and request.method != "OPTIONS":
+            if not is_app_html_request_authorized(request):
+                return JSONResponse(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    content={"detail": "Invalid authentication credentials"},
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+            token = extract_abi_api_token(request)
+            response = await call_next(request)
+            if _should_stamp_app_html_cookie(request, token):
+                assert token is not None
+                _stamp_app_html_token_cookie(response, token=token, request=request)
+            return response
+        return await call_next(request)

--- a/libs/naas-abi-core/naas_abi_core/apps/api/abi_api_key_auth_test.py
+++ b/libs/naas-abi-core/naas_abi_core/apps/api/abi_api_key_auth_test.py
@@ -1,0 +1,167 @@
+"""Tests for ABI API key auth helpers and /app-html middleware."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from naas_abi_core.apps.api.abi_api_key_auth import (
+    AppHtmlAbiKeyMiddleware,
+    clear_app_html_token_validators,
+    extract_abi_api_token,
+    is_abi_api_token_valid,
+    is_app_html_request_authorized,
+    register_app_html_token_validator,
+)
+from starlette.requests import Request
+
+
+@pytest.fixture(autouse=True)
+def _reset_validators() -> Iterator[None]:
+    clear_app_html_token_validators()
+    yield
+    clear_app_html_token_validators()
+
+
+@pytest.fixture()
+def api_key(monkeypatch: pytest.MonkeyPatch) -> str:
+    key = "test-abi-api-key"
+    monkeypatch.setenv("ABI_API_KEY", key)
+    return key
+
+
+def test_is_abi_api_token_valid(api_key: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    assert is_abi_api_token_valid(api_key) is True
+    assert is_abi_api_token_valid("wrong") is False
+    assert is_abi_api_token_valid(None) is False
+    monkeypatch.delenv("ABI_API_KEY", raising=False)
+    assert is_abi_api_token_valid(api_key) is False
+
+
+def test_extract_abi_api_token_from_header_and_query() -> None:
+    header_scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/app-html/axi/devops/host/",
+        "headers": [(b"authorization", b"Bearer header-token")],
+        "query_string": b"",
+    }
+    query_scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/app-html/axi/devops/host/",
+        "headers": [],
+        "query_string": b"token=query-token",
+    }
+    cookie_scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/app-html/axi/devops/host/",
+        "headers": [(b"cookie", b"abi_app_html_token=cookie-token")],
+        "query_string": b"",
+    }
+    assert extract_abi_api_token(Request(header_scope)) == "header-token"
+    assert extract_abi_api_token(Request(query_scope)) == "query-token"
+    assert extract_abi_api_token(Request(cookie_scope)) == "cookie-token"
+
+
+def test_app_html_middleware_stamps_cookie_for_scoped_jwt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("ABI_API_KEY", raising=False)
+
+    def _accept_jwt(token: str, request: Request) -> bool:
+        return token == "jwt-ok" and request.url.path.startswith("/app-html/")
+
+    register_app_html_token_validator(_accept_jwt)
+
+    app = FastAPI()
+    app.add_middleware(AppHtmlAbiKeyMiddleware)
+
+    @app.get("/app-html/{path:path}")
+    def _html(path: str) -> dict[str, str]:
+        return {"path": path}
+
+    client = TestClient(app)
+    first = client.get("/app-html/report/counter_uas/map/?token=jwt-ok")
+    assert first.status_code == 200
+    assert "abi_app_html_token=jwt-ok" in first.headers.get("set-cookie", "")
+
+    # Follow-up asset request uses the cookie (no query token).
+    second = client.get("/app-html/report/counter_uas/reports.json")
+    assert second.status_code == 200
+
+
+def test_app_html_middleware_does_not_stamp_cookie_for_api_key(api_key: str) -> None:
+    app = FastAPI()
+    app.add_middleware(AppHtmlAbiKeyMiddleware)
+
+    @app.get("/app-html/{path:path}")
+    def _html(path: str) -> dict[str, str]:
+        return {"path": path}
+
+    client = TestClient(app)
+    response = client.get(f"/app-html/axi/devops/host/?token={api_key}")
+    assert response.status_code == 200
+    assert "abi_app_html_token" not in response.headers.get("set-cookie", "")
+
+
+def test_app_html_middleware_requires_abi_api_key(api_key: str) -> None:
+    app = FastAPI()
+    app.add_middleware(AppHtmlAbiKeyMiddleware)
+
+    @app.get("/app-html/{path:path}")
+    def _html(path: str) -> dict[str, str]:
+        return {"path": path}
+
+    @app.get("/health")
+    def _health() -> dict[str, str]:
+        return {"ok": "1"}
+
+    client = TestClient(app)
+
+    assert client.get("/health").status_code == 200
+    assert client.get("/app-html/axi/devops/host/").status_code == 401
+    assert (
+        client.get(
+            "/app-html/axi/devops/host/",
+            headers={"Authorization": f"Bearer {api_key}"},
+        ).status_code
+        == 200
+    )
+    assert (
+        client.get(f"/app-html/axi/devops/host/?token={api_key}").status_code == 200
+    )
+    # Preflight must not require a token (CORS).
+    assert client.options("/app-html/axi/devops/host/").status_code in {200, 405}
+
+
+def test_app_html_middleware_accepts_registered_jwt_validator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("ABI_API_KEY", raising=False)
+
+    def _accept_jwt(token: str, request: Request) -> bool:
+        return token == "jwt-ok" and request.url.path.startswith("/app-html/")
+
+    register_app_html_token_validator(_accept_jwt)
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/app-html/axi/devops/host/",
+        "headers": [(b"authorization", b"Bearer jwt-ok")],
+        "query_string": b"",
+    }
+    assert is_app_html_request_authorized(Request(scope)) is True
+
+    bad_scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/app-html/axi/devops/host/",
+        "headers": [(b"authorization", b"Bearer wrong")],
+        "query_string": b"",
+    }
+    assert is_app_html_request_authorized(Request(bad_scope)) is False

--- a/libs/naas-abi-core/naas_abi_core/apps/api/api.py
+++ b/libs/naas-abi-core/naas_abi_core/apps/api/api.py
@@ -145,7 +145,9 @@ oauth2_scheme = OAuth2QueryBearer(tokenUrl="token")
 
 # Update the token validation dependency
 async def is_token_valid(token: str = Depends(oauth2_scheme)):
-    if token != os.environ.get("ABI_API_KEY"):
+    from naas_abi_core.apps.api.abi_api_key_auth import is_abi_api_token_valid
+
+    if not is_abi_api_token_valid(token):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid authentication credentials",
@@ -286,6 +288,12 @@ def _load_runtime_routes():
 
     for module in runtime_engine.modules.values():
         module.api(app)
+
+    # Protect /app-html/ with ABI_API_KEY (same channels as /agents). Added last
+    # so it runs outermost — before per-app object-storage middlewares.
+    from naas_abi_core.apps.api.abi_api_key_auth import AppHtmlAbiKeyMiddleware
+
+    app.add_middleware(AppHtmlAbiKeyMiddleware)
 
     # Kick off background warmup of every IntentMapper's vector index. We
     # deferred this work out of agent __init__ to keep boot fast; doing it

--- a/libs/naas-abi/naas_abi/__init__.py
+++ b/libs/naas-abi/naas_abi/__init__.py
@@ -361,16 +361,44 @@ class NexusConfig(BaseModel):
     magic_link_expire_minutes: int = 15
     magic_link_path: str = "/auth/magic-link"
     magic_link_email_app_name: str = "NEXUS"
-    magic_link_email_subject_template: str = "Your {app_name} magic sign-in link"
+    magic_link_email_subject_template: str = "Your {app_name} sign-in code"
     magic_link_email_text_template: str = (
-        "Use the link below to sign in to {app_name}:\n\n"
-        "{magic_link_url}\n\n"
-        "This link expires in {expire_minutes} minutes."
+        "Your {app_name} sign-in code is: {otp_code}\n\n"
+        "Enter this code in the app to continue.\n\n"
+        "Or use this magic link:\n{magic_link_url}\n\n"
+        "This code and link expire in {expire_minutes} minutes."
     )
     magic_link_email_html_template: str = (
-        "<p>Use the link below to sign in to {app_name}:</p>"
-        '<p><a href="{magic_link_url}">Sign in to {app_name}</a></p>'
-        "<p>This link expires in {expire_minutes} minutes.</p>"
+        '<!DOCTYPE html><html><body style="margin:0;padding:0;'
+        'background-color:{background_color};'
+        'font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif;">'
+        '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" '
+        'style="background-color:{background_color};padding:48px 16px;">'
+        '<tr><td align="center">'
+        '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" '
+        'style="max-width:440px;background-color:{login_card_color};'
+        'padding:40px 48px;border-radius:{login_border_radius}px;">'
+        '<tr><td align="center" style="padding-bottom:24px;">{logo_html}</td></tr>'
+        '<tr><td align="center" style="padding-bottom:24px;">'
+        '<p style="margin:0;font-size:28px;font-weight:600;color:#1a1a1a;">Welcome</p>'
+        '<p style="margin:8px 0 0;font-size:14px;color:#737373;">Sign in to continue</p>'
+        "</td></tr>"
+        '<tr><td align="center" style="padding-bottom:8px;">'
+        '<p style="margin:0;font-size:14px;color:#737373;">Your sign-in code</p>'
+        '<p style="margin:12px 0 0;font-size:28px;letter-spacing:6px;'
+        'font-weight:700;color:#1a1a1a;">{otp_code}</p>'
+        "</td></tr>"
+        '<tr><td align="center" style="padding:24px 0;">'
+        '<a href="{magic_link_url}" style="display:inline-block;background-color:{primary_color};'
+        "color:#ffffff;text-decoration:none;padding:12px 24px;font-size:14px;"
+        'font-weight:500;border-radius:{login_border_radius}px;">Sign in</a>'
+        "</td></tr>"
+        '<tr><td align="center">'
+        '<p style="margin:0;font-size:12px;color:#737373;">'
+        "This code and link expire in {expire_minutes} minutes.</p>"
+        "</td></tr></table>"
+        '<p style="margin:24px 0 0;font-size:12px;color:#737373;">{login_footer_text}</p>'
+        "</td></tr></table></body></html>"
     )
     email_from_address: EmailStr = "no-reply@nexus.example.com"
     email_from_name: str = "NEXUS"

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/config.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/config.py
@@ -394,6 +394,8 @@ class Settings(BaseSettings):
     magic_link_allow_signup: bool = False
     access_token_expire_minutes: int = 30  # 30 minutes (short-lived)
     refresh_token_expire_days: int = 30  # 30 days (long-lived)
+    # Short-lived JWT for opening /app-html apps (Bearer or ?token=).
+    app_html_access_token_expire_minutes: int = Field(default=60, ge=1, le=24 * 60)
     magic_link_expire_minutes: int = 15
     magic_link_max_active: int = 5
     magic_link_path: str = "/auth/magic-link"

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/config.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/config.py
@@ -408,12 +408,41 @@ class Settings(BaseSettings):
         "Or use this magic link:\n{magic_link_url}\n\n"
         "This code and link expire in {expire_minutes} minutes."
     )
+    # Placeholders: app_name, otp_code, magic_link_url, expire_minutes,
+    # primary_color, accent_color, background_color, login_card_color,
+    # login_border_radius, logo_html, logo_url, login_footer_text, tab_title.
+    # Use only inline styles (no CSS {{ }} blocks) — templates use str.format_map.
     magic_link_email_html_template: str = (
-        "<p>Your {app_name} sign-in code is:</p>"
-        '<p style="font-size:28px;letter-spacing:6px;font-weight:700;">{otp_code}</p>'
-        "<p>Enter this code in the app to continue.</p>"
-        '<p>Or <a href="{magic_link_url}">sign in with this magic link</a>.</p>'
-        "<p>This code and link expire in {expire_minutes} minutes.</p>"
+        '<!DOCTYPE html><html><body style="margin:0;padding:0;'
+        'background-color:{background_color};'
+        'font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif;">'
+        '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" '
+        'style="background-color:{background_color};padding:48px 16px;">'
+        '<tr><td align="center">'
+        '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" '
+        'style="max-width:440px;background-color:{login_card_color};'
+        'padding:40px 48px;border-radius:{login_border_radius}px;">'
+        '<tr><td align="center" style="padding-bottom:24px;">{logo_html}</td></tr>'
+        '<tr><td align="center" style="padding-bottom:24px;">'
+        '<p style="margin:0;font-size:28px;font-weight:600;color:#1a1a1a;">Welcome</p>'
+        '<p style="margin:8px 0 0;font-size:14px;color:#737373;">Sign in to continue</p>'
+        "</td></tr>"
+        '<tr><td align="center" style="padding-bottom:8px;">'
+        '<p style="margin:0;font-size:14px;color:#737373;">Your sign-in code</p>'
+        '<p style="margin:12px 0 0;font-size:28px;letter-spacing:6px;'
+        'font-weight:700;color:#1a1a1a;">{otp_code}</p>'
+        "</td></tr>"
+        '<tr><td align="center" style="padding:24px 0;">'
+        '<a href="{magic_link_url}" style="display:inline-block;background-color:{primary_color};'
+        "color:#ffffff;text-decoration:none;padding:12px 24px;font-size:14px;"
+        'font-weight:500;border-radius:{login_border_radius}px;">Sign in</a>'
+        "</td></tr>"
+        '<tr><td align="center">'
+        '<p style="margin:0;font-size:12px;color:#737373;">'
+        "This code and link expire in {expire_minutes} minutes.</p>"
+        "</td></tr></table>"
+        '<p style="margin:24px 0 0;font-size:12px;color:#737373;">{login_footer_text}</p>'
+        "</td></tr></table></body></html>"
     )
 
     # Outgoing email "From" metadata. Transport details (host, credentials,

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/main.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/main.py
@@ -469,6 +469,11 @@ def create_app(app: FastAPI | None = None):
         _configure_middleware(app)
         _register_routes(app)
         _mount_static_assets(app)
+        from naas_abi.apps.nexus.apps.api.app.services.apps.app_html_access import (
+            register_nexus_app_html_jwt_auth,
+        )
+
+        register_nexus_app_html_jwt_auth()
         app.state._nexus_api_patched = True
 
     # Wrap app with WebSocket support (must be LAST, after all middleware)

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/apps/adapters/primary/apps__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/apps/adapters/primary/apps__primary_adapter__FastAPI.py
@@ -38,6 +38,9 @@ from naas_abi.apps.nexus.apps.api.app.api.endpoints.auth import (
     get_current_user_required,
     require_workspace_access,
 )
+from naas_abi.apps.nexus.apps.api.app.services.apps.app_html_access import (
+    mint_app_html_access_token,
+)
 from naas_abi.apps.nexus.apps.api.app.services.apps.port import (
     AppConfigCreate,
     AppConfigCreateInput,
@@ -57,6 +60,7 @@ from naas_abi.apps.nexus.apps.api.app.services.registry import (
     get_service_registry,
 )
 from naas_abi.apps.nexus.apps.api.app.utils.public_urls import public_modules_url
+from pydantic import BaseModel, Field
 
 _log = logging.getLogger(__name__)
 
@@ -290,6 +294,49 @@ class AppsFastAPIPrimaryAdapter:
 # ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
+
+
+class AppHtmlAccessTokenRequest(BaseModel):
+    """Mint a short-lived JWT for ``/app-html/`` (Bearer or ``?token=``)."""
+
+    expires_minutes: int | None = Field(
+        default=None,
+        ge=1,
+        le=24 * 60,
+        description="Lifetime; defaults to app_html_access_token_expire_minutes",
+    )
+    path_prefix: str | None = Field(
+        default=None,
+        description="Optional path lock, e.g. /app-html/axi/devops/",
+    )
+
+
+class AppHtmlAccessTokenResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+    expires_in: int
+    path_prefix: str | None = None
+
+
+@router.post("/access-token", response_model=AppHtmlAccessTokenResponse)
+async def create_app_html_access_token(
+    body: AppHtmlAccessTokenRequest,
+    current_user: User = Depends(get_current_user_required),
+) -> AppHtmlAccessTokenResponse:
+    """Issue a time-limited JWT accepted by ``/app-html/`` (alongside ABI_API_KEY)."""
+    try:
+        token, expires_in = mint_app_html_access_token(
+            user_id=current_user.id,
+            expires_minutes=body.expires_minutes,
+            path_prefix=body.path_prefix,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return AppHtmlAccessTokenResponse(
+        access_token=token,
+        expires_in=expires_in,
+        path_prefix=body.path_prefix,
+    )
 
 
 @router.get("/", response_model=AppsResponse)

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/apps/app_html_access.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/apps/app_html_access.py
@@ -1,0 +1,68 @@
+"""JWT validators and minting for time-limited ``/app-html/`` access."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from naas_abi.apps.nexus.apps.api.app.core.config import settings
+from naas_abi.apps.nexus.apps.api.app.services.auth.service import (
+    create_access_token,
+    decode_token,
+)
+from naas_abi_core.apps.api.abi_api_key_auth import register_app_html_token_validator
+from starlette.requests import Request
+
+APP_HTML_TOKEN_SCOPE = "app-html"
+
+
+def validate_app_html_jwt(token: str, request: Request) -> bool:
+    """Accept Nexus user JWTs and scoped ``app-html`` JWTs (``exp`` enforced by jose)."""
+    payload = decode_token(token)
+    if not payload or not payload.get("sub"):
+        return False
+
+    scope = payload.get("scope")
+    # Scoped tokens must explicitly target app-html; bare session JWTs are OK.
+    if scope is not None and scope != APP_HTML_TOKEN_SCOPE:
+        return False
+
+    path_prefix = payload.get("path_prefix")
+    if path_prefix:
+        prefix = str(path_prefix)
+        if not prefix.startswith("/app-html/"):
+            return False
+        if not request.url.path.startswith(prefix):
+            return False
+
+    return True
+
+
+def mint_app_html_access_token(
+    *,
+    user_id: str,
+    expires_minutes: int | None = None,
+    path_prefix: str | None = None,
+) -> tuple[str, int]:
+    """Return ``(jwt, expires_in_seconds)`` for ``/app-html/`` access."""
+    minutes = expires_minutes or settings.app_html_access_token_expire_minutes
+    minutes = max(1, min(minutes, 24 * 60))
+    claims: dict[str, str] = {
+        "sub": user_id,
+        "scope": APP_HTML_TOKEN_SCOPE,
+    }
+    if path_prefix:
+        prefix = path_prefix.strip()
+        if not prefix.startswith("/app-html/"):
+            raise ValueError("path_prefix must start with /app-html/")
+        claims["path_prefix"] = prefix
+
+    token, _ = create_access_token(
+        data=claims,
+        expires_delta=timedelta(minutes=minutes),
+    )
+    return token, minutes * 60
+
+
+def register_nexus_app_html_jwt_auth() -> None:
+    """Wire Nexus JWT validation into the shared ``/app-html/`` middleware."""
+    register_app_html_token_validator(validate_app_html_jwt)

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/apps/app_html_access_test.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/apps/app_html_access_test.py
@@ -1,0 +1,75 @@
+"""Tests for short-lived /app-html JWT access."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+from naas_abi.apps.nexus.apps.api.app.core.config import settings
+from naas_abi.apps.nexus.apps.api.app.services.apps import app_html_access
+from naas_abi.apps.nexus.apps.api.app.services.auth.service import (
+    create_access_token,
+    decode_token,
+)
+from starlette.requests import Request
+
+
+def _request(path: str) -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": path,
+            "headers": [],
+            "query_string": b"",
+        }
+    )
+
+
+def test_validate_accepts_user_session_jwt(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "secret_key", "test-secret-key")
+    token, _ = create_access_token(
+        data={"sub": "user-1"},
+        expires_delta=timedelta(minutes=15),
+    )
+    assert app_html_access.validate_app_html_jwt(token, _request("/app-html/axi/devops/host/"))
+
+
+def test_validate_rejects_expired_jwt(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "secret_key", "test-secret-key")
+    token, _ = create_access_token(
+        data={"sub": "user-1"},
+        expires_delta=timedelta(minutes=-1),
+    )
+    assert decode_token(token) is None
+    assert (
+        app_html_access.validate_app_html_jwt(token, _request("/app-html/axi/devops/host/"))
+        is False
+    )
+
+
+def test_validate_scoped_path_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "secret_key", "test-secret-key")
+    token, expires_in = app_html_access.mint_app_html_access_token(
+        user_id="user-1",
+        expires_minutes=10,
+        path_prefix="/app-html/axi/devops/",
+    )
+    assert expires_in == 600
+    assert app_html_access.validate_app_html_jwt(
+        token, _request("/app-html/axi/devops/host/")
+    )
+    assert (
+        app_html_access.validate_app_html_jwt(
+            token, _request("/app-html/osint/osint/")
+        )
+        is False
+    )
+
+
+def test_mint_rejects_invalid_path_prefix() -> None:
+    with pytest.raises(ValueError, match="path_prefix"):
+        app_html_access.mint_app_html_access_token(
+            user_id="user-1",
+            path_prefix="/not-app-html/",
+        )

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/auth/adapters/primary/auth__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/auth/adapters/primary/auth__primary_adapter__FastAPI.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import os
-from urllib.parse import urlencode
 
 from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile, status
 from fastapi.responses import Response
@@ -564,8 +563,12 @@ async def _send_magic_link_email(
     otp_code: str,
     email_service: EmailService | None,
 ) -> None:
-    query = urlencode({"token": token})
-    magic_link_url = f"{settings.frontend_url.rstrip('/')}{settings.magic_link_path}?{query}"
+    from naas_abi.apps.nexus.apps.api.app.services.invites.sign_in_email import (
+        magic_link_url_for_token,
+        render_sign_in_email,
+    )
+
+    magic_link_url = magic_link_url_for_token(token)
 
     if email_service is None:
         if settings.log_otp_codes_when_email_unavailable:
@@ -583,21 +586,9 @@ async def _send_magic_link_email(
             )
         return
 
-    app_name = settings.magic_link_email_app_name
-    template_values = {
-        "app_name": app_name,
-        "magic_link_url": magic_link_url,
-        "otp_code": otp_code,
-        "expire_minutes": settings.magic_link_expire_minutes,
-    }
-    subject = settings.magic_link_email_subject_template.format_map(
-        _SafeTemplateValues(template_values)
-    )
-    text_body = settings.magic_link_email_text_template.format_map(
-        _SafeTemplateValues(template_values)
-    )
-    html_body = settings.magic_link_email_html_template.format_map(
-        _SafeTemplateValues(template_values)
+    subject, text_body, html_body, attachments = render_sign_in_email(
+        magic_link_url=magic_link_url,
+        otp_code=otp_code,
     )
     email_service.send(
         to_email=to_email,
@@ -606,12 +597,8 @@ async def _send_magic_link_email(
         html_body=html_body,
         from_email=str(settings.email_from_address),
         from_name=settings.email_from_name,
+        attachments=attachments or None,
     )
-
-
-class _SafeTemplateValues(dict[str, object]):
-    def __missing__(self, key: str) -> str:
-        return "{" + key + "}"
 
 
 class AuthFastAPIPrimaryAdapter:

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/invites/sign_in_email.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/invites/sign_in_email.py
@@ -33,8 +33,9 @@ def _is_private_email_host(hostname: str | None) -> bool:
     if not hostname:
         return True
     host = hostname.lower().rstrip(".")
+    private_hosts = {"localhost", "127.0.0.1", "0.0.0.0", "abi", "::1"}  # nosec B104 - hostname comparison, not a socket bind
     return (
-        host in {"localhost", "127.0.0.1", "0.0.0.0", "abi", "::1"}
+        host in private_hosts
         or host.endswith(".localhost")
         or host.endswith(".local")
     )
@@ -69,13 +70,15 @@ def _logo_fetch_candidates(logo_url: str) -> list[str]:
             ]
         )
     candidates.append(logo_url)
-    # De-dupe while preserving order
+    # De-dupe while preserving order; only http(s) is fetchable (tenant config is
+    # not trusted to keep file:/ or custom schemes out of the logo URL).
     seen: set[str] = set()
     ordered: list[str] = []
     for url in candidates:
-        if url not in seen:
-            seen.add(url)
-            ordered.append(url)
+        if url in seen or urlparse(url).scheme not in ("http", "https"):
+            continue
+        seen.add(url)
+        ordered.append(url)
     return ordered
 
 
@@ -128,7 +131,7 @@ def _load_logo_bytes(logo_url: str) -> bytes | None:
     for url in _logo_fetch_candidates(logo_url):
         try:
             request = Request(url, headers={"User-Agent": "nexus-sign-in-email/1.0"})
-            with urlopen(request, timeout=5) as response:  # noqa: S310 — configured tenant URL
+            with urlopen(request, timeout=5) as response:  # nosec B310 - http(s)-only candidates
                 data = response.read()
                 if data:
                     return data

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/invites/sign_in_email.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/invites/sign_in_email.py
@@ -3,18 +3,199 @@
 from __future__ import annotations
 
 import logging
-from urllib.parse import urlencode
+import mimetypes
+from pathlib import Path
+from urllib.error import URLError
+from urllib.parse import urlencode, urlparse
+from urllib.request import Request, urlopen
 
 from naas_abi.apps.nexus.apps.api.app.core.config import settings
 from naas_abi.apps.nexus.apps.api.app.services.auth.service import AuthService, MagicLinkChallenge
+from naas_abi_core.services.email.EmailPorts import EmailAttachment
 from naas_abi_core.services.email.EmailService import EmailService
 
 logger = logging.getLogger(__name__)
+
+SIGN_IN_LOGO_CID = "sign-in-logo"
 
 
 class _SafeTemplateValues(dict[str, object]):
     def __missing__(self, key: str) -> str:
         return "{" + key + "}"
+
+
+def magic_link_url_for_token(token: str) -> str:
+    query = urlencode({"token": token})
+    return f"{settings.frontend_url.rstrip('/')}{settings.magic_link_path}?{query}"
+
+
+def _is_private_email_host(hostname: str | None) -> bool:
+    if not hostname:
+        return True
+    host = hostname.lower().rstrip(".")
+    return (
+        host in {"localhost", "127.0.0.1", "0.0.0.0", "abi", "::1"}
+        or host.endswith(".localhost")
+        or host.endswith(".local")
+    )
+
+
+def _guess_mime_type(url_or_name: str, content: bytes) -> str:
+    mime, _ = mimetypes.guess_type(url_or_name)
+    if mime and mime.startswith("image/"):
+        return mime
+    if content[:8] == b"\x89PNG\r\n\x1a\n":
+        return "image/png"
+    if content[:2] == b"\xff\xd8":
+        return "image/jpeg"
+    if content[:4] == b"GIF8":
+        return "image/gif"
+    if content[:4] == b"RIFF" and content[8:12] == b"WEBP":
+        return "image/webp"
+    return "image/png"
+
+
+def _logo_fetch_candidates(logo_url: str) -> list[str]:
+    """Prefer loopback HTTP for private hosts so we can CID-embed the bytes."""
+    parsed = urlparse(logo_url)
+    path = parsed.path or "/"
+    candidates: list[str] = []
+    if _is_private_email_host(parsed.hostname):
+        # Same process / Docker network — email clients cannot reach *.localhost.
+        candidates.extend(
+            [
+                f"http://127.0.0.1:9879{path}",
+                f"http://abi:9879{path}",
+            ]
+        )
+    candidates.append(logo_url)
+    # De-dupe while preserving order
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for url in candidates:
+        if url not in seen:
+            seen.add(url)
+            ordered.append(url)
+    return ordered
+
+
+def _try_load_seal_from_disk(logo_url: str) -> bytes | None:
+    """Load the CBP seal from the report module assets when the logo URL points at it."""
+    seal_name = "Seal_of_U.S._Customs_and_Border_Protection.png"
+    if seal_name not in logo_url:
+        return None
+
+    candidates: list[Path] = []
+    try:
+        import report as report_module
+
+        report_root = Path(report_module.__file__).resolve().parent
+        candidates.append(report_root / "assets" / "public" / seal_name)
+    except Exception:
+        pass
+
+    cwd = Path.cwd()
+    for base in (cwd, *cwd.parents[:4]):
+        candidates.append(base / "src" / "report" / "assets" / "public" / seal_name)
+        candidates.append(base / "report" / "assets" / "public" / seal_name)
+
+    seen: set[Path] = set()
+    for candidate in candidates:
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            continue
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        try:
+            if resolved.is_file():
+                return resolved.read_bytes()
+        except OSError:
+            continue
+    return None
+
+
+def _load_logo_bytes(logo_url: str) -> bytes | None:
+    """Load logo bytes for CID embedding (required when URL is not public)."""
+    if not logo_url:
+        return None
+
+    disk = _try_load_seal_from_disk(logo_url)
+    if disk:
+        return disk
+
+    for url in _logo_fetch_candidates(logo_url):
+        try:
+            request = Request(url, headers={"User-Agent": "nexus-sign-in-email/1.0"})
+            with urlopen(request, timeout=5) as response:  # noqa: S310 — configured tenant URL
+                data = response.read()
+                if data:
+                    return data
+        except (URLError, TimeoutError, OSError, ValueError) as exc:
+            logger.debug("Sign-in email logo fetch failed for %s: %s", url, exc)
+    return None
+
+
+def render_sign_in_email(
+    *,
+    magic_link_url: str,
+    otp_code: str,
+) -> tuple[str, str, str, list[EmailAttachment]]:
+    """Render subject/text/html + inline logo attachments for a sign-in email."""
+    tenant = settings.tenant
+    logo_url = tenant.logo_rectangle_url or tenant.logo_url or ""
+    attachments: list[EmailAttachment] = []
+    logo_html = ""
+
+    if logo_url:
+        logo_bytes = _load_logo_bytes(logo_url)
+        if logo_bytes:
+            mime = _guess_mime_type(logo_url, logo_bytes)
+            ext = mimetypes.guess_extension(mime) or ".png"
+            attachments.append(
+                EmailAttachment(
+                    filename=f"logo{ext}",
+                    content=logo_bytes,
+                    mime_type=mime,
+                    content_id=SIGN_IN_LOGO_CID,
+                    is_inline=True,
+                )
+            )
+            logo_src = f"cid:{SIGN_IN_LOGO_CID}"
+        else:
+            # Public absolute URL fallback (clients may still block external images).
+            logo_src = logo_url if not _is_private_email_host(urlparse(logo_url).hostname) else ""
+        if logo_src:
+            logo_html = (
+                f'<img src="{logo_src}" alt="{settings.magic_link_email_app_name}" '
+                'width="96" height="96" '
+                'style="display:block;max-width:96px;height:auto;'
+                'margin:0 auto;border:0;outline:none;text-decoration:none;" />'
+            )
+
+    footer_text = tenant.login_footer_text or ""
+    template_values = {
+        "app_name": settings.magic_link_email_app_name,
+        "magic_link_url": magic_link_url,
+        "otp_code": otp_code,
+        "expire_minutes": settings.magic_link_expire_minutes,
+        "primary_color": tenant.primary_color,
+        "accent_color": tenant.accent_color,
+        "background_color": tenant.background_color,
+        "login_card_color": tenant.login_card_color,
+        "login_input_color": tenant.login_input_color,
+        "login_border_radius": tenant.login_border_radius,
+        "login_footer_text": footer_text,
+        "logo_url": logo_url,
+        "logo_html": logo_html,
+        "tab_title": tenant.tab_title,
+    }
+    safe = _SafeTemplateValues(template_values)
+    subject = settings.magic_link_email_subject_template.format_map(safe)
+    text_body = settings.magic_link_email_text_template.format_map(safe)
+    html_body = settings.magic_link_email_html_template.format_map(safe)
+    return subject, text_body, html_body, attachments
 
 
 def resolve_email_service() -> EmailService | None:
@@ -41,8 +222,7 @@ async def send_invite_sign_in_email(
     email_service: EmailService | None,
 ) -> bool:
     """Send invite sign-in email. Returns True when handed to the email service."""
-    query = urlencode({"token": challenge.token})
-    magic_link_url = f"{settings.frontend_url.rstrip('/')}{settings.magic_link_path}?{query}"
+    magic_link_url = magic_link_url_for_token(challenge.token)
 
     if email_service is None:
         if settings.log_otp_codes_when_email_unavailable:
@@ -60,21 +240,9 @@ async def send_invite_sign_in_email(
             )
         return False
 
-    app_name = settings.magic_link_email_app_name
-    template_values = {
-        "app_name": app_name,
-        "magic_link_url": magic_link_url,
-        "otp_code": challenge.otp_code,
-        "expire_minutes": settings.magic_link_expire_minutes,
-    }
-    subject = settings.magic_link_email_subject_template.format_map(
-        _SafeTemplateValues(template_values)
-    )
-    text_body = settings.magic_link_email_text_template.format_map(
-        _SafeTemplateValues(template_values)
-    )
-    html_body = settings.magic_link_email_html_template.format_map(
-        _SafeTemplateValues(template_values)
+    subject, text_body, html_body, attachments = render_sign_in_email(
+        magic_link_url=magic_link_url,
+        otp_code=challenge.otp_code,
     )
     email_service.send(
         to_email=to_email,
@@ -83,6 +251,7 @@ async def send_invite_sign_in_email(
         html_body=html_body,
         from_email=str(settings.email_from_address),
         from_name=settings.email_from_name,
+        attachments=attachments or None,
     )
     return True
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/invites/sign_in_email_test.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/invites/sign_in_email_test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from naas_abi.apps.nexus.apps.api.app.core.config import settings
 from naas_abi.apps.nexus.apps.api.app.services.auth.service import MagicLinkChallenge
 from naas_abi.apps.nexus.apps.api.app.services.invites import sign_in_email
 from naas_abi.apps.nexus.apps.api.app.services.invites.sign_in_email import (
@@ -83,3 +84,45 @@ async def test_ensure_user_and_send_invite_email_reuses_the_guarded_path(monkeyp
 
     assert result == {"user_created": True, "sign_in_email_sent": False}
     auth.invalidate_magic_link_challenge.assert_awaited_once_with("tid-1")
+
+
+def test_render_sign_in_email_embeds_private_host_logo_as_cid(monkeypatch, tmp_path) -> None:
+    """*.localhost logo URLs are unreachable from mail clients — embed as cid:."""
+    from naas_abi.apps.nexus.apps.api.app.core.config import TenantConfig
+
+    seal = tmp_path / "Seal_of_U.S._Customs_and_Border_Protection.png"
+    seal.write_bytes(b"\x89PNG\r\n\x1a\n" + b"fake-png-bytes")
+
+    monkeypatch.setattr(
+        settings,
+        "tenant",
+        TenantConfig(
+            tab_title="AXI AI",
+            logo_url=f"https://api.localhost/modules/report/assets/public/{seal.name}",
+            primary_color="#00416A",
+            accent_color="#1460AA",
+        ),
+    )
+    monkeypatch.setattr(settings, "magic_link_email_app_name", "AXI AI")
+    monkeypatch.setattr(
+        settings,
+        "magic_link_email_html_template",
+        "<div>{logo_html}</div><a href=\"{magic_link_url}\">Sign in</a>",
+    )
+    monkeypatch.setattr(
+        sign_in_email,
+        "_try_load_seal_from_disk",
+        lambda _url: seal.read_bytes(),
+    )
+
+    _subject, _text, html, attachments = sign_in_email.render_sign_in_email(
+        magic_link_url="https://nexus.example/auth/magic-link?token=abc",
+        otp_code="123456",
+    )
+
+    assert 'src="cid:sign-in-logo"' in html
+    assert "api.localhost" not in html
+    assert len(attachments) == 1
+    assert attachments[0].is_inline is True
+    assert attachments[0].content_id == "sign-in-logo"
+    assert attachments[0].content.startswith(b"\x89PNG")

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/next.config.js
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/next.config.js
@@ -14,12 +14,6 @@ const nextConfig = {
     return config;
   },
   async rewrites() {
-    const apiBase =
-      process.env.NEXUS_INTERNAL_API_URL ||
-      process.env.NEXUS_API_URL ||
-      process.env.NEXT_PUBLIC_API_URL ||
-      'http://localhost:9879';
-
     return [
       {
         source: '/login',
@@ -29,10 +23,8 @@ const nextConfig = {
         source: '/register',
         destination: '/auth/register',
       },
-      {
-        source: '/app-html/:path*',
-        destination: `${apiBase}/app-html/:path*`,
-      },
+      // /app-html/* is handled by the route handler (or Caddy → ABI). Do not
+      // rewrite here and never forge ABI_API_KEY for anonymous browsers.
     ];
   },
   images: {

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/app-html/[...path]/route.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/app-html/[...path]/route.ts
@@ -6,44 +6,89 @@ const UPSTREAM =
   process.env.NEXT_PUBLIC_API_URL ??
   'http://localhost:9879';
 
+const APP_HTML_TOKEN_COOKIE = 'abi_app_html_token';
+
+/**
+ * Forward caller credentials only — never forge ``ABI_API_KEY``.
+ * Accepts Authorization, ``?token=``, or the scoped app-html cookie.
+ */
+function upstreamHeaders(request: NextRequest): HeadersInit {
+  const headers: Record<string, string> = {};
+  const incoming = request.headers.get('authorization');
+  if (incoming) {
+    headers.Authorization = incoming;
+  } else {
+    const queryToken = request.nextUrl.searchParams.get('token');
+    const cookieToken = request.cookies.get(APP_HTML_TOKEN_COOKIE)?.value;
+    const token = queryToken || cookieToken;
+    if (token) {
+      headers.Authorization = `Bearer ${token}`;
+    }
+  }
+  const cookie = request.headers.get('cookie');
+  if (cookie) {
+    headers.Cookie = cookie;
+  }
+  return headers;
+}
+
 /**
  * Proxy bundled Nexus app HTML from the API so iframes load same-origin.
- * (Catalog apps use /app-html/<module>/<app>/… paths.)
+ * Upstream ``/app-html/`` requires a real JWT / cookie — anonymous requests
+ * without ``?token=`` receive 401.
  */
-export async function GET(
-  request: NextRequest,
-  { params }: { params: { path: string[] } },
-) {
+async function proxy(request: NextRequest, params: { path: string[] }) {
   const subpath = params.path.join('/');
   const qs = request.nextUrl.search;
   const target = `${UPSTREAM.replace(/\/$/, '')}/app-html/${subpath}${qs}`;
 
   try {
-    const res = await fetch(target, { cache: 'no-store' });
+    const init: RequestInit = {
+      method: request.method,
+      headers: upstreamHeaders(request),
+      cache: 'no-store',
+    };
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+      init.body = await request.arrayBuffer();
+    }
+    const res = await fetch(target, init);
     const body = await res.arrayBuffer();
     const headers = new Headers();
-    const contentType = res.headers.get('content-type');
-    if (contentType) {
-      headers.set('content-type', contentType);
-    }
-    const contentDisposition = res.headers.get('content-disposition');
-    if (contentDisposition) {
-      headers.set('content-disposition', contentDisposition);
-    }
-    const cacheControl = res.headers.get('cache-control');
-    if (cacheControl) {
-      headers.set('cache-control', cacheControl);
-    }
-    const etag = res.headers.get('etag');
-    if (etag) {
-      headers.set('etag', etag);
-    }
-    const lastModified = res.headers.get('last-modified');
-    if (lastModified) {
-      headers.set('last-modified', lastModified);
+    for (const name of [
+      'content-type',
+      'content-disposition',
+      'cache-control',
+      'etag',
+      'last-modified',
+      'set-cookie',
+      'www-authenticate',
+    ]) {
+      // set-cookie may appear multiple times; Headers#get joins — prefer getSetCookie when available.
+      if (name === 'set-cookie' && typeof res.headers.getSetCookie === 'function') {
+        for (const cookie of res.headers.getSetCookie()) {
+          headers.append('set-cookie', cookie);
+        }
+        continue;
+      }
+      const value = res.headers.get(name);
+      if (value) headers.set(name, value);
     }
     return new NextResponse(body, { status: res.status, headers });
   } catch {
     return NextResponse.json({ error: 'upstream unreachable' }, { status: 502 });
   }
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { path: string[] } },
+) {
+  return proxy(request, params);
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { path: string[] } },
+) {
+  return proxy(request, params);
 }

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/auth/layout.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/auth/layout.tsx
@@ -1,15 +1,10 @@
-import { Metadata } from 'next';
-
-export const metadata: Metadata = {
-  title: 'NEXUS - Sign In',
-  description: 'Sign in to your NEXUS account',
-};
-
 export default function AuthLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  // Do not set route-level `metadata.title` here — it overrides tenant
+  // `tab_title` from the root layout / TenantProvider (e.g. "AXI AI").
   return (
     <div className="min-h-screen bg-gradient-to-br from-background via-background to-muted">
       {children}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/auth/magic-link/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/auth/magic-link/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useEffect, useMemo } from 'react';
+import { Suspense, useEffect, useMemo, type ReactNode } from 'react';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { AlertCircle, Loader2 } from 'lucide-react';
@@ -8,16 +8,124 @@ import { useAuthStore } from '@/stores/auth';
 import { useTenant } from '@/contexts/tenant-context';
 import { shouldSkipMagicLinkConfirmation } from '@/lib/auth-session';
 
-/** Same corner radius the tenant configured for the login card. */
-function useTenantRadius(): string {
+function isLightColor(hex: string): boolean {
+  const c = hex.replace('#', '');
+  const r = parseInt(c.substring(0, 2), 16);
+  const g = parseInt(c.substring(2, 4), 16);
+  const b = parseInt(c.substring(4, 6), 16);
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance > 0.6;
+}
+
+/** Login-page styling tokens from tenant branding. */
+function useLoginBrand() {
   const tenant = useTenant();
-  return `${tenant.login_border_radius || '0'}px`;
+  const primaryColor = tenant.primary_color || '#34D399';
+  const accentColor = tenant.accent_color || '#1FA574';
+  const bgColor = tenant.background_color || '#FFFFFF';
+  const cardColor = tenant.login_card_color || '#FFFFFF';
+  const borderRadius = `${tenant.login_border_radius || '0'}px`;
+  const cardMaxWidth = tenant.login_card_max_width || '440px';
+  const cardPadding = tenant.login_card_padding || '2.5rem 3rem 3rem';
+  const cardIsLight = isLightColor(cardColor);
+  const textColor =
+    tenant.login_text_color || (cardIsLight ? '#1a1a1a' : '#ffffff');
+  const mutedTextColor = cardIsLight ? 'rgba(0,0,0,0.55)' : 'rgba(255,255,255,0.55)';
+  const buttonTextColor = isLightColor(primaryColor) ? '#1a1a1a' : '#ffffff';
+
+  return {
+    tenant,
+    primaryColor,
+    accentColor,
+    bgColor,
+    cardColor,
+    borderRadius,
+    cardMaxWidth,
+    cardPadding,
+    textColor,
+    mutedTextColor,
+    buttonTextColor,
+  };
+}
+
+function BrandShell({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const brand = useLoginBrand();
+  const { tenant } = brand;
+
+  return (
+    <div
+      className="flex min-h-screen flex-col items-center justify-center px-4"
+      style={{
+        backgroundColor: brand.bgColor,
+        backgroundImage: tenant.login_bg_image_url
+          ? `url(${tenant.login_bg_image_url})`
+          : undefined,
+        backgroundSize: tenant.login_bg_image_url ? 'cover' : undefined,
+        backgroundPosition: tenant.login_bg_image_url ? 'center' : undefined,
+        backgroundRepeat: tenant.login_bg_image_url ? 'no-repeat' : undefined,
+        fontFamily: tenant.font_family || undefined,
+      }}
+    >
+      {tenant.font_url && <link rel="stylesheet" href={tenant.font_url} />}
+      <div
+        className="w-full text-center"
+        style={{
+          maxWidth: brand.cardMaxWidth,
+          padding: brand.cardPadding,
+          backgroundColor: brand.cardColor,
+          borderRadius: brand.borderRadius,
+          color: brand.textColor,
+        }}
+      >
+        {(tenant.logo_rectangle_url || tenant.logo_url || tenant.logo_emoji) && (
+          <div className="mb-6 flex items-center justify-center">
+            {tenant.logo_rectangle_url ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={tenant.logo_rectangle_url}
+                alt={tenant.tab_title}
+                className="h-24 max-w-full object-contain"
+              />
+            ) : tenant.logo_url ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={tenant.logo_url}
+                alt={tenant.tab_title}
+                className="h-12 w-12 object-contain"
+                style={{ borderRadius: brand.borderRadius }}
+              />
+            ) : (
+              <div
+                className="flex h-12 w-12 items-center justify-center text-xl font-bold text-white"
+                style={{
+                  backgroundColor: brand.primaryColor,
+                  borderRadius: brand.borderRadius,
+                }}
+              >
+                {tenant.logo_emoji || 'N'}
+              </div>
+            )}
+          </div>
+        )}
+        {children}
+      </div>
+      {tenant.login_footer_text && (
+        <p className="mt-6 text-center text-xs" style={{ color: brand.mutedTextColor }}>
+          {tenant.login_footer_text}
+        </p>
+      )}
+    </div>
+  );
 }
 
 function MagicLinkPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const radius = useTenantRadius();
+  const brand = useLoginBrand();
   const { verifyMagicLink, isLoading, error, clearError, isAuthenticated } = useAuthStore();
 
   const token = searchParams.get('token');
@@ -49,72 +157,90 @@ function MagicLinkPageContent() {
 
   if (!token) {
     return (
-      <div className="flex min-h-screen items-center justify-center px-4">
-        <div className="w-full max-w-md border p-6 text-center" style={{ borderRadius: radius }}>
-          <div className="mb-4 flex justify-center text-destructive">
-            <AlertCircle className="h-8 w-8" />
-          </div>
-          <h1 className="text-lg font-semibold">Invalid magic link</h1>
-          <p className="mt-2 text-sm text-muted-foreground">
-            This link is missing a token. Request a new sign-in link.
-          </p>
-          <Link href="/auth/login" className="mt-4 inline-block text-sm font-medium underline">
-            Back to sign in
-          </Link>
+      <BrandShell>
+        <div className="mb-4 flex justify-center text-destructive">
+          <AlertCircle className="h-8 w-8" />
         </div>
-      </div>
+        <h1 className="text-lg font-semibold" style={{ color: brand.textColor }}>
+          Invalid magic link
+        </h1>
+        <p className="mt-2 text-sm" style={{ color: brand.mutedTextColor }}>
+          This link is missing a token. Request a new sign-in link.
+        </p>
+        <Link
+          href="/auth/login"
+          className="mt-4 inline-block text-sm font-medium underline"
+          style={{ color: brand.primaryColor }}
+        >
+          Back to sign in
+        </Link>
+      </BrandShell>
     );
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center px-4">
-      <div className="w-full max-w-md border p-6 text-center" style={{ borderRadius: radius }}>
-        <div className="mb-4 flex justify-center">
-          <AlertCircle className="h-8 w-8 text-primary" />
-        </div>
-        <h1 className="text-lg font-semibold">Confirm sign-in</h1>
-        <p className="mt-2 text-sm text-muted-foreground">
-          To continue, click the button below to confirm your sign-in request.
-        </p>
-        <button
-          type="button"
-          onClick={handleConfirmSignIn}
-          disabled={isLoading}
-          style={{ borderRadius: radius }}
-          className="mt-4 inline-flex w-full items-center justify-center bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          {isLoading ? (
-            <>
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              Verifying...
-            </>
-          ) : (
-            'Click to confirm sign-in'
-          )}
-        </button>
-        {error && (
-          <p className="mt-4 text-sm text-destructive">{error}</p>
+    <BrandShell>
+      <h1 className="text-lg font-semibold" style={{ color: brand.textColor }}>
+        Confirm sign-in
+      </h1>
+      <p className="mt-2 text-sm" style={{ color: brand.mutedTextColor }}>
+        To continue, click the button below to confirm your sign-in request.
+      </p>
+      <button
+        type="button"
+        onClick={handleConfirmSignIn}
+        disabled={isLoading}
+        style={{
+          borderRadius: brand.borderRadius,
+          backgroundColor: brand.primaryColor,
+          color: brand.buttonTextColor,
+        }}
+        className="mt-4 inline-flex w-full items-center justify-center px-4 py-2.5 text-sm font-medium transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+        onMouseEnter={(e) => {
+          e.currentTarget.style.backgroundColor = brand.accentColor;
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.backgroundColor = brand.primaryColor;
+        }}
+      >
+        {isLoading ? (
+          <>
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            Verifying...
+          </>
+        ) : (
+          'Click to confirm sign-in'
         )}
-        <Link href="/auth/login" className="mt-4 inline-block text-sm font-medium underline">
-          Back to sign in
-        </Link>
-      </div>
-    </div>
+      </button>
+      {error && <p className="mt-4 text-sm text-destructive">{error}</p>}
+      <Link
+        href="/auth/login"
+        className="mt-4 inline-block text-sm font-medium underline"
+        style={{ color: brand.primaryColor }}
+      >
+        Back to sign in
+      </Link>
+    </BrandShell>
   );
 }
 
 function MagicLinkPageFallback() {
-  const radius = useTenantRadius();
+  const brand = useLoginBrand();
   return (
-    <div className="flex min-h-screen items-center justify-center px-4">
-      <div className="w-full max-w-md border p-6 text-center" style={{ borderRadius: radius }}>
-        <div className="mb-4 flex justify-center">
-          <Loader2 className="h-8 w-8 animate-spin text-primary" />
-        </div>
-        <h1 className="text-lg font-semibold">Loading magic link</h1>
-        <p className="mt-2 text-sm text-muted-foreground">Please wait while we prepare sign-in.</p>
+    <BrandShell>
+      <div className="mb-4 flex justify-center">
+        <Loader2
+          className="h-8 w-8 animate-spin"
+          style={{ color: brand.primaryColor }}
+        />
       </div>
-    </div>
+      <h1 className="text-lg font-semibold" style={{ color: brand.textColor }}>
+        Loading magic link
+      </h1>
+      <p className="mt-2 text-sm" style={{ color: brand.mutedTextColor }}>
+        Please wait while we prepare sign-in.
+      </p>
+    </BrandShell>
   );
 }
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/layout.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/layout.tsx
@@ -30,6 +30,7 @@ async function fetchTenantBranding(): Promise<{
   title: string;
   description: string | null;
   ogImageUrl: string | null;
+  faviconUrl: string | null;
 }> {
   const apiBase =
     process.env.NEXUS_INTERNAL_API_URL ||
@@ -39,15 +40,18 @@ async function fetchTenantBranding(): Promise<{
 
   try {
     const res = await fetch(`${apiBase}/api/tenant`, { cache: 'no-store' });
-    if (!res.ok) return { title: DEFAULT_TITLE, description: null, ogImageUrl: null };
+    if (!res.ok) {
+      return { title: DEFAULT_TITLE, description: null, ogImageUrl: null, faviconUrl: null };
+    }
     const data = await res.json();
     return {
       title: (data.og_title ?? data.tab_title ?? DEFAULT_TITLE) as string,
       description: (data.og_description ?? null) as string | null,
       ogImageUrl: (data.og_image_url ?? null) as string | null,
+      faviconUrl: (data.favicon_url ?? null) as string | null,
     };
   } catch {
-    return { title: DEFAULT_TITLE, description: null, ogImageUrl: null };
+    return { title: DEFAULT_TITLE, description: null, ogImageUrl: null, faviconUrl: null };
   }
 }
 
@@ -56,9 +60,10 @@ export async function generateMetadata(): Promise<Metadata> {
     process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3042'
   );
 
-  const { title, description, ogImageUrl } = await fetchTenantBranding();
+  const { title, description, ogImageUrl, faviconUrl } = await fetchTenantBranding();
   const resolvedDescription = description ?? DEFAULT_DESCRIPTION;
   const ogImage = ogImageUrl || DEFAULT_OG_IMAGE;
+  const iconUrl = faviconUrl || '/favicon.ico';
 
   return {
     metadataBase,
@@ -76,13 +81,9 @@ export async function generateMetadata(): Promise<Metadata> {
       images: [ogImage],
     },
     icons: {
-      icon: [
-        { url: '/favicon.ico', sizes: 'any' },
-        { url: '/favicon.ico', sizes: '16x16', type: 'image/x-icon' },
-        { url: '/favicon.ico', sizes: '32x32', type: 'image/x-icon' },
-      ],
-      shortcut: '/favicon.ico',
-      apple: '/favicon.ico',
+      icon: iconUrl,
+      shortcut: iconUrl,
+      apple: iconUrl,
     },
   };
 }

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/apps/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/apps/page.tsx
@@ -7,7 +7,7 @@ import {
   AppWindow, ExternalLink, RefreshCw, AlertTriangle, Info, PanelLeft, X,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { isBundledAppHtmlUrl, resolveAppEmbedUrl, resolveAppExternalUrl } from '@/lib/app-html';
+import { isBundledAppHtmlUrl, resolveAppEmbedUrl, resolveAppExternalUrl, appHtmlPathPrefix, withAppHtmlAccessToken } from '@/lib/app-html';
 import { getApiUrl } from '@/lib/config';
 import { authFetch } from '@/stores/auth';
 import { useTenant } from '@/contexts/tenant-context';
@@ -26,12 +26,62 @@ import {
 
 function EmbedView({ record, onBack }: { record: AppRecord; onBack: () => void }) {
   const url = record.url;
-  const embedUrl = useMemo(() => resolveAppEmbedUrl(url), [url]);
+  const baseEmbedUrl = useMemo(() => resolveAppEmbedUrl(url), [url]);
+  const [embedUrl, setEmbedUrl] = useState<string | null>(
+    isBundledAppHtmlUrl(url) ? null : baseEmbedUrl,
+  );
+  const [embedError, setEmbedError] = useState<string | null>(null);
   const [blocked, setBlocked] = useState(false);
   const [reloadKey, setReloadKey] = useState(0);
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const { activePanelSection, setActivePanelSection, appDetailOpen, setAppDetailOpen } =
     useWorkspaceStore();
+
+  useEffect(() => {
+    let cancelled = false;
+    setEmbedError(null);
+
+    if (!isBundledAppHtmlUrl(url)) {
+      setEmbedUrl(baseEmbedUrl);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    setEmbedUrl(null);
+    const prefix = appHtmlPathPrefix(url);
+    (async () => {
+      try {
+        const res = await authFetch('/api/apps/access-token', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            expires_minutes: 60,
+            path_prefix: prefix,
+          }),
+        });
+        if (!res.ok) {
+          throw new Error(`access-token HTTP ${res.status}`);
+        }
+        const data = (await res.json()) as { access_token?: string };
+        const token = String(data.access_token || '').trim();
+        if (!token) {
+          throw new Error('access-token response missing token');
+        }
+        if (!cancelled) {
+          setEmbedUrl(withAppHtmlAccessToken(baseEmbedUrl, token));
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setEmbedError(err instanceof Error ? err.message : 'Failed to mint app token');
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [url, baseEmbedUrl, reloadKey]);
 
   const handleLoad = useCallback(() => {
     // Same-origin bundled apps are proxied via /app-html/ — never flag them blocked.
@@ -66,6 +116,8 @@ function EmbedView({ record, onBack }: { record: AppRecord; onBack: () => void }
     setAppDetailOpen(true);
     setActivePanelSection('apps');
   };
+
+  const externalHref = embedUrl || resolveAppExternalUrl(url);
 
   return (
     <div className="flex h-full flex-col">
@@ -104,7 +156,7 @@ function EmbedView({ record, onBack }: { record: AppRecord; onBack: () => void }
           <RefreshCw size={13} />
         </button>
         <a
-          href={resolveAppExternalUrl(url)}
+          href={externalHref}
           target="_blank"
           rel="noopener noreferrer"
           title="Open in new tab"
@@ -123,7 +175,23 @@ function EmbedView({ record, onBack }: { record: AppRecord; onBack: () => void }
 
       {/* Body: full-width iframe — detail lives in the left section panel */}
       <div className="relative flex-1 overflow-hidden bg-muted/20">
-        {blocked ? (
+        {embedError ? (
+          <div className="flex h-full flex-col items-center justify-center gap-4 p-8 text-center">
+            <AlertTriangle size={36} className="text-amber-500" />
+            <div>
+              <p className="font-semibold text-foreground">Could not open app</p>
+              <p className="mt-1 max-w-xs text-sm text-muted-foreground">{embedError}</p>
+            </div>
+            <button
+              type="button"
+              onClick={handleReload}
+              className="flex items-center gap-2 bg-workspace-accent px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-workspace-accent/90"
+            >
+              <RefreshCw size={14} />
+              Retry
+            </button>
+          </div>
+        ) : blocked ? (
           <div className="flex h-full flex-col items-center justify-center gap-4 p-8 text-center">
             <AlertTriangle size={36} className="text-amber-500" />
             <div>
@@ -135,7 +203,7 @@ function EmbedView({ record, onBack }: { record: AppRecord; onBack: () => void }
               </p>
             </div>
             <a
-              href={resolveAppExternalUrl(url)}
+              href={externalHref}
               target="_blank"
               rel="noopener noreferrer"
               className="flex items-center gap-2 bg-workspace-accent px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-workspace-accent/90"
@@ -144,9 +212,13 @@ function EmbedView({ record, onBack }: { record: AppRecord; onBack: () => void }
               Open {record.name}
             </a>
           </div>
+        ) : !embedUrl ? (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+            Preparing secure app session…
+          </div>
         ) : (
           <iframe
-            key={reloadKey}
+            key={`${reloadKey}:${embedUrl}`}
             ref={iframeRef}
             src={embedUrl}
             title={record.name}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/contexts/tenant-context.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/contexts/tenant-context.tsx
@@ -175,24 +175,33 @@ export function TenantProvider({ children }: { children: React.ReactNode }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tenant.tab_title, tenant.favicon_url, pathname]);
 
-  // Keep favicon and title persistent: re-apply when something else (e.g. Next.js) changes the icon
+  // Keep favicon and title persistent: re-apply when Next.js (or anything else)
+  // mutates <head> after our initial apply (route metadata races).
   useEffect(() => {
-    if (!tenant.favicon_url || typeof document === 'undefined') return;
-    tenantFaviconUrlRef.current = tenant.favicon_url;
+    if (typeof document === 'undefined') return;
 
-    const observer = new MutationObserver(() => {
-      const icon = document.querySelector('link[rel="icon"]') as HTMLLinkElement | null;
-      const faviconWrong = icon && tenantFaviconUrlRef.current && icon.href !== tenantFaviconUrlRef.current;
-      if (faviconWrong) {
-        const title = getPageTitle(pathnameRef.current, tenantTabTitleRef.current);
-        document.title = title;
-        if (tenantFaviconUrlRef.current) applyFavicon(tenantFaviconUrlRef.current);
+    const reapplyIfDrifted = () => {
+      const expectedTitle = getPageTitle(pathnameRef.current, tenantTabTitleRef.current);
+      if (document.title !== expectedTitle) {
+        document.title = expectedTitle;
       }
-    });
+      if (tenantFaviconUrlRef.current) {
+        const icon = document.querySelector('link[rel="icon"]') as HTMLLinkElement | null;
+        if (icon && icon.href !== tenantFaviconUrlRef.current) {
+          applyFavicon(tenantFaviconUrlRef.current);
+        }
+      }
+    };
 
+    if (tenant.favicon_url) {
+      tenantFaviconUrlRef.current = tenant.favicon_url;
+    }
+
+    const observer = new MutationObserver(reapplyIfDrifted);
     observer.observe(document.head, {
       childList: true,
       subtree: true,
+      characterData: true,
       attributes: true,
       attributeFilter: ['href'],
     });

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/app-html.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/app-html.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+  appHtmlPathPrefix,
+  isBundledAppHtmlUrl,
+  withAppHtmlAccessToken,
+} from './app-html';
+
+describe('app-html helpers', () => {
+  it('detects bundled app-html URLs', () => {
+    expect(isBundledAppHtmlUrl('/app-html/report/counter_uas/dashboard/')).toBe(true);
+    expect(isBundledAppHtmlUrl('https://nexus.localhost/app-html/axi/devops/')).toBe(
+      true,
+    );
+    expect(isBundledAppHtmlUrl('/workspace/primary/apps')).toBe(false);
+  });
+
+  it('derives path_prefix locks for scoped JWTs', () => {
+    expect(appHtmlPathPrefix('/app-html/report/counter_uas/dashboard/')).toBe(
+      '/app-html/report/counter_uas/',
+    );
+    expect(
+      appHtmlPathPrefix(
+        'https://nexus.localhost/app-html/report/counter_uas/map/?report_date=2026-07-26',
+      ),
+    ).toBe('/app-html/report/counter_uas/');
+  });
+
+  it('appends token without dropping existing query params', () => {
+    expect(
+      withAppHtmlAccessToken(
+        '/app-html/report/counter_uas/map/?report_date=2026-07-26',
+        'abc.def',
+      ),
+    ).toBe(
+      '/app-html/report/counter_uas/map/?report_date=2026-07-26&token=abc.def',
+    );
+    expect(
+      withAppHtmlAccessToken('/app-html/report/counter_uas/dashboard/', 'tok'),
+    ).toBe('/app-html/report/counter_uas/dashboard/?token=tok');
+  });
+});

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/app-html.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/app-html.ts
@@ -1,8 +1,10 @@
-import { getApiUrl } from '@/lib/config';
-
 /**
- * Bundled Nexus apps are served from /app-html/ on the API. The web app
- * proxies that path (Caddy + Route Handler) so iframes can load same-origin.
+ * Bundled Nexus apps are served from /app-html/ on the API (proxied
+ * same-origin via Caddy). Access requires a real credential — never the
+ * shared ABI_API_KEY in the browser:
+ *   - logged-in session: mint a scoped JWT via POST /apps/access-token
+ *   - email share links: include ``?token=<scoped-jwt>``
+ *   - follow-up requests: HttpOnly ``abi_app_html_token`` cookie
  */
 
 export function isBundledAppHtmlUrl(url: string): boolean {
@@ -28,20 +30,35 @@ function toAppHtmlPath(url: string): string | null {
   return null;
 }
 
-/** True when the browser is on a host that proxies /app-html/ (Caddy or route handler). */
-function sameOriginAppProxyAvailable(): boolean {
-  if (typeof window === 'undefined') return true;
-  const { hostname, port } = window.location;
-  // Direct Next.js port — proxy is only available after a web rebuild with the route handler.
-  if (hostname === 'localhost' && port === '3042') return false;
-  return true;
+/**
+ * Path lock for scoped ``app-html`` JWTs, e.g. ``/app-html/report/counter_uas/``.
+ */
+export function appHtmlPathPrefix(url: string): string | null {
+  const path = toAppHtmlPath(url);
+  if (!path) return null;
+  const pathname = path.split('?')[0].split('#')[0];
+  const parts = pathname.split('/').filter(Boolean);
+  // app-html / <module> / <app> / …
+  if (parts.length < 3 || parts[0] !== 'app-html') {
+    return '/app-html/';
+  }
+  return `/${parts[0]}/${parts[1]}/${parts[2]}/`;
+}
+
+/** Attach ``?token=`` (preserving existing query) for same-origin app HTML. */
+export function withAppHtmlAccessToken(url: string, token: string): string {
+  if (!url || !token) return url;
+  const path = toAppHtmlPath(url) ?? url;
+  const hashIndex = path.indexOf('#');
+  const withoutHash = hashIndex >= 0 ? path.slice(0, hashIndex) : path;
+  const hash = hashIndex >= 0 ? path.slice(hashIndex) : '';
+  const join = withoutHash.includes('?') ? '&' : '?';
+  return `${withoutHash}${join}token=${encodeURIComponent(token)}${hash}`;
 }
 
 /**
- * Resolve a catalog app URL for iframe embedding.
- *
- * Uses same-origin ``/app-html/…`` when the web host proxies that path; otherwise
- * falls back to the API host (cross-origin, allowed via frame-ancestors).
+ * Resolve a catalog app URL for iframe embedding (same-origin path).
+ * Callers must append a scoped access token before loading.
  */
 export function resolveAppEmbedUrl(url: string): string {
   if (!url) return url;
@@ -49,19 +66,18 @@ export function resolveAppEmbedUrl(url: string): string {
   const path = toAppHtmlPath(url);
   if (!path) return url;
 
-  if (sameOriginAppProxyAvailable()) {
-    return path;
-  }
-
-  return `${getApiUrl().replace(/\/$/, '')}${path}`;
+  return path;
 }
 
-/** Absolute API URL for opening bundled apps in a new browser tab. */
+/**
+ * Same-origin path for opening bundled apps in a new tab.
+ * Callers must append a scoped access token before navigating.
+ */
 export function resolveAppExternalUrl(url: string): string {
   if (!url) return url;
   const path = toAppHtmlPath(url);
   if (path) {
-    return `${getApiUrl().replace(/\/$/, '')}${path}`;
+    return path;
   }
   return url;
 }

--- a/uv.lock
+++ b/uv.lock
@@ -3786,7 +3786,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-marketplace"
-version = "3.33.5"
+version = "3.33.6"
 source = { editable = "libs/naas-abi-marketplace" }
 dependencies = [
     { name = "ijson" },


### PR DESCRIPTION
This pull request resolves #fix-app-html-security

# Summary

This PR introduces a security enhancement and feature improvements related to the handling of `/app-html/` assets and access in the Nexus platform.

# Key Changes

## 1. Secure `/app-html/` Access with ABI API Key and Scoped JWTs

- Added a new middleware `AppHtmlAbiKeyMiddleware` in `naas_abi_core` that enforces authentication for all `/app-html/` requests.
- The middleware accepts credentials via:
  - `Authorization: Bearer <ABI_API_KEY>` header or `?token=<ABI_API_KEY>` query parameter.
  - Registered JWT validators (e.g., Nexus user JWTs with `scope=app-html`).
  - HttpOnly cookie `abi_app_html_token` stamped from a prior scoped JWT.
- Registered Nexus JWT validation for `/app-html/` via `register_nexus_app_html_jwt_auth`.
- Added environment variable `ABI_API_KEY` propagation in Docker Compose and Caddy proxy configuration.
- Updated the API app to add the middleware protecting `/app-html/` routes.

## 2. Minting Scoped JWTs for `/app-html/` Access

- Added a new API endpoint `/api/apps/access-token` to mint short-lived scoped JWTs for `/app-html/` access.
- The token can be scoped to a path prefix (e.g., `/app-html/axi/devops/`) and has a configurable expiration.
- The frontend app fetches this token and appends it as a `?token=` query parameter when embedding `/app-html/` apps in iframes.

## 3. Frontend Proxy and Token Forwarding

- The Next.js route handler for `/app-html/[...path]` proxies requests to the API, forwarding only caller credentials (Authorization header, `?token=`, or scoped cookie).
- It never forges the shared `ABI_API_KEY` in the browser.

## 4. Email Sign-in Link Improvements

- Refactored sign-in email rendering to support inline logo attachments with CID embedding for private hosts.
- Updated magic link email templates to a richer HTML format with tenant branding.

## 5. Tenant Branding and UI Improvements

- Added support for tenant favicon URL in metadata and persistent favicon application.
- Improved the login magic link page UI to use tenant branding colors, fonts, and logos.
- Added utility functions for color luminance and login page styling tokens.

## 6. Tests

- Added comprehensive tests for the ABI API key auth middleware and helpers.
- Added tests for the scoped `/app-html/` JWT access minting and validation.
- Added tests for sign-in email rendering with inline logo attachments.
- Added frontend tests for app-html URL helpers.

# Impact

- `/app-html/` assets and apps are now protected by a shared API key or scoped JWTs, preventing anonymous access.
- Frontend apps must request scoped tokens to embed `/app-html/` apps.
- Email share links include scoped JWT tokens.
- Improved security posture and user experience for app HTML access and sign-in flows.

# Additional Notes

- The shared `ABI_API_KEY` is never exposed or forged in the browser.
- Scoped JWTs can be path-locked to restrict access to specific app-html subpaths.
- CORS preflight requests (`OPTIONS`) to `/app-html/` are allowed without auth.
- The middleware is added outermost to run before other app-specific middlewares.

This PR is a significant step towards securing embedded app HTML content and improving the authentication experience for users accessing these apps.