### PR TITLE
feat(event): add ability to seek consumer cursor to latest event

### DIFF
--- a/libs/naas-abi-core/naas_abi_core/services/event/AGENTS.md
+++ b/libs/naas-abi-core/naas_abi_core/services/event/AGENTS.md
@@ -40,6 +40,7 @@ query(event_type, since_seq, until_seq,
       json_filter, limit) -> list[StoredEvent]
 max_seq(event_type=None) -> int
 get_cursor(consumer_id, event_type) -> int
+set_cursor(consumer_id, event_type, last_seq) -> None
 query_for_consumer(consumer_id, event_type, limit) -> list[StoredEvent]   # atomic cursor advance
 ```
 
@@ -61,6 +62,7 @@ iter_query(event_class, since_seq=None, since_timestamp=None,
 query_for_consumer(consumer_id, event_class, limit=None) -> list[Any]
 iter_query_for_consumer(consumer_id, event_class, limit=None, batch_size=500) -> Iterator[Any]
 # Atomically advance the consumer cursor per batch.
+seek_consumer_to_end(consumer_id, event_class) -> dict  # jump cursor to max seq
 
 subscribe(event_class, callback, filter=None) -> Thread
 # Live-only fanout. Each subscriber is independent. Filter evaluated in-memory.

--- a/libs/naas-abi-core/naas_abi_core/services/event/EventPort.py
+++ b/libs/naas-abi-core/naas_abi_core/services/event/EventPort.py
@@ -80,6 +80,16 @@ class IEventAdapter(ABC):
         """Return last delivered seq for (consumer_id, event_type). 0 if unset."""
 
     @abstractmethod
+    def set_cursor(self, consumer_id: str, event_type: str, last_seq: int) -> None:
+        """Set last delivered seq for (consumer_id, event_type).
+
+        Used to seek a consumer to a known position (for example the current
+        max seq) without draining events. ``last_seq`` may be lower than the
+        stored cursor — that is how a reset event log is repaired after
+        ``seq`` restarts from 1 while the cursor row still holds an old value.
+        """
+
+    @abstractmethod
     def query_for_consumer(
         self,
         consumer_id: str,

--- a/libs/naas-abi-core/naas_abi_core/services/event/EventService.py
+++ b/libs/naas-abi-core/naas_abi_core/services/event/EventService.py
@@ -228,6 +228,27 @@ class EventService(ServiceBase, IEventService):
         )
         return [self._reconstruct(row, event_class) for row in rows]
 
+    def seek_consumer_to_end(
+        self, consumer_id: str, event_class: type[LogProcess]
+    ) -> dict[str, Any]:
+        """Jump ``consumer_id`` to the latest seq for ``event_class``.
+
+        Pending events between the previous cursor and now are skipped
+        permanently for this consumer. Returns ``cursor_before`` /
+        ``cursor_after`` so callers can log how far the seek jumped.
+        """
+        event_type = str(event_class._class_uri)
+        before = self._adapter.get_cursor(consumer_id, event_type)
+        mx = self._adapter.max_seq(event_type)
+        if before != mx:
+            self._adapter.set_cursor(consumer_id, event_type, mx)
+        return {
+            "consumer_id": consumer_id,
+            "event_type": event_type,
+            "cursor_before": before,
+            "cursor_after": mx,
+        }
+
     def iter_query_for_consumer(
         self,
         consumer_id: str,

--- a/libs/naas-abi-core/naas_abi_core/services/event/EventService_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/event/EventService_test.py
@@ -290,6 +290,20 @@ def test_iter_query_limit_zero_yields_nothing(tmp_path):
     assert list(service.iter_query(event_class=UserAuthenticated, limit=0)) == []
 
 
+def test_seek_consumer_to_end_skips_pending_events(tmp_path):
+    service, adapter, _ = _make_service(tmp_path)
+    for i in range(5):
+        service.publish(UserAuthenticated(user_id=f"u{i}"))
+    first = service.query_for_consumer("worker-1", UserAuthenticated, limit=2)
+    assert [e.user_id for e in first] == ["u0", "u1"]
+    assert adapter.get_cursor("worker-1", UserAuthenticated._class_uri) == 2
+
+    result = service.seek_consumer_to_end("worker-1", UserAuthenticated)
+    assert result["cursor_before"] == 2
+    assert result["cursor_after"] == adapter.max_seq(UserAuthenticated._class_uri)
+    assert service.query_for_consumer("worker-1", UserAuthenticated) == []
+
+
 def test_iter_query_for_consumer_respects_limit(tmp_path):
     service, adapter, _ = _make_service(tmp_path)
     for i in range(10):

--- a/libs/naas-abi-core/naas_abi_core/services/event/adapters/secondary/EventSQLiteAdapter.py
+++ b/libs/naas-abi-core/naas_abi_core/services/event/adapters/secondary/EventSQLiteAdapter.py
@@ -180,6 +180,35 @@ class EventSQLiteAdapter(IEventAdapter):
             ).fetchone()
         return int(row[0]) if row else 0
 
+    def set_cursor(self, consumer_id: str, event_type: str, last_seq: int) -> None:
+        if last_seq < 0:
+            raise ValueError(f"last_seq must be >= 0, got {last_seq}")
+        with self._lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                self._upsert_cursor(consumer_id, event_type, last_seq)
+                self._conn.execute("COMMIT")
+            except Exception:
+                self._conn.execute("ROLLBACK")
+                raise
+
+    def _upsert_cursor(
+        self, consumer_id: str, event_type: str, last_seq: int
+    ) -> None:
+        self._conn.execute(
+            "INSERT INTO consumer_cursors (consumer_id, event_type, last_seq, updated_at) "
+            "VALUES (?, ?, ?, ?) "
+            "ON CONFLICT(consumer_id, event_type) DO UPDATE SET "
+            "  last_seq = excluded.last_seq, "
+            "  updated_at = excluded.updated_at",
+            (
+                consumer_id,
+                event_type,
+                last_seq,
+                datetime.datetime.now(datetime.UTC).isoformat(),
+            ),
+        )
+
     def query_for_consumer(
         self,
         consumer_id: str,
@@ -236,20 +265,7 @@ class EventSQLiteAdapter(IEventAdapter):
                 rows = self._conn.execute(sql, params).fetchall()
 
                 if rows:
-                    new_seq = rows[-1][2]
-                    self._conn.execute(
-                        "INSERT INTO consumer_cursors (consumer_id, event_type, last_seq, updated_at) "
-                        "VALUES (?, ?, ?, ?) "
-                        "ON CONFLICT(consumer_id, event_type) DO UPDATE SET "
-                        "  last_seq = excluded.last_seq, "
-                        "  updated_at = excluded.updated_at",
-                        (
-                            consumer_id,
-                            event_type,
-                            new_seq,
-                            datetime.datetime.now(datetime.UTC).isoformat(),
-                        ),
-                    )
+                    self._upsert_cursor(consumer_id, event_type, rows[-1][2])
                 self._conn.execute("COMMIT")
             except Exception:
                 self._conn.execute("ROLLBACK")

--- a/libs/naas-abi-core/naas_abi_core/services/event/adapters/secondary/EventSQLiteAdapter_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/event/adapters/secondary/EventSQLiteAdapter_test.py
@@ -203,6 +203,23 @@ def test_get_cursor_defaults_to_zero(adapter):
     assert adapter.get_cursor("c1", "urn:Type:A") == 0
 
 
+def test_set_cursor_seeks_and_can_move_backward(adapter):
+    adapter.append("urn:e1", "urn:Type:A", _ts(0), b"p1")
+    adapter.append("urn:e2", "urn:Type:A", _ts(1), b"p2")
+    adapter.query_for_consumer("c1", "urn:Type:A")
+    assert adapter.get_cursor("c1", "urn:Type:A") == 2
+
+    adapter.set_cursor("c1", "urn:Type:A", adapter.max_seq("urn:Type:A"))
+    assert adapter.get_cursor("c1", "urn:Type:A") == 2
+    assert adapter.query_for_consumer("c1", "urn:Type:A") == []
+
+    # Repair a stale cursor after seq restart (cursor ahead of max).
+    adapter.set_cursor("c1", "urn:Type:A", 0)
+    assert adapter.get_cursor("c1", "urn:Type:A") == 0
+    rows = adapter.query_for_consumer("c1", "urn:Type:A", limit=1)
+    assert [r.id for r in rows] == ["urn:e1"]
+
+
 def test_query_for_consumer_advances_cursor(adapter):
     adapter.append("urn:e1", "urn:Type:A", _ts(0), b"p1")
     adapter.append("urn:e2", "urn:Type:A", _ts(1), b"p2")

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/__init__.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/__init__.py
@@ -12,7 +12,7 @@ from naas_abi_core.services.secret.Secret import Secret
 from naas_abi_core.services.triple_store.TripleStoreService import (
     TripleStoreService,
 )
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, model_validator
 
 # Cadence applied to a search filter that sets neither `interval_seconds` nor
 # `cron` — the sensor wakes every minute (the spend guard bounds the spend).

--- a/uv.lock
+++ b/uv.lock
@@ -3787,7 +3787,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-marketplace"
-version = "3.34.0"
+version = "3.35.0"
 source = { editable = "libs/naas-abi-marketplace" }
 dependencies = [
     { name = "ijson" },


### PR DESCRIPTION
This pull request resolves #core-event

# Summary

This PR introduces a new feature to the event service system that allows consumers to seek their event cursor to the latest event sequence number, effectively skipping all pending events between the current cursor and the latest event.

# Changes

- **New Interface Method:** Added `set_cursor(consumer_id, event_type, last_seq)` to the `IEventAdapter` interface to allow setting the last delivered sequence number for a consumer and event type.
- **EventService:** Added `seek_consumer_to_end(consumer_id, event_class)` method to jump a consumer's cursor to the latest sequence number for a given event class, skipping all pending events.
- **SQLite Adapter:** Implemented `set_cursor` in `EventSQLiteAdapter` with proper transactional handling and upsert logic.
- **Cursor Upsert Refactor:** Refactored cursor update logic in `query_for_consumer` to use the new `_upsert_cursor` helper method.
- **Documentation:** Updated `AGENTS.md` to document the new `set_cursor` and `seek_consumer_to_end` methods.

# Tests

- Added `test_seek_consumer_to_end_skips_pending_events` to verify that seeking to the end skips pending events and updates the cursor correctly.
- Added `test_set_cursor_seeks_and_can_move_backward` to test the `set_cursor` method, including moving the cursor backward to repair stale cursor states.

# Impact

This feature is useful for consumers that want to skip processing old events and start consuming from the latest event, for example, after a downtime or when resetting state.

# Notes

- The `set_cursor` method allows setting the cursor to a lower sequence number than currently stored, which helps repair cursor states after event log resets.
- All cursor updates are done atomically with proper transaction handling to ensure consistency.