### PR TITLE
fix(nexus): keep workspace catalogs isolated and drop desk rings

### DIFF
--- a/libs/naas-abi/naas_abi/__init__.py
+++ b/libs/naas-abi/naas_abi/__init__.py
@@ -296,8 +296,9 @@ class WorkspaceSeedConfig(BaseModel):
     font_family: str | None = None
     # Same syntax as engine ``default_agent``: ``module AgentClass``.
     default_agent: str | None = None
-    # Registry refs to enable in this workspace. ``None`` keeps class flags
-    # (``ENABLED_BY_DEFAULT``). A list is the roster: listed on, others off.
+    # Registry refs (``module AgentClass``) enabled in this workspace.
+    # ``None`` means the engine default agent only. A list is exclusive:
+    # listed on, others off. An empty list enables none.
     agents: list[str] | None = None
     # Catalog ``app_id`` values (``module.path:folder``) to enable at boot.
     # ``None`` means no seed; missing app-config rows default to off.

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/agents/adapters/primary/agents__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/agents/adapters/primary/agents__primary_adapter__FastAPI.py
@@ -196,22 +196,18 @@ def _get_engine_default_agent_class_name() -> str | None:
     return None
 
 
-def _agent_enabled_by_default(
-    agent_cls: type[Agent],
-    *,
-    name: str | None,
-    class_name: str,
+def _workspace_agent_roster(
+    seeded_class_names: set[str] | None,
     default_class_name: str | None,
-) -> bool:
-    """Whether a newly discovered agent should be enabled in the workspace picker."""
-    if default_class_name is not None and class_name == default_class_name:
-        return True
-    if default_class_name is None and name == "Abi":
-        return True
-    flag = getattr(agent_cls, "enabled_by_default", None)
-    if flag is None:
-        flag = getattr(agent_cls, "ENABLED_BY_DEFAULT", False)
-    return bool(flag)
+) -> set[str]:
+    """Explicit ``agents:`` list, or the engine default only.
+
+    A missing seed is not a wildcard. Class ``enabled_by_default`` must not
+    enable agents in a workspace that never declared a roster.
+    """
+    if seeded_class_names is not None:
+        return set(seeded_class_names)
+    return {default_class_name} if default_class_name else set()
 
 
 def _extract_agent_suggestions(agent_cls: type) -> list[dict] | None:
