### PR TITLE
fix(nexus): show letter when workspace logo fails to load

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/mobile/mobile-top-bar.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/mobile/mobile-top-bar.tsx
@@ -13,6 +13,7 @@ import { useFeature } from '@/hooks/use-feature';
 import { useWorkspaceStore } from '@/stores/workspace';
 import { isMobileChatThreadOpen, parseChatRoute } from '@/app/workspace/[workspaceId]/chat/lib/chat-route';
 import { getWorkspacePath } from '../sidebar/utils';
+import { WorkspaceMark } from '../workspace-mark';
 import { useShellTitle } from '../shell-title';
 import { resolveMobileTopBarTitle } from './mobile-top-bar-title';
 
@@ -129,21 +130,14 @@ export function MobileTopBar({
             title={currentWorkspace?.name || 'Workspace'}
             aria-label="Switch workspace"
           >
-            {currentWorkspace?.theme?.logoUrl ? (
-              // eslint-disable-next-line @next/next/no-img-element
-              <img
-                src={currentWorkspace.theme.logoUrl}
-                alt={currentWorkspace.name}
-                className="h-full w-full object-cover"
-              />
-            ) : (
-              <span className="text-sm font-bold text-white">
-                {currentWorkspace?.theme?.logoEmoji
-                  || currentWorkspace?.icon
-                  || currentWorkspace?.name?.charAt(0)
-                  || 'Z'}
-              </span>
-            )}
+            <WorkspaceMark
+              name={currentWorkspace?.name}
+              icon={currentWorkspace?.icon}
+              logoUrl={currentWorkspace?.theme?.logoUrl}
+              logoEmoji={currentWorkspace?.theme?.logoEmoji}
+              fallbackLetter="Z"
+              letterClassName="text-sm font-bold text-white"
+            />
           </button>
         )}
 
@@ -203,16 +197,18 @@ export function MobileTopBar({
               >
                 <div
                   className="flex h-6 w-6 flex-shrink-0 items-center justify-center overflow-hidden"
-                  style={{ backgroundColor: workspace.theme?.primaryColor || '#22c55e' }}
+                  style={{
+                    backgroundColor: workspace.theme?.primaryColor || '#22c55e',
+                    borderRadius: 0,
+                  }}
                 >
-                  {workspace.theme?.logoUrl ? (
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img src={workspace.theme.logoUrl} alt={workspace.name} className="h-full w-full object-cover" />
-                  ) : (
-                    <span className="text-xs text-white">
-                      {workspace.theme?.logoEmoji || workspace.icon || workspace.name.charAt(0)}
-                    </span>
-                  )}
+                  <WorkspaceMark
+                    name={workspace.name}
+                    icon={workspace.icon}
+                    logoUrl={workspace.theme?.logoUrl}
+                    logoEmoji={workspace.theme?.logoEmoji}
+                    letterClassName="text-xs text-white"
+                  />
                 </div>
                 <span className="flex-1 text-left font-medium">{workspace.name}</span>
                 {currentWorkspaceId === workspace.id && (

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/index.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/index.tsx
@@ -13,6 +13,7 @@ import { useWorkspaceStore, type SidebarSection } from '@/stores/workspace';
 import { useFilesStore } from '@/stores/files';
 import { useOntologyStore } from '@/stores/ontology';
 import { getWorkspacePath } from './utils';
+import { WorkspaceMark } from '../workspace-mark';
 
 type SectionDef = {
   id: SidebarSection;
@@ -213,14 +214,13 @@ export function Sidebar() {
           style={{ backgroundColor: currentWorkspace?.theme?.primaryColor || '#22c55e' }}
           title={currentWorkspace?.name || 'NEXUS'}
         >
-          {currentWorkspace?.theme?.logoUrl ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img src={currentWorkspace.theme.logoUrl} alt={currentWorkspace.name} className="h-full w-full object-cover" />
-          ) : (
-            <span className="text-sm font-bold text-white">
-              {currentWorkspace?.theme?.logoEmoji || currentWorkspace?.icon || currentWorkspace?.name?.charAt(0) || 'N'}
-            </span>
-          )}
+          <WorkspaceMark
+            name={currentWorkspace?.name}
+            icon={currentWorkspace?.icon}
+            logoUrl={currentWorkspace?.theme?.logoUrl}
+            logoEmoji={currentWorkspace?.theme?.logoEmoji}
+            letterClassName="text-sm font-bold text-white"
+          />
         </button>
 
         {expanded && (
@@ -336,17 +336,19 @@ export function Sidebar() {
                 )}
               >
                 <div
-                  className="flex h-6 w-6 flex-shrink-0 items-center justify-center overflow-hidden rounded"
-                  style={{ backgroundColor: workspace.theme?.primaryColor || '#22c55e' }}
+                  className="flex h-6 w-6 flex-shrink-0 items-center justify-center overflow-hidden"
+                  style={{
+                    backgroundColor: workspace.theme?.primaryColor || '#22c55e',
+                    borderRadius: 0,
+                  }}
                 >
-                  {workspace.theme?.logoUrl ? (
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img src={workspace.theme.logoUrl} alt={workspace.name} className="h-full w-full object-cover" />
-                  ) : (
-                    <span className="text-xs text-white">
-                      {workspace.theme?.logoEmoji || workspace.icon || workspace.name.charAt(0)}
-                    </span>
-                  )}
+                  <WorkspaceMark
+                    name={workspace.name}
+                    icon={workspace.icon}
+                    logoUrl={workspace.theme?.logoUrl}
+                    logoEmoji={workspace.theme?.logoEmoji}
+                    letterClassName="text-xs text-white"
+                  />
                 </div>
                 <span className="flex-1 text-left font-medium">{workspace.name}</span>
                 {currentWorkspaceId === workspace.id && (

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/workspace-mark.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/workspace-mark.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+type WorkspaceMarkProps = {
+  name?: string;
+  icon?: string;
+  logoUrl?: string;
+  logoEmoji?: string;
+  fallbackLetter?: string;
+  letterClassName: string;
+};
+
+export function WorkspaceMark({
+  name,
+  icon,
+  logoUrl,
+  logoEmoji,
+  fallbackLetter = 'N',
+  letterClassName,
+}: WorkspaceMarkProps) {
+  const [imgReady, setImgReady] = useState(false);
+
+  useEffect(() => {
+    setImgReady(false);
+  }, [logoUrl]);
+
+  const letter = logoEmoji || icon || name?.charAt(0) || fallbackLetter;
+
+  return (
+    <>
+      {(!logoUrl || !imgReady) && <span className={letterClassName}>{letter}</span>}
+      {logoUrl ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={logoUrl}
+          alt={name || ''}
+          className={imgReady ? 'h-full w-full object-cover' : 'hidden'}
+          onLoad={() => setImgReady(true)}
+          onError={() => setImgReady(false)}
+        />
+      ) : null}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Workspace switcher painted a broken image whenever `theme.logoUrl` was set, even if the asset 404s.
- `WorkspaceMark` paints the letter (emoji, then icon, then first character) immediately and swaps in the image only after `onLoad`.
- Switcher list marks stay square (no border-radius).

Closes #1197

## Test plan
- [ ] Workspace with no `logo_url`: letter shows immediately
- [ ] Workspace with a valid `logo_url`: letter first, then the image once it loads
- [ ] Workspace with a 404 `logo_url`: letter stays; no broken-image glyph
- [ ] Desktop and mobile switcher list marks are 6x6 squares