### PR TITLE
feat(api): mount module workflows, pipelines, and Expose tools

### DIFF
--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/module/pipelines/AGENTS.md
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/module/pipelines/AGENTS.md
@@ -96,7 +96,8 @@ uv run pytest {{module_name_snake}}/pipelines/<Name>Pipeline_test.py -v
 ## Wiring into the module
 
 1. Declare `TripleStoreService` in `ABIModule.dependencies.services`.
-2. Expose `pipeline.as_tools()` from an agent in `../agents/`, **or** invoke the pipeline from an orchestration that batches runs and persists results.
+2. Expose `pipeline.as_tools()` from an agent in `../agents/`, or invoke the pipeline from an orchestration that batches runs and persists results.
+3. HTTP: the kernel calls `as_api` and mounts live pipelines under `/pipelines`. A stub with a typed `run(parameters)` gets a default POST. A stub without `run()` stays unpublished.
 
 ## See also
 

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/module/workflows/AGENTS.md
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/module/workflows/AGENTS.md
@@ -94,7 +94,7 @@ uv run pytest {{module_name_snake}}/workflows/<Name>Workflow_test.py -v
 ## Wiring into the module
 
 - **Expose to an agent**: in `../agents/<Name>Agent.py`, instantiate the workflow and add `workflow.as_tools()` to the agent's `tools=[]`.
-- **Expose over HTTP**: workflows have access to `APIRouter` (`from naas_abi_core.utils.Expose import APIRouter`) — wire routes inside the module's `api(app)` hook.
+- **Expose over HTTP**: the kernel mounts live workflows under `/workflows`. Inherit the Expose default (`POST /{slug}` calls `run()`) or override `as_api`. An empty stub is unpublished unless `run(parameters)` is a real typed override.
 - **Schedule a recurring run**: wrap it in an `../orchestrations/<Name>Orchestration.py` Dagster job.
 
 ## See also

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/pipeline/{{pipeline_name_pascal}}Pipeline.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/pipeline/{{pipeline_name_pascal}}Pipeline.py
@@ -1,13 +1,11 @@
 import uuid
 from dataclasses import dataclass
-from enum import Enum
 from typing import Annotated, Optional
 
 from langchain_core.tools import BaseTool, StructuredTool
 from naas_abi_core import logger
 from naas_abi_core.pipeline import (Pipeline, PipelineConfiguration,
                                     PipelineParameters)
-from naas_abi_core.utils.Expose import APIRouter
 from pydantic import Field
 from rdflib import DCTERMS, OWL, RDF, RDFS, Graph, Literal, Namespace, URIRef
 
@@ -55,15 +53,5 @@ class {{pipeline_name_pascal}}Pipeline(Pipeline[{{pipeline_name_pascal}}Pipeline
             )
         ]
 
-    def as_api(
-        self,
-        router: APIRouter,
-        route_name: str = "",
-        name: str = "",
-        description: str = "",
-        description_stream: str = "",
-        tags: list[str | Enum] | None = None,
-    ) -> None:
-        if tags is None:
-            tags = []
-        return None
+    # as_api is inherited from Expose: POST /{slug} calls run() when this
+    # method is not overridden. Override only for a custom HTTP surface.

--- a/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/workflow/{{workflow_name_pascal}}Workflow.py
+++ b/libs/naas-abi-cli/naas_abi_cli/cli/new/templates/workflow/{{workflow_name_pascal}}Workflow.py
@@ -1,10 +1,8 @@
 from dataclasses import dataclass
-from enum import Enum
 from typing import Annotated, Optional
 
 from langchain_core.tools import BaseTool, StructuredTool
 from naas_abi_core.services.triple_store.TripleStorePorts import ITripleStoreService
-from naas_abi_core.utils.Expose import APIRouter
 from naas_abi_core.workflow import Workflow, WorkflowConfiguration
 from naas_abi_core.workflow.workflow import WorkflowParameters
 from pydantic import Field
@@ -59,15 +57,5 @@ class {{workflow_name_pascal}}Workflow(Workflow[{{workflow_name_pascal}}Workflow
             )
         ]
 
-    def as_api(
-        self,
-        router: APIRouter,
-        route_name: str = "",
-        name: str = "",
-        description: str = "",
-        description_stream: str = "",
-        tags: list[str | Enum] | None = None,
-    ) -> None:
-        if tags is None:
-            tags = []
-        return None
+    # as_api is inherited from Expose: POST /{slug} calls run() when this
+    # method is not overridden. Override only for a custom HTTP surface.

