### PR TITLE
feat(nexus): default workspace apps off and seed catalog roster

### DIFF
--- a/libs/naas-abi/naas_abi/__init__.py
+++ b/libs/naas-abi/naas_abi/__init__.py
@@ -290,6 +290,14 @@ class WorkspaceSeedConfig(BaseModel):
     background_color: str | None = None
     sidebar_color: str | None = None
     font_family: str | None = None
+    # Same syntax as engine ``default_agent``: ``module AgentClass``.
+    default_agent: str | None = None
+    # Registry refs to enable in this workspace. ``None`` keeps class flags
+    # (``ENABLED_BY_DEFAULT``). A list is the roster: listed on, others off.
+    agents: list[str] | None = None
+    # Catalog ``app_id`` values (``module.path:folder``) to enable at boot.
+    # ``None`` means no seed; missing app-config rows default to off.
+    apps: list[str] | None = None
 
 
 class OrganizationSeedConfig(BaseModel):
@@ -553,6 +561,11 @@ class ABIModule(BaseModule):
                         - name: "Ops Workspace"
                           slug: "ops-workspace"
                           owner_email: "owner@example.com"
+                          default_agent: "naas_abi AbiAgent"
+                          agents:
+                            - "naas_abi AbiAgent"
+                          apps:
+                            - example.module:dashboard
                           members:
                             - email: "admin@example.com"
                               role: "member"

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/config.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/config.py
@@ -289,6 +289,9 @@ class WorkspaceSeedConfig(BaseModel):
     background_color: str | None = None
     sidebar_color: str | None = None
     font_family: str | None = None
+    default_agent: str | None = None
+    agents: list[str] | None = None
+    apps: list[str] | None = None
 
 
 class OrganizationSeedConfig(BaseModel):

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/org_seed.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/org_seed.py
@@ -7,6 +7,7 @@ This provisions:
 - organization members
 - workspaces (upsert by slug)
 - workspace members
+- workspace app enable rows from ``WorkspaceSeedConfig.apps``
 
 It can also mirror configured user credentials into the Secret service.
 """
@@ -27,6 +28,7 @@ from naas_abi.apps.nexus.apps.api.app.core.config import (
 from naas_abi.apps.nexus.apps.api.app.core.database import async_engine
 from naas_abi.apps.nexus.apps.api.app.core.datetime_compat import UTC
 from naas_abi.apps.nexus.apps.api.app.models import (
+    AppConfigModel,
     OrganizationMemberModel,
     OrganizationModel,
     UserModel,
@@ -352,6 +354,47 @@ async def _upsert_workspace(
             continue
         member_role = "owner" if member.id == owner.id else membership.role
         await _ensure_workspace_member(session, workspace.id, member.id, member_role)
+
+    await _seed_workspace_apps(session, workspace.id, workspace_cfg.apps)
+
+
+async def _seed_workspace_apps(
+    session: AsyncSession,
+    workspace_id: str,
+    app_ids: list[str] | None,
+) -> None:
+    """Insert missing enabled rows for seeded catalog apps. Existing rows win."""
+    if not app_ids:
+        return
+    now = datetime.now(UTC).replace(tzinfo=None)
+    for raw in app_ids:
+        app_id = str(raw or "").strip()
+        if not app_id:
+            continue
+        result = await session.execute(
+            select(AppConfigModel).where(
+                (AppConfigModel.workspace_id == workspace_id)
+                & (AppConfigModel.app_id == app_id)
+            )
+        )
+        row = result.scalar_one_or_none()
+        if row is not None:
+            continue
+        session.add(
+            AppConfigModel(
+                id=f"app-{uuid4().hex[:12]}",
+                workspace_id=workspace_id,
+                app_id=app_id,
+                enabled=True,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        logger.info(
+            "Seeded app_id=%s enabled on workspace_id=%s",
+            app_id,
+            workspace_id,
+        )
 
 
 async def _upsert_organization(

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/workspace_catalog_seed.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/workspace_catalog_seed.py
@@ -1,0 +1,80 @@
+"""Resolve per-workspace app and agent seed lists from Nexus settings."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from naas_abi.apps.nexus.apps.api.app.core import config as nexus_config
+
+
+def live_settings() -> Any:
+    """Return the live Settings object.
+
+    ``on_initialized`` replaces ``nexus_config.settings``. Callers must not
+    bind the import-time snapshot.
+    """
+    return nexus_config.settings
+
+
+def workspace_seed_for_slug(slug: str | None) -> Any | None:
+    if not slug:
+        return None
+    for org in getattr(live_settings(), "organizations", None) or []:
+        for workspace in getattr(org, "workspaces", None) or []:
+            if workspace.slug == slug:
+                return workspace
+    return None
+
+
+def parse_agent_ref(raw: str) -> tuple[str, str] | None:
+    """Split ``module AgentClass`` (same form as engine ``default_agent``)."""
+    text = (raw or "").strip()
+    if " " not in text:
+        return None
+    module_name, agent_name = text.split(" ", 1)
+    module_name = module_name.strip()
+    agent_name = agent_name.strip()
+    if not module_name or not agent_name:
+        return None
+    return module_name, agent_name
+
+
+def resolve_agent_ref(raw: str, registry: Mapping[str, Any]) -> str | None:
+    """Return the registry key for ``module AgentClass``, or None."""
+    parsed = parse_agent_ref(raw)
+    if parsed is None:
+        return None
+    module_name, agent_name = parsed
+    suffix = f"/{agent_name}"
+    for class_name in registry:
+        if not class_name.endswith(suffix):
+            continue
+        if class_name == f"{module_name}/{agent_name}" or class_name.startswith(
+            f"{module_name}."
+        ):
+            return class_name
+    matches = [key for key in registry if key.endswith(suffix)]
+    if len(matches) == 1:
+        return matches[0]
+    return None
+
+
+def resolve_agent_refs(refs: list[str] | None, registry: Mapping[str, Any]) -> set[str]:
+    resolved: set[str] = set()
+    for raw in refs or []:
+        class_name = resolve_agent_ref(raw, registry)
+        if class_name:
+            resolved.add(class_name)
+    return resolved
+
+
+def resolve_app_enabled(
+    app_id: str,
+    enabled_by_app_id: Mapping[str, bool],
+    seed_apps: set[str],
+) -> bool:
+    """DB row wins; otherwise the seed list; otherwise off."""
+    if app_id in enabled_by_app_id:
+        return enabled_by_app_id[app_id]
+    return app_id in seed_apps

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/workspace_catalog_seed_test.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/workspace_catalog_seed_test.py
@@ -1,0 +1,48 @@
+from naas_abi.apps.nexus.apps.api.app.core.workspace_catalog_seed import (
+    parse_agent_ref,
+    resolve_agent_ref,
+    resolve_agent_refs,
+    resolve_app_enabled,
+)
+
+
+def test_parse_agent_ref() -> None:
+    assert parse_agent_ref("naas_abi AbiAgent") == ("naas_abi", "AbiAgent")
+    assert parse_agent_ref("example.module ExampleAgent") == (
+        "example.module",
+        "ExampleAgent",
+    )
+    assert parse_agent_ref("AbiAgent") is None
+    assert parse_agent_ref("") is None
+
+
+def test_resolve_agent_ref_prefers_module_prefix() -> None:
+    registry = {
+        "naas_abi.agents.AbiAgent/AbiAgent": object(),
+        "example.module.agents.ExampleAgent/ExampleAgent": object(),
+    }
+    assert (
+        resolve_agent_ref("naas_abi AbiAgent", registry)
+        == "naas_abi.agents.AbiAgent/AbiAgent"
+    )
+    assert (
+        resolve_agent_ref("example.module ExampleAgent", registry)
+        == "example.module.agents.ExampleAgent/ExampleAgent"
+    )
+    assert resolve_agent_ref("missing Agent", registry) is None
+
+
+def test_resolve_agent_refs_skips_unknown() -> None:
+    registry = {"naas_abi.agents.AbiAgent/AbiAgent": object()}
+    assert resolve_agent_refs(
+        ["naas_abi AbiAgent", "nope NopeAgent"], registry
+    ) == {"naas_abi.agents.AbiAgent/AbiAgent"}
+
+
+def test_resolve_app_enabled_prefers_db_then_seed() -> None:
+    seed = {"example.module:dashboard"}
+    stored = {"example.module:dashboard": False, "example.module:other": True}
+    assert resolve_app_enabled("example.module:dashboard", stored, seed) is False
+    assert resolve_app_enabled("example.module:other", stored, seed) is True
+    assert resolve_app_enabled("example.module:dashboard", {}, seed) is True
+    assert resolve_app_enabled("example.module:unknown", {}, seed) is False

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/models.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/models.py
@@ -728,7 +728,7 @@ class AppConfigModel(Base):
     # Marketplace app identifier: "<module_path>:<app_name>" (e.g.
     # "naas_abi_marketplace.applications.openrouter:dashboard").
     app_id = Column(String(512), nullable=False, index=True)
-    enabled = Column(Boolean, nullable=False, default=True)
+    enabled = Column(Boolean, nullable=False, default=False)
     created_at = Column(DateTime(timezone=False), nullable=False, default=_utcnow)
     updated_at = Column(DateTime(timezone=False), nullable=False, default=_utcnow, onupdate=_utcnow)
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/agents/adapters/primary/agents__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/agents/adapters/primary/agents__primary_adapter__FastAPI.py
@@ -13,6 +13,11 @@ from naas_abi.apps.nexus.apps.api.app.api.endpoints.auth import (
     get_current_user_required,
     require_workspace_access,
 )
