### PR TITLE
feat(nexus): mint a Pages SSO handshake token from Apps

### DIFF
--- a/libs/naas-abi/naas_abi/__init__.py
+++ b/libs/naas-abi/naas_abi/__init__.py
@@ -363,6 +363,8 @@ class NexusConfig(BaseModel):
 
     secret_key: str = "change-me-in-production"
     auth_password_enabled: bool = False
+    pages_sso_secret: str = ""
+    pages_sso_expire_seconds: int = 300
     magic_link_allow_signup: bool = False
     access_token_expire_minutes: int = 1440
     refresh_token_expire_days: int = 30

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/config.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/config.py
@@ -399,6 +399,9 @@ class Settings(BaseSettings):
     refresh_token_expire_days: int = 30  # 30 days (long-lived)
     # Short-lived JWT for opening /app-html apps (Bearer or ?token=).
     app_html_access_token_expire_minutes: int = Field(default=60, ge=1, le=24 * 60)
+    # HMAC secret for opening Cloudflare Pages portals from Nexus (empty = off).
+    pages_sso_secret: str = ""
+    pages_sso_expire_seconds: int = Field(default=300, ge=30, le=15 * 60)
     magic_link_expire_minutes: int = 15
     magic_link_max_active: int = 5
     magic_link_path: str = "/auth/magic-link"

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/apps/adapters/primary/apps__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/apps/adapters/primary/apps__primary_adapter__FastAPI.py
@@ -8,6 +8,8 @@ configuration over HTTP.
 Routes
 ------
 * ``GET    /api/apps/?workspace_id=…``         — catalog (with enable state)
+* ``POST   /api/apps/access-token``            — scoped JWT for ``/app-html/``
+* ``POST   /api/apps/sso-token``               — HMAC handshake for a Pages portal
 * ``GET    /api/apps/{ws}``                    — list configs for workspace
 * ``POST   /api/apps/{ws}``                    — create config
 * ``GET    /api/apps/{ws}/{app_id:path}``      — get one config
@@ -38,12 +40,16 @@ from naas_abi.apps.nexus.apps.api.app.api.endpoints.auth import (
     get_current_user_required,
     require_workspace_access,
 )
