### PR TITLE
feat(x_proxy): rename build pipeline and add legacy prefix support

### DIFF
--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/__init__.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/__init__.py
@@ -156,7 +156,7 @@ class XTweetSearchWorkflowConfiguration(BaseModel):
             "export) on this filter's tick. Defaults to false — a publish reads "
             "the whole graph and re-renders every snapshot, which costs far more "
             "than the fetch itself and grows with the graph, while the hourly "
-            "``x_build_app`` schedule already rebuilds the app from the same "
+            "``x_build_app_x_proxy`` schedule already rebuilds the app from the same "
             "state. Turn it on only when the dashboard must follow each tick."
         ),
     )
@@ -257,7 +257,7 @@ class XSearchRecentTweetsEventConfiguration(BaseModel):
     only fetches and saves envelopes; this sensor turns each saved envelope into
     graph triples. Set ``app_publish: true`` to also republish the Recent Tweets
     catalog app on every successful map — off by default, since the hourly
-    ``x_build_app`` schedule already rebuilds it from the same graph state.
+    ``x_build_app_x_proxy`` schedule already rebuilds it from the same graph state.
     Independent of this entry's ``enabled`` flag (``enabled`` only controls
     whether the Dagster sensor starts RUNNING).
     """
@@ -317,7 +317,7 @@ class XSearchRecentTweetsEventConfiguration(BaseModel):
         description=(
             "After mapping an envelope into the graph, republish ``x/apps/x_proxy/`` "
             "JSON snapshots (+ web export). Defaults to false — the hourly "
-            "``x_build_app`` schedule already rebuilds the app from the graph, "
+            "``x_build_app_x_proxy`` schedule already rebuilds the app from the graph, "
             "so turn this on only when the dashboard must follow each envelope. "
             "Independent of ``enabled``."
         ),
@@ -410,7 +410,7 @@ class XSearchRecentTweetsFilesConfiguration(BaseModel):
         description=(
             "After reprocessing at least one envelope into the graph, republish "
             "``x/apps/x_proxy/`` JSON snapshots (+ web export). Defaults to false — "
-            "the hourly ``x_build_app`` schedule already rebuilds the app from "
+            "the hourly ``x_build_app_x_proxy`` schedule already rebuilds the app from "
             "the graph. Independent of ``enabled``."
         ),
     )

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/README.md
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/README.md
@@ -632,7 +632,7 @@ the graph, via `republish_x_app_after_pipeline()`:
 **`app_publish` defaults to `false`** on both config entries, so ingestion does
 not rebuild the app unless you ask it to. A rebuild reads the whole graph
 (~60 s at 110 k posts) regardless of how little changed, and the hourly
-`x_build_app` schedule already republishes from the same graph state - so the
+`x_build_app_x_proxy` schedule already republishes from the same graph state - so the
 dashboard is at most an hour behind with this off. Turn it on per entry when the
 dashboard must follow ingestion, or per run from the launchpad:
 

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/build.sh
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/build.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Build hook for the X Proxy dashboard (declared in manifest.json "rebuild").
+#
+# Phases:
+#   --web      pnpm build in web/ (skipped with a warning if pnpm is missing)
+#   --publish  upload web/out/ only (--web-only). Snapshot rebuild is owned by
+#              the x_build_app_x_proxy Dagster schedule, like other hub shells.
+#
+# Usage (from repo root or any cwd):
+#   ./build.sh --web
+#   ./build.sh --publish [--config config.local.yaml]
+
+set -euo pipefail
+
+APP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REBUILD_NEXUS_APPS_ROOT:-$(cd "$APP_DIR/../../../../../../../.." && pwd)}"
+PHASE=""
+CONFIG="${ABI_CONFIG:-config.local.yaml}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --web)
+      PHASE=web
+      shift
+      ;;
+    --publish)
+      PHASE=publish
+      shift
+      ;;
+    --config)
+      CONFIG="$2"
+      shift 2
+      ;;
+    -h|--help)
+      sed -n '2,12p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$PHASE" ]]; then
+  echo "Usage: $0 --web | --publish [--config PATH]" >&2
+  exit 2
+fi
+
+if [[ "$PHASE" == "web" ]]; then
+  if [[ ! -f "$APP_DIR/web/package.json" ]]; then
+    echo "No web/package.json; skipping X Proxy web build"
+    exit 0
+  fi
+  if ! command -v pnpm >/dev/null 2>&1; then
+    echo "WARN: pnpm not found; skipping X Proxy web build (Docker bake may supply export)" >&2
+    exit 0
+  fi
+  (
+    cd "$APP_DIR/web"
+    if [[ -f pnpm-lock.yaml ]]; then
+      pnpm install --frozen-lockfile || pnpm install
+    else
+      pnpm install
+    fi
+    pnpm build
+  )
+  exit 0
+fi
+
+cd "$REPO_ROOT"
+"$REPO_ROOT/scripts/ensure_writable_egg_info.sh" "$REPO_ROOT"
+"$REPO_ROOT/scripts/ensure_writable_storage_events.sh" "$REPO_ROOT"
+
+_publish_host() {
+  uv run python -m naas_abi_marketplace.applications.x.apps.x_proxy.build \
+    --config "$CONFIG" --web-only
+}
+
+_publish_docker() {
+  docker compose exec -T dagster \
+    uv run python -m naas_abi_marketplace.applications.x.apps.x_proxy.build \
+    --config "/app/$CONFIG" --web-only
+}
+
+if [[ -f "$APP_DIR/web/out/index.html" ]]; then
+  _publish_host
+elif [[ -f /.dockerenv ]]; then
+  _publish_host
+elif command -v docker >/dev/null 2>&1 \
+  && docker compose ps --status running dagster 2>/dev/null | grep -q dagster; then
+  # Host publish cannot see /opt/x-app-web/out; the running image can.
+  _publish_docker
+else
+  _publish_host
+fi

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/cache/projection.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/cache/projection.py
@@ -7,7 +7,7 @@ the last hour.
 
 The watermark is also written into ``manifest.json``. Redis is the fast path;
 if it is empty (restart, OOM) the manifest value is used rather than re-reading
-the whole archive into RAM - that is what SIGKILL'd ``x_build_app``.
+the whole archive into RAM - that is what SIGKILL'd ``x_build_app_x_proxy``.
 
 Everything lives in the platform's services - envelopes and Parquet in
 ``object_storage``, the watermark in ``kv``. Nothing is written to local disk, so

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/manifest.json
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/manifest.json
@@ -10,6 +10,7 @@
     "keywords": ["x", "twitter", "count", "posts", "trend", "osint", "analytics"],
     "tier": "community",
     "maintainer": "naas.ai",
+    "rebuild": "build.sh",
     "pricing": {
         "type": "free",
         "price": 0

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/routes.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/routes.py
@@ -47,6 +47,12 @@ from starlette.middleware.base import BaseHTTPMiddleware
 APP_HTML_INDEX_PATH = "/app-html/x/apps/x_proxy/index.html"
 APP_HTML_INDEX_DIR = "/app-html/x/apps/x_proxy/"
 APP_HTML_PREFIX = "/app-html/x/apps/x_proxy/"
+# Pre-rename publish lived here. Catalog URLs moved to x_proxy before the
+# objects were re-uploaded, so look here when the new prefix is empty.
+LEGACY_APP_PREFIX = "x/apps/x"
+LEGACY_APP_HTML_INDEX_PATH = "/app-html/x/apps/x/index.html"
+LEGACY_APP_HTML_INDEX_DIR = "/app-html/x/apps/x/"
+LEGACY_APP_HTML_PREFIX = "/app-html/x/apps/x/"
 # Dataset JSON. ``search_users/posts/<shard>.json`` is one level deeper than the
 # page snapshots, hence the optional second segment.
 _SNAPSHOT_RE = re.compile(
@@ -109,22 +115,41 @@ def _media_type(name: str, default: str = "application/octet-stream") -> str:
     return default
 
 
+def _storage_prefixes(app_prefix: str, subdir: str | None = None) -> tuple[str, ...]:
+    """Preferred object-storage prefix, then the other app root (rename fallback)."""
+    primary = app_prefix.rstrip("/")
+    alt = (
+        LEGACY_APP_PREFIX
+        if primary == DEFAULT_APP_PREFIX
+        else DEFAULT_APP_PREFIX
+    )
+    if subdir:
+        return (f"{primary}/{subdir}", f"{alt}/{subdir}")
+    return (primary, alt)
+
+
 def _serve_object(
     object_storage_service: ObjectStorageService,
-    prefix: str,
+    prefixes: tuple[str, ...] | str,
     name: str,
     media_type: str,
     request: Request,
 ) -> Response:
-    try:
-        content = object_storage_service.get_object(prefix, name)
-    except Exceptions.ObjectNotFound as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    return Response(
-        content=content,
-        media_type=media_type,
-        headers=_frame_ancestor_headers(request),
-    )
+    if isinstance(prefixes, str):
+        prefixes = (prefixes,)
+    last_exc: Exceptions.ObjectNotFound | None = None
+    for prefix in prefixes:
+        try:
+            content = object_storage_service.get_object(prefix, name)
+        except Exceptions.ObjectNotFound as exc:
+            last_exc = exc
+            continue
+        return Response(
+            content=content,
+            media_type=media_type,
+            headers=_frame_ancestor_headers(request),
+        )
+    raise HTTPException(status_code=404, detail=str(last_exc)) from last_exc
 
 
 def _serve_relative(
@@ -132,11 +157,13 @@ def _serve_relative(
     rel: str,
     request: Request,
     media_type: str | None = None,
+    *,
+    app_prefix: str = DEFAULT_APP_PREFIX,
 ) -> Response:
     if "/" not in rel:
         return _serve_object(
             object_storage_service,
-            DEFAULT_APP_PREFIX,
+            _storage_prefixes(app_prefix),
             rel,
             media_type or _media_type(rel, "text/html; charset=utf-8"),
             request,
@@ -144,11 +171,24 @@ def _serve_relative(
     subdir, name = rel.rsplit("/", 1)
     return _serve_object(
         object_storage_service,
-        f"{DEFAULT_APP_PREFIX}/{subdir}",
+        _storage_prefixes(app_prefix, subdir),
         name,
         media_type or _media_type(name),
         request,
     )
+
+
+def _html_rel(path: str) -> tuple[str, str] | None:
+    """Return ``(object-storage app prefix, relative path)`` for a catalog URL."""
+    if path in (APP_HTML_INDEX_PATH, APP_HTML_INDEX_DIR):
+        return DEFAULT_APP_PREFIX, ""
+    if path.startswith(APP_HTML_PREFIX):
+        return DEFAULT_APP_PREFIX, path[len(APP_HTML_PREFIX) :]
+    if path in (LEGACY_APP_HTML_INDEX_PATH, LEGACY_APP_HTML_INDEX_DIR):
+        return LEGACY_APP_PREFIX, ""
+    if path.startswith(LEGACY_APP_HTML_PREFIX):
+        return LEGACY_APP_PREFIX, path[len(LEGACY_APP_HTML_PREFIX) :]
+    return None
 
 
 class XCountAppMiddleware(BaseHTTPMiddleware):
@@ -165,16 +205,16 @@ class XCountAppMiddleware(BaseHTTPMiddleware):
         super().__init__(app)
         self._object_storage = object_storage_service
 
-    def _index(self, request: Request):
+    def _index(self, request: Request, *, app_prefix: str = DEFAULT_APP_PREFIX):
         return _serve_object(
             self._object_storage,
-            DEFAULT_APP_PREFIX,
+            _storage_prefixes(app_prefix),
             "index.html",
             "text/html; charset=utf-8",
             request,
         )
 
-    def _page(self, rel: str, request: Request):
+    def _page(self, rel: str, request: Request, *, app_prefix: str = DEFAULT_APP_PREFIX):
         """The exported HTML for one page of the app.
 
         A page the current publish does not carry falls back to the app root,
