### PR TITLE
fix(nexus): let env PAGES_SSO_SECRET win over empty yaml

### DIFF
--- a/libs/naas-abi/naas_abi/__init__.py
+++ b/libs/naas-abi/naas_abi/__init__.py
@@ -603,6 +603,9 @@ class ABIModule(BaseModule):
         from naas_abi.apps.nexus.apps.api.app.core import config as nexus_config
 
         settings_kwargs = self.configuration.nexus_config.model_dump(exclude_none=True)
+        # Empty yaml (``pages_sso_secret: ""``) would override ``PAGES_SSO_SECRET``.
+        if not str(settings_kwargs.get("pages_sso_secret") or "").strip():
+            settings_kwargs.pop("pages_sso_secret", None)
 
         nexus_config.settings = nexus_config.Settings(**settings_kwargs)
 


### PR DESCRIPTION
## Summary

- `ABIModule.on_initialized` dumps `nexus_config` into `Settings(**kwargs)`. Empty `pages_sso_secret: ""` is not `None`, so it was included and hid `PAGES_SSO_SECRET`.
- Handshake mint stayed off even when the env secret was set.
- Empty or whitespace yaml is now omitted before `Settings()` is built. A non-empty yaml value still wins.

Closes #1214

## Test plan

- [ ] yaml `pages_sso_secret: ""` and `PAGES_SSO_SECRET` set: `POST /api/apps/sso-token` mints a token (not 503).
- [ ] yaml secret set to a real value: that value is used, env is ignored.
- [ ] both empty: `POST /api/apps/sso-token` is 503 (feature off).