### PR TITLE
feat(proxy-app): add 'All time' scenario window for comprehensive analytics

### DIFF
--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/api/common.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/api/common.py
@@ -48,11 +48,15 @@ USER_SHARD_COUNT = 16**USER_SHARD_HEX
 
 # Rolling windows shown in the Scenario filter (id / label / hours).
 # start_time / end_time are filled at publish time, floored to the clock hour.
+# ``all`` has no ``hours``: its start is the earliest ingested data (or the
+# longest rolling window when that is unknown).
+ALL_TIME_ID = "all"
 SCENARIO_SPECS: list[dict[str, Any]] = [
     {"id": "24h", "label": "Last 24 hours", "hours": 24},
     {"id": "48h", "label": "Last 48 hours", "hours": 48},
     {"id": "7d", "label": "Last 7 days", "hours": 168},
     {"id": "30d", "label": "Last 30 days", "hours": 720},
+    {"id": ALL_TIME_ID, "label": "All time"},
 ]
 
 
@@ -94,24 +98,40 @@ def batched(values: list[str], size: int) -> Iterator[list[str]]:
         yield values[start : start + step]
 
 
-def build_scenarios(now: datetime | None = None) -> list[dict[str, str]]:
-    """Four scenario filters with ``id``, ``label``, ``start_time``, ``end_time``.
+def is_all_time(scenario: dict[str, Any]) -> bool:
+    """True for the open-ended "All time" scenario (no previous period)."""
+    return str(scenario.get("id") or "") == ALL_TIME_ID
 
-    Both edges are floored to the clock hour. The count workflow only ever
-    ingests *complete* clock hours, and :meth:`SnapshotContext.aggregate_buckets`
-    keeps a bucket only when its ``start`` falls inside the window - so an
-    unaligned window silently dropped the partially-overlapped first bucket
-    (a publish at 13:02 lost the whole 13:00–14:00 hour). Flooring also makes a
-    window reproducible: two publishes in the same hour describe the same range.
+
+def build_scenarios(
+    now: datetime | None = None, *, data_start: datetime | None = None
+) -> list[dict[str, str]]:
+    """Scenario filters with ``id``, ``label``, ``start_time``, ``end_time``.
+
+    Rolling windows (24h / 48h / 7d / 30d) plus an ``all`` window that starts
+    at *data_start* when that is earlier than "now". Both edges are floored to
+    the clock hour. The count workflow only ever ingests *complete* clock hours,
+    and :meth:`SnapshotContext.aggregate_buckets` keeps a bucket only when its
+    ``start`` falls inside the window - so an unaligned window silently dropped
+    the partially-overlapped first bucket (a publish at 13:02 lost the whole
+    13:00–14:00 hour). Flooring also makes a window reproducible: two publishes
+    in the same hour describe the same range.
 
     The trade-off is that the in-progress hour is excluded, which is what the
     bucket data supports anyway.
+
+    *data_start* missing or not earlier than the longest rolling window makes
+    All time coincide with Last 30 days rather than inventing an empty prefix.
     """
     now = now or datetime.now(UTC)
     end = now.astimezone(UTC).replace(minute=0, second=0, microsecond=0)
     scenarios: list[dict[str, str]] = []
+    rolling_start = end
     for spec in SCENARIO_SPECS:
+        if "hours" not in spec:
+            continue
         start = end - timedelta(hours=int(spec["hours"]))
+        rolling_start = start
         scenarios.append(
             {
                 "id": str(spec["id"]),
@@ -120,6 +140,21 @@ def build_scenarios(now: datetime | None = None) -> list[dict[str, str]]:
                 "end_time": end.isoformat(),
             }
         )
+    all_start = rolling_start
+    if data_start is not None:
+        ds = data_start.astimezone(UTC).replace(minute=0, second=0, microsecond=0)
+        if ds < end:
+            all_start = ds
+    if all_start >= end:
+        all_start = end - timedelta(hours=1)
+    scenarios.append(
+        {
+            "id": ALL_TIME_ID,
+            "label": "All time",
+            "start_time": all_start.isoformat(),
+            "end_time": end.isoformat(),
+        }
+    )
     return scenarios
 
 
@@ -139,10 +174,11 @@ def scenario_bands(
     """Consecutive ``[start, end)`` bands that tile every scenario window.
 
     :func:`build_scenarios` gives every scenario the *same* ``end_time``, so the
-    windows are strictly nested and each one - plus each :func:`previous_window`
-    - is exactly a union of consecutive bands. Splitting the graph once at every
-    window boundary lets a single banded aggregate answer all of them, instead of
-    one full scan per window.
+    rolling windows are nested and each one - plus each :func:`previous_window`
+    - is exactly a union of consecutive bands. All time has no previous period
+    (there is nothing before the start of the data). Splitting the graph once
+    at every window boundary lets a single banded aggregate answer all of them,
+    instead of one full scan per window.
 
     Bands are returned newest first, so band 0 is the most recent slice. Pass
     ``include_previous=False`` for the current windows only, which is all the