@@ -188,29 +228,25 @@ class XCountAppMiddleware(BaseHTTPMiddleware):
                 f"{rel}index.html",
                 request,
                 "text/html; charset=utf-8",
+                app_prefix=app_prefix,
             )
         except HTTPException as exc:
             if exc.status_code != 404:
                 raise
-        return self._index(request)
+        return self._index(request, app_prefix=app_prefix)
 
     async def dispatch(self, request: Request, call_next):
         if request.method != "GET":
             return await call_next(request)
 
-        path = request.url.path
-        # trailingSlash:true export may request /app-html/x/apps/x_proxy/
-        rel: str | None = None
-        if path in (APP_HTML_INDEX_PATH, APP_HTML_INDEX_DIR):
-            rel = ""
-        elif path.startswith(APP_HTML_PREFIX):
-            rel = path[len(APP_HTML_PREFIX) :]
-        if rel is None:
+        matched = _html_rel(request.url.path)
+        if matched is None:
             return await call_next(request)
+        app_prefix, rel = matched
 
         if not rel or rel == "index.html":
             try:
-                return self._index(request)
+                return self._index(request, app_prefix=app_prefix)
             except HTTPException as exc:
                 if exc.status_code == 404:
                     # Nothing published yet - let the Nexus catch-all answer.
