### PR TITLE
feat(new): auto-append local ABI sources to pyproject.toml on new project creation

### DIFF
--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/project.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/project.py
@@ -17,6 +17,26 @@ from .utils import to_kebab_case, to_pascal_case, to_snake_case
 ABI_SUBMODULE_URL = "https://github.com/jupyter-naas/abi.git"
 ABI_SUBMODULE_PATH = ".abi"
 
+_LOCAL_ABI_SOURCES_BLOCK = """\
+# Resolve the framework from the `.abi` submodule rather than PyPI, so this
+# project tracks the checked-out source instead of the last published release.
+# Clone with `--recursive` (or run `git submodule update --init`) or these
+# paths will be empty and `uv sync` will fail.
+[tool.uv.sources]
+naas-abi = { path = ".abi/libs/naas-abi",  editable = true }
+naas-abi-core = { path = ".abi/libs/naas-abi-core",  editable = true }
+naas-abi-marketplace = { path = ".abi/libs/naas-abi-marketplace",  editable = true }
+naas-abi-cli = { path = ".abi/libs/naas-abi-cli",  editable = true }
+"""
+
+
+def _append_local_abi_sources(project_path: str) -> None:
+    """Append editable `.abi` source paths to the generated pyproject.toml."""
+    pyproject_path = os.path.join(project_path, "pyproject.toml")
+    with open(pyproject_path, "a", encoding="utf-8") as file:
+        file.write("\n\n")
+        file.write(_LOCAL_ABI_SOURCES_BLOCK)
+
 
 def _add_abi_submodule(project_path: str) -> bool:
     """Add the upstream ABI repo as a git submodule at `.abi/`.
@@ -194,9 +214,11 @@ def new_project(
             # When the coding stack is provisioned (`--with-coding`), the config
             # enables the "code" feature flag for workspace admins by default.
             "include_coding": with_coding,
-            "use_local_abi_sources": abi_submodule_added,
         }
     )
+
+    if abi_submodule_added:
+        _append_local_abi_sources(project_path)
 
     # Calling new_module to create the module in the src folder
     new_module(project_name, os.path.join(project_path, "src"), quiet=True)

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/project/pyproject.toml
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/project/pyproject.toml
@@ -19,24 +19,13 @@ where = ["src"]
 # (pymupdf-layout -> pymupdf4llm) loosens or onnxruntime releases the wheel.
 override-dependencies = ["onnxruntime<1.26"]
 
-
-{% if use_local_abi_sources -%}
-# Resolve the framework from the `.abi` submodule rather than PyPI, so this
-# project tracks the checked-out source instead of the last published release.
-# Clone with `--recursive` (or run `git submodule update --init`) or these
-# paths will be empty and `uv sync` will fail.
-[tool.uv.sources]
-naas-abi = { path = ".abi/libs/naas-abi",  editable = true }
-naas-abi-core = { path = ".abi/libs/naas-abi-core",  editable = true }
-naas-abi-marketplace = { path = ".abi/libs/naas-abi-marketplace",  editable = true }
-naas-abi-cli = { path = ".abi/libs/naas-abi-cli",  editable = true }
-{%- else -%}
 # To resolve the framework from source instead of PyPI, add the submodule
 #   git submodule add https://github.com/jupyter-naas/abi.git .abi
 # then uncomment the block below and re-run `uv sync`.
+# When scaffolded with --with-abi-submodule (default), `abi new project` appends
+# the [tool.uv.sources] block automatically when `.abi/libs` is present.
 # [tool.uv.sources]
 # naas-abi = { path = ".abi/libs/naas-abi",  editable = true }
 # naas-abi-core = { path = ".abi/libs/naas-abi-core",  editable = true }
 # naas-abi-marketplace = { path = ".abi/libs/naas-abi-marketplace",  editable = true }
 # naas-abi-cli = { path = ".abi/libs/naas-abi-cli",  editable = true }
-{%- endif %}


### PR DESCRIPTION
This pull request resolves #ruff-errors-cli

# Summary

This PR introduces an enhancement to the `naas-abi-cli` project scaffolding process by automatically appending local ABI source paths to the generated `pyproject.toml` file when the ABI submodule is added.

# Details

- Added a constant `_LOCAL_ABI_SOURCES_BLOCK` containing the `[tool.uv.sources]` configuration block that points to local editable paths within the `.abi` submodule.
- Implemented a helper function `_append_local_abi_sources(project_path: str)` that appends this block to the `pyproject.toml` file in the newly created project.
- Modified the `new_project` function to call `_append_local_abi_sources` if the ABI submodule was successfully added.
- Removed the conditional Jinja template block from the `pyproject.toml` template that previously handled local ABI sources, as this is now handled programmatically.

# Motivation

This change ensures that when a new project is scaffolded with the ABI submodule, the local editable source paths are automatically configured in the `pyproject.toml`. This avoids manual steps and potential errors related to missing local source paths, improving developer experience and project setup consistency.

# Additional Notes

- The appended source paths require the `.abi` submodule to be cloned with `--recursive` or initialized with `git submodule update --init` to avoid empty paths and sync failures.
- The change maintains backward compatibility by only appending the local sources block if the ABI submodule is added.

# Files Changed

- `libs/naas-abi-cli/naas_abi_cli/cli/new/project.py`: Added logic to append local ABI source paths.
- `libs/naas-abi-cli/naas_abi_cli/cli/new/templates/project/pyproject.toml`: Removed the conditional template block for local ABI sources.

This enhancement streamlines the project creation process and ensures local ABI sources are correctly referenced in the project configuration.