### PR TITLE
fix(nexus): show workspaces as one alphabetical list

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/workspaces-section.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/workspaces-section.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState } from 'react';
 import { Check, Search } from 'lucide-react';
 import { usePathname, useRouter } from 'next/navigation';
 import { cn } from '@/lib/utils';
-import { filterWorkspaces, recentWorkspaces } from '@/lib/workspace-picker';
+import { listWorkspaces } from '@/lib/workspace-picker';
 import { getWorkspaceSwitchPath } from '@/lib/feature-access';
 import { markAppsSkipRestore } from '@/app/workspace/[workspaceId]/apps/lib/apps-route';
 import { useWorkspaceStore, type Workspace } from '@/stores/workspace';
@@ -17,22 +17,11 @@ export function WorkspacesSection({ onPicked }: { onPicked?: () => void }) {
   const [query, setQuery] = useState('');
   const workspaces = useWorkspaceStore((s) => s.workspaces);
   const currentWorkspaceId = useWorkspaceStore((s) => s.currentWorkspaceId);
-  const recentWorkspaceIds = useWorkspaceStore((s) => s.recentWorkspaceIds);
   const setCurrentWorkspace = useWorkspaceStore((s) => s.setCurrentWorkspace);
   const setActiveConversation = useWorkspaceStore((s) => s.setActiveConversation);
   const setActivePanelSection = useWorkspaceStore((s) => s.setActivePanelSection);
 
-  const filtered = useMemo(
-    () => filterWorkspaces(workspaces, query).sort((a, b) => a.name.localeCompare(b.name)),
-    [workspaces, query],
-  );
-  const recents = useMemo(
-    () => recentWorkspaces(workspaces, recentWorkspaceIds, currentWorkspaceId),
-    [workspaces, recentWorkspaceIds, currentWorkspaceId],
-  );
-  const searching = query.trim().length > 0;
-  // All is the full catalog (including current). Recents is a shortcut strip above it.
-  const listed = filtered;
+  const listed = useMemo(() => listWorkspaces(workspaces, query), [workspaces, query]);
 
   const pick = (workspace: Workspace) => {
     if (workspace.id === currentWorkspaceId) {
@@ -71,48 +60,18 @@ export function WorkspacesSection({ onPicked }: { onPicked?: () => void }) {
         />
       </label>
 
-      {!searching && recents.length > 0 && (
-        <div>
-          <p className={cn('px-1 py-1', shellTokens.sidebar.sectionLabel)}>Recents</p>
-          {recents.map((workspace) => (
-            <WorkspaceRow
-              key={workspace.id}
-              workspace={workspace}
-              current={workspace.id === currentWorkspaceId}
-              onPick={pick}
-            />
-          ))}
-        </div>
+      {listed.length === 0 ? (
+        <p className="px-2 py-2 text-xs text-muted-foreground">No workspaces match</p>
+      ) : (
+        listed.map((workspace) => (
+          <WorkspaceRow
+            key={workspace.id}
+            workspace={workspace}
+            current={workspace.id === currentWorkspaceId}
+            onPick={pick}
+          />
+        ))
       )}
-
-      {searching ? (
-        listed.length === 0 ? (
-          <p className="px-2 py-2 text-xs text-muted-foreground">No workspaces match</p>
-        ) : (
-          listed.map((workspace) => (
-            <WorkspaceRow
-              key={workspace.id}
-              workspace={workspace}
-              current={workspace.id === currentWorkspaceId}
-              onPick={pick}
-            />
-          ))
-        )
-      ) : listed.length > 0 ? (
-        <div>
-          <p className={cn('px-1 py-1', shellTokens.sidebar.sectionLabel)}>
-            {recents.length > 0 ? 'All' : 'Workspaces'}
-          </p>
-          {listed.map((workspace) => (
-            <WorkspaceRow
-              key={workspace.id}
-              workspace={workspace}
-              current={workspace.id === currentWorkspaceId}
-              onPick={pick}
-            />
-          ))}
-        </div>
-      ) : null}
     </div>
   );
 }

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/workspaces-section.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/workspaces-section.tsx
@@ -31,11 +31,8 @@ export function WorkspacesSection({ onPicked }: { onPicked?: () => void }) {
     [workspaces, recentWorkspaceIds, currentWorkspaceId],
   );
   const searching = query.trim().length > 0;
-  const listed = useMemo(() => {
-    if (searching) return filtered;
-    const recentIds = new Set(recents.map((w) => w.id));
-    return filtered.filter((w) => !recentIds.has(w.id));
-  }, [filtered, recents, searching]);
+  // All is the full catalog (including current). Recents is a shortcut strip above it.
+  const listed = filtered;
 
   const pick = (workspace: Workspace) => {
     if (workspace.id === currentWorkspaceId) {

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/workspace-picker.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/workspace-picker.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, it } from 'vitest';
 
 import {
   filterWorkspaces,
+  listWorkspaces,
   pushRecentWorkspaceId,
-  recentWorkspaces,
 } from './workspace-picker';
 
 const ws = (id: string, name: string) => ({ id, name });
-const list = [ws('a', 'TPO'), ws('b', 'Valeo'), ws('c', 'Core Team')];
+const list = [ws('c', 'Gamma'), ws('a', 'Alpha'), ws('b', 'Beta')];
 
 describe('filterWorkspaces', () => {
   it('returns all when the query is empty', () => {
@@ -15,23 +15,30 @@ describe('filterWorkspaces', () => {
   });
 
   it('matches name case-insensitively', () => {
-    expect(filterWorkspaces(list, 'tpo')).toEqual([ws('a', 'TPO')]);
+    expect(filterWorkspaces(list, 'alpha')).toEqual([ws('a', 'Alpha')]);
   });
 });
 
-describe('recentWorkspaces', () => {
-  it('puts the current workspace first and skips unknown ids', () => {
-    expect(recentWorkspaces(list, ['c', 'a', 'gone'], 'a')).toEqual([
-      ws('a', 'TPO'),
-      ws('c', 'Core Team'),
+describe('listWorkspaces', () => {
+  it('returns one alphabetical list', () => {
+    expect(listWorkspaces(list, '')).toEqual([
+      ws('a', 'Alpha'),
+      ws('b', 'Beta'),
+      ws('c', 'Gamma'),
     ]);
   });
 
-  it('injects current even when it is absent from recent ids', () => {
-    expect(recentWorkspaces(list, ['c'], 'b')).toEqual([
-      ws('b', 'Valeo'),
-      ws('c', 'Core Team'),
-    ]);
+  it('keeps the same order after a different workspace is current', () => {
+    const before = listWorkspaces(list, '');
+    const afterSwitch = listWorkspaces(
+      [ws('b', 'Beta'), ws('c', 'Gamma'), ws('a', 'Alpha')],
+      '',
+    );
+    expect(afterSwitch.map((w) => w.id)).toEqual(before.map((w) => w.id));
+  });
+
+  it('filters the same list without splitting sections', () => {
+    expect(listWorkspaces(list, 'alp')).toEqual([ws('a', 'Alpha')]);
   });
 });
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/workspace-picker.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/workspace-picker.test.ts
@@ -20,8 +20,18 @@ describe('filterWorkspaces', () => {
 });
 
 describe('recentWorkspaces', () => {
-  it('skips the current workspace and unknown ids', () => {
-    expect(recentWorkspaces(list, ['c', 'a', 'gone'], 'a')).toEqual([ws('c', 'Core Team')]);
+  it('puts the current workspace first and skips unknown ids', () => {
+    expect(recentWorkspaces(list, ['c', 'a', 'gone'], 'a')).toEqual([
+      ws('a', 'TPO'),
+      ws('c', 'Core Team'),
+    ]);
+  });
+
+  it('injects current even when it is absent from recent ids', () => {
+    expect(recentWorkspaces(list, ['c'], 'b')).toEqual([
+      ws('b', 'Valeo'),
+      ws('c', 'Core Team'),
+    ]);
   });
 });
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/workspace-picker.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/workspace-picker.ts
@@ -12,31 +12,12 @@ export function filterWorkspaces<T extends NamedWorkspace>(
   return workspaces.filter((w) => w.name.toLowerCase().includes(q));
 }
 
-export function recentWorkspaces<T extends NamedWorkspace>(
+/** One alphabetical catalog. Current is highlighted in the UI; it does not change order. */
+export function listWorkspaces<T extends NamedWorkspace>(
   workspaces: readonly T[],
-  recentIds: readonly string[],
-  currentId: string | null,
+  query: string,
 ): T[] {
-  const byId = new Map(workspaces.map((w) => [w.id, w]));
-  const out: T[] = [];
-  const seen = new Set<string>();
-  // Keep the active workspace at the top of Recents with the checkmark.
-  // pushRecentWorkspaceId stores prior destinations only, so inject current here.
-  if (currentId) {
-    const current = byId.get(currentId);
-    if (current) {
-      out.push(current);
-      seen.add(currentId);
-    }
-  }
-  for (const id of recentIds) {
-    if (!id || seen.has(id)) continue;
-    const hit = byId.get(id);
-    if (!hit) continue;
-    seen.add(id);
-    out.push(hit);
-  }
-  return out;
+  return filterWorkspaces(workspaces, query).sort((a, b) => a.name.localeCompare(b.name));
 }
 
 export function pushRecentWorkspaceId(

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/workspace-picker.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/workspace-picker.ts
@@ -20,8 +20,17 @@ export function recentWorkspaces<T extends NamedWorkspace>(
   const byId = new Map(workspaces.map((w) => [w.id, w]));
   const out: T[] = [];
   const seen = new Set<string>();
+  // Keep the active workspace at the top of Recents with the checkmark.
+  // pushRecentWorkspaceId stores prior destinations only, so inject current here.
+  if (currentId) {
+    const current = byId.get(currentId);
+    if (current) {
+      out.push(current);
+      seen.add(currentId);
+    }
+  }
   for (const id of recentIds) {
-    if (!id || id === currentId || seen.has(id)) continue;
+    if (!id || seen.has(id)) continue;
     const hit = byId.get(id);
     if (!hit) continue;
     seen.add(id);

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
@@ -339,7 +339,7 @@ interface WorkspaceState {
   // ============================================
   workspaces: Workspace[];
   currentWorkspaceId: string | null;
-  /** Previous workspace ids, newest first. Used by the Workspaces column Recents group. */
+  /** Previous workspace ids, newest first. Persisted for a future sort; not shown as a section. */
   recentWorkspaceIds: string[];
   recentCommits: GitCommit[];
 


### PR DESCRIPTION
## Summary
- Recents and All made the current workspace jump between sections when selected.
- The picker is one alphabetical list. The current workspace stays in place with a checkmark.
- Last-used ids remain in localStorage for a future sort. They are not rendered as a section.

## Test plan
- [ ] Open the workspace switcher: one list, no Recents or All headings
- [ ] Current workspace is highlighted in its alphabetical position with a checkmark
- [ ] Click another workspace: it stays in the same row position, checkmark moves to it
- [ ] Search filters the same list
- [ ] `pnpm test -- src/lib/workspace-picker.test.ts` in `apps/nexus/apps/web`