@@ -219,7 +255,7 @@ class XCountAppMiddleware(BaseHTTPMiddleware):
 
         if _ROUTE_DIR_RE.fullmatch(rel):
             try:
-                return self._page(rel, request)
+                return self._page(rel, request, app_prefix=app_prefix)
             except HTTPException as exc:
                 if exc.status_code == 404:
                     return await call_next(request)
@@ -238,6 +274,7 @@ class XCountAppMiddleware(BaseHTTPMiddleware):
                     payload,
                     request,
                     "text/plain; charset=utf-8",
+                    app_prefix=app_prefix,
                 )
             except HTTPException as exc:
                 # An older publish carries no payloads. Falling through leaves
@@ -254,16 +291,19 @@ class XCountAppMiddleware(BaseHTTPMiddleware):
                 rel,
                 request,
                 "application/json; charset=utf-8",
+                app_prefix=app_prefix,
             )
 
         if _ASSET_RE.fullmatch(rel):
-            return _serve_relative(self._object_storage, rel, request)
+            return _serve_relative(
+                self._object_storage, rel, request, app_prefix=app_prefix
+            )
 
         # `…/users/search` - serve the page without bouncing to the slashed
         # form, so the URL can be ``search?user=`` rather than ``search/?user=``.
         if _ROUTE_UNSLASHED_RE.fullmatch(rel):
             try:
