### PR TITLE
fix(nexus): point module asset URLs at the live API port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,9 @@ storage/vectorstore/*
 
 # `abi dev` runtime artefacts (per-worktree instance/pid/log files)
 .abi/
+# Same artefacts when this repo is the consumer's `.abi` checkout.
+# `{consumer}/.abi/dev` is `{this-repo}/dev`.
+/dev/
 # Dagster local home dir created by `abi dev up`
 .dagster/
 # Local Docker stack snapshots (abi stack snapshot create)

--- a/libs/naas-abi-cli/naas_abi_cli/cli/dev.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/dev.py
@@ -361,6 +361,11 @@ def _launch_api(
     # Keep config-templated frontend URLs in sync when they reference
     # {{ secret.PUBLIC_WEB_HOST }}.
     env["PUBLIC_WEB_HOST"] = f"{BROWSER_HOST}:{nexus_port}"
+    # Module asset URLs are built from public_api_host / NEXUS_API_URL. The
+    # engine default is localhost:9879. This process is on a worktree port.
+    api_origin = f"http://{BROWSER_HOST}:{spec.port}"
+    env["PUBLIC_API_HOST"] = f"{BROWSER_HOST}:{spec.port}"
+    env["NEXUS_API_URL"] = api_origin
     cmd = ["uv", "run", "python", "-m", "naas_abi_core.apps.api.api"]
     return _spawn(spec, cmd, _project_root(), env)
 

--- a/libs/naas-abi-cli/naas_abi_cli/cli/dev.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/dev.py
@@ -361,9 +361,12 @@ def _launch_api(
     # Keep config-templated frontend URLs in sync when they reference
     # {{ secret.PUBLIC_WEB_HOST }}.
     env["PUBLIC_WEB_HOST"] = f"{BROWSER_HOST}:{nexus_port}"
-    # Module asset URLs are built from public_api_host / NEXUS_API_URL. The
-    # engine default is localhost:9879. This process is on a worktree port.
+    # Module asset URLs are built from public_api_host. The dotenv adapter
+    # prefers .env over process env, so PUBLIC_API_HOST / NEXUS_API_URL here
+    # only win when those keys are absent from .env. ABI_DEV_PUBLIC_API_ORIGIN
+    # is read by public_api_host() from the process env and is never a secret.
     api_origin = f"http://{BROWSER_HOST}:{spec.port}"
+    env["ABI_DEV_PUBLIC_API_ORIGIN"] = api_origin
     env["PUBLIC_API_HOST"] = f"{BROWSER_HOST}:{spec.port}"
     env["NEXUS_API_URL"] = api_origin
     cmd = ["uv", "run", "python", "-m", "naas_abi_core.apps.api.api"]

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/main.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/main.py
@@ -419,11 +419,36 @@ def _register_routes(app: FastAPI) -> None:
     app.add_api_route("/provider-logos/{provider_id}", serve_provider_logo, methods=["GET"])
 
 
+def _first_existing_file(relative: str, *roots: Path) -> Path | None:
+    """Return the first existing file under ``roots`` for a relative path."""
+    rel = Path(relative)
+    if rel.is_absolute() or ".." in rel.parts:
+        return None
+    for root in roots:
+        if not root.is_dir():
+            continue
+        candidate = (root / rel).resolve()
+        try:
+            candidate.relative_to(root.resolve())
+        except ValueError:
+            continue
+        if candidate.is_file():
+            return candidate
+    return None
+
+
 def _mount_static_assets(app: FastAPI) -> None:
-    # Serve static assets (logos, avatars)
-    logos_path = Path(__file__).parent.parent / "public" / "logos"
-    if logos_path.exists():
-        app.mount("/logos", StaticFiles(directory=str(logos_path)), name="logos")
+    # Serve static assets (logos, avatars). ``storage/logos`` in the project
+    # root overlays the engine package defaults.
+    abi_logos_path = Path(__file__).parent.parent / "public" / "logos"
+    project_logos_path = Path.cwd() / "storage" / "logos"
+
+    @app.get("/logos/{path:path}")
+    async def serve_logo(path: str) -> FileResponse:
+        found = _first_existing_file(path, project_logos_path, abi_logos_path)
+        if found is None:
+            raise HTTPException(status_code=404, detail="Logo not found")
+        return FileResponse(found)
 
     avatars_path = Path(__file__).parent.parent / "public" / "avatars"
     if avatars_path.exists():

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/utils/public_urls.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/utils/public_urls.py
@@ -8,24 +8,92 @@ the web origin.
 
 from __future__ import annotations
 
+import os
+
+ENGINE_DEFAULT_HOSTS = frozenset(
+    {
+        "localhost",
+        "localhost:9879",
+        "127.0.0.1",
+        "127.0.0.1:9879",
+    }
+)
+
+
+def _strip_scheme(host: str) -> str:
+    value = host.strip()
+    for prefix in ("https://", "http://"):
+        if value.startswith(prefix):
+            return value[len(prefix) :]
+    return value
+
+
+def _is_engine_default(host: str) -> bool:
+    return _strip_scheme(host).rstrip("/") in ENGINE_DEFAULT_HOSTS
+
+
+def _is_loopback_hostname(host: str) -> bool:
+    hostname = _strip_scheme(host).split("/", 1)[0].split(":", 1)[0]
+    return hostname in {"localhost", "127.0.0.1"}
+
+
+def _with_scheme(host: str) -> str:
+    value = host.strip().rstrip("/")
+    if value.startswith(("http://", "https://")):
+        return value
+    scheme = "http" if _is_loopback_hostname(value) else "https"
+    return f"{scheme}://{value}"
+
+
+def resolve_public_api_host(
+    configured: str | None,
+    *,
+    abi_port: str | None = None,
+    browser_host: str | None = None,
+) -> str | None:
+    """Pick the origin browsers should use for ``/modules`` and ``/logos``.
+
+    An explicit non-default ``public_api_host`` always wins (Docker / remote).
+    When the configured value is still the engine default (loopback + 9879, or
+    empty) and the process exported ``ABI_PORT``, use that port over ``http``.
+    """
+    configured = (configured or "").strip() or None
+    port = (abi_port or "").strip()
+
+    if configured and not _is_engine_default(configured):
+        return _with_scheme(configured)
+
+    if port.isdigit():
+        host = (browser_host or "").strip() or "localhost"
+        return f"http://{host}:{port}"
+
+    if configured:
+        return _with_scheme(configured)
+    return None
+
 
 def public_api_host() -> str | None:
-    """Configured public API host, normalized with an ``https://`` scheme.
+    """Configured public API host, with a scheme.
 
     Returns ``None`` when the ABIModule instance is not initialized (e.g. unit
-    tests), so callers can fall back to a relative path.
+    tests) and ``ABI_PORT`` is unset, so callers can fall back to a relative
+    path.
     """
+    configured: str | None = None
     try:
         from naas_abi import ABIModule
 
-        host = ABIModule.get_instance().configuration.global_config.public_api_host
+        value = ABIModule.get_instance().configuration.global_config.public_api_host
+        if isinstance(value, str) and value.strip():
+            configured = value
     except Exception:
-        return None
-    if not isinstance(host, str) or not host:
-        return None
-    if not host.startswith(("http://", "https://")):
-        host = f"https://{host}"
-    return host.rstrip("/")
+        configured = None
+
+    return resolve_public_api_host(
+        configured,
+        abi_port=os.environ.get("ABI_PORT"),
+        browser_host=os.environ.get("ABI_DEV_BROWSER_HOST"),
+    )
 
 
 def public_modules_url(path: str) -> str:
@@ -37,7 +105,6 @@ def public_modules_url(path: str) -> str:
     """
     host = public_api_host()
     if host is None:
-        # Re-raise via get_instance() when uninitialized; otherwise host is empty.
         from naas_abi import ABIModule
 
         ABIModule.get_instance()

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/utils/public_urls.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/utils/public_urls.py
@@ -10,15 +10,6 @@ from __future__ import annotations
 
 import os
 
-ENGINE_DEFAULT_HOSTS = frozenset(
-    {
-        "localhost",
-        "localhost:9879",
-        "127.0.0.1",
-        "127.0.0.1:9879",
-    }
-)
-
 
 def _strip_scheme(host: str) -> str:
     value = host.strip()
@@ -26,10 +17,6 @@ def _strip_scheme(host: str) -> str:
         if value.startswith(prefix):
             return value[len(prefix) :]
     return value
-
-
-def _is_engine_default(host: str) -> bool:
-    return _strip_scheme(host).rstrip("/") in ENGINE_DEFAULT_HOSTS
 
 
 def _is_loopback_hostname(host: str) -> bool:
@@ -50,17 +37,25 @@ def resolve_public_api_host(
     *,
     abi_port: str | None = None,
     browser_host: str | None = None,
+    dev_origin: str | None = None,
 ) -> str | None:
     """Pick the origin browsers should use for ``/modules`` and ``/logos``.
 
-    An explicit non-default ``public_api_host`` always wins (Docker / remote).
-    When the configured value is still the engine default (loopback + 9879, or
-    empty) and the process exported ``ABI_PORT``, use that port over ``http``.
+    ``dev_origin`` (``ABI_DEV_PUBLIC_API_ORIGIN``) wins. ``abi dev up`` sets it
+    on the process so a ``.env`` public hostname cannot shadow the allocated
+    port. Docker and remote leave it unset.
+
+    Without that, a public hostname in config is left alone. A loopback
+    (any port) plus ``ABI_PORT`` uses the live bind.
     """
+    origin = (dev_origin or "").strip()
+    if origin:
+        return _with_scheme(origin)
+
     configured = (configured or "").strip() or None
     port = (abi_port or "").strip()
 
-    if configured and not _is_engine_default(configured):
+    if configured and not _is_loopback_hostname(configured):
         return _with_scheme(configured)
 
     if port.isdigit():
@@ -76,8 +71,8 @@ def public_api_host() -> str | None:
     """Configured public API host, with a scheme.
 
     Returns ``None`` when the ABIModule instance is not initialized (e.g. unit
-    tests) and ``ABI_PORT`` is unset, so callers can fall back to a relative
-    path.
+    tests) and no live-port override is set, so callers can fall back to a
+    relative path.
     """
     configured: str | None = None
     try:
@@ -93,6 +88,7 @@ def public_api_host() -> str | None:
         configured,
         abi_port=os.environ.get("ABI_PORT"),
         browser_host=os.environ.get("ABI_DEV_BROWSER_HOST"),
+        dev_origin=os.environ.get("ABI_DEV_PUBLIC_API_ORIGIN"),
     )
 
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/utils/public_urls_test.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/utils/public_urls_test.py
@@ -1,0 +1,44 @@
+from naas_abi.apps.nexus.apps.api.app.utils.public_urls import resolve_public_api_host
+
+
+def test_explicit_public_hostname_is_kept() -> None:
+    assert (
+        resolve_public_api_host("https://api.example.com", abi_port="9967")
+        == "https://api.example.com"
+    )
+
+
+def test_explicit_hostname_without_scheme_gets_https() -> None:
+    assert (
+        resolve_public_api_host("api.example.com", abi_port="9967")
+        == "https://api.example.com"
+    )
+
+
+def test_engine_default_defers_to_abi_port() -> None:
+    assert (
+        resolve_public_api_host("localhost:9879", abi_port="9967")
+        == "http://localhost:9967"
+    )
+
+
+def test_engine_default_https_prefix_still_defers_to_abi_port() -> None:
+    assert (
+        resolve_public_api_host("https://localhost:9879", abi_port="9967")
+        == "http://localhost:9967"
+    )
+
+
+def test_missing_config_uses_abi_port() -> None:
+    assert (
+        resolve_public_api_host(None, abi_port="9967", browser_host="127.0.0.1")
+        == "http://127.0.0.1:9967"
+    )
+
+
+def test_loopback_without_scheme_uses_http() -> None:
+    assert resolve_public_api_host("localhost:9879") == "http://localhost:9879"
+
+
+def test_empty_config_and_no_port_is_none() -> None:
+    assert resolve_public_api_host(None) is None

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/utils/public_urls_test.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/utils/public_urls_test.py
@@ -15,14 +15,25 @@ def test_explicit_hostname_without_scheme_gets_https() -> None:
     )
 
 
-def test_engine_default_defers_to_abi_port() -> None:
+def test_docker_local_hostname_is_not_loopback() -> None:
+    assert (
+        resolve_public_api_host("api.localhost", abi_port="9967")
+        == "https://api.localhost"
+    )
+
+
+def test_loopback_any_port_defers_to_abi_port() -> None:
     assert (
         resolve_public_api_host("localhost:9879", abi_port="9967")
         == "http://localhost:9967"
     )
+    assert (
+        resolve_public_api_host("http://127.0.0.1:10400", abi_port="9967")
+        == "http://localhost:9967"
+    )
 
 
-def test_engine_default_https_prefix_still_defers_to_abi_port() -> None:
+def test_loopback_https_prefix_still_defers_to_abi_port() -> None:
     assert (
         resolve_public_api_host("https://localhost:9879", abi_port="9967")
         == "http://localhost:9967"
@@ -33,6 +44,17 @@ def test_missing_config_uses_abi_port() -> None:
     assert (
         resolve_public_api_host(None, abi_port="9967", browser_host="127.0.0.1")
         == "http://127.0.0.1:9967"
+    )
+
+
+def test_dev_origin_wins_over_public_hostname() -> None:
+    assert (
+        resolve_public_api_host(
+            "https://api.example.com",
+            abi_port="10400",
+            dev_origin="http://localhost:9967",
+        )
+        == "http://localhost:9967"
     )
 
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/agents/[agentId]/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/agents/[agentId]/page.tsx
@@ -5,6 +5,7 @@ import { ArrowLeft, Bot, CheckCircle, Save, XCircle } from 'lucide-react';
 import { useParams, useRouter } from 'next/navigation';
 import { cn } from '@/lib/utils';
 import { getApiUrl } from '@/lib/config';
+import { getLogoUrl } from '@/lib/logo-url';
 import { authFetch } from '@/stores/auth';
 import { useAgentsStore } from '@/stores/agents';
 import { useIntegrationsStore } from '@/stores/integrations';
@@ -36,12 +37,6 @@ type ServiceAgent = {
   updated_at: string;
   suggestions?: ServiceSuggestion[] | null;
   intents?: ServiceIntent[] | null;
-};
-
-const getLogoUrl = (url: string | null | undefined): string | undefined => {
-  if (!url) return undefined;
-  if (url.startsWith('http://') || url.startsWith('https://')) return url;
-  return `${getApiUrl()}${url}`;
 };
 
 export default function AgentEditPage() {

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/agents/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/agents/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useMemo, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { Bot, User, Cpu, Plus, Pencil, Trash2, Brain, Sparkles, Zap, Target, Search, X, CheckCircle, XCircle, Server, Check } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { getApiUrl } from '@/lib/config';
+import { getLogoUrl } from '@/lib/logo-url';
 import { useIntegrationsStore } from '@/stores/integrations';
 import { useAgentsStore, RESERVED_AGENT_TYPES, type Agent } from '@/stores/agents';
 import { useModelsStore, modelDisplayName } from '@/stores/models';
@@ -256,14 +256,6 @@ function AgentTypeSelect({
     </div>
   );
 }
-
-const getApiBase = () => getApiUrl();
-
-const getLogoUrl = (url: string | null): string | undefined => {
-  if (!url) return undefined;
-  if (url.startsWith('http://') || url.startsWith('https://')) return url;
-  return `${getApiBase()}${url}`;
-};
 
 const iconMap = {
   bot: Bot,

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/agent-selector.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/agent-selector.tsx
@@ -8,16 +8,7 @@ import { useAgentsStore, type Agent } from '@/stores/agents';
 import { useIntegrationsStore } from '@/stores/integrations';
 import { useModelsStore, modelDisplayName } from '@/stores/models';
 import { useAgentList } from '@/components/ui/dialogs';
-import { getApiUrl } from '@/lib/config';
-
-const getApiBase = () => getApiUrl();
-
-// Helper to get logo URL (prefix relative URLs with API base)
-const getLogoUrl = (url: string | null): string | undefined => {
-  if (!url) return undefined;
-  if (url.startsWith('http://') || url.startsWith('https://')) return url;
-  return `${getApiBase()}${url}`; // Relative URL -> add API base
-};
+import { getLogoUrl } from '@/lib/logo-url';
 
 const iconComponents = {
   user: User,
@@ -36,17 +27,28 @@ function AgentIcon({ icon, size = 16 }: { icon: Agent['icon']; size?: number }) 
 }
 
 export function AgentAvatar({ agent, size = 16 }: { agent: Agent; size?: number }) {
-  if (agent.logoUrl) {
-    return (
-      // eslint-disable-next-line @next/next/no-img-element
-      <img 
-        src={getLogoUrl(agent.logoUrl)} 
-        alt={agent.name} 
-        className="h-full w-full object-cover" 
-      />
-    );
-  }
-  return <AgentIcon icon={agent.icon} size={size} />;
+  const src = getLogoUrl(agent.logoUrl);
+  const [imgReady, setImgReady] = useState(false);
+
+  useEffect(() => {
+    setImgReady(false);
+  }, [src]);
+
+  return (
+    <>
+      {(!src || !imgReady) && <AgentIcon icon={agent.icon} size={size} />}
+      {src ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={src}
+          alt={agent.name}
+          className={imgReady ? 'h-full w-full object-cover' : 'hidden'}
+          onLoad={() => setImgReady(true)}
+          onError={() => setImgReady(false)}
+        />
+      ) : null}
+    </>
+  );
 }
 
 export function AgentSelector({ compact = false }: { compact?: boolean }) {

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
@@ -26,15 +26,9 @@ import { TypingIndicator } from '@/components/typing-indicator';
 import { PdfViewer } from '@/components/files/pdf-viewer';
 
 import { getApiUrl, getOllamaUrl } from '@/lib/config';
+import { getLogoUrl } from '@/lib/logo-url';
 
 const getApiBase = () => getApiUrl();
-
-// Helper to get logo URL (prefix relative URLs with API base)
-const getLogoUrl = (url: string | null): string | undefined => {
-  if (!url) return undefined;
-  if (url.startsWith('http://') || url.startsWith('https://')) return url;
-  return `${getApiBase()}${url}`; // Relative URL -> add API base
-};
 
 // Max image size for uploads (5MB)
 const MAX_IMAGE_SIZE = 5 * 1024 * 1024;
@@ -3174,6 +3168,30 @@ const CTA_SECTION_MAP: Record<string, SidebarSection> = {
   '/apps': 'apps',
 };
 
+function EmptyStateLogo({ src, name }: { src?: string; name: string }) {
+  const [imgReady, setImgReady] = useState(false);
+
+  useEffect(() => {
+    setImgReady(false);
+  }, [src]);
+
+  return (
+    <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-workspace-accent-10 overflow-hidden">
+      {(!src || !imgReady) && <Bot size={24} className="text-workspace-accent" />}
+      {src ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={src}
+          alt={name}
+          className={imgReady ? 'h-full w-full object-contain p-1' : 'hidden'}
+          onLoad={() => setImgReady(true)}
+          onError={() => setImgReady(false)}
+        />
+      ) : null}
+    </div>
+  );
+}
+
 function EmptyState({
   selectedAgentName,
   logoUrl,
@@ -3198,18 +3216,7 @@ function EmptyState({
   const greeting = firstName ? `Hello, ${firstName}.` : 'Hello.';
   return (
     <div className="flex h-full flex-col items-center justify-center px-4">
-      <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-workspace-accent-10 overflow-hidden">
-        {resolvedLogoUrl ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            src={resolvedLogoUrl}
-            alt={selectedAgentName}
-            className="h-full w-full object-contain p-1"
-          />
-        ) : (
-          <Bot size={24} className="text-workspace-accent" />
-        )}
-      </div>
+      <EmptyStateLogo src={resolvedLogoUrl} name={selectedAgentName} />
       <p className="mb-6 text-center text-muted-foreground">
         {greeting} Pick a suggestion or type a message to get started.
       </p>
@@ -3985,7 +3992,14 @@ const MessageBubble = React.memo(function MessageBubble({
           )
         ) : agent?.logoUrl ? (
           // eslint-disable-next-line @next/next/no-img-element
-          <img src={getLogoUrl(agent.logoUrl)} alt={agent.name} className="h-full w-full object-cover" />
+          <img
+            src={getLogoUrl(agent.logoUrl)}
+            alt={agent.name}
+            className="h-full w-full object-cover"
+            onError={(event) => {
+              event.currentTarget.style.display = 'none';
+            }}
+          />
         ) : (
           <Bot size={16} />
         )}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/logo-url.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/logo-url.ts
@@ -1,0 +1,32 @@
+import { getApiUrl } from '@/lib/config';
+
+/** Engine default API port when global_config.public_api_host is unset. */
+const ENGINE_DEFAULT_API_PORTS = new Set(['9879']);
+
+/**
+ * Resolve an agent/app logo for <img src>.
+ *
+ * Relative paths are prefixed with the Nexus API the browser already uses.
+ * Absolute URLs that still point at the engine default (loopback:9879) are
+ * rewritten to that same API so `abi dev up` (allocated ports) does not 404.
+ */
+export function getLogoUrl(url: string | null | undefined): string | undefined {
+  if (!url) return undefined;
+  const api = getApiUrl().replace(/\/$/, '');
+
+  if (url.startsWith('http://') || url.startsWith('https://')) {
+    try {
+      const parsed = new URL(url);
+      const loopback =
+        parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1';
+      if (loopback && ENGINE_DEFAULT_API_PORTS.has(parsed.port)) {
+        return `${api}${parsed.pathname}${parsed.search}`;
+      }
+    } catch {
+      return url;
+    }
+    return url;
+  }
+
+  return url.startsWith('/') ? `${api}${url}` : `${api}/${url}`;
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/logo-url.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/logo-url.ts
@@ -1,14 +1,15 @@
 import { getApiUrl } from '@/lib/config';
 
-/** Engine default API port when global_config.public_api_host is unset. */
-const ENGINE_DEFAULT_API_PORTS = new Set(['9879']);
+function isLoopback(hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '127.0.0.1';
+}
 
 /**
  * Resolve an agent/app logo for <img src>.
  *
  * Relative paths are prefixed with the Nexus API the browser already uses.
- * Absolute URLs that still point at the engine default (loopback:9879) are
- * rewritten to that same API so `abi dev up` (allocated ports) does not 404.
+ * Absolute loopback URLs whose port is not that API's port are rewritten so
+ * a stale config port does not 404.
  */
 export function getLogoUrl(url: string | null | undefined): string | undefined {
   if (!url) return undefined;
@@ -17,9 +18,12 @@ export function getLogoUrl(url: string | null | undefined): string | undefined {
   if (url.startsWith('http://') || url.startsWith('https://')) {
     try {
       const parsed = new URL(url);
-      const loopback =
-        parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1';
-      if (loopback && ENGINE_DEFAULT_API_PORTS.has(parsed.port)) {
+      const apiOrigin = new URL(api);
+      const staleLoopback =
+        isLoopback(parsed.hostname) &&
+        isLoopback(apiOrigin.hostname) &&
+        parsed.port !== apiOrigin.port;
+      if (staleLoopback) {
         return `${api}${parsed.pathname}${parsed.search}`;
       }
     } catch {


### PR DESCRIPTION
## Summary
- Module asset URLs were built from the engine default (`localhost:9879` plus an `https://` prefix) even when `abi dev up` bound the API to another port.
- `public_api_host()` now uses `ABI_PORT` when config is still that default, and `http` for loopback. An explicit public hostname is left alone.
- `abi dev up` exports `PUBLIC_API_HOST` and `NEXUS_API_URL` for the allocated API port, the same way it already exports `PUBLIC_WEB_HOST`.
- `GET /logos/<file>` checks `storage/logos` in the project root, then the engine package defaults.
- Shared `getLogoUrl()` rewrites leftover loopback:9879 URLs to the runtime API. Agent avatars and the chat empty-state keep the icon until the image loads.

Closes #1199

## Test plan
- [ ] `abi dev up` on a worktree whose API port is not 9879: `GET /api/agents` logo URLs use that port over `http`
- [ ] File under `/modules/...` returns 200 in the browser
- [ ] Config sets `public_api_host` to a real `https://` hostname: URLs keep that host; `ABI_PORT` does not override it
- [ ] `storage/logos/mark.png` is served at `/logos/mark.png`; an engine default such as `/logos/abi-logo.png` still 200s
- [ ] Agent with a valid logo: icon first, image after load
- [ ] Agent with a 404 logo: icon stays; no broken-image glyph