+from naas_abi.apps.nexus.apps.api.app.core import config as nexus_config
 from naas_abi.apps.nexus.apps.api.app.core.workspace_catalog_seed import (
     resolve_app_enabled,
     workspace_seed_for_slug,
 )
 from naas_abi.apps.nexus.apps.api.app.services.apps.app_html_access import (
     mint_app_html_access_token,
+)
+from naas_abi.apps.nexus.apps.api.app.services.apps.pages_sso import (
+    mint_pages_sso_token,
 )
 from naas_abi.apps.nexus.apps.api.app.services.apps.port import (
     AppConfigCreate,
@@ -75,6 +81,12 @@ router = APIRouter(dependencies=[Depends(get_current_user_required)])
 # ---------------------------------------------------------------------------
 # Catalog discovery (driven by loaded engine modules)
 # ---------------------------------------------------------------------------
+
+
+def _live_settings():
+    # ``on_initialized`` replaces ``nexus_config.settings``. Do not bind the
+    # module-level ``settings = get_settings()`` snapshot from import time.
+    return nexus_config.settings
 
 
 async def _workspace_slug(workspace_id: str) -> str | None:
@@ -378,6 +390,45 @@ async def create_app_html_access_token(
         expires_in=expires_in,
         path_prefix=body.path_prefix,
     )
+
+
+class PagesSsoTokenRequest(BaseModel):
+    """Mint a short-lived HMAC token for a Cloudflare Pages portal."""
+
+    audience: str = Field(
+        ...,
+        min_length=1,
+        max_length=255,
+        description="Portal hostname, e.g. portal.example.com",
+    )
+
+
+class PagesSsoTokenResponse(BaseModel):
+    token: str
+    token_type: str = "bearer"
+    expires_in: int
+    audience: str
+
+
+@router.post("/sso-token", response_model=PagesSsoTokenResponse)
+async def create_pages_sso_token(
+    body: PagesSsoTokenRequest,
+    current_user: User = Depends(get_current_user_required),
+) -> PagesSsoTokenResponse:
+    """Issue a handshake token so a Pages portal can skip a second login."""
+    live = _live_settings()
+    if not live.pages_sso_secret:
+        raise HTTPException(status_code=503, detail="Pages SSO is not configured")
+    try:
+        token, expires_in = mint_pages_sso_token(
+            email=str(current_user.email),
+            audience=body.audience,
+            secret=live.pages_sso_secret,
+            expires_seconds=live.pages_sso_expire_seconds,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return PagesSsoTokenResponse(token=token, expires_in=expires_in, audience=body.audience.lower())
 
 
 @router.get("/", response_model=AppsResponse)

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/apps/pages_sso.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/apps/pages_sso.py
@@ -1,0 +1,83 @@
+"""HMAC tokens that let a Nexus session open an allowlisted Pages portal."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+
+PAGES_SSO_SCOPE = "pages-sso"
+
+
+def _b64url(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def mint_pages_sso_token(
+    *,
+    email: str,
+    audience: str,
+    secret: str,
+    expires_seconds: int = 300,
+) -> tuple[str, int]:
+    """Return ``(token, expires_in_seconds)``. ``audience`` is the portal hostname."""
+    if not secret:
+        raise ValueError("pages_sso_secret is not configured")
+    host = audience.strip().lower()
+    if not host or "/" in host or ":" in host:
+        raise ValueError("audience must be a hostname")
+    lifetime = max(30, min(int(expires_seconds), 15 * 60))
+    exp = int(time.time()) + lifetime
+    payload = json.dumps(
+        {
+            "aud": host,
+            "email": email.strip().lower(),
+            "exp": exp,
+            "scope": PAGES_SSO_SCOPE,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    body = _b64url(payload.encode("utf-8"))
+    sig = hmac.new(secret.encode("utf-8"), body.encode("ascii"), hashlib.sha256).hexdigest()
+    return f"{body}.{sig}", lifetime
+
+
+def verify_pages_sso_token(
+    token: str,
+    *,
+    secret: str,
+    audience: str,
+) -> str | None:
+    """Return the email when the token is valid for ``audience``, else None."""
+    if not token or not secret or not audience:
+        return None
+    parts = token.split(".")
+    if len(parts) != 2:
+        return None
+    body, sig = parts
+    expected = hmac.new(
+        secret.encode("utf-8"),
+        body.encode("ascii"),
+        hashlib.sha256,
+    ).hexdigest()
+    if not hmac.compare_digest(expected, sig):
+        return None
+    pad = "=" * ((4 - len(body) % 4) % 4)
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(body + pad))
+    except (ValueError, json.JSONDecodeError):
+        return None
+    if payload.get("scope") != PAGES_SSO_SCOPE:
+        return None
+    if str(payload.get("aud") or "").lower() != audience.strip().lower():
+        return None
+    exp = payload.get("exp")
+    if not isinstance(exp, int) or exp < int(time.time()):
+        return None
+    email = str(payload.get("email") or "").strip().lower()
+    if "@" not in email:
+        return None
+    return email

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/apps/pages_sso_test.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/apps/pages_sso_test.py
@@ -1,0 +1,71 @@
+"""Pages SSO HMAC token mint / verify."""
+
+from __future__ import annotations
+
+from naas_abi.apps.nexus.apps.api.app.services.apps.pages_sso import (
+    mint_pages_sso_token,
+    verify_pages_sso_token,
+)
+
+
+def test_mint_roundtrip() -> None:
+    token, lifetime = mint_pages_sso_token(
+        email="Alex.Rivera@example.com",
+        audience="portal.example.com",
+        secret="test-secret",
+        expires_seconds=120,
+    )
+    assert lifetime == 120
+    assert (
+        verify_pages_sso_token(
+            token,
+            secret="test-secret",
+            audience="portal.example.com",
+        )
+        == "alex.rivera@example.com"
+    )
+
+
+def test_wrong_audience_rejected() -> None:
+    token, _ = mint_pages_sso_token(
+        email="alex.rivera@example.com",
+        audience="portal.example.com",
+        secret="test-secret",
+    )
+    assert (
+        verify_pages_sso_token(
+            token,
+            secret="test-secret",
+            audience="other.example.com",
+        )
+        is None
+    )
+
+
+def test_wrong_secret_rejected() -> None:
+    token, _ = mint_pages_sso_token(
+        email="alex.rivera@example.com",
+        audience="portal.example.com",
+        secret="test-secret",
+    )
+    assert (
+        verify_pages_sso_token(
+            token,
+            secret="other",
+            audience="portal.example.com",
+        )
+        is None
+    )
+
+
+def test_mint_rejects_url_audience() -> None:
+    try:
+        mint_pages_sso_token(
+            email="a@b.com",
+            audience="https://portal.example.com",
+            secret="test-secret",
+        )
+    except ValueError as exc:
+        assert "hostname" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/apps/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/apps/page.tsx
@@ -8,7 +8,7 @@ import {
   AppWindow, ExternalLink, RefreshCw, AlertTriangle, Info, PanelLeft, X,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { isBundledAppHtmlUrl, resolveAppEmbedUrl, resolveAppExternalUrl, appHtmlPathPrefix, withAppHtmlAccessToken } from '@/lib/app-html';
+import { isBundledAppHtmlUrl, resolveAppEmbedUrl, resolveAppExternalUrl, appHtmlPathPrefix, pagesSsoAudience, withAppHtmlAccessToken, withPagesSsoToken } from '@/lib/app-html';
 import { getApiUrl } from '@/lib/config';
 import { authFetch } from '@/stores/auth';
 import { useTenant } from '@/contexts/tenant-context';
@@ -43,7 +43,34 @@ function EmbedView({ record, onBack }: { record: AppRecord; onBack: () => void }
     setEmbedError(null);
 
     if (!isBundledAppHtmlUrl(url)) {
-      setEmbedUrl(baseEmbedUrl);
+      const audience = pagesSsoAudience(baseEmbedUrl);
+      if (!audience) {
+        setEmbedUrl(baseEmbedUrl);
+        return () => {
+          cancelled = true;
+        };
+      }
+      setEmbedUrl(null);
+      (async () => {
+        try {
+          const res = await authFetch('/api/apps/sso-token', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ audience }),
+          });
+          if (!res.ok) {
+            if (!cancelled) setEmbedUrl(baseEmbedUrl);
+            return;
+          }
+          const data = (await res.json()) as { token?: string };
+          const token = String(data.token || '').trim();
+          if (!cancelled) {
+            setEmbedUrl(token ? withPagesSsoToken(baseEmbedUrl, token) : baseEmbedUrl);
+          }
+        } catch {
+          if (!cancelled) setEmbedUrl(baseEmbedUrl);
+        }
+      })();
       return () => {
         cancelled = true;
       };

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/app-html.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/app-html.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import {
   appHtmlPathPrefix,
   isBundledAppHtmlUrl,
+  pagesSsoAudience,
   withAppHtmlAccessToken,
+  withPagesSsoToken,
 } from './app-html';
 
 describe('app-html helpers', () => {
@@ -37,5 +39,24 @@ describe('app-html helpers', () => {
     expect(
       withAppHtmlAccessToken('/app-html/report/counter_uas/dashboard/', 'tok'),
     ).toBe('/app-html/report/counter_uas/dashboard/?token=tok');
+  });
+
+  it('derives Pages SSO audience from an absolute portal URL', () => {
+    expect(pagesSsoAudience('https://portal.example.com/login')).toBe(
+      'portal.example.com',
+    );
+    expect(pagesSsoAudience('/app-html/example/web/')).toBe(null);
+  });
+
+  it('appends sso without dropping existing query params', () => {
+    expect(
+      withPagesSsoToken('https://portal.example.com/login', 'abc.def'),
+    ).toBe('https://portal.example.com/login?sso=abc.def');
+    expect(
+      withPagesSsoToken(
+        'https://portal.example.com/login?next=/',
+        'tok',
+      ),
+    ).toBe('https://portal.example.com/login?next=/&sso=tok');
   });
 });

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/app-html.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/app-html.ts
@@ -81,3 +81,24 @@ export function resolveAppExternalUrl(url: string): string {
   }
   return url;
 }
+
+/** Hostname used as the Pages SSO audience (must match the portal host). */
+export function pagesSsoAudience(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+    return parsed.hostname.toLowerCase() || null;
+  } catch {
+    return null;
+  }
+}
+
+/** Attach ``?sso=`` for a Cloudflare Pages portal handshake. */
+export function withPagesSsoToken(url: string, token: string): string {
+  if (!url || !token) return url;
+  const hashIndex = url.indexOf('#');
+  const withoutHash = hashIndex >= 0 ? url.slice(0, hashIndex) : url;
+  const hash = hashIndex >= 0 ? url.slice(hashIndex) : '';
+  const join = withoutHash.includes('?') ? '&' : '?';
+  return `${withoutHash}${join}sso=${encodeURIComponent(token)}${hash}`;
+}


### PR DESCRIPTION
## Summary

- Bundled `/app-html/` apps already get a scoped JWT. External Pages URLs in the Apps iframe do not: the portal has its own login, so a signed-in Nexus user hits a second wall.
- `POST /api/apps/sso-token` mints a short-lived HMAC token bound to the portal **hostname** and the signed-in **email**. Apps appends `?sso=` on the iframe URL. Empty `pages_sso_secret` returns 503; the iframe still loads without the query param (OTP unchanged).
- The portal consume/allowlist lives in the consuming Pages project. This PR only issues the token. It is not SAML/OIDC.

Closes #1211

## Config

```yaml
pages_sso_secret: ""
pages_sso_expire_seconds: 300
```

## Test plan

- [ ] `pages_sso_secret` empty: `POST /api/apps/sso-token` is 503; external app iframe still opens
- [ ] Secret set: endpoint returns `{ token, expires_in, audience }` for a hostname audience
- [ ] URL passed as audience: 400
- [ ] Apps embed of `https://portal.example.com/...` appends `?sso=` when mint succeeds
- [ ] Bundled `/app-html/` app still uses `POST /api/apps/access-token`, not `sso-token`
- [ ] `uv run python -m pytest libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/apps/pages_sso_test.py`
- [ ] `pnpm test -- src/lib/app-html.test.ts` from `apps/web`