### PR TITLE
fix: bump gh-action-pypi-publish to accept metadata 2.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
     branches:
       - dev
       - main
+  workflow_dispatch:
+    inputs:
+      publish_existing_tags:
+        description: "Comma-separated GitHub release tags to upload to PyPI (leave empty for a normal semantic-release run)"
+        required: false
+        default: ""
 
 permissions:
   contents: write
@@ -12,9 +18,35 @@ permissions:
 
 jobs:
 
+  publish-existing:
+    runs-on: ubuntu-latest
+    if: github.repository == 'jupyter-naas/abi' && github.event_name == 'workflow_dispatch' && inputs.publish_existing_tags != ''
+    environment:
+      name: pypi
+    steps:
+      - name: Download GitHub release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p dist
+          IFS=',' read -ra TAGS <<< "${{ inputs.publish_existing_tags }}"
+          for tag in "${TAGS[@]}"; do
+            tag="$(echo "$tag" | xargs)"
+            [ -n "$tag" ] || continue
+            echo "Downloading $tag"
+            gh release download "$tag" --repo "${{ github.repository }}" --dir dist
+          done
+          ls -la dist
+
+      - name: Publish | Upload existing artifacts to PyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
+        with:
+          packages-dir: dist
+          skip-existing: true
+
   release:
     runs-on: ubuntu-latest
-    if: github.repository == 'jupyter-naas/abi'
+    if: github.repository == 'jupyter-naas/abi' && (github.event_name != 'workflow_dispatch' || inputs.publish_existing_tags == '')
     concurrency:
       group: ${{ github.workflow }}-release-${{ github.ref_name }}
       cancel-in-progress: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,26 +114,26 @@ jobs:
       # ------------------------------------------------------------------- #
 
       - name: Publish | Upload naas-abi-core to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # vX.X.X
-        if: steps.release-naas-abi-core.outputs.released == 'true'
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
+        if: always() && steps.release-naas-abi-core.outputs.released == 'true'
         with:
           packages-dir: ${{ format('{0}/dist', env.naas_abi_core_dir) }}
 
       - name: Publish | Upload naas-abi-marketplace to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # vX.X.X
-        if: steps.release-naas-abi-marketplace.outputs.released == 'true'
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
+        if: always() && steps.release-naas-abi-marketplace.outputs.released == 'true'
         with:
           packages-dir: ${{ format('{0}/dist', env.naas_abi_marketplace_dir) }}
 
 
       - name: Publish | Upload naas-abi to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # vX.X.X
-        if: steps.release-naas-abi.outputs.released == 'true'
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
+        if: always() && steps.release-naas-abi.outputs.released == 'true'
         with:
           packages-dir: ${{ format('{0}/dist', env.naas_abi_dir) }}
 
       - name: Publish | Upload naas-abi-cli to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # vX.X.X
-        if: steps.release-naas-abi-cli.outputs.released == 'true'
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
+        if: always() && steps.release-naas-abi-cli.outputs.released == 'true'
         with:
           packages-dir: ${{ format('{0}/dist', env.naas_abi_cli_dir) }}


### PR DESCRIPTION
## Summary
- Hatchling now emits Core Metadata 2.5; the Release workflow was still pinned to `pypa/gh-action-pypi-publish` (Twine 6), which rejects `'2.5' is not a valid metadata version`. That is why [Release #776](https://github.com/jupyter-naas/abi/actions/runs/31780204805) failed after merging #1184, while GitHub releases were created.
- Bump the action to v1.14.2 (Twine 7), which can upload 2.5 wheels to PyPI.
- Run each PyPI upload with `if: always() && …released` so one package failing to publish no longer skips the rest.
- Add `workflow_dispatch` with `publish_existing_tags` so already-tagged GitHub release assets can be uploaded without cutting a new version.

## Already tagged, missing from PyPI
These GitHub releases exist but were never uploaded:

| Package | GitHub | PyPI latest |
|---|---|---|
| `naas-abi-cli` | 2.17.0, 2.17.1 | 2.16.3 |
| `naas-abi-core` | 2.25.0 | 2.24.1 |
| `naas-abi` | 2.53.0 | 2.52.5 |

`naas-abi-marketplace` 3.34.0 did reach PyPI.

After merge, republish with:

```
gh workflow run Release --repo jupyter-naas/abi \
  -f publish_existing_tags='naas-abi-core-v2.25.0,naas-abi-v2.53.0,naas-abi-cli-v2.17.0,naas-abi-cli-v2.17.1'
```

## Test plan
- [ ] Merge to `main` and confirm the automatic Release workflow does not fail on metadata 2.5
- [ ] Dispatch `publish_existing_tags` for the missing versions
- [ ] Confirm PyPI shows `naas-abi-cli 2.17.1`, `naas-abi-core 2.25.0`, `naas-abi 2.53.0`
