### PR TITLE
fix(nexus): honor source and path query params on Files

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/files/browse/browse.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/files/browse/browse.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState, useRef, useCallback } from 'react';
-import { useRouter, useParams } from 'next/navigation';
+import { useRouter, useParams, useSearchParams } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Header } from '@/components/shell/header';
@@ -55,6 +55,11 @@ import {
   filesScopeForSource,
   relativeDrivePath,
 } from '../lib/drive-label';
+import {
+  filesDeepLinkFolderAndPreview,
+  matchListedFile,
+  parseFilesDeepLink,
+} from '../lib/files-route';
 import './browse.css';
 
 type FileWithRelativeDir = { file: File; relativeDir?: string };
@@ -127,6 +132,7 @@ function sortFiles(
 export default function FilesPage() {
   const router = useRouter();
   const params = useParams();
+  const searchParams = useSearchParams();
   const workspaceId = params.workspaceId as string;
   
   const {
@@ -215,6 +221,7 @@ export default function FilesPage() {
   const skipRegularFetchRef = useRef(false);
   // Local path of the file to auto-preview once files finish loading
   const [localPendingPreview, setLocalPendingPreview] = useState<string | null>(null);
+  const deepLinkConsumedRef = useRef(false);
 
   // Helper to open file in Lab
   const handleOpenInLab = (file: FileInfo) => {
@@ -296,10 +303,33 @@ export default function FilesPage() {
     setStarredNavigation(null);
   }, [starredNavigation, setActiveSource, fetchFiles, setStarredNavigation, workspaceId]);
 
+  // Session-authenticated deep link: /workspace/:id/files?source=platform-drive&path=...
+  // Storage keys are not HTTP routes; stay inside the Files UI.
+  useEffect(() => {
+    if (deepLinkConsumedRef.current || starredNavigation) return;
+    const deepLink = parseFilesDeepLink(searchParams?.toString() ?? '');
+    if (!deepLink.source && !deepLink.path) return;
+    deepLinkConsumedRef.current = true;
+    skipRegularFetchRef.current = true;
+    if (deepLink.source) setActiveSource(deepLink.source);
+    setSearchQuery('');
+    setDebouncedSearch('');
+    lastSearchRef.current = '';
+    setCurrentPage(1);
+    const { folderPath, previewPath } = filesDeepLinkFolderAndPreview(deepLink.path || '');
+    fetchFiles(folderPath, {
+      limit: pageSizeRef.current,
+      offset: 0,
+      search: '',
+      workspaceId,
+    });
+    if (previewPath) setLocalPendingPreview(previewPath);
+  }, [searchParams, starredNavigation, setActiveSource, fetchFiles, workspaceId]);
+
   // Once the files list loads, open the pending preview (if any).
   useEffect(() => {
     if (!localPendingPreview || loading) return;
-    const target = files.find((f) => f.path === localPendingPreview);
+    const target = matchListedFile(files, localPendingPreview);
     if (!target) return;
     setLocalPendingPreview(null);
     if (isPdfFile(target)) openPdfViewer(target);
@@ -322,7 +352,7 @@ export default function FilesPage() {
   const relativePath = relativeDrivePath(currentPath, driveRoot, activeSource, workspaceId);
 
   useEffect(() => {
-    // Skip if a starred navigation just updated activeSource — it already called fetchFiles.
+    // Skip if a starred nav or deep link just set the path; it already called fetchFiles.
     if (skipRegularFetchRef.current) {
       skipRegularFetchRef.current = false;
       return;

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/files/lib/files-route.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/files/lib/files-route.test.ts
@@ -1,9 +1,20 @@
 import { describe, expect, it } from 'vitest';
 
-import { filesBrowsePath, parseFilesRoute } from './files-route';
+import {
+  filesBrowseHref,
+  filesBrowsePath,
+  filesDeepLinkFolderAndPreview,
+  hasFilesDeepLink,
+  matchListedFile,
+  parseFilesDeepLink,
+  parseFilesRoute,
+  stripPlatformDrivePrefix,
+} from './files-route';
 
 const WS = 'ws-1';
 const BASE = `/workspace/${WS}/files`;
+const FILE = 'shared/Organization/External/acme/deck.pptx';
+const FOLDER = 'shared/Organization/External/acme';
 
 describe('parseFilesRoute', () => {
   it('shows the drive list on the bare files route', () => {
@@ -48,5 +59,167 @@ describe('filesBrowsePath', () => {
 
   it('degrades to a workspace-less path before a workspace is known', () => {
     expect(filesBrowsePath(null)).toBe('/files/browse');
+  });
+});
+
+describe('filesBrowseHref', () => {
+  it('appends a query string to the browse path', () => {
+    expect(filesBrowseHref(WS, 'source=platform-drive&path=shared/docs')).toBe(
+      `${BASE}/browse?source=platform-drive&path=shared/docs`,
+    );
+  });
+
+  it('accepts a leading question mark', () => {
+    expect(filesBrowseHref(WS, '?source=workspace')).toBe(`${BASE}/browse?source=workspace`);
+  });
+
+  it('omits an empty query', () => {
+    expect(filesBrowseHref(WS, '')).toBe(`${BASE}/browse`);
+    expect(filesBrowseHref(WS, '?')).toBe(`${BASE}/browse`);
+  });
+});
+
+describe('parseFilesDeepLink', () => {
+  it('reads source and a drive-relative path', () => {
+    expect(parseFilesDeepLink(`?source=platform-drive&path=${FILE}`)).toEqual({
+      source: 'platform-drive',
+      path: FILE,
+    });
+  });
+
+  it('reads a query string without a leading question mark', () => {
+    expect(parseFilesDeepLink('source=my-drive&path=uploads/notes.md')).toEqual({
+      source: 'my-drive',
+      path: 'uploads/notes.md',
+    });
+  });
+
+  it('trims whitespace on source and path', () => {
+    expect(parseFilesDeepLink('?source=  platform-drive  &path=  shared/docs  ')).toEqual({
+      source: 'platform-drive',
+      path: 'shared/docs',
+    });
+  });
+
+  it('strips a storage-root prefix from path', () => {
+    expect(
+      parseFilesDeepLink(
+        '?source=platform-drive&path=naas_abi/platform-drive/shared/docs/deck.pptx',
+      ).path,
+    ).toBe('shared/docs/deck.pptx');
+  });
+
+  it('strips a bare platform-drive prefix from path', () => {
+    expect(
+      parseFilesDeepLink('?source=platform-drive&path=platform-drive/shared/docs/deck.pptx').path,
+    ).toBe('shared/docs/deck.pptx');
+  });
+
+  it('keeps source when path is omitted', () => {
+    expect(parseFilesDeepLink('?source=platform-drive')).toEqual({
+      source: 'platform-drive',
+      path: null,
+    });
+  });
+
+  it('keeps path when source is omitted', () => {
+    expect(parseFilesDeepLink('?path=shared/docs')).toEqual({
+      source: null,
+      path: 'shared/docs',
+    });
+  });
+
+  it('returns empty fields when the query is missing or blank', () => {
+    expect(parseFilesDeepLink(null)).toEqual({ source: null, path: null });
+    expect(parseFilesDeepLink('')).toEqual({ source: null, path: null });
+    expect(parseFilesDeepLink('?source=&path=')).toEqual({ source: null, path: null });
+  });
+
+  it('decodes a percent-encoded path', () => {
+    expect(parseFilesDeepLink('?path=shared%2FMy%20Deck.pptx').path).toBe('shared/My Deck.pptx');
+  });
+});
+
+describe('hasFilesDeepLink', () => {
+  it('is true when source or path is present', () => {
+    expect(hasFilesDeepLink('?source=platform-drive')).toBe(true);
+    expect(hasFilesDeepLink('?path=shared/docs')).toBe(true);
+  });
+
+  it('is false when both fields are empty', () => {
+    expect(hasFilesDeepLink(null)).toBe(false);
+    expect(hasFilesDeepLink('?source=&path=')).toBe(false);
+  });
+});
+
+describe('filesDeepLinkFolderAndPreview', () => {
+  it('opens a file by listing its folder and previewing the file', () => {
+    expect(filesDeepLinkFolderAndPreview(FILE)).toEqual({
+      folderPath: FOLDER,
+      previewPath: FILE,
+    });
+  });
+
+  it('treats a folder path as browse-only', () => {
+    expect(filesDeepLinkFolderAndPreview(FOLDER)).toEqual({
+      folderPath: FOLDER,
+    });
+  });
+
+  it('previews a file at the drive root', () => {
+    expect(filesDeepLinkFolderAndPreview('deck.pptx')).toEqual({
+      folderPath: '',
+      previewPath: 'deck.pptx',
+    });
+  });
+
+  it('strips a storage-root prefix before splitting', () => {
+    expect(
+      filesDeepLinkFolderAndPreview('naas_abi/platform-drive/shared/docs/deck.pptx'),
+    ).toEqual({
+      folderPath: 'shared/docs',
+      previewPath: 'shared/docs/deck.pptx',
+    });
+  });
+
+  it('treats an empty or prefix-only path as the drive root', () => {
+    expect(filesDeepLinkFolderAndPreview('')).toEqual({ folderPath: '' });
+    expect(filesDeepLinkFolderAndPreview('naas_abi/platform-drive')).toEqual({ folderPath: '' });
+  });
+});
+
+describe('stripPlatformDrivePrefix', () => {
+  it('leaves a drive-relative path unchanged', () => {
+    expect(stripPlatformDrivePrefix('shared/docs/deck.pptx')).toBe('shared/docs/deck.pptx');
+  });
+
+  it('trims leading and trailing slashes', () => {
+    expect(stripPlatformDrivePrefix('/shared/docs/')).toBe('shared/docs');
+  });
+});
+
+describe('matchListedFile', () => {
+  const listed = [
+    {
+      name: 'deck.pptx',
+      path: 'naas_abi/platform-drive/shared/Organization/External/acme/deck.pptx',
+    },
+    { name: 'notes.md', path: 'naas_abi/platform-drive/shared/docs/notes.md' },
+  ];
+
+  it('matches a drive-relative preview to a full storage-key listing', () => {
+    expect(matchListedFile(listed, FILE)?.name).toBe('deck.pptx');
+  });
+
+  it('matches an exact storage-key preview', () => {
+    expect(matchListedFile(listed, listed[1].path)?.name).toBe('notes.md');
+  });
+
+  it('matches by file name when the prefix differs', () => {
+    expect(matchListedFile(listed, 'deck.pptx')?.name).toBe('deck.pptx');
+  });
+
+  it('returns undefined when nothing matches', () => {
+    expect(matchListedFile(listed, 'missing/report.pdf')).toBeUndefined();
   });
 });

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/files/lib/files-route.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/files/lib/files-route.ts
@@ -3,6 +3,11 @@
  *
  *   /workspace/{id}/files         → drive list (mobile) / browser (desktop)
  *   /workspace/{id}/files/browse → file browser (mobile detail)
+ *
+ * Query params stay inside the authenticated Files UI. Storage keys are not
+ * HTTP routes:
+ *
+ *   ?source=platform-drive&path=shared/docs/deck.pptx
  */
 
 export const FILES_BROWSE_SLUG = 'browse';
@@ -34,4 +39,85 @@ export function filesBrowsePath(workspaceId: string | null): string {
   return workspaceId
     ? `/workspace/${workspaceId}/files/${FILES_BROWSE_SLUG}`
     : `/files/${FILES_BROWSE_SLUG}`;
+}
+
+/** Browse path plus an optional query string (`source`, `path`, and anything else). */
+export function filesBrowseHref(
+  workspaceId: string | null,
+  search?: string | null,
+): string {
+  const base = filesBrowsePath(workspaceId);
+  if (!search) return base;
+  const q = search.startsWith('?') ? search.slice(1) : search;
+  return q ? `${base}?${q}` : base;
+}
+
+const STORAGE_ROOT_PREFIXES = ['naas_abi/platform-drive/', 'platform-drive/'];
+
+/** Strip storage-root prefixes so Files can fetch a drive-relative path. */
+export function stripPlatformDrivePrefix(path: string): string {
+  let normalized = path.replace(/^\/+|\/+$/g, '');
+  for (const prefix of STORAGE_ROOT_PREFIXES) {
+    if (normalized === prefix.slice(0, -1)) return '';
+    if (normalized.startsWith(prefix)) {
+      normalized = normalized.slice(prefix.length);
+    }
+  }
+  return normalized;
+}
+
+export interface FilesDeepLink {
+  source: string | null;
+  path: string | null;
+}
+
+/** Read `?source=&path=` from a Files URL (drive + path inside that drive). */
+export function parseFilesDeepLink(search: string | null | undefined): FilesDeepLink {
+  if (!search) return { source: null, path: null };
+  const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
+  const source = (params.get('source') ?? '').trim() || null;
+  const rawPath = (params.get('path') ?? '').trim();
+  const path = rawPath ? stripPlatformDrivePrefix(rawPath) : null;
+  return { source, path };
+}
+
+export function hasFilesDeepLink(search: string | null | undefined): boolean {
+  const { source, path } = parseFilesDeepLink(search);
+  return Boolean(source || path);
+}
+
+/**
+ * Split a deep-link path into the folder to list and an optional file to preview.
+ * `previewPath` stays drive-relative; the browse page matches listed FileInfo paths.
+ */
+export function filesDeepLinkFolderAndPreview(path: string): {
+  folderPath: string;
+  previewPath?: string;
+} {
+  const normalized = stripPlatformDrivePrefix(path);
+  if (!normalized) return { folderPath: '' };
+  const name = normalized.split('/').pop() ?? '';
+  const looksLikeFile = /\.[A-Za-z0-9]{1,8}$/.test(name);
+  if (!looksLikeFile) return { folderPath: normalized };
+  const slash = normalized.lastIndexOf('/');
+  return {
+    folderPath: slash >= 0 ? normalized.slice(0, slash) : '',
+    previewPath: normalized,
+  };
+}
+
+/** Find a listed row for a drive-relative or storage-root preview path. */
+export function matchListedFile<T extends { path: string; name: string }>(
+  files: T[],
+  previewPath: string,
+): T | undefined {
+  const normalized = stripPlatformDrivePrefix(previewPath);
+  if (!normalized) return undefined;
+  const name = normalized.split('/').pop() ?? '';
+  return files.find((file) => {
+    const listed = stripPlatformDrivePrefix(file.path);
+    if (listed === normalized || file.path === previewPath) return true;
+    if (file.path.endsWith(`/${normalized}`)) return true;
+    return Boolean(name && file.name === name);
+  });
 }

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/files/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/files/page.tsx
@@ -1,15 +1,32 @@
 'use client';
 
+import { useEffect } from 'react';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import FilesBrowse from './browse/browse';
 import { useIsMobile } from '@/hooks/use-is-mobile';
+import { filesBrowseHref, hasFilesDeepLink } from './lib/files-route';
 
 /**
  * Desktop: /files is the file browser.
  * Mobile: /files is the drive list (workspace-layout renders FilesSection);
  * do not mount the browser here or its fetch effects fight the shell.
+ *
+ * A source/path query is a deep link into the browser. On mobile, send that
+ * to /files/browse so the list-then-detail shell opens the folder/file.
  */
 export default function FilesIndexPage() {
   const isMobile = useIsMobile();
+  const router = useRouter();
+  const params = useParams();
+  const searchParams = useSearchParams();
+  const workspaceId = params.workspaceId as string;
+  const search = searchParams?.toString() ?? '';
+
+  useEffect(() => {
+    if (!isMobile || !hasFilesDeepLink(search)) return;
+    router.replace(filesBrowseHref(workspaceId, search));
+  }, [isMobile, search, router, workspaceId]);
+
   if (isMobile) return null;
   return <FilesBrowse />;
 }


### PR DESCRIPTION
Fixes #1221

## Summary

Storage keys are not HTTP routes. A Files URL with `?source=` and `?path=` must stay inside the authenticated Files UI: select the drive, list the folder, and open a preview when the path is a file. Today those query params are ignored, so a shared link opens Files home.

This parses the query on `/files` and `/files/browse`, strips a storage-root prefix so the list request is drive-relative, and on mobile sends the deep link to `/files/browse` so the list-then-detail shell opens the folder or file.

## Test plan

- [x] `pnpm dlx vitest run src/app/workspace/[workspaceId]/files/lib/files-route.test.ts` (33 passed)
- [ ] Signed in, open `/workspace/<id>/files?source=platform-drive&path=shared/docs` and confirm that folder lists
- [ ] Same URL with a file name: parent folder lists and the preview opens
- [ ] No query params: Files home is unchanged
- [ ] Mobile: a deep link on `/files` lands on `/files/browse` with the same query