@@ -518,6 +514,8 @@ async def _reconcile_workspace_agents(
     * **Create** records for newly discovered agent classes (idempotent under
       the partial unique index on workspace_id + class_name).
     * **Backfill** a missing ``module_path`` on existing records.
+    * **Align** ``enabled`` to the workspace roster on every sync: the
+      ``agents:`` seed when present, otherwise the engine default only.
 
     Returns the reconciled agent list (deleted records removed, created ones
     appended, backfilled ones refreshed).
@@ -555,6 +553,8 @@ async def _reconcile_workspace_agents(
     if default_class_name is None:
         default_class_name = _get_engine_default_agent_class_name()
 
+    roster = _workspace_agent_roster(seeded_class_names, default_class_name)
+
     # Persist any newly discovered agent classes to the database.
     for class_name, agent_cls in class_name_to_agent_class.items():
         if class_name in existing_agents_by_class_name:
@@ -562,17 +562,7 @@ async def _reconcile_workspace_agents(
 
         name = _get_agent_class_name(agent_cls)
         description = _get_agent_class_description(agent_cls)
-        # A workspace ``agents:`` list is the roster. Otherwise enable the
-        # engine default (or Abi fallback) plus class ``ENABLED_BY_DEFAULT``.
-        if seeded_class_names is not None:
-            enabled = class_name in seeded_class_names
-        else:
-            enabled = _agent_enabled_by_default(
-                agent_cls,
-                name=name,
-                class_name=class_name,
-                default_class_name=default_class_name,
-            )
+        enabled = class_name in roster
 
         logger.debug("Creating agent in nexus backend: {}", name)
         system_prompt = _get_agent_system_prompt(agent_cls)
@@ -640,23 +630,22 @@ async def _reconcile_workspace_agents(
                     continue
         reconciled.append(agent)
 
-    if seeded_class_names is not None:
-        aligned: list[AgentRecord] = []
-        for agent in reconciled:
-            if not agent.class_name:
-                aligned.append(agent)
-                continue
-            should_enable = agent.class_name in seeded_class_names
-            if agent.enabled == should_enable:
-                aligned.append(agent)
-                continue
-            updated = await agent_service.update_agent(
-                context=context,
-                agent_id=agent.id,
-                updates=AgentUpdateInput(enabled=should_enable),
-            )
-            aligned.append(updated if updated is not None else agent)
-        reconciled = aligned
+    aligned: list[AgentRecord] = []
+    for agent in reconciled:
+        if not agent.class_name:
+            aligned.append(agent)
+            continue
+        should_enable = agent.class_name in roster
+        if agent.enabled == should_enable:
+            aligned.append(agent)
+            continue
+        updated = await agent_service.update_agent(
+            context=context,
+            agent_id=agent.id,
+            updates=AgentUpdateInput(enabled=should_enable),
+        )
+        aligned.append(updated if updated is not None else agent)
+    reconciled = aligned
 
     # Ensure the workspace (or engine) default agent is enabled and marked.
     if default_class_name:

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/agents/adapters/primary/agents__primary_adapter__FastAPI_test.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/agents/adapters/primary/agents__primary_adapter__FastAPI_test.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 from naas_abi.apps.nexus.apps.api.app.services.agents.adapters.primary.agents__primary_adapter__FastAPI import (
     _canonical_agent_sort_key,
     _class_declared_model_ids,
+    _workspace_agent_roster,
 )
 from naas_abi.apps.nexus.apps.api.app.services.agents.port import AgentRecord
 
@@ -68,3 +69,13 @@ def test_class_declared_model_ids_reads_getter_then_attr_then_single() -> None:
     assert _class_declared_model_ids(AttrOnly) == ["a", "b"]
     assert _class_declared_model_ids(Single) == ["claude-sonnet-5"]
     assert _class_declared_model_ids(object) == []
+
+
+def test_workspace_agent_roster_uses_seed_when_present() -> None:
+    assert _workspace_agent_roster({"mod/Listed"}, "mod/Default") == {"mod/Listed"}
+    assert _workspace_agent_roster(set(), "mod/Default") == set()
+
+
+def test_workspace_agent_roster_unseeded_is_default_only() -> None:
+    assert _workspace_agent_roster(None, "mod/Default") == {"mod/Default"}
+    assert _workspace_agent_roster(None, None) == set()

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/apps/components/primitives.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/apps/components/primitives.tsx
@@ -31,7 +31,7 @@ export function AppIcon({
       <span
         className={cn(
           ICON_DIMS[size],
-          'relative flex-shrink-0 overflow-hidden p-0 ring-2 ring-workspace-accent',
+          'relative flex-shrink-0 overflow-hidden p-0',
         )}
       >
         {/* eslint-disable-next-line @next/next/no-img-element */}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/home/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/home/page.tsx
@@ -66,7 +66,7 @@ export default function HomePage() {
             onClick={() => openSurface(section)}
             title={section === 'chat' ? 'Chat' : 'Files'}
           >
-            <span className="flex h-14 w-14 items-center justify-center bg-black/35 shadow-lg ring-2 ring-workspace-accent">
+            <span className="flex h-14 w-14 items-center justify-center bg-black/35 shadow-lg">
               {section === 'chat' ? <MessageSquare size={28} /> : <Folder size={28} />}
             </span>
             <span className="w-full truncate text-center text-[11px] font-medium leading-tight [text-shadow:0_1px_2px_rgba(0,0,0,0.8)]">
@@ -87,7 +87,7 @@ export default function HomePage() {
           >
             {app.avatar_url ? (
               // eslint-disable-next-line @next/next/no-img-element
-              <span className="relative h-14 w-14 overflow-hidden p-0 shadow-lg ring-2 ring-workspace-accent">
+              <span className="relative h-14 w-14 overflow-hidden p-0 shadow-lg">
                 <img
                   src={app.avatar_url}
                   alt=""
@@ -95,7 +95,7 @@ export default function HomePage() {
                 />
               </span>
             ) : (
-              <span className="flex h-14 w-14 items-center justify-center bg-black/35 text-2xl shadow-lg ring-2 ring-workspace-accent">
+              <span className="flex h-14 w-14 items-center justify-center bg-black/35 text-2xl shadow-lg">
                 {app.icon_emoji || app.name.slice(0, 1)}
               </span>
             )}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/index.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/index.tsx
@@ -491,7 +491,7 @@ export function Sidebar() {
                 'flex items-center rounded-lg touch-none outline-none focus-visible:ring-0',
                 'hover:bg-workspace-accent-10 hover:text-workspace-accent',
                 active ? 'bg-workspace-accent-15 text-workspace-accent' : 'text-muted-foreground',
-                labeled ? 'w-full gap-3 px-3 py-2' : 'h-10 w-10 justify-center',
+                labeled ? 'w-full gap-3 py-2 pl-3 pr-4' : 'h-10 w-10 justify-center',
                 isDragging ? 'cursor-grabbing' : 'cursor-grab',
               )}
               style={{
@@ -535,7 +535,7 @@ export function Sidebar() {
                 'flex items-center rounded-lg transition-all outline-none focus-visible:ring-0',
                 'hover:bg-workspace-accent-10 hover:text-workspace-accent',
                 active ? 'bg-workspace-accent-15 text-workspace-accent' : 'text-muted-foreground',
-                labeled ? 'w-full gap-3 px-3 py-2' : 'h-10 w-10 justify-center'
+                labeled ? 'w-full gap-3 py-2 pl-3 pr-4' : 'h-10 w-10 justify-center'
               )}
             >
               <span className="flex-shrink-0">{item.icon}</span>
@@ -554,7 +554,7 @@ export function Sidebar() {
                 'flex items-center rounded-lg transition-all outline-none focus-visible:ring-0',
                 'hover:bg-workspace-accent-10 hover:text-workspace-accent',
                 active ? 'bg-workspace-accent-15 text-workspace-accent' : 'text-muted-foreground',
-                labeled ? 'w-full gap-3 px-3 py-2' : 'h-10 w-10 justify-center'
+                labeled ? 'w-full gap-3 py-2 pl-3 pr-4' : 'h-10 w-10 justify-center'
               )}
             >
               <span className="flex-shrink-0">{section.icon}</span>

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/workspaces-section.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/workspaces-section.tsx
@@ -134,7 +134,7 @@ function WorkspaceRow({
       type="button"
       onClick={() => onPick(workspace)}
       className={cn(
-        'flex w-full items-center gap-3 px-2 py-1.5 text-left text-sm transition-colors',
+        'flex w-full items-center gap-3 py-1.5 pl-2 pr-4 text-left text-sm transition-colors',
         shellTokens.sidebar.listRow,
         'hover:bg-workspace-accent-10',
         current && 'bg-workspace-accent-5',

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/apps.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/apps.ts
@@ -42,21 +42,25 @@ export const useAppsStore = create<AppsState>()((set, get) => ({
   workspaceId: null,
 
   fetchApps: async (workspaceId: string) => {
-    set({ loading: true, workspaceId });
+    const switched = get().workspaceId !== workspaceId;
+    set({ loading: true, workspaceId, ...(switched ? { apps: [] } : {}) });
     try {
       const response = await authFetch(
         `${apiBase()}/api/apps/?workspace_id=${encodeURIComponent(workspaceId)}`
       );
+      if (get().workspaceId !== workspaceId) return;
       if (!response.ok) {
-        set({ loading: false });
+        set({ apps: [], loading: false });
         return;
       }
       const data = await response.json();
       const apps: AppItem[] = Array.isArray(data?.apps) ? data.apps : [];
+      if (get().workspaceId !== workspaceId) return;
       set({ apps, loading: false });
     } catch (error) {
       console.error('Failed to fetch apps:', error);
-      set({ loading: false });
+      if (get().workspaceId !== workspaceId) return;
+      set({ apps: [], loading: false });
     }
   },
 


### PR DESCRIPTION
## Summary
- Unseeded workspaces now take the engine default agent only. Class `enabled_by_default` no longer turns on extra agents, and existing rows are realigned on every sync.
- `WorkspaceSeedConfig.agents` docstring matches that contract: omit the list for the engine default only.
- The apps store clears the catalog when the workspace changes or a fetch fails, and ignores stale responses.
- Home desk tiles and Apps store logos no longer paint an accent ring on every icon. Selected dock and workspace-switcher rows keep 16px on the right.

## Test plan
- [ ] Open a workspace with no `agents:` seed: only the engine default agent is enabled after sync
- [ ] Open a workspace with an `agents:` list: only those agents stay enabled
- [ ] Switch workspaces on Home: desk apps update, previous catalog does not linger
- [ ] Home desk icons have no blue square ring
- [ ] Apps gallery and list logos have no blue square ring
- [ ] Selected workspace row and labeled dock item have 16px padding on the right