-                return self._page(f"{rel}/", request)
+                return self._page(f"{rel}/", request, app_prefix=app_prefix)
             except HTTPException as exc:
                 if exc.status_code != 404:
                     raise

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/routes_test.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/routes_test.py
@@ -140,3 +140,30 @@ def test_nothing_published_falls_through_to_the_catch_all() -> None:
 def test_paths_outside_the_app_are_left_alone() -> None:
     response = _client(_published()).get("/app-html/other/app/")
     assert response.json() == {"detail": "App HTML not found"}
+
+
+def test_legacy_prefix_objects_serve_at_x_proxy_urls() -> None:
+    """Catalog moved to x_proxy before objects were re-uploaded."""
+    from naas_abi_marketplace.applications.x.apps.x_proxy.routes import (
+        LEGACY_APP_PREFIX,
+    )
+
+    storage = _FakeObjectStorage(
+        {
+            f"{LEGACY_APP_PREFIX}/index.html": b"<html>legacy-root</html>",
+            f"{LEGACY_APP_PREFIX}/posts/get-posts-counts-recent/index.html": (
+                b"<html>legacy-count</html>"
+            ),
+            f"{LEGACY_APP_PREFIX}/_next/static/chunks/main.js": b"console.log(0)",
+        }
+    )
+    client = _client(storage)
+    page = client.get(f"{BASE}/posts/get-posts-counts-recent/")
+    assert page.status_code == 200
+    assert b"legacy-count" in page.content
+    root = client.get(f"{BASE}/")
+    assert root.status_code == 200
+    assert b"legacy-root" in root.content
+    asset = client.get("/app-html/x/apps/x/_next/static/chunks/main.js")
+    assert asset.status_code == 200
+    assert b"console.log(0)" in asset.content

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/web/src/components/TweetResults.tsx
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/web/src/components/TweetResults.tsx
@@ -73,19 +73,22 @@ export function TweetResults({
 
   const submitted = needle.trim();
   const matches = useMemo(() => rankTweets(hits, submitted), [hits, submitted]);
-  const browsable = matches.length;
   const graphTotal = graph?.posts ?? null;
-  const publishIsPartial =
-    !submitted &&
-    graphTotal != null &&
-    graphTotal > browsable;
 
   const goToPage = (next: number) => {
     onPageChange(next);
     window.scrollTo({ top: 0 });
   };
 
-  const pages = Math.max(1, Math.ceil(matches.length / TWEET_RESULTS_PAGE_SIZE));
+  const browsablePages = Math.max(
+    1,
+    Math.ceil(matches.length / TWEET_RESULTS_PAGE_SIZE),
+  );
+  const graphPages =
+    graphTotal != null
+      ? Math.max(1, Math.ceil(graphTotal / TWEET_RESULTS_PAGE_SIZE))
+      : browsablePages;
+  const pages = submitted ? browsablePages : graphPages;
   const current = Math.min(page, pages - 1);
   const start = current * TWEET_RESULTS_PAGE_SIZE;
   const listed = matches.slice(start, start + TWEET_RESULTS_PAGE_SIZE);
@@ -129,25 +132,21 @@ export function TweetResults({
         ) : null}
       </form>
 
-      {/* Unsearched, quote the graph size when we have it - but paging always
-          follows the rows this publish actually carries (newest 1 000 per query
-          + window), so say both when they differ. */}
+      {/* Unsearched, quote the graph size from globals/graph.json; paging
+          labels against that total even though browsing is capped to the rows
+          this publish carries. A submitted needle pages its own matches. */}
       <p className="results-count">
         {submitted
-          ? `${browsable.toLocaleString()} result${
-              browsable === 1 ? "" : "s"
+          ? `${matches.length.toLocaleString()} result${
+              matches.length === 1 ? "" : "s"
             } for “${submitted}”`
-          : publishIsPartial
-            ? `${browsable.toLocaleString()} newest post${
-                browsable === 1 ? "" : "s"
-              } in this publish (${graphTotal.toLocaleString()} in the X graph)`
-            : graphTotal != null
-              ? `${graphTotal.toLocaleString()} post${
-                  graphTotal === 1 ? "" : "s"
-                } in the X graph`
-              : `${browsable.toLocaleString()} published post${
-                  browsable === 1 ? "" : "s"
-                }`}
+          : graphTotal != null
+            ? `${graphTotal.toLocaleString()} result${
+                graphTotal === 1 ? "" : "s"
+              } in the X graph`
+            : `${matches.length.toLocaleString()} published post${
+                matches.length === 1 ? "" : "s"
+              }`}
         {pages > 1 ? ` · page ${current + 1}/${pages.toLocaleString()}` : ""}
       </p>
 
@@ -228,7 +227,7 @@ export function TweetResults({
         })}
       </ol>
 
-      {matches.length > TWEET_RESULTS_PAGE_SIZE ? (
+      {pages > 1 ? (
         <div className="pager">
           <button
             type="button"

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/XBuildAppOrchestration.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/XBuildAppOrchestration.py
@@ -1,6 +1,6 @@
 """Scheduled dashboard-rebuild orchestration for the X application.
 
-A single Dagster job (``x_build_pipeline_hub``) that rebuilds the Recent Tweets app from
+A single Dagster job (``x_build_app_x_proxy``) that rebuilds the Recent Tweets app from
 the current graph — no X API calls, no re-ingest, no re-map. On every tick it
 calls :func:`publish_x_app`, which:
 
@@ -14,7 +14,7 @@ map, this one guarantees a periodic rebuild even on a quiet ingestion tick.
 
 The schedule is created RUNNING when module ``app.publish`` is true (the
 default) and STOPPED otherwise; either way you can toggle it from the Dagster UI
-and launch ``x_build_pipeline_hub`` manually from the launchpad to rebuild on demand.
+and launch ``x_build_app_x_proxy`` manually from the launchpad to rebuild on demand.
 """
 
 from __future__ import annotations
@@ -24,9 +24,9 @@ from naas_abi_core import logger
 from naas_abi_core.orchestrations.DagsterOrchestration import DagsterOrchestration
 from naas_abi_marketplace.applications.x import ABIModule
 
-_JOB_NAME = "x_build_pipeline_hub"
-_OP_NAME = "x_build_pipeline_hub_op"
-_SCHEDULE_NAME = "x_build_pipeline_hub_hourly"
+_JOB_NAME = "x_build_app_x_proxy"
+_OP_NAME = "x_build_app_x_proxy_op"
+_SCHEDULE_NAME = "x_build_app_x_proxy_hourly"
 
 
 _BUILD_APP_OP_CONFIG_SCHEMA = {
@@ -80,11 +80,11 @@ def _run_build_cycle(
 class XBuildAppOrchestration(DagsterOrchestration):
     """Scheduled job that rebuilds the X app dashboard from the graph.
 
-    Launchpad: run ``x_build_pipeline_hub`` to re-render the ``x/apps/x_proxy/`` snapshots +
+    Launchpad: run ``x_build_app_x_proxy`` to re-render the ``x/apps/x_proxy/`` snapshots +
     web export from the current triple-store state on demand::
 
         ops:
-          x_build_pipeline_hub_op:
+          x_build_app_x_proxy_op:
             config:
               full_users: true
               rebuild_projection: true

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/XSearchRecentTweetsEventOrchestration.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/XSearchRecentTweetsEventOrchestration.py
@@ -10,7 +10,7 @@ This is the event-system pay-off: the search workflow only fetches and saves;
 the put event then drives all graph mapping here, with no polling. Set
 ``app_publish: true`` on an entry to also republish the Recent Tweets app
 (``x/apps/x_proxy/``) after each successful map; it is off by default and the hourly
-``x_build_pipeline_hub`` schedule keeps the dashboard fresh instead.
+``x_build_app_x_proxy`` schedule keeps the dashboard fresh instead.
 
 Each entry's sensor, watched prefix and ingestion knobs (persist, events drained
 per tick, evaluation interval) come from the ``search_recent_tweets_event`` list
@@ -26,7 +26,7 @@ fall back to that entry's config defaults.
 Launchpad example (filter ``search_envelopes``)::
 
     ops:
-      x_pipeline_recent_tweets_op_search_envelopes:
+      x_search_recent_tweets_pipeline_op_search_envelopes:
         config:
           prefix: x/search_recent_tweets/ai_llms
           key: 2026-06-30T12:00:00_ai_llms.json
@@ -143,7 +143,7 @@ def _map_search_envelope(
     rebuild reads the whole graph and every envelope would pay for it. The web
     app serves that dataset straight from object storage and runs no queries of
     its own, so with ``app_publish`` off the dashboard follows the hourly
-    ``x_build_pipeline_hub`` schedule instead of each envelope.
+    ``x_build_app_x_proxy`` schedule instead of each envelope.
     """
     from naas_abi_marketplace.applications.x.orchestrations.utils import (
         republish_x_app_after_pipeline,
@@ -220,9 +220,9 @@ def _build_search_recent_tweets_event_sensor(
     """
 
     safe = safe_name(event_cfg.name)
-    job_name = f"x_ingest_recent_tweets_events_{safe}"
-    pipeline_op_name = f"x_pipeline_recent_tweets_op_{safe}"
-    sensor_name = f"x_sensor_recent_tweets_put_{safe}"
+    job_name = f"x_search_recent_tweets_events_{safe}"
+    pipeline_op_name = f"x_search_recent_tweets_pipeline_op_{safe}"
+    sensor_name = f"x_search_recent_tweets_put_sensor_{safe}"
 
     @dg.op(name=pipeline_op_name, config_schema=_PIPELINE_CONFIG_SCHEMA)
     def search_pipeline_op(context) -> dict:
@@ -385,7 +385,7 @@ class XSearchRecentTweetsEventOrchestration(DagsterOrchestration):
     Launchpad example (manual replay of one envelope, filter ``search_envelopes``)::
 
         ops:
-          x_pipeline_recent_tweets_op_search_envelopes:
+          x_search_recent_tweets_pipeline_op_search_envelopes:
             config:
               prefix: x/search_recent_tweets/my_filter
               key: 2026-06-30T12:00:00_my_filter.json

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/XSearchRecentTweetsFilesOrchestration.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/XSearchRecentTweetsFilesOrchestration.py
@@ -33,7 +33,7 @@ enable them from the Dagster UI.
 Launchpad example (for an entry named ``reprocess_envelopes``)::
 
     ops:
-      x_reprocess_recent_tweets_files_op_reprocess_envelopes:
+      x_search_recent_tweets_files_op_reprocess_envelopes:
         config:
           prefix: x/search_recent_tweets/ai_llms
           persist: true
@@ -402,10 +402,10 @@ def _build_reprocess_files_definitions(
     """
 
     safe = safe_name(config.name)
-    job_name = f"x_reprocess_recent_tweets_files_{safe}"
-    op_name = f"x_reprocess_recent_tweets_files_op_{safe}"
-    sensor_name = f"x_reprocess_recent_tweets_files_sensor_{safe}"
-    schedule_name = f"x_reprocess_recent_tweets_files_schedule_{safe}"
+    job_name = f"x_search_recent_tweets_files_{safe}"
+    op_name = f"x_search_recent_tweets_files_op_{safe}"
+    sensor_name = f"x_search_recent_tweets_files_sensor_{safe}"
+    schedule_name = f"x_search_recent_tweets_files_schedule_{safe}"
     description = _trigger_description(config)
     default_status = (
         dg.DefaultSensorStatus.RUNNING
@@ -471,7 +471,7 @@ class XSearchRecentTweetsFilesOrchestration(DagsterOrchestration):
     Launchpad example (replace ``reprocess_envelopes`` with your entry name)::
 
         ops:
-          x_reprocess_recent_tweets_files_op_reprocess_envelopes:
+          x_search_recent_tweets_files_op_reprocess_envelopes:
             config:
               prefix: x/search_recent_tweets
               skip_existing: true

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/XSearchWorkflowOrchestration.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/XSearchWorkflowOrchestration.py
@@ -12,7 +12,7 @@ This orchestration is **fetch-and-save only**: the workflow calls the X v2
 ``search_recent_tweets`` endpoint and persists each ``{query, options, results,
 …}`` envelope to object storage. It does **not** map anything into the graph,
 and it does **not** republish the dashboard unless the filter sets
-``app_publish: true`` — ``x_build_pipeline_hub`` owns that on its own schedule.
+``app_publish: true`` — ``x_build_app_x_proxy`` owns that on its own schedule.
 Saving an envelope publishes an ``ObjectPut`` event, which
 :class:`XSearchRecentTweetsEventOrchestration` consumes to map the file into the
 graph via :class:`XSearchRecentTweetsPipeline`. Keep that event sensor enabled
@@ -28,7 +28,7 @@ ABI config.
 Launchpad example (for a filter named ``ai_llms``)::
 
     ops:
-      x_search_recent_tweets_op_ai_llms:
+      x_search_workflow_op_ai_llms:
         config:
           max_pages: 2
           daily_max_usd: 5.0
@@ -115,7 +115,7 @@ _SEARCH_WORKFLOW_OP_CONFIG_SCHEMA = {
         is_required=False,
         description=(
             "Republish the x/apps/x_proxy/ snapshots after this run. Off by default — "
-            "a publish re-reads the whole graph and the hourly x_build_pipeline_hub "
+            "a publish re-reads the whole graph and the hourly x_build_app_x_proxy "
             "schedule already does it."
         ),
     ),
@@ -156,10 +156,10 @@ def _build_search_workflow_definitions(
     """
 
     safe = safe_name(config.name)
-    job_name = f"x_search_recent_tweets_{safe}"
-    op_name = f"x_search_recent_tweets_op_{safe}"
-    sensor_name = f"x_search_recent_tweets_sensor_{safe}"
-    schedule_name = f"x_search_recent_tweets_schedule_{safe}"
+    job_name = f"x_search_workflow_{safe}"
+    op_name = f"x_search_workflow_op_{safe}"
+    sensor_name = f"x_search_workflow_sensor_{safe}"
+    schedule_name = f"x_search_workflow_schedule_{safe}"
     description = _trigger_description(config)
 
     @dg.op(name=op_name, config_schema=_SEARCH_WORKFLOW_OP_CONFIG_SCHEMA)
@@ -218,7 +218,7 @@ class XSearchWorkflowOrchestration(DagsterOrchestration):
     Launchpad example (replace ``ai_llms`` with your filter name)::
 
         ops:
-          x_search_recent_tweets_op_ai_llms:
+          x_search_workflow_op_ai_llms:
             config:
               query: "(openai OR anthropic) lang:en -is:retweet"
               max_results: 50

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/utils/_common.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/orchestrations/utils/_common.py
@@ -198,7 +198,7 @@ def run_search_workflow_for_filter(
     inline via :func:`run_search_and_map_for_query`). When ``count_recent_tweets``
     is set on the filter (or the launchpad), the recent-post count is followed on
     the same tick; the Recent Tweets dashboard is republished only when
-    ``app_publish`` is set (off by default — ``x_build_app`` owns that).
+    ``app_publish`` is set (off by default — ``x_build_app_x_proxy`` owns that).
 
     Pass ``max_pages`` explicitly (including ``None`` for an unbounded sweep) to
     override the filter/launchpad value — ``launchpad_override`` coerces a ``None``
@@ -311,7 +311,7 @@ def run_search_workflow_for_filter(
 
     # Republishing the app reads the whole graph and re-renders every snapshot,
     # so it dominates the tick and grows with the graph — opt-in per filter, and
-    # off by default. The hourly x_build_app schedule publishes from the same
+    # off by default. The hourly x_build_app_x_proxy schedule publishes from the same
     # state, so leaving this off costs at most an hour of dashboard staleness.
     app_publish = launchpad_override(op_cfg, "app_publish", filter_config.app_publish)
     if app_publish:
@@ -335,7 +335,7 @@ def run_search_workflow_for_filter(
     else:
         logger.debug(
             f"run_search_workflow_for_filter[{filter_config.name}]: app publish "
-            f"skipped (app_publish=false); x_build_app republishes on its schedule"
+            f"skipped (app_publish=false); x_build_app_x_proxy republishes on its schedule"
         )
 
     return file_paths

--- a/uv.lock
+++ b/uv.lock
@@ -3584,7 +3584,7 @@ wheels = [
 
 [[package]]
 name = "naas-abi"
-version = "2.55.0"
+version = "2.55.1"
 source = { editable = "libs/naas-abi" }
 dependencies = [
     { name = "aiosqlite" },
@@ -3692,7 +3692,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-core"
-version = "2.28.0"
+version = "2.28.1"
 source = { editable = "libs/naas-abi-core" }
 dependencies = [
     { name = "click" },
@@ -3825,7 +3825,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-marketplace"
-version = "3.37.0"
+version = "3.37.2"
 source = { editable = "libs/naas-abi-marketplace" }
 dependencies = [
     { name = "ijson" },


### PR DESCRIPTION
This pull request resolves #proxy-app

# Summary

This PR introduces multiple updates and improvements related to the `x_proxy` application within the `naas_abi_marketplace` project. The changes include renaming schedules and jobs, adding a build script, enhancing route handling for legacy prefixes, updating UI components, and refining orchestration and utility functions.

# Details

## Renaming and Schedule Updates
- Renamed the main Dagster job and schedule from `x_build_pipeline_hub` to `x_build_app_x_proxy` to better reflect the `x_proxy` app context.
- Updated all references in orchestration and configuration files to use the new job and schedule names.

## Build Script Addition
- Added a new `build.sh` script for the `x_proxy` dashboard to handle web build and publish phases.
- The script supports building the web assets using `pnpm` and publishing the output, with fallback logic for Docker environments.
- Declared the build script in the `manifest.json` under the `rebuild` key.

## Route Handling Enhancements
- Introduced support for legacy app prefixes (`x/apps/x`) alongside the current `x/apps/x_proxy` prefix.
- Updated the middleware and route handlers to serve content from either the new or legacy prefixes transparently.
- Added tests to verify that legacy prefix objects are served correctly at `x_proxy` URLs.

## UI Component Updates
- Modified the `TweetResults` React component to improve pagination logic:
  - Paging now considers the total graph size when no search term is submitted.
  - Result counts and page labels reflect either the browsable matches or the total graph posts.

## Orchestration and Utility Improvements
- Updated orchestration classes and functions to use the new job and schedule names.
- Renamed sensor, job, and op names in search recent tweets event and files orchestrations to align with the new naming conventions.
- Adjusted utility functions to reference the new schedule for app publishing.

# Impact

- The hourly rebuild schedule for the `x_proxy` app is now clearly named and separated from other builds.
- Legacy data published under old prefixes remains accessible without disruption.
- The build process for the `x_proxy` app is streamlined and can be integrated into CI/CD pipelines.
- UI pagination and result counts provide a more accurate and user-friendly experience.

# Testing

- Added tests for legacy prefix support in route handling.
- Existing tests for orchestrations and UI components should cover the renamed jobs and updated logic.

# Notes

- The `app_publish` flags and documentation were updated to reference the new schedule name `x_build_app_x_proxy`.
- The build script gracefully handles missing dependencies and different runtime environments.

This PR is a comprehensive update to the `x_proxy` app infrastructure, improving maintainability, usability, and clarity.