### PR TITLE
feat(nexus): multi-model ABI agents via llm_model

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/agents/adapters/primary/agents__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/agents/adapters/primary/agents__primary_adapter__FastAPI.py
@@ -350,6 +350,25 @@ def _catalog_model_id_for_provider(provider: str) -> str | None:
     return None
 
 
+def _class_declared_model_ids(agent_cls: type | None) -> list[str]:
+    """Chat model ids the agent class can load (``get_chat_model_ids`` / ``MODEL_IDS``)."""
+    if agent_cls is None:
+        return []
+    getter = getattr(agent_cls, "get_chat_model_ids", None)
+    if callable(getter):
+        try:
+            ids = getter()
+        except Exception:
+            ids = None
+        if isinstance(ids, (list, tuple)):
+            return [str(item).strip() for item in ids if str(item).strip()]
+    attr = getattr(agent_cls, "MODEL_IDS", None)
+    if isinstance(attr, (list, tuple)):
+        return [str(item).strip() for item in attr if str(item).strip()]
+    single = _class_declared_model_id(agent_cls)
+    return [single] if single else []
+
+
 def _class_declared_model_id(agent_cls: type | None) -> str | None:
     """Model id declared by the agent class via ``get_chat_model_id``.
 
@@ -444,6 +463,7 @@ def _enrich_agent(
         logo_url=logo_url,
         intents=intents,
         resolved_model_id=_resolve_agent_model_id(agent, resolved_cls),
+        model_ids=_class_declared_model_ids(resolved_cls) or None,
     )
 
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/agents/adapters/primary/agents__primary_adapter__FastAPI_test.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/agents/adapters/primary/agents__primary_adapter__FastAPI_test.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 
 from naas_abi.apps.nexus.apps.api.app.services.agents.adapters.primary.agents__primary_adapter__FastAPI import (
     _canonical_agent_sort_key,
+    _class_declared_model_ids,
 )
 from naas_abi.apps.nexus.apps.api.app.services.agents.port import AgentRecord
 
@@ -47,3 +48,23 @@ def test_canonical_agent_sort_prefers_default_then_enabled_then_oldest() -> None
         key=_canonical_agent_sort_key,
     )
     assert [agent.id for agent in ordered] == ["a", "b", "e", "d"]
+
+
+def test_class_declared_model_ids_reads_getter_then_attr_then_single() -> None:
+    class Multi:
+        @classmethod
+        def get_chat_model_ids(cls) -> list[str]:
+            return ["gpt-5.2", "gpt-5.6-sol"]
+
+    class AttrOnly:
+        MODEL_IDS = ("a", "b")
+
+    class Single:
+        @classmethod
+        def get_chat_model_id(cls) -> str:
+            return "claude-sonnet-5"
+
+    assert _class_declared_model_ids(Multi) == ["gpt-5.2", "gpt-5.6-sol"]
+    assert _class_declared_model_ids(AttrOnly) == ["a", "b"]
+    assert _class_declared_model_ids(Single) == ["claude-sonnet-5"]
+    assert _class_declared_model_ids(object) == []

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/agents/port.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/agents/port.py
@@ -27,6 +27,8 @@ class AgentRecord:
     # layer (not persisted): falls back to a catalog/registry default when the
     # agent has no explicitly assigned ``model_id``.
     resolved_model_id: str | None = None
+    # Chat models the agent class can load. Empty/None means a single resolved id.
+    model_ids: list[str] | None = None
 
 
 @dataclass

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__dependencies.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__dependencies.py
@@ -131,6 +131,7 @@ def to_complete_chat_input(request: ChatRequest) -> CompleteChatInput:
             api_key=request.provider.api_key,
             account_id=request.provider.account_id,
             model=request.provider.model,
+            llm_model=request.provider.llm_model,
         )
 
     return CompleteChatInput(
@@ -183,6 +184,7 @@ async def resolve_provider(
             api_key=resolved.api_key,
             account_id=resolved.account_id,
             model=resolved.model,
+            llm_model=resolved.llm_model,
         )
 
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__schemas.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__schemas.py
@@ -31,6 +31,7 @@ class MessageMetadataUpdate(BaseModel):
     execution_time: float | None = None
     steps: list[MessageStep] = Field(default_factory=list)
     sources: list[str] = Field(default_factory=list)
+    llm_model: str | None = None
 
 
 class ExportMessageMetadata(BaseModel):
@@ -83,6 +84,7 @@ class ProviderConfigRequest(BaseModel):
     api_key: str | None = None
     account_id: str | None = None
     model: str
+    llm_model: str | None = None
 
     def model_post_init(self, __context: Any) -> None:
         if self.type not in VALID_PROVIDER_TYPES:
@@ -107,6 +109,7 @@ class ChatRequest(BaseModel):
     messages: list[MessageRequest] = Field(default_factory=list, max_length=200)
     agent: str = Field(default="aia", min_length=1, max_length=50)
     provider: ProviderConfigRequest | None = None
+    llm_model: str | None = Field(None, max_length=200)
     context: dict[str, Any] | None = None
     system_prompt: str | None = Field(None, max_length=50_000)
     search_enabled: bool = False

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__streaming.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__streaming.py
@@ -352,6 +352,7 @@ async def stream_chat_response(
         api_key=provider.api_key,
         account_id=provider.account_id,
         model=provider.model,
+        llm_model=getattr(provider, "llm_model", None) or request.llm_model,
     )
 
     assistant_msg_id = ""
@@ -442,6 +443,7 @@ async def stream_chat_response(
                 "execution_time": round(loop.time() - stream_started_at, 3),
                 "steps": _strip_internal_step_keys(steps),
                 "sources": _merge_source_urls(list(context_sources), web_source_urls),
+                "llm_model": request.llm_model,
             }
             try:
                 await persist_stream_metadata(

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/chat__schema.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/chat__schema.py
@@ -45,6 +45,7 @@ class ChatProviderConfigInput:
     endpoint: str | None = None
     api_key: str | None = None
     account_id: str | None = None
+    llm_model: str | None = None
 
 
 @dataclass(frozen=True)

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/service.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/service.py
@@ -63,6 +63,7 @@ class ResolvedProvider:
     api_key: str | None
     account_id: str | None
     model: str
+    llm_model: str | None = None
 
 
 # Metadata keys tracking "refresh" (regenerate) lineage on messages.
@@ -1129,6 +1130,7 @@ class ChatService:
         agent_id: str | None = None,
         workspace_id: str | None = None,
     ) -> ResolvedProvider | None:
+        incoming_llm = getattr(provider, "llm_model", None) if provider else None
         if provider and getattr(provider, "enabled", False):
             return ResolvedProvider(
                 id=provider.id,
@@ -1139,6 +1141,7 @@ class ChatService:
                 api_key=provider.api_key,
                 account_id=provider.account_id,
                 model=provider.model,
+                llm_model=incoming_llm,
             )
 
         if agent_id:
@@ -1167,6 +1170,7 @@ class ChatService:
                                 api_key=abi_server.api_key,
                                 account_id=None,
                                 model=external_agent_ref,
+                                llm_model=incoming_llm,
                             )
                         return ResolvedProvider(
                             id=f"abi-inprocess-{agent.id}",
@@ -1177,6 +1181,7 @@ class ChatService:
                             api_key=None,
                             account_id=None,
                             model=inprocess_agent_ref,
+                            llm_model=incoming_llm,
                         )
 
                     secret_key_map = {

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/provider_runtime.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/provider_runtime.py
@@ -42,6 +42,7 @@ class ProviderConfig(BaseModel):
     api_key: str | None = None
     account_id: str | None = None  # For Cloudflare
     model: str
+    llm_model: str | None = None
 
 
 class Message(BaseModel):
@@ -1424,6 +1425,7 @@ async def stream_with_abi_inprocess(
 
     agent_name = config.model
     template_agent = _resolve_inprocess_abi_agent(agent_name)
+    llm_model = (getattr(config, "llm_model", None) or "").strip() or None
     if template_agent is None:
         with _INPROCESS_AGENT_LOCK:
             available_hint = ", ".join(_INPROCESS_AGENT_HINTS[:20]) or "unavailable"
@@ -1438,7 +1440,21 @@ async def stream_with_abi_inprocess(
     # (the previous behaviour) caused cross-conversation response leakage when
     # two requests overlapped — see jupyter-naas/abi#991.
     assert thread_id is not None, "thread_id is required"
-    agent = _duplicate_inprocess_agent(template_agent, thread_id)
+    agent = None
+    if llm_model:
+        new_fn = getattr(type(template_agent), "New", None)
+        if callable(new_fn):
+            try:
+                from naas_abi_core.services.agent.Agent import AgentSharedState
+
+                agent = new_fn(
+                    agent_shared_state=AgentSharedState(thread_id=str(thread_id)),
+                    model_id=llm_model,
+                )
+            except TypeError:
+                agent = None
+    if agent is None:
+        agent = _duplicate_inprocess_agent(template_agent, thread_id)
 
     logger.debug(
         f"Agent.state.thread_id: {getattr(getattr(agent, 'state', None), 'thread_id', None)}"

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/chat/components/chat-agent-selector.css
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/chat/components/chat-agent-selector.css
@@ -2,7 +2,7 @@
 
 .chat-agent-selector-trigger {
   display: flex;
-  max-width: 9.5rem;
+  max-width: 16rem;
   align-items: center;
   gap: 4px;
   min-height: 32px;
@@ -34,7 +34,7 @@
 
 @media (min-width: 768px) {
   .chat-agent-selector-trigger {
-    max-width: 12rem;
+    max-width: 18rem;
     font-size: var(--font-size-sm, 14px);
   }
 }
@@ -159,6 +159,28 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   font-weight: var(--font-weight-medium, 500);
+}
+
+.chat-agent-selector-row-meta {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+  color: var(--muted-foreground-hex);
+}
+
+.chat-agent-selector-row.is-nested {
+  padding-left: calc(var(--space-2) + 16px);
+}
+
+.chat-agent-selector-chevron {
+  flex-shrink: 0;
+  color: var(--muted-foreground-hex);
+  transition: transform 0.15s ease;
+}
+
+.chat-agent-selector-chevron.is-open {
+  transform: rotate(90deg);
 }
 
 .chat-agent-selector-check {

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/chat/components/chat-agent-selector.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/chat/components/chat-agent-selector.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Check, ChevronDown, X } from 'lucide-react';
+import { Check, ChevronDown, ChevronRight, X } from 'lucide-react';
 import { createPortal } from 'react-dom';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { cn } from '@/lib/utils';
@@ -8,6 +8,7 @@ import { useIsMobile } from '@/hooks/use-is-mobile';
 import { useAgentList } from '@/components/ui/dialogs';
 import { useWorkspaceStore } from '@/stores/workspace';
 import type { Agent } from '@/stores/agents';
+import { useModelsStore, modelDisplayName } from '@/stores/models';
 import './chat-agent-selector.css';
 
 function AutoToggle({
@@ -40,7 +41,8 @@ export type ChatAgentSelectorSource = 'chat' | 'pane';
 
 /**
  * Compact agent picker for the chat composer.
- * Panel = Search + Auto toggle + agents list (no dual-panel / model drill-down).
+ * Panel = Search + Auto toggle + agents list. Agents that declare more than
+ * one ``modelIds`` expand in place so you pick the model without leaving.
  * Mobile: bottom sheet. Desktop: compact popover above the trigger.
  *
  * `source="pane"` binds to the right AI / compare surface (paneAgent).
@@ -53,6 +55,7 @@ export function ChatAgentSelector({
   const [mounted, setMounted] = useState(false);
   const [open, setOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
+  const [expandedAgentId, setExpandedAgentId] = useState<string | null>(null);
   const ref = useRef<HTMLDivElement>(null);
   const sheetRef = useRef<HTMLDivElement>(null);
   const isMobile = useIsMobile();
@@ -70,6 +73,10 @@ export function ChatAgentSelector({
   const clearAgentExplicitSelection = useWorkspaceStore((s) =>
     isPane ? s.clearPaneAgentExplicitSelection : s.clearAgentExplicitSelection
   );
+  const selectedChatModels = useWorkspaceStore((s) => s.selectedChatModels);
+  const setSelectedChatModel = useWorkspaceStore((s) => s.setSelectedChatModel);
+  const catalogModels = useModelsStore((s) => s.models);
+  const fetchModels = useModelsStore((s) => s.fetchModels);
   const { defaultAgents, customAgents, filteredAgents } = useAgentList(searchQuery);
 
   const enabledAgents = useMemo(
@@ -101,9 +108,14 @@ export function ChatAgentSelector({
     setMounted(true);
   }, []);
 
+  useEffect(() => {
+    fetchModels();
+  }, [fetchModels]);
+
   const closePicker = useCallback(() => {
     setOpen(false);
     setSearchQuery('');
+    setExpandedAgentId(null);
   }, []);
 
   useEffect(() => {
@@ -159,7 +171,14 @@ export function ChatAgentSelector({
     };
   }, [open, isMobile]);
 
+  const selectableModels = (agent: Agent | undefined): string[] =>
+    (agent?.modelIds || []).map((id) => id.trim()).filter(Boolean);
+
   const openPicker = () => {
+    const current = enabledAgents.find((a) => a.id === selectedAgent);
+    setExpandedAgentId(
+      current && selectableModels(current).length > 1 ? current.id : null
+    );
     setOpen(true);
   };
 
@@ -173,18 +192,53 @@ export function ChatAgentSelector({
     }
   };
 
+  const defaultModelFor = (agent: Agent): string | null => {
+    const models = selectableModels(agent);
+    if (models.length === 0) return null;
+    return (
+      selectedChatModels[agent.id] ||
+      (models.includes(agent.resolvedModelId || '') ? agent.resolvedModelId : null) ||
+      models[0]
+    );
+  };
+
+  const pinDefaultModel = (agent: Agent) => {
+    const next = defaultModelFor(agent);
+    if (next && !selectedChatModels[agent.id]) {
+      setSelectedChatModel(agent.id, next);
+    }
+  };
+
   const selectAgent = (agent: Agent) => {
     setSelectedAgent(agent.id, true);
+    const models = selectableModels(agent);
+    if (models.length > 1) {
+      pinDefaultModel(agent);
+      setExpandedAgentId((current) => (current === agent.id ? null : agent.id));
+      return;
+    }
     closePicker();
   };
 
+  const selectAgentModel = (agent: Agent, modelId: string) => {
+    setSelectedAgent(agent.id, true);
+    setSelectedChatModel(agent.id, modelId);
+    closePicker();
+  };
+
+  const activeModelId = activeAgent ? defaultModelFor(activeAgent) : null;
+  const activeModelLabel = modelDisplayName(catalogModels, activeModelId) ?? activeModelId;
+
   // Pane surface: always show the resolved agent name (Abi by default).
-  // Main chat keeps Cursor-style "Auto" until the user picks an agent.
+  // After an explicit pick, show the agent (and model). Auto is only the
+  // workspace default before the user chooses.
   const triggerLabel = isPane
     ? activeAgent?.name ?? 'Abi'
     : autoMode
       ? 'Auto'
-      : activeAgent?.name ?? 'Agent';
+      : activeAgent && activeModelLabel && selectableModels(activeAgent).length > 1
+        ? `${activeAgent.name} · ${activeModelLabel}`
+        : activeAgent?.name ?? 'Agent';
 
   if (!mounted || !activeAgent) {
     return null;
@@ -192,19 +246,67 @@ export function ChatAgentSelector({
 
   const renderAgentRow = (agent: Agent) => {
     const isSelected = selectedAgent === agent.id && !autoMode;
+    const models = selectableModels(agent);
+    const hasModels = models.length > 1;
+    const isExpanded = expandedAgentId === agent.id;
+    const activeModel =
+      selectedChatModels[agent.id] ||
+      (models.includes(agent.resolvedModelId || '') ? agent.resolvedModelId : null) ||
+      models[0] ||
+      null;
 
     return (
-      <button
-        key={agent.id}
-        type="button"
-        className={cn('chat-agent-selector-row', isSelected && 'is-active')}
-        onClick={() => selectAgent(agent)}
-      >
-        <div className="chat-agent-selector-row-body">
-          <div className="chat-agent-selector-row-title">{agent.name}</div>
-        </div>
-        {isSelected ? <Check size={14} className="chat-agent-selector-check" /> : null}
-      </button>
+      <div key={agent.id} className="chat-agent-selector-agent">
+        <button
+          type="button"
+          className={cn('chat-agent-selector-row', isSelected && 'is-active')}
+          onClick={() => selectAgent(agent)}
+        >
+          <div className="chat-agent-selector-row-body">
+            <div className="chat-agent-selector-row-title">{agent.name}</div>
+            {hasModels ? (
+              <div className="chat-agent-selector-row-meta">
+                {modelDisplayName(catalogModels, activeModel) ?? activeModel}
+              </div>
+            ) : null}
+          </div>
+          {hasModels ? (
+            <ChevronRight
+              size={14}
+              className={cn(
+                'chat-agent-selector-chevron',
+                isExpanded && 'is-open'
+              )}
+            />
+          ) : isSelected ? (
+            <Check size={14} className="chat-agent-selector-check" />
+          ) : null}
+        </button>
+        {hasModels && isExpanded
+          ? models.map((modelId) => {
+              const modelSelected = isSelected && modelId === activeModel;
+              const label = modelDisplayName(catalogModels, modelId) ?? modelId;
+              return (
+                <button
+                  key={modelId}
+                  type="button"
+                  className={cn(
+                    'chat-agent-selector-row is-nested',
+                    modelSelected && 'is-active'
+                  )}
+                  onClick={() => selectAgentModel(agent, modelId)}
+                >
+                  <div className="chat-agent-selector-row-body">
+                    <div className="chat-agent-selector-row-title">{label}</div>
+                  </div>
+                  {modelSelected ? (
+                    <Check size={14} className="chat-agent-selector-check" />
+                  ) : null}
+                </button>
+              );
+            })
+          : null}
+      </div>
     );
   };
 
@@ -295,8 +397,8 @@ export function ChatAgentSelector({
           isPane
             ? activeAgent.name
             : autoMode
-              ? 'Auto agent selection'
-              : activeAgent.name
+              ? 'Auto: workspace default agent'
+              : triggerLabel
         }
       >
         <span className="chat-agent-selector-trigger-label">{triggerLabel}</span>

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/chat/components/chat-section.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/chat/components/chat-section.tsx
@@ -41,7 +41,6 @@ export function ChatSection({ collapsed, detailOnly }: { collapsed: boolean; det
     selectedAgent,
     agentExplicitlySelected,
     setSelectedAgent,
-    clearAgentExplicitSelection,
     togglePinConversation,
     toggleArchiveConversation,
     renameConversation,
@@ -68,10 +67,6 @@ export function ChatSection({ collapsed, detailOnly }: { collapsed: boolean; det
   const isChatRoute = pathname.startsWith(getWorkspacePath(currentWorkspaceId, '/chat'));
   const isNewChatState = isChatRoute && !activeConversationId;
   const isNewChatActive = isNewChatState && !agentExplicitlySelected;
-
-  useEffect(() => {
-    if (!isChatRoute) clearAgentExplicitSelection();
-  }, [isChatRoute, clearAgentExplicitSelection]);
 
   useEffect(() => {
     if (!currentWorkspaceId) return;
@@ -147,22 +142,26 @@ export function ChatSection({ collapsed, detailOnly }: { collapsed: boolean; det
   }, [conversations, safeProjects]);
 
   const handleNewChat = useCallback(() => {
-    const defaultAgent =
-      safeAgents.find((a) => a.isDefault && a.enabled) ??
-      safeAgents.find((a) => a.enabled);
-    if (defaultAgent) setSelectedAgent(defaultAgent.id);
+    if (!agentExplicitlySelected) {
+      const defaultAgent =
+        safeAgents.find((a) => a.isDefault && a.enabled) ??
+        safeAgents.find((a) => a.enabled);
+      if (defaultAgent) setSelectedAgent(defaultAgent.id);
+    }
     setActiveConversation(null);
     setMobilePendingChatSlug(NEW_CHAT_SLUG);
     router.push(newChatPath(currentWorkspaceId));
-  }, [safeAgents, setSelectedAgent, setActiveConversation, setMobilePendingChatSlug, router, currentWorkspaceId]);
+  }, [safeAgents, agentExplicitlySelected, setSelectedAgent, setActiveConversation, setMobilePendingChatSlug, router, currentWorkspaceId]);
 
   const handleChatHeaderNavigate = useCallback(() => {
-    const defaultAgent =
-      safeAgents.find((a) => a.isDefault && a.enabled) ??
-      safeAgents.find((a) => a.enabled);
-    if (defaultAgent) setSelectedAgent(defaultAgent.id);
+    if (!agentExplicitlySelected) {
+      const defaultAgent =
+        safeAgents.find((a) => a.isDefault && a.enabled) ??
+        safeAgents.find((a) => a.enabled);
+      if (defaultAgent) setSelectedAgent(defaultAgent.id);
+    }
     setActiveConversation(null);
-  }, [safeAgents, setSelectedAgent, setActiveConversation]);
+  }, [safeAgents, agentExplicitlySelected, setSelectedAgent, setActiveConversation]);
 
   const handleSelectConversation = useCallback((id: string) => {
     setMobilePendingChatSlug(id);

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/agents/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/agents/page.tsx
@@ -424,34 +424,26 @@ export default function AgentsPage() {
     return 'Model Registry';
   };
 
-  const getModelDisplay = (agent: Agent): string => {
-    // Resolve the effective model id, then surface its human-readable catalog
-    // name (e.g. "Claude Sonnet 5") instead of the raw id ("claude-sonnet-5").
+  const getModelIds = (agent: Agent): string[] => {
+    const declared = (agent.modelIds || []).map((id) => id.trim()).filter(Boolean);
+    if (declared.length > 0) return Array.from(new Set(declared));
+
     let rawId: string | null = null;
     if (agent.provider === 'abi') {
-      // ABI agents don't carry an explicit model, but the backend resolves the
-      // effective one (the engine default chat model) — surface it when known.
       rawId = agent.modelId || agent.resolvedModelId || null;
-      if (!rawId) return 'Not exposed';
     } else if (agent.provider) {
-      // Modern agents: agent.modelId overrides the provider's default model.
       const provider = enabledProviders.find((p) => p.type === agent.provider && p.enabled);
       rawId = agent.modelId || provider?.model || agent.resolvedModelId || null;
-      if (!rawId) return 'Not assigned';
     } else if (agent.providerId) {
-      // Legacy providerId mapping.
       rawId =
         getAssignedProvider(agent.providerId)?.model ||
         agent.modelId ||
         agent.resolvedModelId ||
         null;
-      if (!rawId) return 'Not assigned';
     } else {
-      // Fallback to a bare model id from the registry.
       rawId = agent.modelId || agent.resolvedModelId || null;
-      if (!rawId) return 'Not assigned';
     }
-    return modelDisplayName(models, rawId) ?? rawId;
+    return rawId ? [rawId] : [];
   };
 
   if (!mounted) {
@@ -621,7 +613,7 @@ export default function AgentsPage() {
                 <tr className="border-b bg-muted/50 text-left text-sm">
                   <th className="p-3 font-medium">Agent</th>
                   <th className="p-3 font-medium">Source</th>
-                  <th className="p-3 font-medium">Model</th>
+                  <th className="p-3 font-medium">Models</th>
                   <th className="p-3 font-medium">Type</th>
                   <th className="p-3 font-medium w-24">Enabled</th>
                   <th className="p-3 font-medium w-32">Actions</th>
@@ -673,27 +665,40 @@ export default function AgentsPage() {
                         </td>
                         <td className="p-3">
                           {(() => {
-                            const model = getModelDisplay(agent);
-                            if (agent.provider === 'abi') {
-                              return (
-                                <div className="flex items-center gap-2">
-                                  <Server size={14} className="text-muted-foreground" />
-                                  <span className="text-sm text-muted-foreground italic">{model}</span>
-                                </div>
-                              );
-                            }
-                            if (model === 'Not assigned') {
+                            const modelIds = getModelIds(agent);
+                            if (modelIds.length === 0) {
                               return (
                                 <div className="flex items-center gap-2">
                                   <XCircle size={14} className="text-muted-foreground" />
-                                  <span className="text-sm text-muted-foreground">Not assigned</span>
+                                  <span className="text-sm text-muted-foreground">
+                                    {agent.provider === 'abi' ? 'Not exposed' : 'Not assigned'}
+                                  </span>
                                 </div>
                               );
                             }
                             return (
-                              <div className="flex items-center gap-2">
-                                <CheckCircle size={14} className="text-green-500" />
-                                <span className="text-sm">{model}</span>
+                              <div className="flex flex-col gap-1">
+                                {modelIds.map((id) => {
+                                  const label = modelDisplayName(models, id) ?? id;
+                                  return (
+                                    <div key={id} className="flex items-center gap-2">
+                                      {agent.provider === 'abi' ? (
+                                        <Server size={14} className="shrink-0 text-muted-foreground" />
+                                      ) : (
+                                        <CheckCircle size={14} className="shrink-0 text-green-500" />
+                                      )}
+                                      <span
+                                        className={cn(
+                                          'text-sm',
+                                          agent.provider === 'abi' && 'text-muted-foreground italic'
+                                        )}
+                                        title={id}
+                                      >
+                                        {label}
+                                      </span>
+                                    </div>
+                                  );
+                                })}
                               </div>
                             );
                           })()}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
@@ -13,6 +13,7 @@ import { useSurfaceConversation } from '@/stores/chat-thread-selectors';
 import { nextChatUrl } from '@/app/workspace/[workspaceId]/chat/lib/chat-route';
 import { useIntegrationsStore } from '@/stores/integrations';
 import { useAgentsStore } from '@/stores/agents';
+import { useModelsStore, modelDisplayName } from '@/stores/models';
 import { useSkillsStore, type Skill, type SkillScope } from '@/stores/skills';
 import { useSecretsStore } from '@/stores/secrets';
 import { dispatchSlidesDeckUpdated, useSlidesStore } from '@/stores/slides';
@@ -1914,6 +1915,13 @@ export function ChatInterface({
       const token = useAuthStore.getState().token;
       const workspaceId = useWorkspaceStore.getState().currentWorkspaceId;
 
+      const agentDataForModel = getAgent(effectiveAgent);
+      const llmModel =
+        (agentDataForModel && useWorkspaceStore.getState().selectedChatModels[agentDataForModel.id]) ||
+        agentDataForModel?.modelIds?.[0] ||
+        agentDataForModel?.resolvedModelId ||
+        null;
+
       const providerPayload = provider ? {
         id: provider.id,
         name: provider.name,
@@ -1923,6 +1931,7 @@ export function ChatInterface({
         api_key: provider.apiKey,
         account_id: provider.accountId,
         model: provider.model,
+        llm_model: llmModel,
       } : null;
 
       // Get agent's system prompt
@@ -1964,6 +1973,7 @@ export function ChatInterface({
           content: '▌',
           // content: searchEnabled ? '🌐 Searching the web...' : '▌',
           agent: effectiveAgent,
+          modelId: llmModel,
           activityLine: 'Processing...',
           // activityLine: searchEnabled ? 'Web search in progress' : 'Processing...',
           // Records which answer this one re-runs, so later turns leave the
@@ -2220,6 +2230,7 @@ export function ChatInterface({
             messages: fullHistory,
             agent: effectiveAgent,
             provider: providerPayload,
+            llm_model: llmModel,
             system_prompt: systemPrompt,
             search_enabled: false,
             regenerate_of: regenerateOf ?? null,
@@ -2385,6 +2396,7 @@ export function ChatInterface({
                   output: t.output ?? null,
                 })),
                 sources: streamSources,
+                llm_model: llmModel,
               }),
             },
           ).catch(() => { /* non-blocking */ });
@@ -2436,6 +2448,7 @@ export function ChatInterface({
             messages: fullHistory,
             agent: effectiveAgent,
             provider: providerPayload,
+            llm_model: llmModel,
             system_prompt: systemPrompt,
             regenerate_of: regenerateOf ?? null,
             ...(slidesChatContext ? { context: slidesChatContext } : {}),
@@ -2453,6 +2466,7 @@ export function ChatInterface({
           role: 'assistant',
           content: data.message.content,
           agent: effectiveAgent,
+          modelId: llmModel,
           thinkingDuration,
           sources: data.context_used?.length > 0 ? data.context_used : undefined,
           ...(regenerateOf ? { regenerateOf } : {}),
@@ -3528,6 +3542,17 @@ function ToolCallRow({ tool }: { tool: ToolCall }) {
   );
 }
 
+function formatMessageStamp(value: Date | string | undefined): string {
+  const date = value instanceof Date ? value : value ? new Date(value) : null;
+  if (!date || Number.isNaN(date.getTime())) return '';
+  return date.toLocaleString(undefined, {
+    day: 'numeric',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
 // Matches page titles that indicate a soft-404 ("Page Not Found", etc.)
 const NOT_FOUND_TITLE_RE = /\b(404|not found|page not found|introuvable|doesn.t exist|no page)\b/i;
 
@@ -3570,6 +3595,7 @@ const MessageBubble = React.memo(function MessageBubble({
   // Get user name and agent info for display
   const user = useAuthStore(state => state.user);
   const resolveAgent = useAgentsStore(state => state.resolveAgent);
+  const catalogModels = useModelsStore(state => state.models);
   const agent = resolveAgent(message.agent);
   const isFromDifferentAgent = !isUser && Boolean(message.agent) && message.agent !== currentSelectedAgent;
   
@@ -4108,6 +4134,28 @@ const MessageBubble = React.memo(function MessageBubble({
               {transformBareUrls(responseForRender as string)}
             </ReactMarkdown>
           )}
+        </div>
+
+        <div
+          className={cn(
+            'px-1 pt-0.5 text-[10px] leading-4 text-muted-foreground',
+            isUser && 'text-right'
+          )}
+        >
+          {(() => {
+            const when = formatMessageStamp(message.timestamp);
+            if (isUser) return when;
+            const modelRaw =
+              message.modelId ||
+              agent?.modelIds?.[0] ||
+              agent?.resolvedModelId ||
+              agent?.modelId ||
+              null;
+            const modelLabel = modelDisplayName(catalogModels, modelRaw) ?? modelRaw;
+            return [senderName, modelLabel ? `model: ${modelLabel}` : null, when]
+              .filter(Boolean)
+              .join(' · ');
+          })()}
         </div>
 
         {/* RAG document source pills (filenames only; URLs use the panel below) */}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/agents.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/agents.ts
@@ -63,6 +63,7 @@ export interface Agent {
   provider: string | null; // Provider name (xai, openai, anthropic, etc.)
   modelId: string | null; // Model ID (grok-beta, gpt-4o, claude-3-5-sonnet, etc.)
   resolvedModelId?: string | null; // Effective model resolved by the backend (catalog/registry default when modelId is unset)
+  modelIds?: string[]; // Chat models the agent class can load
   logoUrl: string | null; // URL to agent/provider logo
   enabled: boolean; // Whether agent is available for chat
   suggestions?: Array<{ label: string; value: string }>; // Optional class-level prompt suggestions
@@ -193,6 +194,9 @@ export const useAgentsStore = create<AgentsState>()(
               provider: a.provider || null, // Provider name (xai, openai, etc.)
               modelId: cleanModel(a.model_id) || cleanModel(a.model) || null, // Model ID (grok-beta, gpt-4o, etc.)
               resolvedModelId: cleanModel(a.resolved_model_id) || null, // Backend-resolved effective model
+              modelIds: Array.isArray(a.model_ids)
+                ? a.model_ids.filter((id: unknown): id is string => typeof id === 'string' && id.trim().length > 0)
+                : undefined,
 
               logoUrl: a.logo_url || null, // Logo URL from API
               enabled: a.enabled || false, // Whether agent is available for chat

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
@@ -72,6 +72,7 @@ export interface Message {
   content: string;
   timestamp: Date;
   agent?: AgentType;
+  modelId?: string | null;
   activityLine?: string; // Single-line live status (legacy, kept for backward compat)
   toolCalls?: ToolCall[]; // Ordered list of tool invocations for this message
   images?: string[]; // Base64-encoded images for multimodal chat
@@ -247,9 +248,11 @@ interface WorkspaceState {
   selectedAgent: AgentType;
   /** True when the user deliberately picked an agent (sidebar or composer),
    *  false when the agent was auto-selected as the workspace default.
-   *  Drives the sidebar highlight: "New Chat" vs a specific agent. Not persisted. */
+   *  Persisted so refresh and new chat keep the last pick. */
   agentExplicitlySelected: boolean;
   setSelectedAgent: (agent: AgentType, explicit?: boolean) => void;
+  selectedChatModels: Record<string, string>;
+  setSelectedChatModel: (agentId: string, modelId: string) => void;
   /** Drop the explicit selection without changing the agent — landing back on
    *  the chat route will then reset to the workspace default. */
   clearAgentExplicitSelection: () => void;
@@ -448,6 +451,12 @@ const mapApiMessage = (message: ApiChatMessage): Message => {
     content: message.content,
     timestamp: new Date(message.created_at || Date.now()),
     agent: message.agent || undefined,
+    modelId:
+      typeof meta.llm_model === 'string' && meta.llm_model.trim()
+        ? meta.llm_model.trim()
+        : typeof meta.model === 'string' && meta.model.trim()
+          ? meta.model.trim()
+          : undefined,
     toolCalls: toolCalls && toolCalls.length > 0 ? toolCalls : undefined,
     sources: sources && sources.length > 0 ? sources : undefined,
     executionTime,
@@ -529,6 +538,11 @@ export const useWorkspaceStore = create<WorkspaceState>()(
   agentExplicitlySelected: false,
   setSelectedAgent: (agent, explicit = false) =>
     set({ selectedAgent: agent, agentExplicitlySelected: explicit }),
+  selectedChatModels: {},
+  setSelectedChatModel: (agentId, modelId) =>
+    set((state) => ({
+      selectedChatModels: { ...state.selectedChatModels, [agentId]: modelId },
+    })),
   clearAgentExplicitSelection: () => set({ agentExplicitlySelected: false }),
   pendingComposerText: null,
   setPendingComposerText: (text) => set({ pendingComposerText: text }),
@@ -625,7 +639,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
       return {
         activeConversationId: id,
         ...(conv?.agent
-          ? { selectedAgent: conv.agent, agentExplicitlySelected: false }
+          ? { selectedAgent: conv.agent, agentExplicitlySelected: true }
           : {}),
       };
     }),
@@ -1599,9 +1613,11 @@ export const useWorkspaceStore = create<WorkspaceState>()(
         sidebarCollapsed: state.sidebarCollapsed,
         expandedSections: state.expandedSections,
         selectedAgent: state.selectedAgent,
+        agentExplicitlySelected: state.agentExplicitlySelected,
+        selectedChatModels: state.selectedChatModels,
         paneAgent: state.paneAgent,
-        // Do not persist paneAgentExplicitlySelected (same as main chat): a hard
-        // refresh should re-default the right pane to Abi via agents sync.
+        // Do not persist paneAgentExplicitlySelected: a hard refresh should
+        // re-default the right pane to Abi via agents sync.
         paneConversationId: state.paneConversationId,
         paneOpenTabIds: state.paneOpenTabIds,
         activePanelSection: state.activePanelSection,


### PR DESCRIPTION
## Summary
- ABI agent classes can declare `get_chat_model_ids()` / `MODEL_IDS`. Nexus returns them as `model_ids` and the composer drills in when there is more than one.
- The selected LLM is sent as `llm_model`. In-process send still uses `ProviderConfig.model` as the **agent name**. Writing an LLM id there breaks lookup.
- Runtime calls `New(model_id=...)` when the class accepts it; `TypeError` falls back to a template duplicate so hardcoded agents stay hardcoded.
- Last explicit agent + model persist. New chat and refresh no longer snap back to Auto.

Closes #1193

Proven against FMZ Azure Foundry in ForvisMazarsAI/bob#1004 (`AzureFoundryAgent` with `gpt-5.2` + `gpt-5.6-sol`).

## Test plan
- [ ] Agent with `MODEL_IDS` of length 2: composer expands, default model is selected, switch sticks after refresh
- [ ] Agent with hardcoded `New()`: one click, no drill-down; a forged `llm_model` is ignored
- [ ] In-process send still resolves the agent from `provider.model` (class name), not from `llm_model`
- [ ] `uv run pytest libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/agents/adapters/primary/agents__primary_adapter__FastAPI_test.py`