--- a/libs/naas-abi-core/naas_abi_core/apps/api/AGENTS.md
+++ b/libs/naas-abi-core/naas_abi_core/apps/api/AGENTS.md
@@ -1,0 +1,73 @@
+# ABI kernel API
+
+> Scope: `libs/naas-abi-core/naas_abi_core/apps/api/`. Canonical reference for the FastAPI kernel.
+
+## Purpose
+
+The kernel HTTP app. Every loaded **Expose** process that actually registers routes becomes an endpoint. Agents already were. Workflows, pipelines, and module tools now follow the same rule.
+
+Empty stubs do not appear in OpenAPI. A LangChain-only `BaseTool` stays agent-internal.
+
+## Files
+
+| File | Role |
+|---|---|
+| `api.py` | FastAPI app, auth, `_load_runtime_routes` |
+| `abi_api_key_auth.py` | Bearer / query-token check |
+| `openapi_doc.py` | Landing HTML and tag copy |
+| `../utils/process_api.py` | Instantiate processes; mount `as_api` or a default `run()` POST |
+
+## What `_load_runtime_routes` mounts
+
+1. **Agents** (`/agents`): `agent.New()` then `agent.as_api(agents_router)`. Unchanged.
+2. **Workflows** (`/workflows`): every `module.workflows` instance through `mount_module_processes`.
+3. **Pipelines** (`/pipelines`): same for `module.pipelines`.
+4. **Tools** (`/tools`): only items on `module.tools` that implement `as_api`. No invented `POST /tools/{name}` for LangChain tools.
+
+`/workflows`, `/pipelines`, and `/tools` routers are included only when they have routes, so OpenAPI does not advertise dead tags.
+
+Discovery happens in `BaseModule.on_load` (class walk). Instantiation happens in `on_initialized` (services are up). See [module/AGENTS.md](../../module/AGENTS.md).
+
+## Default `run()` POST
+
+If `as_api` adds no routes, the kernel registers `POST /{class_slug}` only when:
+
+- the class overrides `run` (not `Workflow.run` / `Pipeline.run`)
+- the first parameter is a Pydantic model
+
+`rdflib.Graph` results are returned as `{"format": "turtle", "data": "..."}`.
+
+## Tests
+
+```bash
+uv run pytest libs/naas-abi-core/naas_abi_core/utils/process_api_test.py -v
+uv run pytest libs/naas-abi-core/naas_abi_core/module/ModuleComponentLoader_test.py -v
+uv run pytest libs/naas-abi-core/naas_abi_core/apps/api/api_test.py -v
+```
+
+`process_api_test.py` uses fixture workflows, pipelines, and tools. It does not invent customer agents.
+
+`api_test.py` boots the real engine. It needs a working local config. If ABI services are missing, report that rather than weakening the test.
+
+## Local curl
+
+After `abi dev up` (API port from `abi dev ports`):
+
+```bash
+# Auth
+curl -s -X POST "http://127.0.0.1:<api-port>/token" \
+  -d "username=user&password=abi"
+
+# OpenAPI: agent paths stay; process paths appear only when live
+curl -s "http://127.0.0.1:<api-port>/openapi.json" | python -c \
+  "import json,sys; p=json.load(sys.stdin)['paths'];
+print('\n'.join(sorted(k for k in p if k.startswith(('/agents','/workflows','/pipelines','/tools')))))"
+
+# Example default run() (only if that class is loaded and constructible)
+curl -s -X POST "http://127.0.0.1:<api-port>/workflows/<slug>" \
+  -H "Authorization: Bearer ${ABI_API_KEY:-abi}" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+Issue: [jupyter-naas/abi#1202](https://github.com/jupyter-naas/abi/issues/1202). Related: #1195 (CLI / Nexus list), #1011 (engine catalog).

--- a/libs/naas-abi-core/naas_abi_core/apps/api/api.py
+++ b/libs/naas-abi-core/naas_abi_core/apps/api/api.py
@@ -2,7 +2,11 @@ import sys
 import time
 
 _BOOT_T0 = time.monotonic()
-print(f"[abi-boot] api module import started (pid={__import__('os').getpid()})", file=sys.stderr, flush=True)
+print(
+    f"[abi-boot] api module import started (pid={__import__('os').getpid()})",
+    file=sys.stderr,
+    flush=True,
+)
 
 import os
 import subprocess
@@ -23,10 +27,18 @@ from fastapi.security.oauth2 import OAuth2
 from fastapi.security.utils import get_authorization_scheme_param
 from fastapi.staticfiles import StaticFiles
 
-print(f"[abi-boot] heavy imports starting (+{time.monotonic() - _BOOT_T0:.2f}s)", file=sys.stderr, flush=True)
+print(
+    f"[abi-boot] heavy imports starting (+{time.monotonic() - _BOOT_T0:.2f}s)",
+    file=sys.stderr,
+    flush=True,
+)
 from naas_abi_core import logger
 
-print(f"[abi-boot] naas_abi_core imported (+{time.monotonic() - _BOOT_T0:.2f}s)", file=sys.stderr, flush=True)
+print(
+    f"[abi-boot] naas_abi_core imported (+{time.monotonic() - _BOOT_T0:.2f}s)",
+    file=sys.stderr,
+    flush=True,
+)
 
 # Docs
 from naas_abi_core.apps.api.openapi_doc import API_LANDING_HTML
@@ -183,12 +195,21 @@ pipelines_router = APIRouter(
     dependencies=[Depends(is_token_valid)],  # Apply token verification
 )
 
-# Create Pipelines API Router
+# Create Workflows API Router
 workflows_router = APIRouter(
     prefix="/workflows",
     tags=["Workflows"],
     responses={401: {"description": "Unauthorized"}},
     dependencies=[Depends(is_token_valid)],  # Apply token verification
+)
+
+# Create Tools API Router. Only Expose tools that register routes are mounted.
+# LangChain BaseTool instances stay agent-internal.
+tools_router = APIRouter(
+    prefix="/tools",
+    tags=["Tools"],
+    responses={401: {"description": "Unauthorized"}},
+    dependencies=[Depends(is_token_valid)],
 )
 
 
@@ -269,10 +290,24 @@ def _load_runtime_routes():
         logger.debug(f"Adding agent to API: {runtime_agent.name}")
         runtime_agent.as_api(agents_router)
 
-    # Include routers only once
+    from naas_abi_core.utils.process_api import mount_module_processes
+
+    mount_module_processes(
+        runtime_engine.modules.values(),
+        workflows_router=workflows_router,
+        pipelines_router=pipelines_router,
+        tools_router=tools_router,
+    )
+
+    # Include routers only once. Process routers stay out of OpenAPI when
+    # empty so Workflows / Pipelines / Tools tags are not advertised as live.
     app.include_router(agents_router)
-    app.include_router(pipelines_router)
-    app.include_router(workflows_router)
+    if pipelines_router.routes:
+        app.include_router(pipelines_router)
+    if workflows_router.routes:
+        app.include_router(workflows_router)
+    if tools_router.routes:
+        app.include_router(tools_router)
 
     for module in runtime_engine.modules.values():
         public_dir = os.path.join(module.module_root_path, "assets", "public")
@@ -317,7 +352,11 @@ def get_app() -> FastAPI:
 
 
 def api():
-    print(f"[abi-boot] api() entered, starting uvicorn (+{time.monotonic() - _BOOT_T0:.2f}s)", file=sys.stderr, flush=True)
+    print(
+        f"[abi-boot] api() entered, starting uvicorn (+{time.monotonic() - _BOOT_T0:.2f}s)",
+        file=sys.stderr,
+        flush=True,
+    )
     import uvicorn
 
     reload_enabled = api_runtime_configuration.reload

--- a/libs/naas-abi-core/naas_abi_core/apps/api/openapi_doc.py
+++ b/libs/naas-abi-core/naas_abi_core/apps/api/openapi_doc.py
@@ -84,6 +84,13 @@ API endpoints for interacting with ABI's pipelines.
 API endpoints for interacting with ABI's workflows.
         """,
     },
+    {
+        "name": "Tools",
+        "description": """
+API endpoints for module tools that implement Expose.as_api (or a live run()).
+LangChain-only tools stay agent-internal and are not listed here.
+        """,
+    },
 ]
 
 API_LANDING_HTML = """

--- a/libs/naas-abi-core/naas_abi_core/module/AGENTS.md
+++ b/libs/naas-abi-core/naas_abi_core/module/AGENTS.md
@@ -1,0 +1,40 @@
+# Module loaders
+
+> Scope: `libs/naas-abi-core/naas_abi_core/module/`. How a module discovers its components.
+
+## Purpose
+
+`BaseModule` is the unit of composition. `on_load` walks folders. `on_initialized` constructs what it can. The kernel API then calls `as_api` on the instances.
+
+## Files
+
+| File | Role |
+|---|---|
+| `Module.py` | `BaseModule` lists and lifecycle |
+| `ModuleAgentLoader.py` | `agents/*.py` → `Expose` subclasses |
+| `ModuleOrchestrationLoader.py` | `orchestrations/*.py` |
+| `ModuleModelLoader.py` | `models/` → model registry |
+| `ModuleComponentLoader.py` | Shared recursive folder walk |
+| `ModuleWorkflowLoader.py` | `workflows/` → `Workflow` subclasses |
+| `ModulePipelineLoader.py` | `pipelines/` → `Pipeline` subclasses |
+| `ModuleToolLoader.py` | `tools/` → `Expose` and `BaseTool` subclasses |
+| `../utils/process_api.py` | `instantiate_process`, default `run()` POST |
+
+## Lifecycle
+
+1. `on_load`: discover classes. Do not touch other modules or services.
+2. `on_initialized`: `instantiate_all` on workflow, pipeline, and tool classes. Call `super().on_initialized()` if you override this hook.
+3. Kernel `_load_runtime_routes`: agents via `New()` + `as_api`; processes via `mount_module_processes`.
+
+A class that needs constructor config we cannot supply is skipped and logged. That is intentional. Do not invent a fake instance.
+
+## Tools
+
+`module.tools` is the walk #1195 needs (Nexus list and compose). HTTP is narrower: only an `Expose` with a live `as_api` (or a live `run()`) is mounted under `/tools`. A LangChain `BaseTool` is not given REST.
+
+## Tests
+
+```bash
+uv run pytest libs/naas-abi-core/naas_abi_core/module/ModuleComponentLoader_test.py -v
+uv run pytest libs/naas-abi-core/naas_abi_core/module/ModuleModelLoader_test.py -v
+```

--- a/libs/naas-abi-core/naas_abi_core/module/Module.py
+++ b/libs/naas-abi-core/naas_abi_core/module/Module.py
@@ -12,7 +12,10 @@ from naas_abi_core.integration.integration import Integration
 from naas_abi_core.module.ModuleAgentLoader import ModuleAgentLoader
 from naas_abi_core.module.ModuleModelLoader import ModuleModelLoader
 from naas_abi_core.module.ModuleOrchestrationLoader import ModuleOrchestrationLoader
+from naas_abi_core.module.ModulePipelineLoader import ModulePipelineLoader
+from naas_abi_core.module.ModuleToolLoader import ModuleToolLoader
 from naas_abi_core.module.ModuleUtils import find_class_module_root_path
+from naas_abi_core.module.ModuleWorkflowLoader import ModuleWorkflowLoader
 from naas_abi_core.orchestrations.Orchestrations import Orchestrations
 from naas_abi_core.pipeline.pipeline import Pipeline
 from naas_abi_core.utils.Expose import Expose
@@ -75,7 +78,12 @@ class BaseModule(Generic[TConfig]):
     __integrations: list[Integration] = []
     __workflows: list[Workflow] = []
     __pipelines: list[Pipeline] = []
+    __tools: list[object] = []
     __orchestrations: list[type[Orchestrations]] = []
+    __workflow_classes: list[type[Workflow]] = []
+    __pipeline_classes: list[type[Pipeline]] = []
+    __tool_classes: list[type] = []
+    __processes_loaded: bool = False
 
     def __init__(self, engine: EngineProxy, configuration: TConfig):
         assert isinstance(configuration, ModuleConfiguration), (
@@ -90,7 +98,12 @@ class BaseModule(Generic[TConfig]):
         self.__agents = []
         self.__workflows = []
         self.__pipelines = []
+        self.__tools = []
         self.__orchestrations = []
+        self.__workflow_classes = []
+        self.__pipeline_classes = []
+        self.__tool_classes = []
+        self.__processes_loaded = False
 
         assert hasattr(self.__class__, "Configuration"), (
             "BaseModule must have a Configuration class"
@@ -143,6 +156,10 @@ class BaseModule(Generic[TConfig]):
         return self.__pipelines
 
     @property
+    def tools(self) -> list[object]:
+        return self.__tools
+
+    @property
     def orchestrations(self) -> list[type[Orchestrations]]:
         return self.__orchestrations
 
@@ -154,6 +171,10 @@ class BaseModule(Generic[TConfig]):
         self.__orchestrations = ModuleOrchestrationLoader.load_orchestrations(
             self.__class__
         )
+        self.__workflow_classes = ModuleWorkflowLoader.load_workflows(self.__class__)
+        self.__pipeline_classes = ModulePipelineLoader.load_pipelines(self.__class__)
+        self.__tool_classes = ModuleToolLoader.load_tools(self.__class__)
+        self.__processes_loaded = False
 
         # Auto-discover models from <module_root>/models/*.py whenever the
         # engine has a registry. ``ModelRegistryService`` is intentionally NOT
@@ -179,6 +200,23 @@ class BaseModule(Generic[TConfig]):
         services, or ontologies to be available and loaded.
         """
         logger.debug(f"on_initialized for module {self.__module__}")
+        self._ensure_processes_loaded()
+
+    def _ensure_processes_loaded(self) -> None:
+        """Instantiate discovered workflows, pipelines, and tools.
+
+        Called from ``on_initialized`` after services are available.
+        Classes that need constructor config we cannot supply are skipped.
+        Subclasses that override ``on_initialized`` must call ``super()``.
+        """
+        if self.__processes_loaded:
+            return
+        from naas_abi_core.utils.process_api import instantiate_all
+
+        self.__workflows = instantiate_all(self.__workflow_classes)
+        self.__pipelines = instantiate_all(self.__pipeline_classes)
+        self.__tools = instantiate_all(self.__tool_classes)
+        self.__processes_loaded = True
 
     def on_unloaded(self):
         pass

--- a/libs/naas-abi-core/naas_abi_core/module/ModuleComponentLoader.py
+++ b/libs/naas-abi-core/naas_abi_core/module/ModuleComponentLoader.py
@@ -1,0 +1,73 @@
+"""Shared filesystem discovery for module component classes.
+
+Walks ``<module_root>/<folder>/`` the same way ``ModuleAgentLoader`` walks
+``agents/``, including nested packages (marketplace pipelines already nest).
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import os
+
+from naas_abi_core.module.ModuleUtils import find_class_module_root_path
+from naas_abi_core.utils.Logger import logger
+
+
+def _is_component_source(filename: str) -> bool:
+    if not filename.endswith(".py"):
+        return False
+    if filename == "__init__.py":
+        return False
+    return not filename.endswith("test.py")
+
+
+def load_subclasses(class_: type, folder: str, base: type) -> list[type]:
+    """Return subclasses of ``base`` defined under ``<module_root>/<folder>/``.
+
+    Skips the base class itself, test modules, and classes that were only
+    imported into the file (``value.__module__`` must match the file).
+    """
+    found: list[type] = []
+    module_root_path = find_class_module_root_path(class_)
+    folder_path = module_root_path / folder
+    top_package = class_.__module__.split(".")[0]
+
+    if not os.path.exists(folder_path):
+        return found
+
+    logger.debug(f"Loading {folder} from {folder_path}")
+
+    for dirpath, _dirnames, filenames in os.walk(folder_path):
+        rel_dir = os.path.relpath(dirpath, folder_path)
+        for file in sorted(filenames):
+            if not _is_component_source(file):
+                continue
+
+            if rel_dir == ".":
+                dotted = f"{class_.__module__}.{folder}.{file[:-3]}"
+            else:
+                subpackage = rel_dir.replace(os.sep, ".")
+                dotted = f"{class_.__module__}.{folder}.{subpackage}.{file[:-3]}"
+
+            try:
+                imported = importlib.import_module(dotted)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "ModuleComponentLoader: failed to import %s: %s; skipping.",
+                    dotted,
+                    exc,
+                )
+                continue
+
+            for _name, value in inspect.getmembers(imported, inspect.isclass):
+                if value is base or not issubclass(value, base):
+                    continue
+                if value.__module__ != imported.__name__:
+                    continue
+                if value.__module__.split(".")[0] != top_package:
+                    continue
+                found.append(value)
+
+    logger.debug(f"{folder} classes: {found}")
+    return found

--- a/libs/naas-abi-core/naas_abi_core/module/ModuleComponentLoader_test.py
+++ b/libs/naas-abi-core/naas_abi_core/module/ModuleComponentLoader_test.py
@@ -1,0 +1,182 @@
+"""Discovery tests for workflows, pipelines, and module tools."""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+
+from naas_abi_core.module.ModulePipelineLoader import ModulePipelineLoader
+from naas_abi_core.module.ModuleToolLoader import ModuleToolLoader
+from naas_abi_core.module.ModuleWorkflowLoader import ModuleWorkflowLoader
+
+_WORKFLOW = textwrap.dedent(
+    """
+    from dataclasses import dataclass
+    from langchain_core.tools import BaseTool
+    from naas_abi_core.workflow import Workflow, WorkflowConfiguration
+    from naas_abi_core.workflow.workflow import WorkflowParameters
+
+
+    @dataclass
+    class EchoWorkflowConfiguration(WorkflowConfiguration):
+        pass
+
+
+    class EchoWorkflowParameters(WorkflowParameters):
+        text: str = "ok"
+
+
+    class EchoWorkflow(Workflow):
+        def run(self, parameters: EchoWorkflowParameters) -> dict:
+            return {"echo": parameters.text}
+
+        def as_tools(self) -> list[BaseTool]:
+            return []
+    """
+).strip()
+
+_PIPELINE = textwrap.dedent(
+    """
+    from dataclasses import dataclass
+    from langchain_core.tools import BaseTool
+    from naas_abi_core.pipeline import Pipeline, PipelineConfiguration, PipelineParameters
+    from rdflib import Graph
+
+
+    @dataclass
+    class EchoPipelineConfiguration(PipelineConfiguration):
+        pass
+
+
+    class EchoPipelineParameters(PipelineParameters):
+        text: str = "ok"
+
+
+    class EchoPipeline(Pipeline):
+        def run(self, parameters: EchoPipelineParameters) -> Graph:
+            return Graph()
+
+        def as_tools(self) -> list[BaseTool]:
+            return []
+    """
+).strip()
+
+_EXPOSE_TOOL = textwrap.dedent(
+    """
+    from enum import Enum
+    from fastapi import APIRouter
+    from langchain_core.tools import BaseTool
+    from naas_abi_core.utils.Expose import Expose
+
+
+    class FixtureExposeTool(Expose):
+        def as_tools(self) -> list[BaseTool]:
+            return []
+
+        def as_api(
+            self,
+            router: APIRouter,
+            route_name: str = "",
+            name: str = "",
+            description: str = "",
+            description_stream: str = "",
+            tags: list[str | Enum] | None = None,
+        ) -> None:
+            @router.post("/fixture_expose_tool")
+            def run_tool() -> dict:
+                return {"ok": True}
+    """
+).strip()
+
+
+def _make_module(tmp_path: Path, name: str, layout: dict[str, str]) -> type:
+    pkg = tmp_path / name
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text(
+        textwrap.dedent(
+            """
+            class FakeModule:
+                pass
+            """
+        ).strip()
+    )
+    for relpath, content in layout.items():
+        dest = pkg / relpath
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(content)
+        current = dest.parent
+        while current != pkg:
+            init = current / "__init__.py"
+            if not init.exists():
+                init.write_text("")
+            current = current.parent
+
+    sys.path.insert(0, str(tmp_path))
+    imported = __import__(name, fromlist=["FakeModule"])
+    return imported.FakeModule
+
+
+def test_workflow_loader_finds_class_in_workflows(tmp_path: Path) -> None:
+    cls = _make_module(
+        tmp_path,
+        "pkg_wf",
+        {"workflows/EchoWorkflow.py": _WORKFLOW},
+    )
+    found = ModuleWorkflowLoader.load_workflows(cls)
+    assert [item.__name__ for item in found] == ["EchoWorkflow"]
+
+
+def test_pipeline_loader_walks_nested_package(tmp_path: Path) -> None:
+    cls = _make_module(
+        tmp_path,
+        "pkg_pipe",
+        {"pipelines/nested/EchoPipeline.py": _PIPELINE},
+    )
+    found = ModulePipelineLoader.load_pipelines(cls)
+    assert [item.__name__ for item in found] == ["EchoPipeline"]
+
+
+def test_loaders_skip_test_modules(tmp_path: Path) -> None:
+    cls = _make_module(
+        tmp_path,
+        "pkg_skip",
+        {
+            "workflows/EchoWorkflow.py": _WORKFLOW,
+            "workflows/EchoWorkflow_test.py": _WORKFLOW.replace(
+                "EchoWorkflow", "TestOnlyWorkflow"
+            ),
+        },
+    )
+    found = ModuleWorkflowLoader.load_workflows(cls)
+    assert [item.__name__ for item in found] == ["EchoWorkflow"]
+
+
+def test_tool_loader_finds_expose_in_tools(tmp_path: Path) -> None:
+    cls = _make_module(
+        tmp_path,
+        "pkg_tool",
+        {"tools/FixtureExposeTool.py": _EXPOSE_TOOL},
+    )
+    found = ModuleToolLoader.load_tools(cls)
+    assert [item.__name__ for item in found] == ["FixtureExposeTool"]
+
+
+def test_import_failure_does_not_abort_sibling_files(tmp_path: Path) -> None:
+    cls = _make_module(
+        tmp_path,
+        "pkg_broken",
+        {
+            "workflows/broken.py": "import this_module_does_not_exist\n",
+            "workflows/EchoWorkflow.py": _WORKFLOW,
+        },
+    )
+    found = ModuleWorkflowLoader.load_workflows(cls)
+    assert [item.__name__ for item in found] == ["EchoWorkflow"]
+
+
+def test_missing_folder_returns_empty(tmp_path: Path) -> None:
+    cls = _make_module(tmp_path, "pkg_empty", {})
+    assert ModuleWorkflowLoader.load_workflows(cls) == []
+    assert ModulePipelineLoader.load_pipelines(cls) == []
+    assert ModuleToolLoader.load_tools(cls) == []

--- a/libs/naas-abi-core/naas_abi_core/module/ModulePipelineLoader.py
+++ b/libs/naas-abi-core/naas_abi_core/module/ModulePipelineLoader.py
@@ -1,0 +1,8 @@
+from naas_abi_core.module.ModuleComponentLoader import load_subclasses
+from naas_abi_core.pipeline.pipeline import Pipeline
+
+
+class ModulePipelineLoader:
+    @classmethod
+    def load_pipelines(cls, class_: type) -> list[type[Pipeline]]:
+        return load_subclasses(class_, "pipelines", Pipeline)

--- a/libs/naas-abi-core/naas_abi_core/module/ModuleToolLoader.py
+++ b/libs/naas-abi-core/naas_abi_core/module/ModuleToolLoader.py
@@ -1,0 +1,37 @@
+"""Discover module-level tools under ``tools/``.
+
+#1195 is the CLI scaffold and Nexus list/compose. This loader is the engine
+walk those features need: find tool classes, register them on the module.
+
+HTTP is a separate concern. Only ``Expose`` subclasses can grow REST via
+``as_api``. A LangChain ``BaseTool`` stays agent-internal.
+"""
+
+from __future__ import annotations
+
+from naas_abi_core.module.ModuleComponentLoader import load_subclasses
+from naas_abi_core.utils.Expose import Expose
+
+
+class ModuleToolLoader:
+    @classmethod
+    def load_tools(cls, class_: type) -> list[type]:
+        found: list[type] = []
+        seen: set[type] = set()
+
+        for tool_cls in load_subclasses(class_, "tools", Expose):
+            if tool_cls not in seen:
+                seen.add(tool_cls)
+                found.append(tool_cls)
+
+        try:
+            from langchain_core.tools import BaseTool
+        except ImportError:
+            return found
+
+        for tool_cls in load_subclasses(class_, "tools", BaseTool):
+            if tool_cls not in seen:
+                seen.add(tool_cls)
+                found.append(tool_cls)
+
+        return found

--- a/libs/naas-abi-core/naas_abi_core/module/ModuleWorkflowLoader.py
+++ b/libs/naas-abi-core/naas_abi_core/module/ModuleWorkflowLoader.py
@@ -1,0 +1,8 @@
+from naas_abi_core.module.ModuleComponentLoader import load_subclasses
+from naas_abi_core.workflow.workflow import Workflow
+
+
+class ModuleWorkflowLoader:
+    @classmethod
+    def load_workflows(cls, class_: type) -> list[type[Workflow]]:
+        return load_subclasses(class_, "workflows", Workflow)

--- a/libs/naas-abi-core/naas_abi_core/utils/Expose.py
+++ b/libs/naas-abi-core/naas_abi_core/utils/Expose.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from fastapi import APIRouter
 
-if TYPE_CHECKING:    
+if TYPE_CHECKING:
     from langchain_core.tools import BaseTool
 
 
@@ -26,7 +26,6 @@ class Expose(ABC):
         """
         raise NotImplementedError()
 
-    @abstractmethod
     def as_api(
         self,
         router: APIRouter,
@@ -36,20 +35,21 @@ class Expose(ABC):
         description_stream: str = "",
         tags: list[str | Enum] | None = None,
     ) -> None:
-        """Registers API routes for the class's functionality on the provided FastAPI router.
+        """Register HTTP routes on ``router``.
 
-        This method should be implemented by concrete classes to expose their functionality
-        via HTTP endpoints using FastAPI. The method should register routes on the provided
-        router that allow accessing the class's functionality through HTTP requests.
-
-        Args:
-            router (APIRouter): The FastAPI router on which to register the routes
-
-        Returns:
-            None
-
-        Raises:
-            NotImplementedError: If the concrete class does not implement this method
+        The default implementation posts ``run(parameters)`` when that method
+        is a real override with a Pydantic body. Subclasses that need a
+        custom surface override this. Stubs that return None are treated as
+        empty; the kernel then tries the same default and skips if ``run``
+        is not live. See ``naas_abi_core.utils.process_api``.
         """
-        raise NotImplementedError()
-        raise NotImplementedError()
+        from naas_abi_core.utils.process_api import register_run_route
+
+        register_run_route(
+            self,
+            router,
+            route_name=route_name,
+            name=name,
+            description=description,
+            tags=tags,
+        )

--- a/libs/naas-abi-core/naas_abi_core/utils/process_api.py
+++ b/libs/naas-abi-core/naas_abi_core/utils/process_api.py
@@ -1,0 +1,358 @@
+"""Mount module workflows, pipelines, and tools on FastAPI routers.
+
+The kernel calls ``as_api`` first. If that adds no routes, a default
+``POST /{slug}`` is registered only when ``run(parameters)`` is a real
+override with a Pydantic parameters model. Stubs without a live ``run``
+stay unpublished. LangChain-only tools are not given a REST path.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import re
+import sys
+import textwrap
+from collections.abc import Iterable
+from enum import Enum
+from typing import Any, TypeVar, get_type_hints
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from naas_abi_core.utils.Logger import logger
+
+T = TypeVar("T")
+
+_CAMEL_ACRONYM = re.compile(r"([A-Z]+)([A-Z][a-z])")
+_CAMEL_BOUNDARY = re.compile(r"([a-z0-9])([A-Z])")
+
+
+def process_route_slug(instance: Any) -> str:
+    name = instance.__class__.__name__
+    stepped = _CAMEL_ACRONYM.sub(r"\1_\2", name)
+    stepped = _CAMEL_BOUNDARY.sub(r"\1_\2", stepped)
+    return stepped.replace(" ", "_").replace("-", "_").lower()
+
+
+def _configuration_class(process_cls: type) -> type | None:
+    module = sys.modules.get(process_cls.__module__)
+    expected = f"{process_cls.__name__}Configuration"
+    if module is not None:
+        candidate = getattr(module, expected, None)
+        if isinstance(candidate, type):
+            return candidate
+    nested = getattr(process_cls, "Configuration", None)
+    if isinstance(nested, type):
+        return nested
+    return None
+
+
+def instantiate_process(process_cls: type[T]) -> T | None:
+    """Build a process with ``New()`` or an empty Configuration.
+
+    Returns None when the constructor needs arguments we do not have. The
+    kernel logs that and skips the process rather than crashing boot.
+    """
+    new = getattr(process_cls, "New", None)
+    if callable(new):
+        try:
+            instance = new()
+            if instance is not None:
+                return instance
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "instantiate_process: %s.New() failed: %s. Trying Configuration.",
+                process_cls.__name__,
+                exc,
+            )
+
+    config_cls = _configuration_class(process_cls)
+    if config_cls is not None:
+        try:
+            return process_cls(config_cls())  # type: ignore[call-arg]
+        except TypeError as exc:
+            logger.debug(
+                "instantiate_process: %s needs constructor config we cannot "
+                "supply (%s). Skipping.",
+                process_cls.__name__,
+                exc,
+            )
+            return None
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "instantiate_process: %s(%s()) failed: %s. Skipping.",
+                process_cls.__name__,
+                config_cls.__name__,
+                exc,
+            )
+            return None
+
+    try:
+        return process_cls()  # type: ignore[call-arg]
+    except TypeError as exc:
+        logger.debug(
+            "instantiate_process: %s() failed: %s. Skipping.",
+            process_cls.__name__,
+            exc,
+        )
+        return None
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "instantiate_process: %s() failed: %s. Skipping.",
+            process_cls.__name__,
+            exc,
+        )
+        return None
+
+
+def instantiate_all(classes: list[type[T]]) -> list[T]:
+    instances: list[T] = []
+    for process_cls in classes:
+        instance = instantiate_process(process_cls)
+        if instance is not None:
+            instances.append(instance)
+    return instances
+
+
+def _run_body_is_trivial(run: Any) -> bool:
+    """True when run() is only ``pass`` or ``raise NotImplementedError``.
+
+    Scaffold overrides must not become HTTP. If the source cannot be read,
+    treat the method as live so a real implementation is not dropped.
+    """
+    try:
+        source = inspect.getsource(run)
+    except (OSError, TypeError):
+        return False
+    try:
+        tree = ast.parse(textwrap.dedent(source))
+    except (SyntaxError, IndentationError):
+        return False
+    for node in tree.body:
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        body = [
+            stmt
+            for stmt in node.body
+            if not (
+                isinstance(stmt, ast.Expr)
+                and isinstance(getattr(stmt, "value", None), ast.Constant)
+                and isinstance(stmt.value.value, str)
+            )
+        ]
+        if not body:
+            return True
+        if len(body) == 1 and isinstance(body[0], ast.Pass):
+            return True
+        if len(body) == 1 and isinstance(body[0], ast.Raise):
+            exc = body[0].exc
+            if isinstance(exc, ast.Call) and getattr(exc.func, "id", None) == (
+                "NotImplementedError"
+            ):
+                return True
+            if isinstance(exc, ast.Name) and exc.id == "NotImplementedError":
+                return True
+        return False
+    return False
+
+
+def _run_is_live(instance: Any) -> bool:
+    run = getattr(type(instance), "run", None)
+    if run is None or not callable(run):
+        return False
+
+    from naas_abi_core.pipeline.pipeline import Pipeline
+    from naas_abi_core.workflow.workflow import Workflow
+
+    if isinstance(instance, Workflow) and type(instance).run is Workflow.run:
+        return False
+    if isinstance(instance, Pipeline) and type(instance).run is Pipeline.run:
+        return False
+    return not _run_body_is_trivial(run)
+
+
+def _run_parameters_type(instance: Any) -> type[BaseModel] | None:
+    run = getattr(type(instance), "run", None)
+    if run is None:
+        return None
+
+    try:
+        hints = get_type_hints(run)
+    except Exception:  # noqa: BLE001
+        hints = {}
+
+    for key in ("parameters", "params"):
+        annotated = hints.get(key)
+        if isinstance(annotated, type) and issubclass(annotated, BaseModel):
+            return annotated
+
+    try:
+        signature = inspect.signature(run)
+    except (TypeError, ValueError):
+        signature = None
+
+    if signature is not None:
+        for param_name, param in signature.parameters.items():
+            if param_name == "self":
+                continue
+            annotation = hints.get(param_name, param.annotation)
+            if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+                return annotation
+
+    expected = f"{instance.__class__.__name__}Parameters"
+    module = sys.modules.get(instance.__class__.__module__)
+    if module is not None:
+        candidate = getattr(module, expected, None)
+        if isinstance(candidate, type) and issubclass(candidate, BaseModel):
+            return candidate
+    return None
+
+
+def serialize_process_result(result: Any) -> Any:
+    try:
+        from rdflib import Graph
+    except ImportError:  # pragma: no cover
+        Graph = None  # type: ignore[assignment, misc]
+
+    if Graph is not None and isinstance(result, Graph):
+        return {"format": "turtle", "data": result.serialize(format="turtle")}
+    if isinstance(result, BaseModel):
+        return result.model_dump()
+    if isinstance(result, (bytes, bytearray)):
+        return {"data": result.decode("utf-8", errors="replace")}
+    return result
+
+
+def register_run_route(
+    instance: Any,
+    router: APIRouter,
+    route_name: str = "",
+    name: str = "",
+    description: str = "",
+    tags: list[str | Enum] | None = None,
+) -> bool:
+    """Register ``POST /{slug}`` that calls ``run()``. Returns True if mounted."""
+    if not _run_is_live(instance):
+        return False
+    parameters_type = _run_parameters_type(instance)
+    if parameters_type is None:
+        logger.debug(
+            "No Pydantic parameters type for %s.run. Not inventing a body.",
+            instance.__class__.__name__,
+        )
+        return False
+
+    slug = route_name or process_route_slug(instance)
+    display = name or instance.__class__.__name__
+    doc = (instance.__class__.__doc__ or "").strip()
+    desc = description or doc or display
+    prefix = (getattr(router, "prefix", None) or "").strip("/")
+    operation_id = f"{prefix}_{slug}" if prefix else slug
+
+    def run_process(parameters):
+        return serialize_process_result(instance.run(parameters))
+
+    # ``from __future__ import annotations`` would leave a ForwardRef here.
+    # FastAPI needs the real model class to build the JSON body.
+    run_process.__annotations__ = {
+        "parameters": parameters_type,
+        "return": object,
+    }
+    router.add_api_route(
+        f"/{slug}",
+        run_process,
+        methods=["POST"],
+        name=display,
+        description=desc,
+        tags=tags,
+        operation_id=operation_id,
+    )
+
+    return True
+
+
+def mount_expose_process(
+    instance: Any,
+    router: APIRouter,
+    route_name: str = "",
+    name: str = "",
+    description: str = "",
+    tags: list[str | Enum] | None = None,
+) -> bool:
+    """Call ``as_api``. If it added no routes, try the default ``run()`` POST."""
+    before = len(router.routes)
+    as_api = getattr(instance, "as_api", None)
+    if callable(as_api):
+        try:
+            as_api(
+                router,
+                route_name=route_name,
+                name=name,
+                description=description,
+                tags=tags,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "as_api failed for %s: %s",
+                instance.__class__.__name__,
+                exc,
+            )
+    if len(router.routes) > before:
+        return True
+    return register_run_route(
+        instance,
+        router,
+        route_name=route_name,
+        name=name,
+        description=description,
+        tags=tags,
+    )
+
+
+def _sort_key(obj: Any) -> str:
+    name = getattr(obj, "name", None)
+    if isinstance(name, str) and name:
+        return name.lower()
+    return obj.__class__.__name__.lower()
+
+
+def mount_module_processes(
+    modules: Iterable[Any],
+    *,
+    workflows_router: APIRouter,
+    pipelines_router: APIRouter,
+    tools_router: APIRouter,
+) -> None:
+    workflows: list[Any] = []
+    pipelines: list[Any] = []
+    tools: list[Any] = []
+
+    for module in modules:
+        for workflow in getattr(module, "workflows", None) or []:
+            if workflow is not None:
+                workflows.append(workflow)
+        for pipeline in getattr(module, "pipelines", None) or []:
+            if pipeline is not None:
+                pipelines.append(pipeline)
+        for tool in getattr(module, "tools", None) or []:
+            if tool is not None:
+                tools.append(tool)
+
+    for workflow in sorted(workflows, key=_sort_key):
+        logger.debug("Adding workflow to API: %s", workflow.__class__.__name__)
+        mount_expose_process(workflow, workflows_router)
+
+    for pipeline in sorted(pipelines, key=_sort_key):
+        logger.debug("Adding pipeline to API: %s", pipeline.__class__.__name__)
+        mount_expose_process(pipeline, pipelines_router)
+
+    for tool in sorted(tools, key=_sort_key):
+        if not callable(getattr(tool, "as_api", None)):
+            logger.debug(
+                "Skipping LangChain-only tool %s. No REST path invented.",
+                getattr(tool, "name", tool.__class__.__name__),
+            )
+            continue
+        logger.debug("Adding tool to API: %s", tool.__class__.__name__)
+        mount_expose_process(tool, tools_router)

--- a/libs/naas-abi-core/naas_abi_core/utils/process_api.py
+++ b/libs/naas-abi-core/naas_abi_core/utils/process_api.py
@@ -132,15 +132,12 @@ def _run_body_is_trivial(run: Any) -> bool:
     for node in tree.body:
         if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
-        body = [
-            stmt
-            for stmt in node.body
-            if not (
-                isinstance(stmt, ast.Expr)
-                and isinstance(getattr(stmt, "value", None), ast.Constant)
-                and isinstance(stmt.value.value, str)
-            )
-        ]
+        body: list[ast.stmt] = []
+        for stmt in node.body:
+            if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Constant):
+                if isinstance(stmt.value.value, str):
+                    continue
+            body.append(stmt)
         if not body:
             return True
         if len(body) == 1 and isinstance(body[0], ast.Pass):

--- a/libs/naas-abi-core/naas_abi_core/utils/process_api_test.py
+++ b/libs/naas-abi-core/naas_abi_core/utils/process_api_test.py
@@ -32,7 +32,22 @@ class EchoWorkflowParameters(WorkflowParameters):
     text: Annotated[str, Field(..., description="Text to echo")]
 
 
-class EchoWorkflow(Workflow):
+class _StubAsApi:
+    """Empty as_api with the Expose signature. Kernel should fall back to run()."""
+
+    def as_api(
+        self,
+        router: APIRouter,
+        route_name: str = "",
+        name: str = "",
+        description: str = "",
+        description_stream: str = "",
+        tags: list[str | Enum] | None = None,
+    ) -> None:
+        return None
+
+
+class EchoWorkflow(_StubAsApi, Workflow):
     """Fixture workflow with a stub as_api and a live run()."""
 
     def run(self, parameters: EchoWorkflowParameters) -> dict:
@@ -41,18 +56,12 @@ class EchoWorkflow(Workflow):
     def as_tools(self) -> list[BaseTool]:
         return []
 
-    def as_api(self, router, **kwargs) -> None:
-        return None
 
-
-class DeadWorkflow(Workflow):
+class DeadWorkflow(_StubAsApi, Workflow):
     """Fixture workflow: stub as_api and no run() override."""
 
     def as_tools(self) -> list[BaseTool]:
         return []
-
-    def as_api(self, router, **kwargs) -> None:
-        return None
 
 
 class LiveWorkflow(Workflow):
@@ -64,7 +73,15 @@ class LiveWorkflow(Workflow):
     def as_tools(self) -> list[BaseTool]:
         return []
 
-    def as_api(self, router, **kwargs) -> None:
+    def as_api(
+        self,
+        router: APIRouter,
+        route_name: str = "",
+        name: str = "",
+        description: str = "",
+        description_stream: str = "",
+        tags: list[str | Enum] | None = None,
+    ) -> None:
         @router.post("/custom_live")
         def custom(parameters: EchoWorkflowParameters) -> dict:
             return self.run(parameters)
@@ -75,19 +92,12 @@ class EchoPipelineConfiguration(PipelineConfiguration):
     pass
 
 
-class EchoPipelineParameters(PipelineParameters):
-    text: Annotated[str, Field(..., description="Unused")] = "ok"
-
-
-class EchoPipeline(Pipeline):
-    def run(self, parameters: EchoPipelineParameters) -> Graph:
+class EchoPipeline(_StubAsApi, Pipeline):
+    def run(self, parameters: PipelineParameters) -> Graph:
         return Graph()
 
     def as_tools(self) -> list[BaseTool]:
         return []
-
-    def as_api(self, router, **kwargs) -> None:
-        return None
 
 
 @dataclass
@@ -296,7 +306,7 @@ class InheritedRunWorkflow(Workflow):
 
 
 class PassOnlyWorkflow(Workflow):
-    def run(self, parameters: EchoWorkflowParameters) -> dict:  # type: ignore[return-value]
+    def run(self, parameters: EchoWorkflowParameters) -> dict:  # type: ignore[empty-body]
         pass
 
     def as_tools(self) -> list[BaseTool]:

--- a/libs/naas-abi-core/naas_abi_core/utils/process_api_test.py
+++ b/libs/naas-abi-core/naas_abi_core/utils/process_api_test.py
@@ -1,0 +1,323 @@
+"""Kernel process mounts: live as_api, default run(), stubs, no fiction."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Annotated
+
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+from langchain_core.tools import BaseTool, StructuredTool
+from pydantic import Field
+from rdflib import Graph
+
+from naas_abi_core.pipeline import Pipeline, PipelineConfiguration, PipelineParameters
+from naas_abi_core.utils.Expose import Expose
+from naas_abi_core.utils.process_api import (
+    instantiate_process,
+    mount_expose_process,
+    mount_module_processes,
+)
+from naas_abi_core.workflow import Workflow, WorkflowConfiguration
+from naas_abi_core.workflow.workflow import WorkflowParameters
+
+
+@dataclass
+class EchoWorkflowConfiguration(WorkflowConfiguration):
+    pass
+
+
+class EchoWorkflowParameters(WorkflowParameters):
+    text: Annotated[str, Field(..., description="Text to echo")]
+
+
+class EchoWorkflow(Workflow):
+    """Fixture workflow with a stub as_api and a live run()."""
+
+    def run(self, parameters: EchoWorkflowParameters) -> dict:
+        return {"echo": parameters.text}
+
+    def as_tools(self) -> list[BaseTool]:
+        return []
+
+    def as_api(self, router, **kwargs) -> None:
+        return None
+
+
+class DeadWorkflow(Workflow):
+    """Fixture workflow: stub as_api and no run() override."""
+
+    def as_tools(self) -> list[BaseTool]:
+        return []
+
+    def as_api(self, router, **kwargs) -> None:
+        return None
+
+
+class LiveWorkflow(Workflow):
+    """Fixture workflow that registers its own route."""
+
+    def run(self, parameters: EchoWorkflowParameters) -> dict:
+        return {"live": parameters.text}
+
+    def as_tools(self) -> list[BaseTool]:
+        return []
+
+    def as_api(self, router, **kwargs) -> None:
+        @router.post("/custom_live")
+        def custom(parameters: EchoWorkflowParameters) -> dict:
+            return self.run(parameters)
+
+
+@dataclass
+class EchoPipelineConfiguration(PipelineConfiguration):
+    pass
+
+
+class EchoPipelineParameters(PipelineParameters):
+    text: Annotated[str, Field(..., description="Unused")] = "ok"
+
+
+class EchoPipeline(Pipeline):
+    def run(self, parameters: EchoPipelineParameters) -> Graph:
+        return Graph()
+
+    def as_tools(self) -> list[BaseTool]:
+        return []
+
+    def as_api(self, router, **kwargs) -> None:
+        return None
+
+
+@dataclass
+class NeedsStoreConfiguration(WorkflowConfiguration):
+    store: object
+
+
+class NeedsStoreWorkflow(Workflow):
+    def __init__(self, configuration: NeedsStoreConfiguration):
+        super().__init__(configuration)
+
+    def as_tools(self) -> list[BaseTool]:
+        return []
+
+
+class LiveExposeTool(Expose):
+    def as_tools(self) -> list[BaseTool]:
+        return []
+
+    def as_api(
+        self,
+        router: APIRouter,
+        route_name: str = "",
+        name: str = "",
+        description: str = "",
+        description_stream: str = "",
+        tags: list[str | Enum] | None = None,
+    ) -> None:
+        @router.post("/live_expose_tool")
+        def run_tool() -> dict:
+            return {"tool": True}
+
+
+class FakeAgent:
+    name = "fixture_agent"
+
+    @classmethod
+    def New(cls) -> FakeAgent:
+        return cls()
+
+    def as_api(self, router: APIRouter, **kwargs) -> None:
+        @router.post(f"/{self.name}/completion")
+        def completion() -> dict:
+            return {"ok": True}
+
+        @router.post(f"/{self.name}/stream-completion")
+        def stream() -> dict:
+            return {"ok": True}
+
+
+class FakeModule:
+    def __init__(
+        self,
+        *,
+        workflows: list | None = None,
+        pipelines: list | None = None,
+        tools: list | None = None,
+    ):
+        self.workflows = workflows or []
+        self.pipelines = pipelines or []
+        self.tools = tools or []
+
+
+def _openapi_paths(app: FastAPI) -> set[str]:
+    return set(TestClient(app).get("/openapi.json").json().get("paths", {}))
+
+
+def test_live_as_api_appears_in_openapi() -> None:
+    workflows_router = APIRouter(prefix="/workflows")
+    assert mount_expose_process(
+        LiveWorkflow(EchoWorkflowConfiguration()), workflows_router
+    )
+    app = FastAPI()
+    app.include_router(workflows_router)
+    assert "/workflows/custom_live" in _openapi_paths(app)
+
+
+def test_stub_with_live_run_gets_default_post() -> None:
+    workflows_router = APIRouter(prefix="/workflows")
+    workflow = EchoWorkflow(EchoWorkflowConfiguration())
+    assert mount_expose_process(workflow, workflows_router)
+    app = FastAPI()
+    app.include_router(workflows_router)
+    client = TestClient(app)
+    paths = set(client.get("/openapi.json").json()["paths"])
+    assert "/workflows/echo_workflow" in paths
+    response = client.post("/workflows/echo_workflow", json={"text": "hi"})
+    assert response.status_code == 200
+    assert response.json() == {"echo": "hi"}
+
+
+def test_stub_without_run_is_not_published() -> None:
+    workflows_router = APIRouter(prefix="/workflows")
+    assert not mount_expose_process(
+        DeadWorkflow(EchoWorkflowConfiguration()), workflows_router
+    )
+    assert workflows_router.routes == []
+
+
+def test_pipeline_default_run_serializes_graph() -> None:
+    pipelines_router = APIRouter(prefix="/pipelines")
+    assert mount_expose_process(
+        EchoPipeline(EchoPipelineConfiguration()), pipelines_router
+    )
+    app = FastAPI()
+    app.include_router(pipelines_router)
+    client = TestClient(app)
+    response = client.post("/pipelines/echo_pipeline", json={})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["format"] == "turtle"
+    assert isinstance(body["data"], str)
+
+
+def test_langchain_tool_does_not_get_rest() -> None:
+    tools_router = APIRouter(prefix="/tools")
+    langchain_only = StructuredTool.from_function(
+        func=lambda: "nope",
+        name="only_langchain",
+        description="Agent-internal only",
+    )
+    mount_module_processes(
+        [FakeModule(tools=[langchain_only])],
+        workflows_router=APIRouter(prefix="/workflows"),
+        pipelines_router=APIRouter(prefix="/pipelines"),
+        tools_router=tools_router,
+    )
+    assert tools_router.routes == []
+
+
+def test_expose_tool_with_as_api_is_mounted() -> None:
+    tools_router = APIRouter(prefix="/tools")
+    mount_module_processes(
+        [FakeModule(tools=[LiveExposeTool()])],
+        workflows_router=APIRouter(prefix="/workflows"),
+        pipelines_router=APIRouter(prefix="/pipelines"),
+        tools_router=tools_router,
+    )
+    app = FastAPI()
+    app.include_router(tools_router)
+    assert "/tools/live_expose_tool" in _openapi_paths(app)
+
+
+def test_agent_routes_still_exist_beside_processes() -> None:
+    agents_router = APIRouter(prefix="/agents")
+    workflows_router = APIRouter(prefix="/workflows")
+    pipelines_router = APIRouter(prefix="/pipelines")
+    tools_router = APIRouter(prefix="/tools")
+
+    FakeAgent.New().as_api(agents_router)
+    mount_module_processes(
+        [
+            FakeModule(
+                workflows=[
+                    LiveWorkflow(EchoWorkflowConfiguration()),
+                    DeadWorkflow(EchoWorkflowConfiguration()),
+                ],
+                pipelines=[EchoPipeline(EchoPipelineConfiguration())],
+                tools=[
+                    LiveExposeTool(),
+                    StructuredTool.from_function(
+                        func=lambda: "nope",
+                        name="only_langchain",
+                        description="skip",
+                    ),
+                ],
+            )
+        ],
+        workflows_router=workflows_router,
+        pipelines_router=pipelines_router,
+        tools_router=tools_router,
+    )
+
+    app = FastAPI()
+    app.include_router(agents_router)
+    if workflows_router.routes:
+        app.include_router(workflows_router)
+    if pipelines_router.routes:
+        app.include_router(pipelines_router)
+    if tools_router.routes:
+        app.include_router(tools_router)
+
+    paths = _openapi_paths(app)
+    assert "/agents/fixture_agent/completion" in paths
+    assert "/agents/fixture_agent/stream-completion" in paths
+    assert "/workflows/custom_live" in paths
+    assert "/pipelines/echo_pipeline" in paths
+    assert "/tools/live_expose_tool" in paths
+    assert not any("dead_workflow" in path for path in paths)
+    assert not any("only_langchain" in path for path in paths)
+
+
+def test_instantiate_skips_required_config() -> None:
+    assert instantiate_process(NeedsStoreWorkflow) is None
+    assert isinstance(instantiate_process(EchoWorkflow), EchoWorkflow)
+
+
+class InheritedRunWorkflow(Workflow):
+    """No as_api override. Expose default should POST run()."""
+
+    def run(self, parameters: EchoWorkflowParameters) -> dict:
+        return {"echo": parameters.text}
+
+    def as_tools(self) -> list[BaseTool]:
+        return []
+
+
+class PassOnlyWorkflow(Workflow):
+    def run(self, parameters: EchoWorkflowParameters) -> dict:  # type: ignore[return-value]
+        pass
+
+    def as_tools(self) -> list[BaseTool]:
+        return []
+
+
+def test_inherited_as_api_posts_live_run() -> None:
+    workflows_router = APIRouter(prefix="/workflows")
+    workflow = InheritedRunWorkflow(EchoWorkflowConfiguration())
+    assert mount_expose_process(workflow, workflows_router)
+    app = FastAPI()
+    app.include_router(workflows_router)
+    client = TestClient(app)
+    response = client.post("/workflows/inherited_run_workflow", json={"text": "ok"})
+    assert response.status_code == 200
+    assert response.json() == {"echo": "ok"}
+
+
+def test_pass_only_run_is_not_published() -> None:
+    workflows_router = APIRouter(prefix="/workflows")
+    assert not mount_expose_process(
+        PassOnlyWorkflow(EchoWorkflowConfiguration()), workflows_router
+    )
+    assert workflows_router.routes == []


### PR DESCRIPTION
## Summary
- Kernel `_load_runtime_routes` now mounts workflows, pipelines, and Expose tools the same way it already mounts agents. `/workflows` and `/pipelines` are no longer empty routers advertised as live.
- `BaseModule` discovers `workflows/`, `pipelines/`, and `tools/` on load and instantiates what it can after services are up. Classes that need constructor config we cannot supply are skipped.
- A real `as_api` is used as-is. A stub gets a default `POST /{slug}` only when `run(parameters)` is a typed override. LangChain-only tools stay agent-internal. No invented customer agents.

Fixes #1202. Related: #1195 (CLI / Nexus list), #1011 (engine catalog).

## Test plan
- [ ] `uv run pytest libs/naas-abi-core/naas_abi_core/utils/process_api_test.py libs/naas-abi-core/naas_abi_core/module/ModuleComponentLoader_test.py -v`
- [ ] `abi dev up` and confirm `/agents/.../completion` still exists in `GET /openapi.json`
- [ ] Confirm `/workflows` and `/pipelines` tags appear only when a constructible process registered routes
- [ ] `curl` a known live process (example: ArXiv `POST /workflows/arxiv/query` if that module is loaded) with `Authorization: Bearer $ABI_API_KEY`
- [ ] Confirm a stub without `run()` does not show up in OpenAPI