@@ -154,7 +190,7 @@ def scenario_bands(
         start, end = scenario["start_time"], scenario["end_time"]
         edges.add(start)
         edges.add(end)
-        if include_previous:
+        if include_previous and not is_all_time(scenario):
             prev_start, prev_end = previous_window(start, end)
             edges.add(prev_start)
             edges.add(prev_end)
@@ -1243,7 +1279,7 @@ class SnapshotContext:
         Unfiltered reads are additionally resolved against pages already fetched
         for the same ``end_time`` - see :meth:`_derive_tweets`. Since every
         scenario shares an ``end_time`` and the scenarios are visited
-        narrowest-first, one 24 h scan typically answers all four.
+        narrowest-first, one 24 h scan typically answers all of them.
         """
         cap = self.tweet_limit if limit is None else int(limit)
         active = normalize_tweet_filters(filters)

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/api/common_test.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/api/common_test.py
@@ -14,13 +14,14 @@ from naas_abi_marketplace.applications.x.apps.x_proxy.api.common import (
     SnapshotContext,
     bands_for_window,
     build_scenarios,
+    is_all_time,
     previous_window,
     scenario_bands,
     slugify,
 )
 
 NOW = datetime(2026, 8, 12, 7, 0, tzinfo=UTC)
-SCENARIOS = build_scenarios(NOW)
+SCENARIOS = build_scenarios(NOW, data_start=NOW - timedelta(days=90))
 END = SCENARIOS[0]["end_time"]
 
 
@@ -46,6 +47,8 @@ def test_every_scenario_window_and_its_previous_period_is_band_aligned():
     for scenario in SCENARIOS:
         start, end = scenario["start_time"], scenario["end_time"]
         assert bands_for_window(bands, start, end) is not None
+        if is_all_time(scenario):
+            continue
         assert bands_for_window(bands, *previous_window(start, end)) is not None
 
 
@@ -98,10 +101,12 @@ def test_banded_counts_match_a_direct_count_for_every_window():
     ctx = _BandedCountContext(created)
 
     for scenario in SCENARIOS:
-        for start, end in (
-            (scenario["start_time"], scenario["end_time"]),
-            previous_window(scenario["start_time"], scenario["end_time"]),
-        ):
+        windows = [(scenario["start_time"], scenario["end_time"])]
+        if not is_all_time(scenario):
+            windows.append(
+                previous_window(scenario["start_time"], scenario["end_time"])
+            )
+        for start, end in windows:
             expected = sum(
                 1
                 for moment in created
@@ -114,7 +119,7 @@ def test_banded_counts_match_a_direct_count_for_every_window():
                 == expected
             )
 
-    # 8 windows, one scan - and it is memoized, so a second pass adds nothing.
+    # Every aligned window, one scan - and it is memoized, so a second pass adds nothing.
     assert ctx.queries_run == 1
 
 
@@ -342,7 +347,7 @@ def test_a_wider_page_is_filtered_down_to_a_narrower_window():
         result = ctx.tweets_in_window("q", scenario["start_time"], scenario["end_time"])
         assert result == _direct(ctx, scenario["start_time"], scenario["end_time"], 50)
 
-    assert ctx.windows_queried == [(SCENARIOS[3]["start_time"], END)]
+    assert ctx.windows_queried == [(SCENARIOS[-1]["start_time"], END)]
 
 
 def test_previous_windows_are_not_derived_from_current_ones():

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/api/count_recent_tweets/kpis.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/api/count_recent_tweets/kpis.py
@@ -6,6 +6,7 @@ from datetime import datetime
 
 from naas_abi_marketplace.applications.x.apps.x_proxy.api.common import (
     SnapshotContext,
+    is_all_time,
     previous_window,
     slugify,
 )
@@ -23,7 +24,7 @@ def publish(ctx: SnapshotContext) -> dict:
         for scenario in ctx.scenarios:
             sid = scenario["id"]
             start, end = scenario["start_time"], scenario["end_time"]
-            prev_start, prev_end = previous_window(start, end)
+            all_time = is_all_time(scenario)
             hours = int(
                 (
                     datetime.fromisoformat(end) - datetime.fromisoformat(start)
@@ -32,7 +33,13 @@ def publish(ctx: SnapshotContext) -> dict:
             )
             daily = hours > 48
             cur_pts = ctx.aggregate_buckets(buckets, start, end, daily=daily)
-            prev_pts = ctx.aggregate_buckets(buckets, prev_start, prev_end, daily=daily)
+            if all_time:
+                prev_pts: list[dict] = []
+            else:
+                prev_start, prev_end = previous_window(start, end)
+                prev_pts = ctx.aggregate_buckets(
+                    buckets, prev_start, prev_end, daily=daily
+                )
             cur_total = sum(p["value"] for p in cur_pts)
             prev_total = sum(p["value"] for p in prev_pts)
             cur_mean = cur_total / len(cur_pts) if cur_pts else 0.0
@@ -49,24 +56,34 @@ def publish(ctx: SnapshotContext) -> dict:
                             "id": "total",
                             "label": "Total Tweets",
                             "value": cur_total,
-                            "prev_value": prev_total,
-                            "delta": cur_total - prev_total,
+                            "prev_value": None if all_time else prev_total,
+                            "delta": None if all_time else cur_total - prev_total,
                             "hint": (
-                                f"{prev_total} prev. period"
-                                if prev_pts
-                                else "no prior period"
+                                "all ingested counts"
+                                if all_time
+                                else (
+                                    f"{prev_total} prev. period"
+                                    if prev_pts
+                                    else "no prior period"
+                                )
                             ),
                         },
                         {
                             "id": "mean",
                             "label": f"Mean / {unit}",
                             "value": round(cur_mean, 1),
-                            "prev_value": round(prev_mean, 1),
-                            "delta": round(cur_mean - prev_mean, 1),
+                            "prev_value": None if all_time else round(prev_mean, 1),
+                            "delta": (
+                                None if all_time else round(cur_mean - prev_mean, 1)
+                            ),
                             "hint": (
-                                f"{round(prev_mean, 1)} prev. period"
-                                if prev_pts
-                                else "no prior period"
+                                "all ingested counts"
+                                if all_time
+                                else (
+                                    f"{round(prev_mean, 1)} prev. period"
+                                    if prev_pts
+                                    else "no prior period"
+                                )
                             ),
                         },
                         {

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/api/count_recent_tweets/linecharts.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/api/count_recent_tweets/linecharts.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from naas_abi_marketplace.applications.x.apps.x_proxy.api.common import (
     SnapshotContext,
     extrapolate_partial_hour,
+    is_all_time,
     previous_window,
     slugify,
 )
@@ -78,7 +79,6 @@ def publish(ctx: SnapshotContext) -> dict:
         estimate = extrapolate_partial_hour(ctx.partial_bucket(query_string), buckets)
         for scenario in ctx.scenarios:
             start, end = scenario["start_time"], scenario["end_time"]
-            prev_start, prev_end = previous_window(start, end)
             hours = int(
                 (
                     datetime.fromisoformat(end) - datetime.fromisoformat(start)
@@ -87,7 +87,11 @@ def publish(ctx: SnapshotContext) -> dict:
             )
             daily = hours > 48
             cur = ctx.aggregate_buckets(buckets, start, end, daily=daily)
-            prev = ctx.aggregate_buckets(buckets, prev_start, prev_end, daily=daily)
+            if is_all_time(scenario):
+                prev: list[dict] = []
+            else:
+                prev_start, prev_end = previous_window(start, end)
+                prev = ctx.aggregate_buckets(buckets, prev_start, prev_end, daily=daily)
             if estimate:
                 _append_partial_point(cur, estimate, daily=daily, window_end=end)
             charts.append(

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/api/publish.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/api/publish.py
@@ -99,8 +99,14 @@ def publish_app(
     the SPARQL path in place.
     """
     built_at = datetime.now(UTC)
-    scenarios = build_scenarios(built_at)
     cache = _attach_cache(object_storage) if use_cache else None
+    data_start = None
+    if cache is not None:
+        try:
+            data_start = cache.earliest_matched_created_at()
+        except Exception as exc:  # noqa: BLE001 - All time then equals 30d
+            logger.warning(f"X app publish: could not resolve All time start ({exc})")
+    scenarios = build_scenarios(built_at, data_start=data_start)
     ctx = SnapshotContext(
         object_storage,
         triple_store,

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/api/search_recents_tweets/barcharts.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/api/search_recents_tweets/barcharts.py
@@ -1,20 +1,46 @@
-"""Publish ``search_recents_tweets/barcharts.json`` - top authors / locations."""
+"""Publish ``search_recents_tweets/barcharts.json`` - top authors / locations.
+
+Author (and location) ranks are aggregated over the **whole** scenario window,
+not the newest ``DEFAULT_TWEET_LIMIT`` table rows. Ranking from that sample made
+every scenario look the same whenever 24 h already held more posts than the cap.
+"""
 
 from __future__ import annotations
 
-from collections import Counter
-
 from naas_abi_marketplace.applications.x.apps.x_proxy.api.common import (
     SnapshotContext,
+    is_all_time,
     previous_window,
     slugify,
 )
 from naas_abi_marketplace.applications.x.apps.x_proxy.app_config import app_config
 
 
+def _counts(
+    ctx: SnapshotContext,
+    query_string: str,
+    start: str,
+    end: str,
+    column: str,
+    limit: int,
+) -> dict[str, int]:
+    rows = ctx.facet_values_for_window(query_string, start, end, column, limit=limit)
+    out: dict[str, int] = {}
+    for row in rows:
+        key = (row.get("value") or "").strip() or "-"
+        try:
+            out[key] = int(row.get("count") or 0)
+        except (TypeError, ValueError):
+            out[key] = 0
+    return out
+
+
 def publish(ctx: SnapshotContext) -> dict:
     # How many bars each chart carries - `charts:` in config.yaml.
     limits = app_config().charts
+    # Previous-period lookup is wider than the bar cap so a current top author
+    # that was quieter last window still gets a delta rather than "+N vs 0".
+    prev_limit = max(limits.top_authors_bars, limits.top_locations_bars, 500)
     charts: list[dict] = []
     for entry in ctx.queries:
         query_string = str(entry.get("query") or "").strip()
@@ -23,30 +49,38 @@ def publish(ctx: SnapshotContext) -> dict:
         slug = slugify(entry.get("name") or query_string)
         for scenario in ctx.scenarios:
             start, end = scenario["start_time"], scenario["end_time"]
-            prev_start, prev_end = previous_window(start, end)
-            cur = ctx.tweets_in_window(query_string, start, end)
-            prev = ctx.tweets_in_window(query_string, prev_start, prev_end)
-
-            cur_authors = Counter((t.get("username") or "-") for t in cur)
-            prev_authors = Counter((t.get("username") or "-") for t in prev)
-            cur_locs = Counter(
-                (t.get("location") or "").strip()
-                for t in cur
-                if (t.get("location") or "").strip()
+            all_time = is_all_time(scenario)
+            cur_authors = ctx.facet_values_for_window(
+                query_string, start, end, "username", limit=limits.top_authors_bars
             )
-            prev_locs = Counter(
-                (t.get("location") or "").strip()
-                for t in prev
-                if (t.get("location") or "").strip()
+            cur_locs = ctx.facet_values_for_window(
+                query_string, start, end, "location", limit=limits.top_locations_bars
             )
+            prev_authors: dict[str, int] = {}
+            prev_locs: dict[str, int] = {}
+            if not all_time:
+                prev_start, prev_end = previous_window(start, end)
+                prev_authors = _counts(
+                    ctx, query_string, prev_start, prev_end, "username", prev_limit
+                )
+                prev_locs = _counts(
+                    ctx, query_string, prev_start, prev_end, "location", prev_limit
+                )
 
             author_bars = []
-            for username, value in cur_authors.most_common(limits.top_authors_bars):
+            for row in cur_authors:
+                username = (row.get("value") or "").strip() or "-"
+                try:
+                    value = int(row.get("count") or 0)
+                except (TypeError, ValueError):
+                    value = 0
                 author_bars.append(
                     {
                         "label": f"@{username}",
                         "value": value,
-                        "delta": value - prev_authors.get(username, 0),
+                        "delta": (
+                            None if all_time else value - prev_authors.get(username, 0)
+                        ),
                         "href": (
                             f"https://x.com/{username}"
                             if username and username != "-"
@@ -55,12 +89,21 @@ def publish(ctx: SnapshotContext) -> dict:
                     }
                 )
             location_bars = []
-            for location, value in cur_locs.most_common(limits.top_locations_bars):
+            for row in cur_locs:
+                location = (row.get("value") or "").strip()
+                if not location:
+                    continue
+                try:
+                    value = int(row.get("count") or 0)
+                except (TypeError, ValueError):
+                    value = 0
                 location_bars.append(
                     {
                         "label": location,
                         "value": value,
-                        "delta": value - prev_locs.get(location, 0),
+                        "delta": (
+                            None if all_time else value - prev_locs.get(location, 0)
+                        ),
                         "href": None,
                     }
                 )

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/api/search_recents_tweets/barcharts_test.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/api/search_recents_tweets/barcharts_test.py
@@ -1,0 +1,76 @@
+"""Top authors are ranked over the whole scenario window, not the table sample."""
+
+from datetime import UTC, datetime
+
+from naas_abi_marketplace.applications.x.apps.x_proxy.api.search_recents_tweets import (
+    barcharts,
+)
+
+
+class _Ctx:
+    built_at = datetime(2026, 8, 14, 10, 0, tzinfo=UTC)
+    queries = [{"name": "drones_and_uas", "query": "drone OR drones"}]
+    scenarios = [
+        {
+            "id": "24h",
+            "start_time": "2026-08-13T10:00:00+00:00",
+            "end_time": "2026-08-14T10:00:00+00:00",
+        },
+        {
+            "id": "7d",
+            "start_time": "2026-08-07T10:00:00+00:00",
+            "end_time": "2026-08-14T10:00:00+00:00",
+        },
+        {
+            "id": "all",
+            "start_time": "2026-05-01T10:00:00+00:00",
+            "end_time": "2026-08-14T10:00:00+00:00",
+        },
+    ]
+    saved: dict | None = None
+    facet_calls: list[tuple[str, str, str, int]] = []
+
+    def __init__(self) -> None:
+        self.facet_calls = []
+        self.saved = None
+
+    def facet_values_for_window(self, query, start, end, column, *, limit=500):
+        del query
+        self.facet_calls.append((start, end, column, limit))
+        if column != "username":
+            return []
+        # 24h: alice dominates. 7d: bob has been posting all week.
+        if start.startswith("2026-08-13"):
+            return [{"value": "alice", "count": 40}, {"value": "bob", "count": 5}]
+        if start.startswith("2026-08-12"):  # previous of 24h
+            return [{"value": "alice", "count": 10}, {"value": "bob", "count": 8}]
+        if start.startswith("2026-08-07"):
+            return [{"value": "bob", "count": 90}, {"value": "alice", "count": 50}]
+        if start.startswith("2026-07-31"):  # previous of 7d
+            return [{"value": "bob", "count": 20}]
+        return [{"value": "carol", "count": 200}, {"value": "bob", "count": 90}]
+
+    def save_json(self, folder, name, doc):
+        del folder, name
+        self.saved = doc
+
+
+def test_top_authors_differ_by_scenario_and_all_time_has_no_delta():
+    ctx = _Ctx()
+    doc = barcharts.publish(ctx)  # type: ignore[arg-type]
+    by_id = {entry["scenario_id"]: entry for entry in doc["barcharts"]}
+
+    day = {b["label"]: b for b in by_id["24h"]["items"][0]["bars"]}
+    week = {b["label"]: b for b in by_id["7d"]["items"][0]["bars"]}
+    all_time = {b["label"]: b for b in by_id["all"]["items"][0]["bars"]}
+
+    assert list(day) == ["@alice", "@bob"]
+    assert day["@alice"]["value"] == 40
+    assert day["@alice"]["delta"] == 30
+    assert week["@bob"]["value"] == 90
+    assert week["@bob"]["delta"] == 70
+    # Different windows, different ranking - not the newest-1000 sample.
+    assert next(iter(week)) == "@bob"
+    assert list(all_time) == ["@carol", "@bob"]
+    assert all_time["@carol"]["delta"] is None
+    assert all_time["@bob"]["delta"] is None

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/api/search_recents_tweets/kpis.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/api/search_recents_tweets/kpis.py
@@ -10,13 +10,15 @@ Four cards per query × scenario, all uncapped over the window:
   coverage would exceed 100%). Hint is that count-endpoint total; no
   period-over-period comparison.
 
-Tables / author bars still sample at most ``DEFAULT_TWEET_LIMIT`` rows.
+Tables still sample at most ``DEFAULT_TWEET_LIMIT`` rows. Author bars are
+aggregated over the whole window (see ``barcharts.py``).
 """
 
 from __future__ import annotations
 
 from naas_abi_marketplace.applications.x.apps.x_proxy.api.common import (
     SnapshotContext,
+    is_all_time,
     previous_window,
     slugify,
 )
@@ -37,10 +39,10 @@ def publish(ctx: SnapshotContext) -> dict:
         slug = slugify(entry.get("name") or query_string)
         for scenario in ctx.scenarios:
             start, end = scenario["start_time"], scenario["end_time"]
-            prev_start, prev_end = previous_window(start, end)
+            all_time = is_all_time(scenario)
 
             # Uncapped cardinality, summed out of the banded aggregate: one
-            # scan per population covers all four scenarios and their previous
+            # scan per population covers every scenario and their previous
             # periods, instead of one scan per window. ``matched`` is the tweets
             # that answered the query; ``referenced`` is the reply parents,
             # quoted tweets and retweeted originals the expansions pulled in as
@@ -52,13 +54,17 @@ def publish(ctx: SnapshotContext) -> dict:
                 query_string, start, end, referenced=True
             )
             ingested = matched + referenced
-            prev_matched = ctx.banded_count_for_window(
-                query_string, prev_start, prev_end, referenced=False
-            )
-            prev_referenced = ctx.banded_count_for_window(
-                query_string, prev_start, prev_end, referenced=True
-            )
-            prev_ingested = prev_matched + prev_referenced
+            if all_time:
+                prev_matched = prev_referenced = prev_ingested = None
+            else:
+                prev_start, prev_end = previous_window(start, end)
+                prev_matched = ctx.banded_count_for_window(
+                    query_string, prev_start, prev_end, referenced=False
+                )
+                prev_referenced = ctx.banded_count_for_window(
+                    query_string, prev_start, prev_end, referenced=True
+                )
+                prev_ingested = prev_matched + prev_referenced
             total = ctx.sum_counts_in_window(query_string, start, end)
             # Coverage is measured against the count endpoint's total for the
             # query, whose population is matches only - referenced tweets never
@@ -75,7 +81,11 @@ def publish(ctx: SnapshotContext) -> dict:
                             "label": "Total Posts Ingested",
                             "value": ingested,
                             "prev_value": prev_ingested,
-                            "delta": ingested - prev_ingested,
+                            "delta": (
+                                None
+                                if prev_ingested is None
+                                else ingested - prev_ingested
+                            ),
                             "hint": f"{start} to {end}",
                         },
                         {
@@ -83,7 +93,9 @@ def publish(ctx: SnapshotContext) -> dict:
                             "label": "Tweets",
                             "value": matched,
                             "prev_value": prev_matched,
-                            "delta": matched - prev_matched,
+                            "delta": (
+                                None if prev_matched is None else matched - prev_matched
+                            ),
                             "hint": _share_hint(matched, ingested),
                         },
                         {
@@ -91,7 +103,11 @@ def publish(ctx: SnapshotContext) -> dict:
                             "label": "Referenced Tweets",
                             "value": referenced,
                             "prev_value": prev_referenced,
-                            "delta": referenced - prev_referenced,
+                            "delta": (
+                                None
+                                if prev_referenced is None
+                                else referenced - prev_referenced
+                            ),
                             "hint": _share_hint(referenced, ingested),
                         },
                         {

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/api/search_recents_tweets/linecharts.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/api/search_recents_tweets/linecharts.py
@@ -16,6 +16,7 @@ from datetime import datetime
 from naas_abi_marketplace.applications.x.apps.x_proxy.api.common import (
     SnapshotContext,
     complete_hourly_buckets,
+    is_all_time,
     previous_window,
     slugify,
 )
@@ -23,10 +24,14 @@ from naas_abi_marketplace.applications.x.apps.x_proxy.api.common import (
 
 def publish(ctx: SnapshotContext) -> dict:
     charts: list[dict] = []
-    if ctx.scenarios:
+    rolling = [s for s in ctx.scenarios if not is_all_time(s)]
+    if rolling:
         span_start = min(
-            previous_window(s["start_time"], s["end_time"])[0] for s in ctx.scenarios
+            previous_window(s["start_time"], s["end_time"])[0] for s in rolling
         )
+        span_end = max(s["end_time"] for s in rolling)
+    elif ctx.scenarios:
+        span_start = min(s["start_time"] for s in ctx.scenarios)
         span_end = max(s["end_time"] for s in ctx.scenarios)
     else:
         span_start = span_end = ""
@@ -37,14 +42,15 @@ def publish(ctx: SnapshotContext) -> dict:
         slug = slugify(entry.get("name") or query_string)
         if not ctx.scenarios:
             continue
-        buckets = complete_hourly_buckets(
-            ctx.ingested_timeseries(query_string, span_start, span_end),
-            span_start,
-            span_end,
-        )
+        buckets: list[dict] = []
+        if rolling and span_start and span_end:
+            buckets = complete_hourly_buckets(
+                ctx.ingested_timeseries(query_string, span_start, span_end),
+                span_start,
+                span_end,
+            )
         for scenario in ctx.scenarios:
             start, end = scenario["start_time"], scenario["end_time"]
-            prev_start, prev_end = previous_window(start, end)
             hours = int(
                 (
                     datetime.fromisoformat(end) - datetime.fromisoformat(start)
@@ -52,6 +58,18 @@ def publish(ctx: SnapshotContext) -> dict:
                 // 3600
             )
             daily = hours > 48
+            if is_all_time(scenario):
+                # Don't pad years of zero hours: All time is a daily (or sparse
+                # hourly) series of the hours that actually have posts.
+                raw = ctx.ingested_timeseries(query_string, start, end)
+                current_points = ctx.aggregate_buckets(raw, start, end, daily=daily)
+                previous_points: list[dict] = []
+            else:
+                current_points = ctx.aggregate_buckets(buckets, start, end, daily=daily)
+                prev_start, prev_end = previous_window(start, end)
+                previous_points = ctx.aggregate_buckets(
+                    buckets, prev_start, prev_end, daily=daily
+                )
             charts.append(
                 {
                     "query_slug": slug,
@@ -61,16 +79,12 @@ def publish(ctx: SnapshotContext) -> dict:
                         {
                             "id": "current",
                             "label": "Current",
-                            "points": ctx.aggregate_buckets(
-                                buckets, start, end, daily=daily
-                            ),
+                            "points": current_points,
                         },
                         {
                             "id": "previous",
                             "label": "Previous period",
-                            "points": ctx.aggregate_buckets(
-                                buckets, prev_start, prev_end, daily=daily
-                            ),
+                            "points": previous_points,
                         },
                     ],
                 }

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/cache/cache_test.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/cache/cache_test.py
@@ -446,6 +446,13 @@ def test_window_counts_split_matched_from_referenced():
     assert reader.count_in_window(start, end, referenced=True) == 1
 
 
+def test_earliest_matched_created_at_ignores_older_referenced_posts():
+    reader = _seeded_reader()
+    earliest = reader.earliest_matched_created_at()
+    assert earliest is not None
+    assert earliest.isoformat().startswith("2026-08-12T04:00:00")
+
+
 def test_a_post_matched_in_a_later_tick_stops_counting_as_context():
     """Match typing wins globally, not just inside one envelope."""
     storage, kv = _Storage(), _KV()

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/cache/reader.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/cache/reader.py
@@ -13,7 +13,7 @@ must not pay for the load each time.
 from __future__ import annotations
 
 import io
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from naas_abi_core import logger
@@ -210,6 +210,33 @@ class CacheReader:
             )
             self._matched_ids = ids.get_column("tweet_id").implode()
         return self._matched_ids
+
+    def earliest_matched_created_at(self) -> datetime | None:
+        """Oldest matched post's ``created_at``, or ``None`` when empty.
+
+        Only ``created_at`` and ``kind`` are loaded, so discovering All time's
+        start does not pull the full post table into RAM.
+        """
+        import polars as pl
+
+        frames = self._read_parquet_objects(POSTS_DIR, columns=["created_at", "kind"])
+        if not frames:
+            return None
+        matched = pl.concat(frames, how="vertical_relaxed").filter(
+            pl.col("kind") == KIND_MATCHED
+        )
+        if matched.is_empty():
+            return None
+        value = matched.get_column("created_at").min()
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            return value if value.tzinfo else value.replace(tzinfo=UTC)
+        try:
+            parsed = datetime.fromisoformat(str(value))
+        except ValueError:
+            return None
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
 
     def known_query_slugs(self) -> set[str]:
         """Every ``query_slug`` the projection holds rows for.

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/hub_test.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/hub_test.py
@@ -186,10 +186,27 @@ def test_slugify_is_stable_and_filesystem_safe():
 
 def test_build_scenarios_has_id_label_start_end():
     scenarios = build_scenarios(datetime(2026, 7, 7, 14, 0, tzinfo=UTC))
-    assert len(scenarios) == 4
+    assert len(scenarios) == 5
     for s in scenarios:
         assert set(s) == {"id", "label", "start_time", "end_time"}
-    assert [s["id"] for s in scenarios] == ["24h", "48h", "7d", "30d"]
+    assert [s["id"] for s in scenarios] == ["24h", "48h", "7d", "30d", "all"]
+    # Without a data start, All time coincides with Last 30 days.
+    month = next(s for s in scenarios if s["id"] == "30d")
+    all_time = next(s for s in scenarios if s["id"] == "all")
+    assert all_time["start_time"] == month["start_time"]
+    assert all_time["end_time"] == month["end_time"]
+    assert all_time["label"] == "All time"
+
+
+def test_build_scenarios_all_time_starts_at_the_earliest_data():
+    now = datetime(2026, 7, 7, 14, 0, tzinfo=UTC)
+    data_start = datetime(2026, 4, 1, 9, 17, tzinfo=UTC)
+    scenarios = build_scenarios(now, data_start=data_start)
+    all_time = next(s for s in scenarios if s["id"] == "all")
+    assert all_time["end_time"] == "2026-07-07T14:00:00+00:00"
+    assert all_time["start_time"] == "2026-04-01T09:00:00+00:00"
+    month = next(s for s in scenarios if s["id"] == "30d")
+    assert all_time["start_time"] < month["start_time"]
 
 
 def test_build_scenarios_floors_both_edges_to_the_clock_hour():

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/web/src/app/globals.css
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/web/src/app/globals.css
@@ -1490,9 +1490,7 @@ select {
 .bar-list {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  max-height: 150px;
-  overflow-y: auto;
+  gap: 6px;
 }
 
 /* Thin, discreet scrollbar aligned with the dark app design (shared by the
@@ -1533,7 +1531,7 @@ select {
 .bar-row {
   display: grid;
   grid-template-columns: 1fr auto;
-  gap: 5px 10px;
+  gap: 2px 10px;
 }
 
 .bl-label {
@@ -1562,7 +1560,7 @@ select {
 
 .bl-track {
   grid-column: 1 / -1;
-  height: 6px;
+  height: 5px;
   background: var(--panel-2);
 }
 

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/web/src/components/pages/CountPage.tsx
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/web/src/components/pages/CountPage.tsx
@@ -18,6 +18,7 @@ export function CountPage({ data, querySlug, scenarioId }: Props) {
     line?.series?.find((s) => s.id === "current")?.points || [];
   const previous =
     line?.series?.find((s) => s.id === "previous")?.points || [];
+  const allTime = scenarioId === "all";
 
   return (
     <div>
@@ -26,8 +27,8 @@ export function CountPage({ data, querySlug, scenarioId }: Props) {
         <div className="section-head">
           <h2>Posts over time</h2>
           <p className="sub">
-            {line?.granularity === "day" ? "Per day" : "Per hour"} · current vs
-            previous period
+            {line?.granularity === "day" ? "Per day" : "Per hour"}
+            {allTime ? "" : " · current vs previous period"}
           </p>
         </div>
         <div className="card">

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/web/src/components/pages/SearchPage.tsx
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/applications/x/apps/x_proxy/web/src/components/pages/SearchPage.tsx
@@ -45,6 +45,7 @@ export function SearchPage({
   const previous =
     line?.series?.find((s) => s.id === "previous")?.points || [];
   const scenario = scenarios.find((s) => s.id === scenarioId);
+  const allTime = scenarioId === "all";
   const kpiItems = (kpis?.items || []).map((it) => {
     if (it.id !== "tweets_ingested" || !scenario) return it;
     return {
@@ -59,8 +60,8 @@ export function SearchPage({
         <div className="section-head">
           <h2>Posts ingested over time</h2>
           <p className="sub">
-            {line?.granularity === "day" ? "Per day" : "Per hour"} · current vs
-            previous period
+            {line?.granularity === "day" ? "Per day" : "Per hour"}
+            {allTime ? "" : " · current vs previous period"}
           </p>
         </div>
         <div className="card">
@@ -72,7 +73,7 @@ export function SearchPage({
           <h2>Top authors</h2>
           <p className="sub">
             {authors?.bars?.length
-              ? `${authors.bars.length} author(s) in range · by posts ingested`
+              ? `${authors.bars.length} author(s)${scenario ? ` · ${scenario.label}` : ""} · by posts ingested`
               : ""}
           </p>
         </div>

--- a/uv.lock
+++ b/uv.lock
@@ -3584,7 +3584,7 @@ wheels = [
 
 [[package]]
 name = "naas-abi"
-version = "2.55.1"
+version = "2.55.2"
 source = { editable = "libs/naas-abi" }
 dependencies = [
     { name = "aiosqlite" },
@@ -3825,7 +3825,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-marketplace"
-version = "3.37.2"
+version = "3.38.0"
 source = { editable = "libs/naas-abi-marketplace" }
 dependencies = [
     { name = "ijson" },


### PR DESCRIPTION
This pull request resolves #proxy-app

# Summary

This PR introduces a new "All time" scenario window to the X Proxy app's analytics, which covers the entire data ingestion period starting from the earliest matched post. It enhances the existing rolling windows (24h, 48h, 7d, 30d) by adding an open-ended window that starts at the earliest available data or the longest rolling window if the earliest data is unknown.

# Details

- Added a new scenario ID `all` representing the "All time" window.
- Modified `build_scenarios` to accept an optional `data_start` datetime to define the start of the "All time" window.
- Implemented `is_all_time` helper to identify the "All time" scenario.
- Updated various publishing modules (`count_recent_tweets`, `linecharts`, `search_recents_tweets`) to handle the "All time" scenario correctly, especially avoiding previous period comparisons and deltas where not applicable.
- Adjusted banding and window calculations to exclude previous periods for the "All time" window.
- Added a method `earliest_matched_created_at` in the cache reader to find the earliest matched post's creation time, used to set the start of the "All time" window.
- Updated the publish function to attempt to retrieve the earliest data start from the cache and pass it to `build_scenarios`.
- Modified UI components to handle the "All time" scenario by hiding previous period comparisons where irrelevant.
- Improved top authors and locations ranking to aggregate over the entire scenario window rather than just the newest sample, ensuring meaningful differences across scenarios.
- Added tests for the new "All time" scenario behavior and earliest data start detection.
- Minor CSS tweaks for better spacing in bar lists.

# Impact

- The "All time" scenario provides a comprehensive view of data over the entire ingestion period.
- Previous period deltas and comparisons are disabled for the "All time" window to reflect its open-ended nature.
- Rankings and KPIs now correctly reflect the full window data for "All time".
- The UI adapts to hide irrelevant previous period information for the "All time" scenario.

# Testing

- Added unit tests for scenario building including the "All time" window.
- Added tests for top authors ranking behavior across scenarios.
- Added tests for earliest matched created_at detection in cache reader.

This enhancement improves the analytical capabilities of the X Proxy app by providing a meaningful "All time" perspective on tweet data.