### PR TITLE
Add bootstrap lock for triple store schema graph to avoid redundant insertions

### DIFF
--- a/libs/naas-abi-core/naas_abi_core/services/triple_store/TripleStoreService.py
+++ b/libs/naas-abi-core/naas_abi_core/services/triple_store/TripleStoreService.py
@@ -71,6 +71,16 @@ internal:content a owl:DatatypeProperty ;
     rdfs:comment "Base64 encoded content of the schema file" .
 """
 GRAPH_CLASS = URIRef("http://ontology.naas.ai/abi/Graph")
+_SCHEMA_GRAPH = URIRef("http://ontology.naas.ai/graph/schema")
+_SCHEMA_CLASS = URIRef("http://triple-store.internal#Schema")
+_OWL_CLASS = URIRef("http://www.w3.org/2002/07/owl#Class")
+_SCHEMA_BOOTSTRAP_ASK = f"""
+ASK WHERE {{
+  GRAPH <{_SCHEMA_GRAPH}> {{
+    <{_SCHEMA_CLASS}> a <{_OWL_CLASS}>
+  }}
+}}
+"""
 
 
 class TripleStoreService(ServiceBase, ITripleStoreService):
@@ -98,9 +108,47 @@ class TripleStoreService(ServiceBase, ITripleStoreService):
     ):
         super().__init__()
         self.__triple_store_adapter = triple_store_adapter
-        self.__schema_graph = URIRef("http://ontology.naas.ai/graph/schema")
+        self.__schema_graph = _SCHEMA_GRAPH
 
-        # Load SCHEMA_TTL in IOBuffer
+        self._bootstrap_schema_graph()
+
+    def _schema_graph_bootstrapped(self) -> bool:
+        """Return True when the built-in schema vocabulary is already in the store.
+
+        Read-only ASK — no distributed write lock — so Dagster run workers that
+        only need to check boot state do not contend with active writers.
+        """
+        try:
+            result = self.__triple_store_adapter.query(_SCHEMA_BOOTSTRAP_ASK)
+        except Exception as exc:
+            logger.debug(
+                "TripleStoreService: schema bootstrap probe failed (%s) — "
+                "will attempt insert",
+                exc,
+            )
+            return False
+
+        ask_answer = getattr(result, "askAnswer", None)
+        if ask_answer is not None:
+            return bool(ask_answer)
+
+        if isinstance(result, rdflib.query.Result) and result.type == "ASK":
+            return bool(result.askAnswer)
+
+        logger.debug(
+            "TripleStoreService: schema bootstrap probe returned unexpected "
+            "%r — will attempt insert",
+            type(result),
+        )
+        return False
+
+    def _bootstrap_schema_graph(self) -> None:
+        if self._schema_graph_bootstrapped():
+            logger.debug(
+                "TripleStoreService: schema graph already present — skip bootstrap insert"
+            )
+            return
+
         schema_ttl_buffer = io.StringIO(SCHEMA_TTL)
         self.insert(
             Graph().parse(schema_ttl_buffer, format="turtle"),

--- a/libs/naas-abi-core/naas_abi_core/services/triple_store/TripleStoreService.py
+++ b/libs/naas-abi-core/naas_abi_core/services/triple_store/TripleStoreService.py
@@ -120,7 +120,7 @@ class TripleStoreService(ServiceBase, ITripleStoreService):
         """
         try:
             result = self.__triple_store_adapter.query(_SCHEMA_BOOTSTRAP_ASK)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             logger.debug(
                 "TripleStoreService: schema bootstrap probe failed (%s) — "
                 "will attempt insert",

--- a/libs/naas-abi-core/naas_abi_core/services/triple_store/TripleStoreService_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/triple_store/TripleStoreService_test.py
@@ -54,9 +54,12 @@ class _FakeTripleStoreAdapter(ITripleStorePort):
         self.clear_graph_calls: list[URIRef | None] = []
         self.drop_graph_calls: list[URIRef] = []
         self.graphs_to_return: list[URIRef] = []
+        self.schema_graph_present = False
 
     def insert(self, triples: Graph, graph_name: URIRef | None = None):
         self.insert_calls.append((triples, graph_name))
+        if graph_name == URIRef("http://ontology.naas.ai/graph/schema"):
+            self.schema_graph_present = True
 
     def remove(self, triples: Graph, graph_name: URIRef | None = None):
         self.remove_calls.append((triples, graph_name))
@@ -65,6 +68,10 @@ class _FakeTripleStoreAdapter(ITripleStorePort):
         return Graph()
 
     def query(self, query: str) -> rdflib.query.Result:
+        if "ASK" in query.upper() and "triple-store.internal#Schema" in query:
+            result = rdflib.query.Result("ASK")
+            result.askAnswer = self.schema_graph_present
+            return result
         return rdflib.query.Result("SELECT")
 
     def query_view(self, view: str, query: str) -> rdflib.query.Result:
@@ -169,6 +176,23 @@ def _build_service() -> tuple[TripleStoreService, _FakeTripleStoreAdapter, _Fake
     bus = _FakeBus()
     service.set_services(cast(Any, SimpleNamespace(bus=bus)))
     return service, adapter, bus
+
+
+def test_constructor_skips_schema_insert_when_schema_graph_already_present():
+    adapter = _InMemoryTripleStoreAdapter()
+
+    TripleStoreService(adapter)
+    schema_inserts = [
+        call
+        for call in adapter.insert_calls
+        if call[1] == URIRef("http://ontology.naas.ai/graph/schema")
+    ]
+    assert len(schema_inserts) == 1
+
+    adapter.insert_calls.clear()
+    TripleStoreService(adapter)
+
+    assert adapter.insert_calls == []
 
 
 def test_insert_default_graph_publishes_default_topic_and_passes_none_graph():

--- a/uv.lock
+++ b/uv.lock
@@ -3548,7 +3548,7 @@ wheels = [
 
 [[package]]
 name = "naas-abi"
-version = "2.54.1"
+version = "2.54.3"
 source = { editable = "libs/naas-abi" }
 dependencies = [
     { name = "aiosqlite" },
@@ -3630,7 +3630,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-cli"
-version = "2.17.2"
+version = "2.18.1"
 source = { editable = "libs/naas-abi-cli" }
 dependencies = [
     { name = "naas-abi" },
@@ -3656,7 +3656,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-core"
-version = "2.26.2"
+version = "2.27.2"
 source = { editable = "libs/naas-abi-core" }
 dependencies = [
     { name = "click" },
@@ -3787,7 +3787,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-marketplace"
-version = "3.36.1"
+version = "3.36.4"
 source = { editable = "libs/naas-abi-marketplace" }
 dependencies = [
     { name = "ijson" },


### PR DESCRIPTION
This pull request resolves #bootstrap-triplestore-lock

# Summary

This PR introduces a bootstrap lock mechanism for the triple store schema graph in the `TripleStoreService`. It adds a check to determine if the built-in schema vocabulary is already present in the triple store before attempting to insert it, preventing redundant insertions.

# Changes

- Added constants for schema graph URI, schema class, OWL class, and an ASK query to check if the schema graph is bootstrapped.
- Implemented `_schema_graph_bootstrapped` method to perform a read-only ASK query to check if the schema graph is already present.
- Modified the constructor to call `_bootstrap_schema_graph`, which skips the schema insertion if the schema graph is already present.
- Updated the test double `_FakeTripleStoreAdapter` to simulate the presence of the schema graph and respond to the ASK query accordingly.
- Added a new test `test_constructor_skips_schema_insert_when_schema_graph_already_present` to verify that the schema graph insertion is skipped if already present.

# Benefits

- Avoids redundant schema graph insertions, reducing unnecessary writes and potential contention.
- Uses a read-only ASK query for bootstrapping check, which does not require distributed write locks, improving concurrency for Dagster run workers.

# Testing

- Added unit test to confirm that the schema graph is inserted only once and subsequent service initializations skip the insertion if the schema graph is already present.

This improves the robustness and efficiency of the triple store schema bootstrapping process.