### PR TITLE
fix(ci): bump pypa/gh-action-pypi-publish so Metadata-Version 2.5 uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,27 +113,31 @@ jobs:
       # python-semantic-release team.                                       #
       # ------------------------------------------------------------------- #
 
+      # Each upload runs independently (`!cancelled()`) so a tagged package is
+      # not left unpublished on PyPI just because an earlier package in the
+      # list failed to upload.
+
       - name: Publish | Upload naas-abi-core to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # vX.X.X
-        if: steps.release-naas-abi-core.outputs.released == 'true'
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
+        if: "!cancelled() && steps.release-naas-abi-core.outputs.released == 'true'"
         with:
           packages-dir: ${{ format('{0}/dist', env.naas_abi_core_dir) }}
 
       - name: Publish | Upload naas-abi-marketplace to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # vX.X.X
-        if: steps.release-naas-abi-marketplace.outputs.released == 'true'
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
+        if: "!cancelled() && steps.release-naas-abi-marketplace.outputs.released == 'true'"
         with:
           packages-dir: ${{ format('{0}/dist', env.naas_abi_marketplace_dir) }}
 
 
       - name: Publish | Upload naas-abi to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # vX.X.X
-        if: steps.release-naas-abi.outputs.released == 'true'
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
+        if: "!cancelled() && steps.release-naas-abi.outputs.released == 'true'"
         with:
           packages-dir: ${{ format('{0}/dist', env.naas_abi_dir) }}
 
       - name: Publish | Upload naas-abi-cli to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # vX.X.X
-        if: steps.release-naas-abi-cli.outputs.released == 'true'
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
+        if: "!cancelled() && steps.release-naas-abi-cli.outputs.released == 'true'"
         with:
           packages-dir: ${{ format('{0}/dist', env.naas_abi_cli_dir) }}


### PR DESCRIPTION
## Problem

The `Release` workflow fails at **Publish | Upload naas-abi-core to PyPI** ([run 31496178970](https://github.com/jupyter-naas/abi/actions/runs/31496178970/job/93794351604)):

```
Checking libs/naas-abi-core/dist/naas_abi_core-2.25.0-py3-none-any.whl:
ERROR InvalidDistribution: Invalid distribution metadata:
      '2.5' is not a valid metadata version
```

`hatchling 1.32.0` was published on 2026-08-11 at 05:03 UTC and bumped generated wheel/sdist metadata to `Metadata-Version: 2.5`. `uv build` resolves the build backend unpinned, so every release built after that upload carries 2.5 (verified locally: hatchling 1.31.0 → `2.4`, 1.32.0 → `2.5`).

The publish action was pinned to `ed0c539` = **v1.13.0**, which ships `twine 6.1.0` + `packaging 25.0`. That packaging version's `_VALID_METADATA_VERSIONS` stops at `2.4`, so twine's pre-upload check rejects the wheel before it ever reaches PyPI.

## Fix

Bump the pin to `dc37677` = **v1.14.2**, which ships `twine 7.0.0` + `packaging 26.2` — `_VALID_METADATA_VERSIONS` there includes `2.5`.

Bumping the action is the right fix rather than pinning `hatchling<1.32`: PyPI itself already accepts Metadata-Version 2.5 (hatchling 1.32.0 is published with it), so only the client-side check was stale.

## Also

Each PyPI upload now runs independently via `!cancelled()`. In the failing run, the `naas-abi-core` upload failure skipped the `naas-abi` and `naas-abi-cli` uploads, so both were tagged and released on GitHub but never landed on PyPI:

| package | git tag | on PyPI |
|---|---|---|
| naas-abi-core | 2.25.0 | 2.24.1 |
| naas-abi | 2.53.0 | 2.52.5 |
| naas-abi-cli | 2.17.0 | 2.16.3 |

Those three versions stay missing from PyPI — the next release cycle will publish fresh versions on top of them.