+from naas_abi.apps.nexus.apps.api.app.core.workspace_catalog_seed import (
+    resolve_agent_ref,
+    resolve_agent_refs,
+    workspace_seed_for_slug,
+)
 from naas_abi.apps.nexus.apps.api.app.services.agents import (
     AgentCreateInput,
     AgentRecord,
@@ -27,6 +32,7 @@ from naas_abi.apps.nexus.apps.api.app.services.registry import (
 from naas_abi.apps.nexus.apps.api.app.utils.public_urls import public_modules_url
 from naas_abi_core import logger
 from naas_abi_core.services.agent.Agent import Agent
+from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
 router = APIRouter(dependencies=[Depends(get_current_user_required)])
@@ -137,6 +143,17 @@ def request_context(current_user: User) -> RequestContext:
     return RequestContext(
         token_data=TokenData(user_id=current_user.id, scopes={"*"}, is_authenticated=True)
     )
+
+
+async def _workspace_slug(workspace_id: str) -> str | None:
+    from naas_abi.apps.nexus.apps.api.app.core.database import AsyncSessionLocal
+    from naas_abi.apps.nexus.apps.api.app.models import WorkspaceModel
+
+    async with AsyncSessionLocal() as db:
+        result = await db.execute(
+            select(WorkspaceModel.slug).where(WorkspaceModel.id == workspace_id)
+        )
+        return result.scalar_one_or_none()
 
 
 def _get_engine_default_agent_class_name() -> str | None:
@@ -547,7 +564,18 @@ async def _reconcile_workspace_agents(
         stale_ids = {agent.id for agent in stale_agents}
         agent_list = [agent for agent in agent_list if agent.id not in stale_ids]
 
-    default_class_name = _get_engine_default_agent_class_name()
+    seed = workspace_seed_for_slug(await _workspace_slug(workspace_id))
+    seeded_class_names: set[str] | None = None
+    if seed is not None and seed.agents is not None:
+        seeded_class_names = resolve_agent_refs(seed.agents, class_name_to_agent_class)
+
+    default_class_name: str | None = None
+    if seed is not None and seed.default_agent:
+        default_class_name = resolve_agent_ref(
+            seed.default_agent, class_name_to_agent_class
+        )
+    if default_class_name is None:
+        default_class_name = _get_engine_default_agent_class_name()
 
     # Persist any newly discovered agent classes to the database.
     for class_name, agent_cls in class_name_to_agent_class.items():
@@ -556,15 +584,17 @@ async def _reconcile_workspace_agents(
 
         name = _get_agent_class_name(agent_cls)
         description = _get_agent_class_description(agent_cls)
-        # Enable engine default (or Abi fallback) plus agents that opt in via
-        # ENABLED_BY_DEFAULT / enabled_by_default. The chat/pane pickers only
-        # list enabled agents, so product agents must opt in or stay invisible.
-        enabled = _agent_enabled_by_default(
-            agent_cls,
-            name=name,
-            class_name=class_name,
-            default_class_name=default_class_name,
-        )
+        # A workspace ``agents:`` list is the roster. Otherwise enable the
+        # engine default (or Abi fallback) plus class ``ENABLED_BY_DEFAULT``.
+        if seeded_class_names is not None:
+            enabled = class_name in seeded_class_names
+        else:
+            enabled = _agent_enabled_by_default(
+                agent_cls,
+                name=name,
+                class_name=class_name,
+                default_class_name=default_class_name,
+            )
 
         logger.debug("Creating agent in nexus backend: {}", name)
         system_prompt = _get_agent_system_prompt(agent_cls)
@@ -632,7 +662,25 @@ async def _reconcile_workspace_agents(
                     continue
         reconciled.append(agent)
 
-    # Ensure the engine default agent is enabled and marked as workspace default.
+    if seeded_class_names is not None:
+        aligned: list[AgentRecord] = []
+        for agent in reconciled:
+            if not agent.class_name:
+                aligned.append(agent)
+                continue
+            should_enable = agent.class_name in seeded_class_names
+            if agent.enabled == should_enable:
+                aligned.append(agent)
+                continue
+            updated = await agent_service.update_agent(
+                context=context,
+                agent_id=agent.id,
+                updates=AgentUpdateInput(enabled=should_enable),
+            )
+            aligned.append(updated if updated is not None else agent)
+        reconciled = aligned
+
+    # Ensure the workspace (or engine) default agent is enabled and marked.
     if default_class_name:
         default_agent = next(
             (agent for agent in reconciled if agent.class_name == default_class_name),

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/apps/adapters/primary/apps__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/apps/adapters/primary/apps__primary_adapter__FastAPI.py
@@ -252,6 +252,7 @@ _APP_ASSET_SUFFIXES = {
     ".jpeg",
     ".jpg",
     ".js",
+    ".json",
     ".mjs",
     ".png",
     ".svg",
@@ -265,9 +266,10 @@ _APP_ASSET_SUFFIXES = {
 def _scan_apps_html_paths() -> dict[str, str]:
     """Build a URL map for safe browser assets under app directories.
 
-    HTML entry points commonly import colocated scripts, styles, fonts, and
-    images. Serve those assets from the same authenticated ``/app-html/``
-    namespace while excluding source, configuration, and dataset files.
+    HTML entry points commonly import colocated scripts, styles, fonts,
+    images, and JSON (for example ``graph.json``). Serve those assets from
+    the same authenticated ``/app-html/`` namespace while excluding source
+    and other non-browser files.
     """
     html_map: dict[str, str] = {}
     for module in _iter_loaded_modules():

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/apps/adapters/primary/apps__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/apps/adapters/primary/apps__primary_adapter__FastAPI.py
@@ -38,6 +38,10 @@ from naas_abi.apps.nexus.apps.api.app.api.endpoints.auth import (
     get_current_user_required,
     require_workspace_access,
 )
+from naas_abi.apps.nexus.apps.api.app.core.workspace_catalog_seed import (
+    resolve_app_enabled,
+    workspace_seed_for_slug,
+)
 from naas_abi.apps.nexus.apps.api.app.services.apps.app_html_access import (
     mint_app_html_access_token,
 )
@@ -61,6 +65,7 @@ from naas_abi.apps.nexus.apps.api.app.services.registry import (
 )
 from naas_abi.apps.nexus.apps.api.app.utils.public_urls import public_modules_url
 from pydantic import BaseModel, Field
+from sqlalchemy import select
 
 _log = logging.getLogger(__name__)
 
@@ -70,6 +75,17 @@ router = APIRouter(dependencies=[Depends(get_current_user_required)])
 # ---------------------------------------------------------------------------
 # Catalog discovery (driven by loaded engine modules)
 # ---------------------------------------------------------------------------
+
+
+async def _workspace_slug(workspace_id: str) -> str | None:
+    from naas_abi.apps.nexus.apps.api.app.core.database import AsyncSessionLocal
+    from naas_abi.apps.nexus.apps.api.app.models import WorkspaceModel
+
+    async with AsyncSessionLocal() as db:
+        result = await db.execute(
+            select(WorkspaceModel.slug).where(WorkspaceModel.id == workspace_id)
+        )
+        return result.scalar_one_or_none()
 
 
 def _fallback_name(dir_name: str) -> str:
@@ -372,7 +388,7 @@ async def list_apps(
     """Return every app discovered from loaded-module manifests.
 
     When ``workspace_id`` is provided, results carry the workspace's enable
-    state. Apps without a stored record default to ``enabled=True``.
+    state. Apps without a stored record default to ``enabled=False``.
     """
     if workspace_id:
         await require_workspace_access(current_user.id, workspace_id)
@@ -385,14 +401,26 @@ async def list_apps(
         loaded_modules = {}
 
     catalog = _scan_apps_catalog()
+    workspace_slug: str | None = None
+    if workspace_id:
+        workspace_slug = await _workspace_slug(workspace_id)
 
     enabled_by_app_id: dict[str, bool] = (
         await apps_service.get_enabled_states(workspace_id) if workspace_id else {}
     )
+    seed_apps: set[str] = set()
+    if workspace_id:
+        seed = workspace_seed_for_slug(workspace_slug)
+        if seed is not None and seed.apps:
+            seed_apps = {
+                str(app_id).strip() for app_id in seed.apps if str(app_id).strip()
+            }
 
     results: list[AppInfo] = []
     for app in catalog:
-        update: dict = {"enabled": enabled_by_app_id.get(app.app_id, True)}
+        update: dict = {
+            "enabled": resolve_app_enabled(app.app_id, enabled_by_app_id, seed_apps)
+        }
 
         # Manifest values take precedence; only fall back to runtime config
         # when the manifest omits the credential.
@@ -488,9 +516,9 @@ async def update_app_config(
         updates=AppConfigUpdateInput(enabled=updates.enabled),
     )
     if record is None:
-        # No existing row — create one. Missing fields fall back to defaults
-        # (enabled=True), then we apply the requested update on top.
-        enabled = True if updates.enabled is None else updates.enabled
+        # No existing row: create one. Missing fields fall back to defaults
+        # (enabled=False), then we apply the requested update on top.
+        enabled = False if updates.enabled is None else updates.enabled
         record = await apps_service.create_app_config(
             AppConfigCreateInput(
                 workspace_id=workspace_id,
@@ -508,7 +536,7 @@ async def delete_app_config(
     current_user: User = Depends(get_current_user_required),
     apps_service: AppsService = Depends(get_apps_service),
 ) -> dict[str, str]:
-    """Delete the app config (reverts to the default ``enabled=True``)."""
+    """Delete the app config (reverts to the default ``enabled=False``)."""
     await require_workspace_access(current_user.id, workspace_id)
     _ensure_app_exists(app_id)
     deleted = await apps_service.delete_app_config(workspace_id, app_id)

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/apps/port.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/apps/port.py
@@ -61,8 +61,8 @@ class AppInfo(BaseModel):
 
     # Runtime
     installed: bool = False
-    # Per-workspace enable state. Defaults to True (apps enabled by default).
-    enabled: bool = True
+    # Per-workspace enable state. Missing config rows default to off.
+    enabled: bool = False
 
 
 class AppsResponse(BaseModel):

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/apps/service.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/apps/service.py
@@ -68,7 +68,7 @@ class AppsService:
         """Return ``{app_id: enabled}`` for every record in ``workspace_id``.
 
         Apps without a stored record are absent from the result; callers
-        should default missing entries to ``True`` (enabled by default).
+        should default missing entries to ``False`` (disabled by default).
         """
         records = await self.list_app_configs(workspace_id)
         return {r.app_id: r.enabled for r in records}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/apps/lib/apps-route.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/apps/lib/apps-route.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+
+import { appsPath, nextAppsRestoreUrl } from './apps-route';
+
+const WS_A = 'ws-43114186ff0d';
+const WS_B = 'ws-valeo';
+const ARMOR = 'operations.audit.armor:armor';
+
+describe('appsPath', () => {
+  it('points at the section home', () => {
+    expect(appsPath(WS_A)).toBe(`/workspace/${WS_A}/apps`);
+  });
+
+  it('encodes the open app id', () => {
+    expect(appsPath(WS_A, ARMOR)).toBe(
+      `/workspace/${WS_A}/apps?open=${encodeURIComponent(ARMOR)}`,
+    );
+  });
+});
+
+describe('nextAppsRestoreUrl', () => {
+  it('restores last-open for the workspace in the URL', () => {
+    expect(
+      nextAppsRestoreUrl({
+        urlWorkspaceId: WS_A,
+        storeWorkspaceId: WS_A,
+        searchOpen: null,
+        savedOpen: ARMOR,
+      }),
+    ).toBe(appsPath(WS_A, ARMOR));
+  });
+
+  it('does not rewrite to the previous workspace mid-switch', () => {
+    // URL already moved to Valeo; store still has Next Gen. Restoring from the
+    // store id sent the user back to Next Gen with ?open=armor.
+    expect(
+      nextAppsRestoreUrl({
+        urlWorkspaceId: WS_B,
+        storeWorkspaceId: WS_A,
+        searchOpen: null,
+        savedOpen: ARMOR,
+      }),
+    ).toBeNull();
+  });
+
+  it('does not restore from a saved id that belongs to another workspace key', () => {
+    expect(
+      nextAppsRestoreUrl({
+        urlWorkspaceId: WS_B,
+        storeWorkspaceId: WS_B,
+        searchOpen: null,
+        savedOpen: null,
+      }),
+    ).toBeNull();
+  });
+
+  it('leaves an explicit ?open= alone', () => {
+    expect(
+      nextAppsRestoreUrl({
+        urlWorkspaceId: WS_A,
+        storeWorkspaceId: WS_A,
+        searchOpen: ARMOR,
+        savedOpen: ARMOR,
+      }),
+    ).toBeNull();
+  });
+
+  it('skips restore after a workspace switch', () => {
+    expect(
+      nextAppsRestoreUrl({
+        urlWorkspaceId: WS_B,
+        storeWorkspaceId: WS_B,
+        searchOpen: null,
+        savedOpen: ARMOR,
+        skipRestore: true,
+      }),
+    ).toBeNull();
+  });
+
+  it('waits until a workspace id is in the URL', () => {
+    expect(
+      nextAppsRestoreUrl({
+        urlWorkspaceId: null,
+        storeWorkspaceId: WS_A,
+        searchOpen: null,
+        savedOpen: ARMOR,
+      }),
+    ).toBeNull();
+  });
+});

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/apps/lib/apps-route.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/apps/lib/apps-route.ts
@@ -1,0 +1,50 @@
+/**
+ * Apps URL helpers. The workspace id in the URL is the source of truth.
+ * Restoring last-open from the zustand id (which lags a workspace switch)
+ * was rewriting /workspace/{valeo}/apps back to the previous workspace.
+ */
+
+let skipAppsRestore = false;
+
+/** Call before router.push when switching workspaces so Apps stays on the list. */
+export function markAppsSkipRestore(): void {
+  skipAppsRestore = true;
+}
+
+/** Call when the user picks Apps (or another section) inside a workspace. */
+export function clearAppsSkipRestore(): void {
+  skipAppsRestore = false;
+}
+
+export function shouldSkipAppsRestore(): boolean {
+  return skipAppsRestore;
+}
+
+export function appsPath(workspaceId: string, open?: string | null): string {
+  const base = `/workspace/${workspaceId}/apps`;
+  if (!open) return base;
+  return `${base}?open=${encodeURIComponent(open)}`;
+}
+
+/**
+ * Where to send the apps URL to reopen the last app, or null to leave it.
+ *
+ * Returns null when:
+ * - the URL already has ?open=
+ * - nothing was saved for this workspace
+ * - the store is still on another workspace (switch in flight)
+ */
+export function nextAppsRestoreUrl(params: {
+  urlWorkspaceId: string | null | undefined;
+  storeWorkspaceId: string | null | undefined;
+  searchOpen: string | null | undefined;
+  savedOpen: string | null | undefined;
+  skipRestore?: boolean;
+}): string | null {
+  const { urlWorkspaceId, storeWorkspaceId, searchOpen, savedOpen, skipRestore } = params;
+  if (skipRestore) return null;
+  if (!urlWorkspaceId || !savedOpen) return null;
+  if (searchOpen) return null;
+  if (storeWorkspaceId && storeWorkspaceId !== urlWorkspaceId) return null;
+  return appsPath(urlWorkspaceId, savedOpen);
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/apps/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/apps/page.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useSearchParams, useRouter } from 'next/navigation';
+import { useSearchParams, useRouter, useParams } from 'next/navigation';
 import { Header } from '@/components/shell/header';
+import { appsPath, nextAppsRestoreUrl, shouldSkipAppsRestore } from './lib/apps-route';
 import {
   AppWindow, ExternalLink, RefreshCw, AlertTriangle, Info, PanelLeft, X,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { isBundledAppHtmlUrl, resolveAppEmbedUrl, resolveAppExternalUrl, appHtmlPathPrefix, withAppHtmlAccessToken } from '@/lib/app-html';
+import { isBundledAppHtmlUrl, resolveAppEmbedUrl, resolveAppExternalUrl, appHtmlPathPrefix, pagesSsoAudience, withAppHtmlAccessToken, withPagesSsoToken } from '@/lib/app-html';
 import { getApiUrl } from '@/lib/config';
 import { authFetch } from '@/stores/auth';
 import { useTenant } from '@/contexts/tenant-context';
@@ -42,7 +43,34 @@ function EmbedView({ record, onBack }: { record: AppRecord; onBack: () => void }
     setEmbedError(null);
 
     if (!isBundledAppHtmlUrl(url)) {
-      setEmbedUrl(baseEmbedUrl);
+      const audience = pagesSsoAudience(baseEmbedUrl);
+      if (!audience) {
+        setEmbedUrl(baseEmbedUrl);
+        return () => {
+          cancelled = true;
+        };
+      }
+      setEmbedUrl(null);
+      (async () => {
+        try {
+          const res = await authFetch('/api/apps/sso-token', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ audience }),
+          });
+          if (!res.ok) {
+            if (!cancelled) setEmbedUrl(baseEmbedUrl);
+            return;
+          }
+          const data = (await res.json()) as { token?: string };
+          const token = String(data.token || '').trim();
+          if (!cancelled) {
+            setEmbedUrl(token ? withPagesSsoToken(baseEmbedUrl, token) : baseEmbedUrl);
+          }
+        } catch {
+          if (!cancelled) setEmbedUrl(baseEmbedUrl);
+        }
+      })();
       return () => {
         cancelled = true;
       };
@@ -224,7 +252,7 @@ function EmbedView({ record, onBack }: { record: AppRecord; onBack: () => void }
             title={record.name}
             onLoad={handleLoad}
             className="h-full w-full border-0"
-            sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-presentation"
+            sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-presentation allow-downloads"
             allow="fullscreen"
           />
         )}
@@ -264,6 +292,8 @@ function EmptyState({ filtered }: { filtered: boolean }) {
 
 export default function AppsPage() {
   const tenant = useTenant();
+  const params = useParams();
+  const urlWorkspaceId = params.workspaceId as string;
   const { currentWorkspaceId, setOpenAppModule, setAppDetailOpen } = useWorkspaceStore();
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -274,7 +304,7 @@ export default function AppsPage() {
   const [activeApp, setActiveApp] = useState<AppRecord | null>(null);
   const [search, setSearch] = useState('');
 
-  const views = useAppViews(currentWorkspaceId);
+  const views = useAppViews(urlWorkspaceId);
 
   useEffect(() => {
     return () => {
@@ -284,26 +314,31 @@ export default function AppsPage() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Restore last opened app when navigating back to the section without ?open=
+  // Restore last opened app when landing on the section without ?open=.
+  // Keyed on the URL workspace, not the store: the store lags a workspace
+  // switch and used to rewrite Valeo back to the previous workspace.
   useEffect(() => {
-    if (!currentWorkspaceId) return;
-    if (searchParams?.get('open')) return;
+    if (!urlWorkspaceId) return;
     try {
-      const saved = sessionStorage.getItem(`nexus.apps.last_open.${currentWorkspaceId}`);
-      if (saved) {
-        router.replace(`/workspace/${currentWorkspaceId}/apps?open=${encodeURIComponent(saved)}`);
-      }
+      const saved = sessionStorage.getItem(`nexus.apps.last_open.${urlWorkspaceId}`);
+      const next = nextAppsRestoreUrl({
+        urlWorkspaceId,
+        storeWorkspaceId: currentWorkspaceId,
+        searchOpen: searchParams?.get('open'),
+        savedOpen: saved,
+        skipRestore: shouldSkipAppsRestore(),
+      });
+      if (next) router.replace(next);
     } catch {
       // sessionStorage unavailable (e.g. private mode restrictions) — ignore
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentWorkspaceId]);
+  }, [urlWorkspaceId, currentWorkspaceId, searchParams, router]);
 
   useEffect(() => {
     const apiBase = getApiUrl();
-    if (!currentWorkspaceId) return;
+    if (!urlWorkspaceId) return;
     setLoading(true);
-    authFetch(`${apiBase}/api/apps/?workspace_id=${encodeURIComponent(currentWorkspaceId)}`)
+    authFetch(`${apiBase}/api/apps/?workspace_id=${encodeURIComponent(urlWorkspaceId)}`)
       .then((r) => (r.ok ? r.json() : Promise.reject(r.statusText)))
       .then((data: AppsResponse) => {
         setApps(
@@ -312,8 +347,7 @@ export default function AppsPage() {
       })
       .catch((e) => setError(String(e)))
       .finally(() => setLoading(false));
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentWorkspaceId]);
+  }, [urlWorkspaceId]);
 
   // Module apps and tenant-level external apps are one database. "Source" is a
   // property you can filter or group by — not a separate section.
@@ -341,14 +375,14 @@ export default function AppsPage() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams, records]);
 
-  const lastOpenKey = currentWorkspaceId ? `nexus.apps.last_open.${currentWorkspaceId}` : null;
+  const lastOpenKey = urlWorkspaceId ? `nexus.apps.last_open.${urlWorkspaceId}` : null;
 
   const handleClose = () => {
     setActiveApp(null);
     setOpenAppModule(null);
     setAppDetailOpen(false);
     if (lastOpenKey) sessionStorage.removeItem(lastOpenKey);
-    router.replace(`/workspace/${currentWorkspaceId}/apps`);
+    router.replace(appsPath(urlWorkspaceId));
   };
 
   // Opening an app never forces the metadata panel open — that stays opt-in.
@@ -356,9 +390,7 @@ export default function AppsPage() {
     setActiveApp(record);
     setOpenAppModule(record.source === 'module' ? recordToOpenModule(record) : null);
     if (lastOpenKey) sessionStorage.setItem(lastOpenKey, record.id);
-    router.replace(
-      `/workspace/${currentWorkspaceId}/apps?open=${encodeURIComponent(record.id)}`,
-    );
+    router.replace(appsPath(urlWorkspaceId, record.id));
   };
 
   const view = views.activeView;

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/apps/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/apps/page.tsx
@@ -8,7 +8,7 @@ import {
   AppWindow, ExternalLink, RefreshCw, AlertTriangle, Info, PanelLeft, X,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { isBundledAppHtmlUrl, resolveAppEmbedUrl, resolveAppExternalUrl, appHtmlPathPrefix, pagesSsoAudience, withAppHtmlAccessToken, withPagesSsoToken } from '@/lib/app-html';
+import { isBundledAppHtmlUrl, resolveAppEmbedUrl, resolveAppExternalUrl, appHtmlPathPrefix, withAppHtmlAccessToken } from '@/lib/app-html';
 import { getApiUrl } from '@/lib/config';
 import { authFetch } from '@/stores/auth';
 import { useTenant } from '@/contexts/tenant-context';
@@ -43,34 +43,7 @@ function EmbedView({ record, onBack }: { record: AppRecord; onBack: () => void }
     setEmbedError(null);
 
     if (!isBundledAppHtmlUrl(url)) {
-      const audience = pagesSsoAudience(baseEmbedUrl);
-      if (!audience) {
-        setEmbedUrl(baseEmbedUrl);
-        return () => {
-          cancelled = true;
-        };
-      }
-      setEmbedUrl(null);
-      (async () => {
-        try {
-          const res = await authFetch('/api/apps/sso-token', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ audience }),
-          });
-          if (!res.ok) {
-            if (!cancelled) setEmbedUrl(baseEmbedUrl);
-            return;
-          }
-          const data = (await res.json()) as { token?: string };
-          const token = String(data.token || '').trim();
-          if (!cancelled) {
-            setEmbedUrl(token ? withPagesSsoToken(baseEmbedUrl, token) : baseEmbedUrl);
-          }
-        } catch {
-          if (!cancelled) setEmbedUrl(baseEmbedUrl);
-        }
-      })();
+      setEmbedUrl(baseEmbedUrl);
       return () => {
         cancelled = true;
       };

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/layout.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/layout.tsx
@@ -1,133 +1,11 @@
 'use client';
 
-import { Component, useEffect, useState } from 'react';
+import { useEffect, useLayoutEffect } from 'react';
 import { useParams, usePathname, useRouter } from 'next/navigation';
-import { isWorkspacePathAllowed } from '@/lib/feature-access';
-import { WorkspaceLayout } from '@/components/shell/workspace-layout';
-import { ShellTitleProvider } from '@/components/shell/shell-title';
+import { getWorkspaceSwitchPath, isWorkspacePathAllowed, pathNeedsAgentCatalog, pathNeedsGraphExport } from '@/lib/feature-access';
 import { GraphExportToastHost } from '@/components/graph/graph-export-toast-host';
 import { useWorkspaceStore } from '@/stores/workspace';
-import { clearAuthFlagCookie } from '@/lib/auth-session';
 import { useAuthStore } from '@/stores/auth';
-
-// Catches unhandled promise rejections (not caught by React error boundaries)
-// Next.js uses thrown sentinels (NEXT_REDIRECT, NEXT_NOT_FOUND) to drive
-// navigation from Server Components. They are not real errors and must not
-// surface in any user-facing error UI.
-function isNextNavigationSentinel(reason: unknown): boolean {
-  if (!reason) return false;
-  const digest = (reason as { digest?: unknown }).digest;
-  if (typeof digest === 'string' && digest.startsWith('NEXT_')) return true;
-  const message = (reason as { message?: unknown }).message;
-  if (typeof message === 'string' && (message === 'NEXT_REDIRECT' || message === 'NEXT_NOT_FOUND')) {
-    return true;
-  }
-  return false;
-}
-
-function AsyncErrorCatcher() {
-  const [asyncError, setAsyncError] = useState<string | null>(null);
-
-  useEffect(() => {
-    const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
-      if (isNextNavigationSentinel(event.reason)) {
-        event.preventDefault();
-        return;
-      }
-      const msg = event.reason?.message || event.reason?.toString() || 'Unknown async error';
-      const stack = event.reason?.stack || '';
-      console.error('[NEXUS Unhandled Rejection]', msg, stack);
-      setAsyncError(`${msg}\n\n${stack}`);
-      event.preventDefault();
-    };
-
-    const handleError = (event: ErrorEvent) => {
-      if (isNextNavigationSentinel(event.error) || event.message === 'Uncaught Error: NEXT_REDIRECT' || event.message === 'Uncaught Error: NEXT_NOT_FOUND') {
-        return;
-      }
-      console.error('[NEXUS Global Error]', event.message, event.error?.stack);
-      setAsyncError(`${event.message}\n\n${event.error?.stack || ''}`);
-    };
-
-    window.addEventListener('unhandledrejection', handleUnhandledRejection);
-    window.addEventListener('error', handleError);
-    return () => {
-      window.removeEventListener('unhandledrejection', handleUnhandledRejection);
-      window.removeEventListener('error', handleError);
-    };
-  }, []);
-
-  if (!asyncError) return null;
-
-  return (
-    <div style={{ position: 'fixed', bottom: 16, right: 16, zIndex: 99999, maxWidth: 500, backgroundColor: '#1a1a2e', border: '2px solid #e94560', borderRadius: 8, padding: 16, boxShadow: '0 4px 20px rgba(0,0,0,0.5)' }}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
-        <span style={{ color: '#ff6b6b', fontWeight: 'bold', fontSize: 14 }}>Async Error Caught</span>
-        <button onClick={() => setAsyncError(null)} style={{ color: '#a8a8a8', background: 'none', border: 'none', fontSize: 18, cursor: 'pointer' }}>x</button>
-      </div>
-      <pre style={{ color: '#a8a8a8', fontSize: 11, whiteSpace: 'pre-wrap', wordBreak: 'break-all', maxHeight: 200, overflow: 'auto', margin: 0 }}>{asyncError}</pre>
-    </div>
-  );
-}
-
-// Error boundary to catch React rendering crashes and show a useful message
-class WorkspaceErrorBoundary extends Component<
-  { children: React.ReactNode },
-  { hasError: boolean; error: Error | null }
-> {
-  constructor(props: { children: React.ReactNode }) {
-    super(props);
-    this.state = { hasError: false, error: null };
-  }
-
-  static getDerivedStateFromError(error: Error) {
-    return { hasError: true, error };
-  }
-
-  componentDidCatch(error: Error, info: React.ErrorInfo) {
-    console.error('[WorkspaceErrorBoundary]', error, info.componentStack);
-  }
-
-  render() {
-    if (this.state.hasError) {
-      return (
-        <>
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100vh', width: '100vw', backgroundColor: '#1a1a2e', padding: 32 }}>
-            <div style={{ maxWidth: 600, textAlign: 'center' }}>
-              <h2 style={{ color: '#ff6b6b', fontSize: 24, fontWeight: 'bold', marginBottom: 16 }}>NEXUS Crash Report</h2>
-              <div style={{ backgroundColor: '#16213e', border: '1px solid #e94560', borderRadius: 8, padding: 16, textAlign: 'left', marginBottom: 16, maxHeight: 300, overflow: 'auto' }}>
-                <p style={{ color: '#ff6b6b', fontSize: 14, fontWeight: 'bold', marginBottom: 8 }}>{this.state.error?.message}</p>
-                <pre style={{ color: '#a8a8a8', fontSize: 11, whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
-                  {this.state.error?.stack}
-                </pre>
-              </div>
-              <div style={{ display: 'flex', gap: 8, justifyContent: 'center' }}>
-                <button
-                  onClick={() => this.setState({ hasError: false, error: null })}
-                  style={{ backgroundColor: '#e94560', color: 'white', border: 'none', borderRadius: 6, padding: '8px 20px', fontSize: 14, cursor: 'pointer' }}
-                >
-                  Try again
-                </button>
-                <button
-                  onClick={() => {
-                    localStorage.removeItem('nexus-workspace-storage');
-                    localStorage.removeItem('nexus-auth-storage');
-                    window.location.href = '/auth/login';
-                  }}
-                  style={{ backgroundColor: '#16213e', color: '#e94560', border: '1px solid #e94560', borderRadius: 6, padding: '8px 20px', fontSize: 14, cursor: 'pointer' }}
-                >
-                  Clear cache &amp; login
-                </button>
-              </div>
-            </div>
-          </div>
-          <div hidden>{this.props.children}</div>
-        </>
-      );
-    }
-    return this.props.children;
-  }
-}
 
 export default function WorkspaceIdLayout({
   children,
@@ -138,97 +16,59 @@ export default function WorkspaceIdLayout({
   const pathname = usePathname();
   const router = useRouter();
   const workspaceId = params.workspaceId as string;
-  
-  const { workspaces, currentWorkspaceId, setCurrentWorkspace, syncWorkspaceConversations, fetchWorkspaces } = useWorkspaceStore();
-  const { token } = useAuthStore();
-  const [authReady, setAuthReady] = useState(false);
-  const [membershipChecked, setMembershipChecked] = useState(false);
+
+  const workspaces = useWorkspaceStore((s) => s.workspaces);
+  const currentWorkspaceId = useWorkspaceStore((s) => s.currentWorkspaceId);
+  const setCurrentWorkspace = useWorkspaceStore((s) => s.setCurrentWorkspace);
+  const syncWorkspaceConversations = useWorkspaceStore((s) => s.syncWorkspaceConversations);
+  const contextPanelOpen = useWorkspaceStore((s) => s.contextPanelOpen);
+  const token = useAuthStore((s) => s.token);
   const currentWorkspace = workspaces.find((w) => w.id === workspaceId);
 
-  // Wait for the auth store to rehydrate from localStorage, then silently
-  // validate / refresh the session. authReady becomes true only after
-  // checkAuth() resolves so the redirect (authReady && !token) never fires
-  // prematurely while a token refresh is in flight.
-  useEffect(() => {
-    let cancelled = false;
-    let started = false;
-
-    const runAuth = async () => {
-      if (started) return;
-      started = true;
-      await useAuthStore.getState().checkAuth();
-      if (!cancelled) setAuthReady(true);
-    };
-
-    const unsub = useAuthStore.persist.onFinishHydration(() => {
-      void runAuth();
-    });
-
-    // If already hydrated (e.g., navigating between pages in the same session)
-    if (useAuthStore.persist.hasHydrated()) {
-      void runAuth();
+  // Before paint, so section pages fetch the target workspace instead of
+  // rendering one frame against the previous id.
+  useLayoutEffect(() => {
+    if (workspaceId && workspaceId !== currentWorkspaceId && currentWorkspace) {
+      setCurrentWorkspace(workspaceId);
     }
+  }, [workspaceId, currentWorkspaceId, currentWorkspace, setCurrentWorkspace]);
 
-    return () => {
-      cancelled = true;
-      unsub();
-    };
-  }, []);
-
-  // Redirect to login if not authenticated (after hydration)
   useEffect(() => {
-    if (authReady && !token) {
-      // Drop stale middleware cookie so /auth/login is not bounced back here.
-      clearAuthFlagCookie();
-      router.replace(`/auth/login?redirect=/workspace/${workspaceId}/chat`);
-    }
-  }, [authReady, token, router, workspaceId]);
+    if (!workspaceId) return;
+    if (!contextPanelOpen && !pathNeedsAgentCatalog(pathname)) return;
+    void syncWorkspaceConversations(workspaceId);
+  }, [workspaceId, pathname, contextPanelOpen, syncWorkspaceConversations]);
 
-  // After auth, confirm the user still has at least one workspace membership.
+  // Unknown id: wait for a fresh list before bouncing. A stale in-memory
+  // list used to send people to workspaces[0] on the first paint of a switch,
+  // which cancelled navigation to a workspace that was already in the dropdown.
   useEffect(() => {
-    if (!authReady || !token) return;
+    if (!workspaceId) return;
+    if (workspaces.some((w) => w.id === workspaceId)) return;
+
     let cancelled = false;
-    void fetchWorkspaces().finally(() => {
-      if (!cancelled) setMembershipChecked(true);
+    void useWorkspaceStore.getState().fetchWorkspaces().then(() => {
+      if (cancelled) return;
+      const list = useWorkspaceStore.getState().workspaces;
+      if (list.some((w) => w.id === workspaceId)) return;
+      if (list.length === 0) return;
+      const fallback = list[0];
+      router.replace(
+        getWorkspaceSwitchPath({
+          pathname: pathname || '',
+          targetWorkspaceId: fallback.id,
+          role: fallback.currentUserRole,
+          workspaceFlags: fallback.featureFlags,
+        }),
+      );
     });
     return () => {
       cancelled = true;
     };
-  }, [authReady, token, fetchWorkspaces]);
+  }, [workspaceId, workspaces, pathname, router]);
 
   useEffect(() => {
-    if (!membershipChecked || !token) return;
-    if (workspaces.length === 0) {
-      router.replace('/no-workspace');
-    }
-  }, [membershipChecked, token, workspaces.length, router]);
-
-  // Sync URL workspaceId with store
-  useEffect(() => {
-    if (!membershipChecked) return;
-    if (workspaceId && workspaceId !== currentWorkspaceId) {
-      // Check if workspace exists
-      const workspace = workspaces.find(w => w.id === workspaceId);
-      if (workspace) {
-        setCurrentWorkspace(workspaceId);
-        void syncWorkspaceConversations(workspaceId);
-      } else if (workspaces.length > 0) {
-        // Redirect to first workspace if not found
-        router.replace(`/workspace/${workspaces[0].id}/chat`);
-      } else {
-        router.replace('/no-workspace');
-      }
-    }
-  }, [membershipChecked, workspaceId, currentWorkspaceId, workspaces, setCurrentWorkspace, syncWorkspaceConversations, router]);
-
-  useEffect(() => {
-    if (workspaceId) {
-      void syncWorkspaceConversations(workspaceId);
-    }
-  }, [workspaceId, syncWorkspaceConversations]);
-
-  useEffect(() => {
-    if (!authReady || !token || !workspaceId || !pathname || !currentWorkspace) {
+    if (!token || !workspaceId || !pathname || !currentWorkspace) {
       return;
     }
 
@@ -246,29 +86,12 @@ export default function WorkspaceIdLayout({
     if (notAvailablePath !== pathname) {
       router.replace(notAvailablePath);
     }
-  }, [authReady, token, workspaceId, pathname, currentWorkspace, router]);
-
-  const showShell = authReady && !!token;
+  }, [token, workspaceId, pathname, currentWorkspace, router]);
 
   return (
-    <WorkspaceErrorBoundary>
-      <AsyncErrorCatcher />
-      {/* `children` must appear in exactly ONE place in this tree. It used to be
-          rendered here as well as inside the shell below, and because the two
-          positions do not reconcile, React unmounted and remounted the entire
-          page subtree the moment `showShell` flipped — every route fired all of
-          its data fetches twice per load, the first time before auth was even
-          ready. Render the spinner alone while the session is being checked. */}
-      {!showShell ? (
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100vh', backgroundColor: '#0a0a1a' }}>
-          <div style={{ color: '#666', fontSize: 14 }}>Loading...</div>
-        </div>
-      ) : (
-        <ShellTitleProvider>
-          <GraphExportToastHost workspaceId={workspaceId} />
-          <WorkspaceLayout>{children}</WorkspaceLayout>
-        </ShellTitleProvider>
-      )}
-    </WorkspaceErrorBoundary>
+    <>
+      {pathNeedsGraphExport(pathname) && <GraphExportToastHost workspaceId={workspaceId} />}
+      {children}
+    </>
   );
 }

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/layout.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/layout.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import { Component, useEffect, useState } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import { WorkspaceLayout } from '@/components/shell/workspace-layout';
+import { ShellTitleProvider } from '@/components/shell/shell-title';
+import { useWorkspaceStore } from '@/stores/workspace';
+import { clearAuthFlagCookie } from '@/lib/auth-session';
+import { useAuthStore } from '@/stores/auth';
+
+// Catches unhandled promise rejections (not caught by React error boundaries)
+// Next.js uses thrown sentinels (NEXT_REDIRECT, NEXT_NOT_FOUND) to drive
+// navigation from Server Components. They are not real errors and must not
+// surface in any user-facing error UI.
+function isNextNavigationSentinel(reason: unknown): boolean {
+  if (!reason) return false;
+  const digest = (reason as { digest?: unknown }).digest;
+  if (typeof digest === 'string' && digest.startsWith('NEXT_')) return true;
+  const message = (reason as { message?: unknown }).message;
+  if (typeof message === 'string' && (message === 'NEXT_REDIRECT' || message === 'NEXT_NOT_FOUND')) {
+    return true;
+  }
+  return false;
+}
+
+function AsyncErrorCatcher() {
+  const [asyncError, setAsyncError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
+      if (isNextNavigationSentinel(event.reason)) {
+        event.preventDefault();
+        return;
+      }
+      const msg = event.reason?.message || event.reason?.toString() || 'Unknown async error';
+      const stack = event.reason?.stack || '';
+      console.error('[NEXUS Unhandled Rejection]', msg, stack);
+      setAsyncError(`${msg}\n\n${stack}`);
+      event.preventDefault();
+    };
+
+    const handleError = (event: ErrorEvent) => {
+      if (isNextNavigationSentinel(event.error) || event.message === 'Uncaught Error: NEXT_REDIRECT' || event.message === 'Uncaught Error: NEXT_NOT_FOUND') {
+        return;
+      }
+      console.error('[NEXUS Global Error]', event.message, event.error?.stack);
+      setAsyncError(`${event.message}\n\n${event.error?.stack || ''}`);
+    };
+
+    window.addEventListener('unhandledrejection', handleUnhandledRejection);
+    window.addEventListener('error', handleError);
+    return () => {
+      window.removeEventListener('unhandledrejection', handleUnhandledRejection);
+      window.removeEventListener('error', handleError);
+    };
+  }, []);
+
+  if (!asyncError) return null;
+
+  return (
+    <div style={{ position: 'fixed', bottom: 16, right: 16, zIndex: 99999, maxWidth: 500, backgroundColor: '#1a1a2e', border: '2px solid #e94560', borderRadius: 8, padding: 16, boxShadow: '0 4px 20px rgba(0,0,0,0.5)' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
+        <span style={{ color: '#ff6b6b', fontWeight: 'bold', fontSize: 14 }}>Async Error Caught</span>
+        <button onClick={() => setAsyncError(null)} style={{ color: '#a8a8a8', background: 'none', border: 'none', fontSize: 18, cursor: 'pointer' }}>x</button>
+      </div>
+      <pre style={{ color: '#a8a8a8', fontSize: 11, whiteSpace: 'pre-wrap', wordBreak: 'break-all', maxHeight: 200, overflow: 'auto', margin: 0 }}>{asyncError}</pre>
+    </div>
+  );
+}
+
+// Error boundary to catch React rendering crashes and show a useful message
+class WorkspaceErrorBoundary extends Component<
+  { children: React.ReactNode },
+  { hasError: boolean; error: Error | null }
+> {
+  constructor(props: { children: React.ReactNode }) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error('[WorkspaceErrorBoundary]', error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100vh', width: '100vw', backgroundColor: '#1a1a2e', padding: 32 }}>
+            <div style={{ maxWidth: 600, textAlign: 'center' }}>
+              <h2 style={{ color: '#ff6b6b', fontSize: 24, fontWeight: 'bold', marginBottom: 16 }}>NEXUS Crash Report</h2>
+              <div style={{ backgroundColor: '#16213e', border: '1px solid #e94560', borderRadius: 8, padding: 16, textAlign: 'left', marginBottom: 16, maxHeight: 300, overflow: 'auto' }}>
+                <p style={{ color: '#ff6b6b', fontSize: 14, fontWeight: 'bold', marginBottom: 8 }}>{this.state.error?.message}</p>
+                <pre style={{ color: '#a8a8a8', fontSize: 11, whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+                  {this.state.error?.stack}
+                </pre>
+              </div>
+              <div style={{ display: 'flex', gap: 8, justifyContent: 'center' }}>
+                <button
+                  onClick={() => this.setState({ hasError: false, error: null })}
+                  style={{ backgroundColor: '#e94560', color: 'white', border: 'none', borderRadius: 6, padding: '8px 20px', fontSize: 14, cursor: 'pointer' }}
+                >
+                  Try again
+                </button>
+                <button
+                  onClick={() => {
+                    localStorage.removeItem('nexus-workspace-storage');
+                    localStorage.removeItem('nexus-auth-storage');
+                    window.location.href = '/auth/login';
+                  }}
+                  style={{ backgroundColor: '#16213e', color: '#e94560', border: '1px solid #e94560', borderRadius: 6, padding: '8px 20px', fontSize: 14, cursor: 'pointer' }}
+                >
+                  Clear cache &amp; login
+                </button>
+              </div>
+            </div>
+          </div>
+          <div hidden>{this.props.children}</div>
+        </>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export default function WorkspaceShellLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const { workspaces, fetchWorkspaces } = useWorkspaceStore();
+  const { token } = useAuthStore();
+  const [authReady, setAuthReady] = useState(false);
+  const [membershipChecked, setMembershipChecked] = useState(false);
+
+  // Wait for the auth store to rehydrate from localStorage, then silently
+  // validate / refresh the session. This layout sits above [workspaceId], so
+  // switching workspaces does not remount it and does not re-run this gate.
+  useEffect(() => {
+    let cancelled = false;
+    let started = false;
+
+    const runAuth = async () => {
+      if (started) return;
+      started = true;
+      await useAuthStore.getState().checkAuth();
+      if (!cancelled) setAuthReady(true);
+    };
+
+    const unsub = useAuthStore.persist.onFinishHydration(() => {
+      void runAuth();
+    });
+
+    if (useAuthStore.persist.hasHydrated()) {
+      void runAuth();
+    }
+
+    return () => {
+      cancelled = true;
+      unsub();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (authReady && !token) {
+      // Drop stale middleware cookie so /auth/login is not bounced back here.
+      clearAuthFlagCookie();
+      const redirect = pathname && pathname.startsWith('/') ? pathname : '/';
+      router.replace(`/auth/login?redirect=${encodeURIComponent(redirect)}`);
+    }
+  }, [authReady, token, router, pathname]);
+
+  useEffect(() => {
+    if (!authReady || !token) return;
+    let cancelled = false;
+    void fetchWorkspaces().finally(() => {
+      if (!cancelled) setMembershipChecked(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [authReady, token, fetchWorkspaces]);
+
+  useEffect(() => {
+    if (!membershipChecked || !token) return;
+    if (workspaces.length === 0) {
+      router.replace('/no-workspace');
+    }
+  }, [membershipChecked, token, workspaces.length, router]);
+
+  const showShell = authReady && !!token;
+
+  return (
+    <WorkspaceErrorBoundary>
+      <AsyncErrorCatcher />
+      {/* `children` must appear in exactly ONE place in this tree. It used to be
+          rendered here as well as inside the shell below, and because the two
+          positions do not reconcile, React unmounted and remounted the entire
+          page subtree the moment `showShell` flipped — every route fired all of
+          its data fetches twice per load, the first time before auth was even
+          ready. Render the spinner alone while the session is being checked. */}
+      {!showShell ? (
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100vh', backgroundColor: '#0a0a1a' }}>
+          <div style={{ color: '#666', fontSize: 14 }}>Loading...</div>
+        </div>
+      ) : (
+        <ShellTitleProvider>
+          <WorkspaceLayout>{children}</WorkspaceLayout>
+        </ShellTitleProvider>
+      )}
+    </WorkspaceErrorBoundary>
+  );
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/mobile/mobile-top-bar.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/mobile/mobile-top-bar.tsx
@@ -14,6 +14,8 @@ import { useWorkspaceStore } from '@/stores/workspace';
 import { isMobileChatThreadOpen, parseChatRoute } from '@/app/workspace/[workspaceId]/chat/lib/chat-route';
 import { getWorkspacePath } from '../sidebar/utils';
 import { WorkspaceMark } from '../workspace-mark';
+import { getWorkspaceSwitchPath } from '@/lib/feature-access';
+import { markAppsSkipRestore } from '@/app/workspace/[workspaceId]/apps/lib/apps-route';
 import { useShellTitle } from '../shell-title';
 import { resolveMobileTopBarTitle } from './mobile-top-bar-title';
 
@@ -52,6 +54,7 @@ export function MobileTopBar({
   const mobilePendingChatSlug = useWorkspaceStore((s) => s.mobilePendingChatSlug);
   const conversations = useWorkspaceStore((s) => s.conversations);
   const setActiveConversation = useWorkspaceStore((s) => s.setActiveConversation);
+  const setCurrentWorkspace = useWorkspaceStore((s) => s.setCurrentWorkspace);
   const setMobilePendingChatSlug = useWorkspaceStore((s) => s.setMobilePendingChatSlug);
 
   const { logout, user } = useAuthStore();
@@ -186,8 +189,18 @@ export function MobileTopBar({
                 type="button"
                 onClick={() => {
                   setWorkspaceOpen(false);
+                  if (workspace.id === currentWorkspaceId) return;
                   setActiveConversation(null);
-                  router.push(`/workspace/${workspace.id}/maps/presence`);
+                  markAppsSkipRestore();
+                  setCurrentWorkspace(workspace.id);
+                  router.push(
+                    getWorkspaceSwitchPath({
+                      pathname,
+                      targetWorkspaceId: workspace.id,
+                      role: workspace.currentUserRole,
+                      workspaceFlags: workspace.featureFlags,
+                    }),
+                  );
                 }}
                 className={cn(
                   'flex w-full items-center gap-2 px-3 py-2 text-sm transition-colors',

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/index.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/index.tsx
@@ -14,6 +14,8 @@ import { useFilesStore } from '@/stores/files';
 import { useOntologyStore } from '@/stores/ontology';
 import { getWorkspacePath } from './utils';
 import { WorkspaceMark } from '../workspace-mark';
+import { getWorkspaceSwitchPath } from '@/lib/feature-access';
+import { markAppsSkipRestore, clearAppsSkipRestore } from '@/app/workspace/[workspaceId]/apps/lib/apps-route';
 
 type SectionDef = {
   id: SidebarSection;
@@ -58,6 +60,7 @@ export function Sidebar() {
     currentWorkspaceId,
     activePanelSection,
     setActivePanelSection,
+    setCurrentWorkspace,
   } = useWorkspaceStore();
 
   const { fetchFiles, fetchLabFiles, setActiveSource } = useFilesStore();
@@ -79,9 +82,7 @@ export function Sidebar() {
 
   useEffect(() => {
     setMounted(true);
-    if (canFiles) { fetchFiles(); fetchLabFiles(); }
-    if (canOntology) { fetchOntology(); }
-  }, [canFiles, canOntology, fetchFiles, fetchLabFiles, fetchOntology]);
+  }, []);
 
   // Resolve the section that owns the current URL — single source of truth
   // for the highlighted icon, the sub-panel, and the browser tab title.
@@ -96,6 +97,11 @@ export function Sidebar() {
       return false;
     }) ?? null;
   }, [pathname, currentWorkspaceId]);
+
+  useEffect(() => {
+    if (urlSection?.id === 'files' && canFiles) { fetchFiles(); fetchLabFiles(); }
+    if (urlSection?.id === 'ontology' && canOntology) { fetchOntology(); }
+  }, [urlSection?.id, currentWorkspaceId, canFiles, canOntology, fetchFiles, fetchLabFiles, fetchOntology]);
 
   // Reconcile activePanelSection with the URL whenever the URL changes
   // (incl. initial mount after rehydration). Without this, a persisted
@@ -170,6 +176,7 @@ export function Sidebar() {
   };
 
   const handleSectionClick = (section: SectionDef) => {
+    clearAppsSkipRestore();
     if (activePanelSection === section.id) {
       setActivePanelSection(null);
       return;
@@ -327,7 +334,17 @@ export function Sidebar() {
                 key={workspace.id}
                 onClick={() => {
                   setWorkspaceMenuOpen(false);
-                  router.push(`/workspace/${workspace.id}/chat`);
+                  if (workspace.id === currentWorkspaceId) return;
+                  markAppsSkipRestore();
+                  setCurrentWorkspace(workspace.id);
+                  router.push(
+                    getWorkspaceSwitchPath({
+                      pathname,
+                      targetWorkspaceId: workspace.id,
+                      role: workspace.currentUserRole,
+                      workspaceFlags: workspace.featureFlags,
+                    }),
+                  );
                 }}
                 className={cn(
                   'flex w-full items-center gap-2 px-3 py-2 text-sm transition-colors',

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/workspace-layout.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/workspace-layout.tsx
@@ -26,6 +26,7 @@ import { useIsMobile } from '@/hooks/use-is-mobile';
 import { useWorkspaceStore } from '@/stores/workspace';
 import { PresenceIndicator } from '@/components/presence-indicator';
 import { getWorkspacePath } from './sidebar/utils';
+import { pathNeedsAgentCatalog } from '@/lib/feature-access';
 
 interface WorkspaceLayoutProps {
   children: React.ReactNode;
@@ -66,6 +67,7 @@ export function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
   const fetchWorkspaces = useWorkspaceStore((state) => state.fetchWorkspaces);
   const mobilePendingChatSlug = useWorkspaceStore((state) => state.mobilePendingChatSlug);
   const setMobilePendingChatSlug = useWorkspaceStore((state) => state.setMobilePendingChatSlug);
+  const contextPanelOpen = useWorkspaceStore((state) => state.contextPanelOpen);
   const { setTheme } = useTheme();
   const [orgBorderRadius, setOrgBorderRadius] = useState('0');
   const [moreOpen, setMoreOpen] = useState(false);
@@ -147,23 +149,25 @@ export function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentWorkspaceId]);
 
-  // Fetch agents and skills when workspace loads
+  // Agents/skills belong to chat, lab, agent settings, and the open AI pane.
+  // Fetching them on every workspace switch (including Apps) POSTed
+  // /agents/sync and starved GET /api/apps.
   useEffect(() => {
+    const needsAgents = Boolean(
+      currentWorkspaceId && (contextPanelOpen || pathNeedsAgentCatalog(pathname)),
+    );
+    if (!needsAgents || !currentWorkspaceId) return;
     const loadAgents = async () => {
-      if (currentWorkspaceId) {
-        const { useAgentsStore } = await import('@/stores/agents');
-        await useAgentsStore.getState().fetchAgents(currentWorkspaceId);
-      }
+      const { useAgentsStore } = await import('@/stores/agents');
+      await useAgentsStore.getState().fetchAgents(currentWorkspaceId);
     };
     const loadSkills = async () => {
-      if (currentWorkspaceId) {
-        const { useSkillsStore } = await import('@/stores/skills');
-        await useSkillsStore.getState().fetchSkills(currentWorkspaceId);
-      }
+      const { useSkillsStore } = await import('@/stores/skills');
+      await useSkillsStore.getState().fetchSkills(currentWorkspaceId);
     };
     loadAgents();
     loadSkills();
-  }, [currentWorkspaceId]);
+  }, [currentWorkspaceId, contextPanelOpen, pathname]);
 
   // Keyboard shortcut: Cmd+K to toggle the side chat pane (desktop only).
   // Capture phase so Monaco / editors do not swallow ⌘K as a chord starter.

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/feature-access.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/feature-access.test.ts
@@ -1,122 +1,212 @@
-import assert from 'node:assert/strict';
-import test from 'node:test';
+import { describe, expect, it } from 'vitest';
 
 import {
   getFeatureForWorkspacePath,
   getFirstAllowedWorkspacePath,
+  getWorkspaceSwitchPath,
   isWorkspacePathAllowed,
   mergeFeatureFlags,
+  pathNeedsAgentCatalog,
+  pathNeedsGraphExport,
 } from './feature-access';
 
-test('mergeFeatureFlags keeps member defaults', () => {
-  const flags = mergeFeatureFlags('member');
+describe('mergeFeatureFlags', () => {
+  it('keeps member defaults', () => {
+    const flags = mergeFeatureFlags('member');
 
-  assert.equal(flags.maps, true);
-  assert.equal(flags.chat, true);
-  assert.equal(flags.files, true);
-  assert.equal(flags.slides, true);
-  assert.equal(flags.agents, false);
-  assert.equal(flags.apps, false);
-  assert.equal(flags.marketplace, false);
-  assert.equal(flags.search, false);
-  assert.equal(flags.ontology, false);
-  assert.equal(flags.graph, false);
-  assert.equal(flags.settings, false);
-});
-
-test('mergeFeatureFlags can enable apps and marketplace independently', () => {
-  const flags = mergeFeatureFlags('member', { apps: true, marketplace: true });
-
-  assert.equal(flags.apps, true);
-  assert.equal(flags.marketplace, true);
-  assert.equal(flags.agents, false);
-});
-
-test('mergeFeatureFlags applies workspace overrides', () => {
-  const flags = mergeFeatureFlags('member', { search: true, chat: false });
-
-  assert.equal(flags.chat, false);
-  assert.equal(flags.files, true);
-  assert.equal(flags.search, true);
-});
-
-test('guard maps workspace paths to features', () => {
-  assert.equal(getFeatureForWorkspacePath('/workspace/ws1/maps'), 'maps');
-  assert.equal(getFeatureForWorkspacePath('/workspace/ws1/maps/presence'), 'maps');
-  assert.equal(getFeatureForWorkspacePath('/workspace/ws1/chat'), 'chat');
-  assert.equal(getFeatureForWorkspacePath('/workspace/ws1/search'), 'search');
-  assert.equal(getFeatureForWorkspacePath('/workspace/ws1/ontology'), 'ontology');
-  assert.equal(getFeatureForWorkspacePath('/workspace/ws1/graph'), 'graph');
-  assert.equal(getFeatureForWorkspacePath('/workspace/ws1/settings/agents'), 'agents');
-  assert.equal(getFeatureForWorkspacePath('/workspace/ws1/settings/theme'), 'settings.workspace');
-  assert.equal(getFeatureForWorkspacePath('/workspace/ws1/organization'), 'settings.organization');
-  assert.equal(getFeatureForWorkspacePath('/workspace/ws1/organization/billing'), 'settings.organization');
-  assert.equal(getFeatureForWorkspacePath('/workspace/ws1/apps'), 'apps');
-  assert.equal(getFeatureForWorkspacePath('/workspace/ws1/marketplace'), 'marketplace');
-  assert.equal(getFeatureForWorkspacePath('/workspace/ws1/help'), 'settings');
-});
-
-test('guard supports org-scoped rewritten routes', () => {
-  assert.equal(getFeatureForWorkspacePath('/org/acme/workspace/ws1/chat'), 'chat');
-  assert.equal(getFeatureForWorkspacePath('/org/acme/workspace/ws1/lab'), 'agents');
-});
-
-test('guard maps code and ide paths to the code feature', () => {
-  assert.equal(getFeatureForWorkspacePath('/workspace/ws1/code'), 'code');
-  assert.equal(getFeatureForWorkspacePath('/workspace/ws1/code/workspaces'), 'code');
-  assert.equal(getFeatureForWorkspacePath('/workspace/ws1/ide'), 'code');
-});
-
-test('guard maps slides paths to the slides feature', () => {
-  assert.equal(getFeatureForWorkspacePath('/workspace/ws1/slides'), 'slides');
-  assert.equal(getFeatureForWorkspacePath('/workspace/ws1/slides/new'), 'slides');
-  assert.equal(mergeFeatureFlags('owner').slides, true);
-  assert.equal(
-    isWorkspacePathAllowed({ pathname: '/workspace/ws1/slides', role: 'member' }),
-    true,
-  );
-});
-
-test('code feature is off by default and opt-in via flags', () => {
-  // Opt-in: even an owner does not get code from the default baseline.
-  assert.equal(mergeFeatureFlags('owner').code, false);
-  assert.equal(mergeFeatureFlags('member').code, false);
-  // Enabling it via the workspace flags (from nexus_config.feature_flags) turns
-  // it on and unblocks the routes.
-  assert.equal(mergeFeatureFlags('owner', { code: true }).code, true);
-  assert.equal(
-    isWorkspacePathAllowed({ pathname: '/workspace/ws1/code', role: 'owner' }),
-    false,
-  );
-  assert.equal(
-    isWorkspacePathAllowed({
-      pathname: '/workspace/ws1/code',
-      role: 'owner',
-      workspaceFlags: { code: true },
-    }),
-    true,
-  );
-});
-
-test('isWorkspacePathAllowed blocks disabled routes', () => {
-  const allowedChat = isWorkspacePathAllowed({
-    pathname: '/workspace/ws1/chat',
-    role: 'member',
-  });
-  const blockedGraph = isWorkspacePathAllowed({
-    pathname: '/workspace/ws1/graph',
-    role: 'member',
+    expect(flags.maps).toBe(true);
+    expect(flags.chat).toBe(true);
+    expect(flags.files).toBe(true);
+    expect(flags.slides).toBe(true);
+    expect(flags.agents).toBe(false);
+    expect(flags.apps).toBe(false);
+    expect(flags.marketplace).toBe(false);
+    expect(flags.search).toBe(false);
+    expect(flags.ontology).toBe(false);
+    expect(flags.graph).toBe(false);
+    expect(flags.settings).toBe(false);
   });
 
-  assert.equal(allowedChat, true);
-  assert.equal(blockedGraph, false);
-});
+  it('can enable apps and marketplace independently', () => {
+    const flags = mergeFeatureFlags('member', { apps: true, marketplace: true });
 
-test('getFirstAllowedWorkspacePath returns first enabled route', () => {
-  const path = getFirstAllowedWorkspacePath({
-    workspaceId: 'ws1',
-    role: 'member',
+    expect(flags.apps).toBe(true);
+    expect(flags.marketplace).toBe(true);
+    expect(flags.agents).toBe(false);
   });
 
-  assert.equal(path, '/workspace/ws1/chat');
+  it('applies workspace overrides', () => {
+    const flags = mergeFeatureFlags('member', { search: true, chat: false });
+
+    expect(flags.chat).toBe(false);
+    expect(flags.files).toBe(true);
+    expect(flags.search).toBe(true);
+  });
+});
+
+describe('getFeatureForWorkspacePath', () => {
+  it('maps workspace paths to features', () => {
+    expect(getFeatureForWorkspacePath('/workspace/ws1/maps')).toBe('maps');
+    expect(getFeatureForWorkspacePath('/workspace/ws1/maps/presence')).toBe('maps');
+    expect(getFeatureForWorkspacePath('/workspace/ws1/chat')).toBe('chat');
+    expect(getFeatureForWorkspacePath('/workspace/ws1/search')).toBe('search');
+    expect(getFeatureForWorkspacePath('/workspace/ws1/ontology')).toBe('ontology');
+    expect(getFeatureForWorkspacePath('/workspace/ws1/graph')).toBe('graph');
+    expect(getFeatureForWorkspacePath('/workspace/ws1/settings/agents')).toBe('agents');
+    expect(getFeatureForWorkspacePath('/workspace/ws1/settings/theme')).toBe('settings.workspace');
+    expect(getFeatureForWorkspacePath('/workspace/ws1/organization')).toBe('settings.organization');
+    expect(getFeatureForWorkspacePath('/workspace/ws1/organization/billing')).toBe('settings.organization');
+    expect(getFeatureForWorkspacePath('/workspace/ws1/apps')).toBe('apps');
+    expect(getFeatureForWorkspacePath('/workspace/ws1/marketplace')).toBe('marketplace');
+    expect(getFeatureForWorkspacePath('/workspace/ws1/help')).toBe('settings');
+  });
+
+  it('supports org-scoped rewritten routes', () => {
+    expect(getFeatureForWorkspacePath('/org/acme/workspace/ws1/chat')).toBe('chat');
+    expect(getFeatureForWorkspacePath('/org/acme/workspace/ws1/lab')).toBe('agents');
+  });
+
+  it('maps code and ide paths to the code feature', () => {
+    expect(getFeatureForWorkspacePath('/workspace/ws1/code')).toBe('code');
+    expect(getFeatureForWorkspacePath('/workspace/ws1/code/workspaces')).toBe('code');
+    expect(getFeatureForWorkspacePath('/workspace/ws1/ide')).toBe('code');
+  });
+
+  it('maps slides paths to the slides feature', () => {
+    expect(getFeatureForWorkspacePath('/workspace/ws1/slides')).toBe('slides');
+    expect(getFeatureForWorkspacePath('/workspace/ws1/slides/new')).toBe('slides');
+    expect(mergeFeatureFlags('owner').slides).toBe(true);
+    expect(
+      isWorkspacePathAllowed({ pathname: '/workspace/ws1/slides', role: 'member' }),
+    ).toBe(true);
+  });
+});
+
+describe('feature guards', () => {
+  it('keeps code off by default and opt-in via flags', () => {
+    expect(mergeFeatureFlags('owner').code).toBe(false);
+    expect(mergeFeatureFlags('member').code).toBe(false);
+    expect(mergeFeatureFlags('owner', { code: true }).code).toBe(true);
+    expect(
+      isWorkspacePathAllowed({ pathname: '/workspace/ws1/code', role: 'owner' }),
+    ).toBe(false);
+    expect(
+      isWorkspacePathAllowed({
+        pathname: '/workspace/ws1/code',
+        role: 'owner',
+        workspaceFlags: { code: true },
+      }),
+    ).toBe(true);
+  });
+
+  it('blocks disabled routes', () => {
+    expect(
+      isWorkspacePathAllowed({
+        pathname: '/workspace/ws1/chat',
+        role: 'member',
+      }),
+    ).toBe(true);
+    expect(
+      isWorkspacePathAllowed({
+        pathname: '/workspace/ws1/graph',
+        role: 'member',
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('getFirstAllowedWorkspacePath', () => {
+  it('returns first enabled route', () => {
+    expect(
+      getFirstAllowedWorkspacePath({
+        workspaceId: 'ws1',
+        role: 'member',
+      }),
+    ).toBe('/workspace/ws1/chat');
+  });
+});
+
+describe('getWorkspaceSwitchPath', () => {
+  it('stays on the same section', () => {
+    expect(
+      getWorkspaceSwitchPath({
+        pathname: '/workspace/ws-next-gen/apps',
+        targetWorkspaceId: 'ws-other',
+        role: 'owner',
+      }),
+    ).toBe('/workspace/ws-other/apps');
+    expect(
+      getWorkspaceSwitchPath({
+        pathname: '/workspace/ws-next-gen/apps?open=fm-slides',
+        targetWorkspaceId: 'ws-other',
+        role: 'owner',
+      }),
+    ).toBe('/workspace/ws-other/apps');
+    expect(
+      getWorkspaceSwitchPath({
+        pathname: '/workspace/ws-next-gen/chat/conv-42',
+        targetWorkspaceId: 'ws-other',
+        role: 'owner',
+      }),
+    ).toBe('/workspace/ws-other/chat');
+    expect(
+      getWorkspaceSwitchPath({
+        pathname: '/workspace/ws-next-gen/maps/presence',
+        targetWorkspaceId: 'ws-other',
+        role: 'owner',
+      }),
+    ).toBe('/workspace/ws-other/maps/presence');
+  });
+
+  it('falls back when the target workspace lacks the section', () => {
+    expect(
+      getWorkspaceSwitchPath({
+        pathname: '/workspace/ws-next-gen/apps',
+        targetWorkspaceId: 'ws-member',
+        role: 'member',
+      }),
+    ).toBe('/workspace/ws-member/chat');
+  });
+
+  it('preserves admin routes that are not feature-gated', () => {
+    expect(
+      getWorkspaceSwitchPath({
+        pathname: '/workspace/ws-next-gen/admin/events',
+        targetWorkspaceId: 'ws-other',
+        role: 'owner',
+      }),
+    ).toBe('/workspace/ws-other/admin/events');
+  });
+
+  it('works with org-scoped rewritten paths', () => {
+    expect(
+      getWorkspaceSwitchPath({
+        pathname: '/org/acme/workspace/ws-next-gen/apps',
+        targetWorkspaceId: 'ws-other',
+        role: 'owner',
+      }),
+    ).toBe('/workspace/ws-other/apps');
+  });
+});
+
+describe('pathNeedsAgentCatalog', () => {
+  it('is true on chat, lab, and agent settings', () => {
+    expect(pathNeedsAgentCatalog('/workspace/ws1/chat')).toBe(true);
+    expect(pathNeedsAgentCatalog('/workspace/ws1/chat/conv-1')).toBe(true);
+    expect(pathNeedsAgentCatalog('/workspace/ws1/lab')).toBe(true);
+    expect(pathNeedsAgentCatalog('/workspace/ws1/settings/agents')).toBe(true);
+  });
+
+  it('is false on apps and other sections', () => {
+    expect(pathNeedsAgentCatalog('/workspace/ws1/apps')).toBe(false);
+    expect(pathNeedsAgentCatalog('/workspace/ws1/files')).toBe(false);
+    expect(pathNeedsAgentCatalog('/workspace/ws1/settings/theme')).toBe(false);
+  });
+});
+
+describe('pathNeedsGraphExport', () => {
+  it('is true only on graph routes', () => {
+    expect(pathNeedsGraphExport('/workspace/ws1/graph/network')).toBe(true);
+    expect(pathNeedsGraphExport('/workspace/ws1/apps')).toBe(false);
+  });
 });

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/feature-access.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/feature-access.ts
@@ -95,8 +95,12 @@ export function isFeatureEnabled(params: {
   return resolved[params.feature] === true;
 }
 
+function pathWithoutQuery(pathname: string): string {
+  return pathname.split(/[?#]/)[0];
+}
+
 export function getFeatureForWorkspacePath(pathname: string): FeatureKey | null {
-  const parts = pathname.split('/').filter(Boolean);
+  const parts = pathWithoutQuery(pathname).split('/').filter(Boolean);
   const workspaceIndex = parts.indexOf('workspace');
   if (workspaceIndex < 0 || parts.length <= workspaceIndex + 2) {
     return null;
@@ -155,6 +159,17 @@ export function getFeatureForWorkspacePath(pathname: string): FeatureKey | null 
   return null;
 }
 
+/** Surfaces that need the agent catalog (chat, lab, agent settings). Apps does not. */
+export function pathNeedsAgentCatalog(pathname: string | null | undefined): boolean {
+  const feature = getFeatureForWorkspacePath(pathname || '');
+  return feature === 'chat' || feature === 'agents';
+}
+
+/** Graph export toasts are only meaningful on graph routes. */
+export function pathNeedsGraphExport(pathname: string | null | undefined): boolean {
+  return getFeatureForWorkspacePath(pathname || '') === 'graph';
+}
+
 export function isWorkspacePathAllowed(params: {
   pathname: string;
   role?: string;
@@ -186,4 +201,57 @@ export function getFirstAllowedWorkspacePath(params: {
   }
 
   return `/workspace/${params.workspaceId}/chat`;
+}
+
+/**
+ * Destination when switching workspaces from the current URL.
+ *
+ * Stays on the same product surface (apps stays apps) and drops resource ids
+ * (a chat thread, an opened app) that belong to the previous workspace.
+ * If the target workspace does not enable that surface, falls back to its
+ * first allowed route.
+ */
+export function getWorkspaceSwitchPath(params: {
+  pathname: string;
+  targetWorkspaceId: string;
+  role?: string;
+  workspaceFlags?: WorkspaceFeatureFlags;
+}): string {
+  const feature = getFeatureForWorkspacePath(params.pathname);
+  if (feature) {
+    if (
+      isFeatureEnabled({
+        feature,
+        role: params.role,
+        workspaceFlags: params.workspaceFlags,
+      })
+    ) {
+      return `/workspace/${params.targetWorkspaceId}${FEATURE_FALLBACK_ROUTE[feature]}`;
+    }
+    return getFirstAllowedWorkspacePath({
+      workspaceId: params.targetWorkspaceId,
+      role: params.role,
+      workspaceFlags: params.workspaceFlags,
+    });
+  }
+
+  const suffix = workspacePathSuffix(params.pathname);
+  if (suffix) {
+    return `/workspace/${params.targetWorkspaceId}${suffix}`;
+  }
+
+  return getFirstAllowedWorkspacePath({
+    workspaceId: params.targetWorkspaceId,
+    role: params.role,
+    workspaceFlags: params.workspaceFlags,
+  });
+}
+
+function workspacePathSuffix(pathname: string): string | null {
+  const parts = pathWithoutQuery(pathname).split('/').filter(Boolean);
+  const workspaceIndex = parts.indexOf('workspace');
+  if (workspaceIndex < 0 || parts.length <= workspaceIndex + 2) {
+    return null;
+  }
+  return `/${parts.slice(workspaceIndex + 2).join('/')}`;
 }

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/agents.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/agents.ts
@@ -79,10 +79,9 @@ export interface Agent {
 const AGENTS_CACHE_TTL_MS = 5 * 60 * 1000;
 
 // Workspaces reconciled with the backend code class registry this session.
-// The backend `GET /agents` is read-only; reconciliation (create newly
-// discovered agents, prune stale ones) happens via `POST /agents/sync`. We run
-// sync at most once per workspace per session — module-level so it resets on a
-// full page reload — and use the cheap GET listing for every later refresh.
+// GET /agents is read-only. POST /agents/sync is only sent when fetchAgents
+// is called with force=true (chat, lab, agent settings). Module-level so it
+// resets on a full page reload; we still guard against parallel POSTs.
 const syncedWorkspaces = new Set<string>();
 
 // Reserved type names that always appear in the type selector.
@@ -151,13 +150,11 @@ export const useAgentsStore = create<AgentsState>()(
           const { getApiUrl } = await import('@/lib/config');
           const API_BASE = getApiUrl();
 
-          // Reconcile the DB with the code class registry (POST /sync) on the
-          // first fetch of this workspace this session, and on any forced
-          // refresh; other refreshes just list (GET).
-          // Mark the workspace as syncing *before* awaiting so concurrent
-          // fetchAgents calls in the same tab do not fire parallel POSTs
-          // (check-then-insert races used to create duplicate Abi rows).
-          const shouldSync = force || !syncedWorkspaces.has(workspaceId);
+          // Reconcile the DB with the code class registry (POST /sync) only when
+          // the caller asks (`force`). A workspace switch used to POST /sync on
+          // the first GET, which blocks the API (Python agent imports + DB
+          // writes) while Apps is still loading. Chat/lab/settings pass force.
+          const shouldSync = force;
           if (shouldSync) syncedWorkspaces.add(workspaceId);
           let response: Response;
           try {


### PR DESCRIPTION
## Summary

- Missing workspace app-config rows now default to **disabled**, same contract as agents. Settings → Apps is the operator surface. Existing `enabled=true` rows stay on.
- `WorkspaceSeedConfig` can turn a subset of catalog apps on at boot (`apps:`). Seed only inserts missing rows; a later Settings disable is kept.
- Same seed object can pin the workspace default agent and an exclusive agent roster (`default_agent`, `agents:`). `POST /api/agents/sync` applies the roster. Omit `agents:` to keep class `ENABLED_BY_DEFAULT` flags.
- Workspace switch keeps the current section (Apps stays Apps) instead of always landing on Chat or Maps.
- Auth and chrome live above `[workspaceId]`, so a switch does not remount the shell or refetch `/api/auth/me`.
- Apps last-open restore keys off the URL workspace id, so it cannot `router.replace` back to the previous workspace.
- Switching on Apps no longer posts `/api/agents/sync`. Agent catalog loads only when the AI pane is open or the route needs it.

Closes #1207

## Seed shape

```yaml
workspaces:
  - name: "Ops"
    slug: "ops"
    default_agent: "naas_abi AbiAgent"
    agents:
      - "naas_abi AbiAgent"
    apps:
      - example.module:dashboard
```

## Test plan

- [ ] New workspace with no app-config rows: `GET /api/apps/?workspace_id=` returns every catalog app as `enabled=false`
- [ ] Settings → Apps enable one app: it stays on after API restart
- [ ] Seed `apps: [example.module:dashboard]`: that app is on at boot; others stay off
- [ ] Disable a seeded app in Settings, restart: it stays off (existing row wins)
- [ ] Delete an app-config row: it reverts to off (or on only if still listed in seed)
- [ ] Seed `agents:` list: `POST /api/agents/sync` enables only those classes
- [ ] Omit `agents:`: class `ENABLED_BY_DEFAULT` / engine `default_agent` behavior is unchanged
- [ ] `uv run python -m pytest libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/workspace_catalog_seed_test.py`
- [ ] On Apps, switch workspace: stay on Apps in the target workspace (no bounce to Chat, no `?open=` from the previous workspace)
- [ ] Switch does not show a full-screen Loading state or refetch `/api/auth/me`
- [ ] Network tab on an Apps switch: no `POST /api/agents/sync`
- [ ] `pnpm test -- src/lib/feature-access.test.ts src/app/workspace/[workspaceId]/apps/lib/apps-route.test.ts` from `apps/web`