### PR TITLE
fix(nexus): one-line chat suggestions above the composer

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/chat/components/chat-agent-selector.css
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/chat/components/chat-agent-selector.css
@@ -394,6 +394,8 @@
   flex: 0 0 auto;
   width: auto;
   max-width: min(280px, 80vw);
+  height: 32px;
+  white-space: nowrap;
 }
 
 @media (max-width: 767px) {

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/chat/components/chat-agent-selector.css
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/chat/components/chat-agent-selector.css
@@ -367,6 +367,51 @@
   padding: 8px 12px;
 }
 
+/* One-line suggestion chips immediately above the composer */
+.chat-suggestion-row {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 4px;
+  padding: 0 0 8px;
+}
+
+.chat-suggestion-scroller {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  align-items: center;
+  gap: 6px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: thin;
+}
+
+.chat-suggestion-chip {
+  flex: 0 0 auto;
+  width: auto;
+  max-width: min(280px, 80vw);
+}
+
+@media (max-width: 767px) {
+  .chat-suggestion-nav {
+    display: none !important;
+  }
+}
+
+@media (min-width: 768px) {
+  .chat-suggestion-scroller {
+    scrollbar-width: none;
+  }
+
+  .chat-suggestion-scroller::-webkit-scrollbar {
+    display: none;
+  }
+}
+
 .chat-composer-input {
   /* 16px: prevent iOS Safari focus zoom */
   font-size: 16px;

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useRef, useEffect, useMemo, useCallback, useLayoutEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { Send, Plus, Bot, User, AlertCircle, Brain, ChevronDown, X, ArrowUp, ExternalLink, HardDrive, RefreshCw, Mic, Check, Loader2, Wrench, Copy, FileText, ThumbsUp, ThumbsDown, Volume2, Square, Columns2 } from 'lucide-react';
+import { Send, Plus, Bot, User, AlertCircle, Brain, ChevronDown, ChevronLeft, ChevronRight, X, ArrowUp, ExternalLink, HardDrive, RefreshCw, Mic, Check, Loader2, Wrench, Copy, FileText, ThumbsUp, ThumbsDown, Volume2, Square, Columns2 } from 'lucide-react';
 import Image from 'next/image';
 import { usePathname, useRouter } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
@@ -27,6 +27,7 @@ import { PdfViewer } from '@/components/files/pdf-viewer';
 
 import { getApiUrl, getOllamaUrl } from '@/lib/config';
 import { getLogoUrl } from '@/lib/logo-url';
+import { suggestionRowNavState, suggestionScrollStep } from '@/lib/suggestion-row';
 
 const getApiBase = () => getApiUrl();
 
@@ -2640,10 +2641,6 @@ export function ChatInterface({
           <EmptyState
             selectedAgentName={selectedAgentData?.name || selectedAgent}
             logoUrl={selectedAgentData?.logoUrl ?? undefined}
-            suggestions={selectedAgentData?.suggestions}
-            onSuggestionClick={(prompt) => handleSubmit(undefined, prompt)}
-            onSuggestionHover={(value) => setInput(value)}
-            onSuggestionLeave={() => setInput('')}
           />
         ) : (
           <div className="mx-auto max-w-3xl space-y-6">
@@ -2689,6 +2686,14 @@ export function ChatInterface({
       {/* Composer: flex sibling at column bottom (sticky as safety for scroll parents) */}
       <div className="chat-composer-root mt-auto shrink-0 px-4">
         <div className="mx-auto max-w-3xl">
+          {(!activeConversation || activeConversation.messages.length === 0) && (
+            <SuggestionChipsRow
+              suggestions={selectedAgentData?.suggestions}
+              onSuggestionClick={(prompt) => handleSubmit(undefined, prompt)}
+              onSuggestionHover={(value) => setInput(value)}
+              onSuggestionLeave={() => setInput('')}
+            />
+          )}
           <form onSubmit={handleSubmit}>
             {/* Image previews */}
             {attachedImages.length > 0 && (
@@ -3176,8 +3181,8 @@ function EmptyStateLogo({ src, name }: { src?: string; name: string }) {
   }, [src]);
 
   return (
-    <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-workspace-accent-10 overflow-hidden">
-      {(!src || !imgReady) && <Bot size={24} className="text-workspace-accent" />}
+    <div className="mb-6 flex h-24 w-24 items-center justify-center rounded-xl bg-workspace-accent-10 overflow-hidden">
+      {(!src || !imgReady) && <Bot size={48} className="text-workspace-accent" />}
       {src ? (
         // eslint-disable-next-line @next/next/no-img-element
         <img
@@ -3192,23 +3197,152 @@ function EmptyStateLogo({ src, name }: { src?: string; name: string }) {
   );
 }
 
-function EmptyState({
-  selectedAgentName,
-  logoUrl,
+type ChatSuggestion = {
+  label: string;
+  value: string;
+  description?: string;
+  disabled?: boolean;
+  cta?: string;
+};
+
+function SuggestionChipsRow({
   suggestions,
   onSuggestionClick,
   onSuggestionHover,
   onSuggestionLeave,
 }: {
-  selectedAgentName: string;
-  logoUrl?: string | null;
-  suggestions?: Array<{ label: string; value: string; description?: string; disabled?: boolean; cta?: string }>;
+  suggestions?: ChatSuggestion[];
   onSuggestionClick: (prompt: string) => void;
   onSuggestionHover?: (value: string) => void;
   onSuggestionLeave?: () => void;
 }) {
   const router = useRouter();
   const { setActivePanelSection } = useWorkspaceStore();
+  const scrollerRef = useRef<HTMLDivElement>(null);
+  const [nav, setNav] = useState({ overflow: false, canPrev: false, canNext: false });
+
+  const updateNav = useCallback(() => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    setNav(suggestionRowNavState(el.scrollLeft, el.clientWidth, el.scrollWidth));
+  }, []);
+
+  useLayoutEffect(() => {
+    updateNav();
+    const el = scrollerRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver(updateNav);
+    observer.observe(el);
+    el.addEventListener('scroll', updateNav, { passive: true });
+    return () => {
+      observer.disconnect();
+      el.removeEventListener('scroll', updateNav);
+    };
+  }, [updateNav, suggestions]);
+
+  const scrollByPage = (direction: -1 | 1) => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    el.scrollBy({ left: direction * suggestionScrollStep(el.clientWidth), behavior: 'smooth' });
+  };
+
+  if (!Array.isArray(suggestions) || suggestions.length === 0) return null;
+
+  return (
+    <div className="chat-suggestion-row" onMouseLeave={() => onSuggestionLeave?.()}>
+      <button
+        type="button"
+        className="chat-composer-action chat-suggestion-nav"
+        aria-label="Previous suggestions"
+        hidden={!nav.overflow}
+        disabled={!nav.canPrev}
+        onClick={() => scrollByPage(-1)}
+      >
+        <ChevronLeft size={16} />
+      </button>
+      <div ref={scrollerRef} className="chat-suggestion-scroller" aria-label="Suggested questions">
+        {suggestions.map((suggestion) => {
+          const baseClass = cn(
+            'chat-suggestion-chip glass-card flex min-w-0 items-center justify-between px-4 py-2.5 text-left transition-all',
+            suggestion.disabled
+              ? 'opacity-40 cursor-not-allowed'
+              : 'hover:border-primary/30 hover:glow-primary-sm cursor-pointer'
+          );
+
+          const content = (
+            <>
+              <div className="min-w-0 flex-1">
+                <span className="block truncate text-sm font-medium leading-tight">{suggestion.label}</span>
+                {suggestion.description && (
+                  <span className="block truncate text-xs text-muted-foreground leading-snug">
+                    {suggestion.description}
+                  </span>
+                )}
+                {suggestion.disabled && (
+                  <span className="block text-xs text-muted-foreground/60 italic">
+                    Coming soon
+                  </span>
+                )}
+              </div>
+              {!suggestion.disabled && (
+                <span className="ml-3 shrink-0 text-muted-foreground/40">›</span>
+              )}
+            </>
+          );
+
+          if (suggestion.cta && !suggestion.disabled) {
+            const sectionId = (CTA_SECTION_MAP[suggestion.cta] ?? suggestion.cta.replace(/^\//, '')) as SidebarSection;
+            return (
+              <button
+                key={`${suggestion.label}:${suggestion.value}`}
+                type="button"
+                onMouseEnter={() => onSuggestionHover?.(suggestion.label)}
+                onClick={() => {
+                  setActivePanelSection(sectionId);
+                  router.push(suggestion.cta!);
+                }}
+                className={baseClass}
+              >
+                {content}
+              </button>
+            );
+          }
+
+          return (
+            <button
+              key={`${suggestion.label}:${suggestion.value}`}
+              type="button"
+              onMouseEnter={() => !suggestion.disabled && onSuggestionHover?.(suggestion.value)}
+              onClick={() => !suggestion.disabled && onSuggestionClick(suggestion.value)}
+              disabled={suggestion.disabled}
+              className={baseClass}
+            >
+              {content}
+            </button>
+          );
+        })}
+      </div>
+      <button
+        type="button"
+        className="chat-composer-action chat-suggestion-nav"
+        aria-label="Next suggestions"
+        hidden={!nav.overflow}
+        disabled={!nav.canNext}
+        onClick={() => scrollByPage(1)}
+      >
+        <ChevronRight size={16} />
+      </button>
+    </div>
+  );
+}
+
+function EmptyState({
+  selectedAgentName,
+  logoUrl,
+}: {
+  selectedAgentName: string;
+  logoUrl?: string | null;
+}) {
   const { user } = useAuthStore();
   const resolvedLogoUrl = logoUrl ? getLogoUrl(logoUrl) : undefined;
 
@@ -3220,71 +3354,6 @@ function EmptyState({
       <p className="mb-6 text-center text-muted-foreground">
         {greeting} Pick a suggestion or type a message to get started.
       </p>
-      {Array.isArray(suggestions) && suggestions.length > 0 && (
-        <div
-          className="flex w-full max-w-lg flex-col gap-1.5"
-          onMouseLeave={() => onSuggestionLeave?.()}
-        >
-          {suggestions.map((suggestion) => {
-            const baseClass = cn(
-              'glass-card flex min-w-0 items-center justify-between px-4 py-2.5 text-left transition-all',
-              suggestion.disabled
-                ? 'opacity-40 cursor-not-allowed'
-                : 'hover:border-primary/30 hover:glow-primary-sm cursor-pointer'
-            );
-
-            const content = (
-              <>
-                <div className="min-w-0 flex-1">
-                  <span className="block truncate text-sm font-medium leading-tight">{suggestion.label}</span>
-                  {suggestion.description && (
-                    <span className="block truncate text-xs text-muted-foreground leading-snug">
-                      {suggestion.description}
-                    </span>
-                  )}
-                  {suggestion.disabled && (
-                    <span className="block text-xs text-muted-foreground/60 italic">
-                      Coming soon
-                    </span>
-                  )}
-                </div>
-                {!suggestion.disabled && (
-                  <span className="ml-3 shrink-0 text-muted-foreground/40">›</span>
-                )}
-              </>
-            );
-
-            if (suggestion.cta && !suggestion.disabled) {
-              const sectionId = (CTA_SECTION_MAP[suggestion.cta] ?? suggestion.cta.replace(/^\//, '')) as SidebarSection;
-              return (
-                <button
-                  key={`${suggestion.label}:${suggestion.value}`}
-                  onMouseEnter={() => onSuggestionHover?.(suggestion.label)}
-                  onClick={() => {
-                    setActivePanelSection(sectionId);
-                    router.push(suggestion.cta!);
-                  }}
-                  className={baseClass}
-                >
-                  {content}
-                </button>
-              );
-            }
-
-            return (
-              <button
-                key={`${suggestion.label}:${suggestion.value}`}
-                onMouseEnter={() => !suggestion.disabled && onSuggestionHover?.(suggestion.value)}
-                onClick={() => !suggestion.disabled && onSuggestionClick(suggestion.value)}
-                disabled={suggestion.disabled}
-                className={baseClass}
-              >
-                {content}
-              </button>
-            );
-          })}
-        </div>
-      )}
     </div>
   );
 }

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
@@ -3333,7 +3333,7 @@ function EmptyState({
     <div className="flex h-full flex-col items-center justify-center px-4">
       <EmptyStateLogo src={resolvedLogoUrl} name={selectedAgentName} />
       <p className="mb-6 text-center text-muted-foreground">
-        {greeting} Pick a suggestion or type a message to get started.
+        {greeting} {selectedAgentName} here, how can I help?
       </p>
     </div>
   );

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
@@ -27,7 +27,12 @@ import { PdfViewer } from '@/components/files/pdf-viewer';
 
 import { getApiUrl, getOllamaUrl } from '@/lib/config';
 import { getLogoUrl } from '@/lib/logo-url';
-import { suggestionRowNavState, suggestionScrollStep } from '@/lib/suggestion-row';
+import {
+  activeSuggestions,
+  suggestionRowNavState,
+  suggestionScrollStep,
+  type ChatSuggestion,
+} from '@/lib/suggestion-row';
 
 const getApiBase = () => getApiUrl();
 
@@ -3197,14 +3202,6 @@ function EmptyStateLogo({ src, name }: { src?: string; name: string }) {
   );
 }
 
-type ChatSuggestion = {
-  label: string;
-  value: string;
-  description?: string;
-  disabled?: boolean;
-  cta?: string;
-};
-
 function SuggestionChipsRow({
   suggestions,
   onSuggestionClick,
@@ -3220,6 +3217,7 @@ function SuggestionChipsRow({
   const { setActivePanelSection } = useWorkspaceStore();
   const scrollerRef = useRef<HTMLDivElement>(null);
   const [nav, setNav] = useState({ overflow: false, canPrev: false, canNext: false });
+  const chips = useMemo(() => activeSuggestions(suggestions), [suggestions]);
 
   const updateNav = useCallback(() => {
     const el = scrollerRef.current;
@@ -3238,7 +3236,7 @@ function SuggestionChipsRow({
       observer.disconnect();
       el.removeEventListener('scroll', updateNav);
     };
-  }, [updateNav, suggestions]);
+  }, [updateNav, chips]);
 
   const scrollByPage = (direction: -1 | 1) => {
     const el = scrollerRef.current;
@@ -3246,7 +3244,7 @@ function SuggestionChipsRow({
     el.scrollBy({ left: direction * suggestionScrollStep(el.clientWidth), behavior: 'smooth' });
   };
 
-  if (!Array.isArray(suggestions) || suggestions.length === 0) return null;
+  if (chips.length === 0) return null;
 
   return (
     <div className="chat-suggestion-row" onMouseLeave={() => onSuggestionLeave?.()}>
@@ -3261,36 +3259,20 @@ function SuggestionChipsRow({
         <ChevronLeft size={16} />
       </button>
       <div ref={scrollerRef} className="chat-suggestion-scroller" aria-label="Suggested questions">
-        {suggestions.map((suggestion) => {
-          const baseClass = cn(
-            'chat-suggestion-chip glass-card flex min-w-0 items-center justify-between px-4 py-2.5 text-left transition-all',
-            suggestion.disabled
-              ? 'opacity-40 cursor-not-allowed'
-              : 'hover:border-primary/30 hover:glow-primary-sm cursor-pointer'
-          );
+        {chips.map((suggestion) => {
+          const baseClass =
+            'chat-suggestion-chip glass-card flex min-w-0 items-center px-3 py-1.5 text-left transition-all hover:border-primary/30 hover:glow-primary-sm cursor-pointer';
 
           const content = (
             <>
-              <div className="min-w-0 flex-1">
-                <span className="block truncate text-sm font-medium leading-tight">{suggestion.label}</span>
-                {suggestion.description && (
-                  <span className="block truncate text-xs text-muted-foreground leading-snug">
-                    {suggestion.description}
-                  </span>
-                )}
-                {suggestion.disabled && (
-                  <span className="block text-xs text-muted-foreground/60 italic">
-                    Coming soon
-                  </span>
-                )}
-              </div>
-              {!suggestion.disabled && (
-                <span className="ml-3 shrink-0 text-muted-foreground/40">›</span>
-              )}
+              <span className="min-w-0 flex-1 truncate text-sm font-medium leading-none">
+                {suggestion.label}
+              </span>
+              <span className="ml-2 shrink-0 text-muted-foreground/40">›</span>
             </>
           );
 
-          if (suggestion.cta && !suggestion.disabled) {
+          if (suggestion.cta) {
             const sectionId = (CTA_SECTION_MAP[suggestion.cta] ?? suggestion.cta.replace(/^\//, '')) as SidebarSection;
             return (
               <button
@@ -3312,9 +3294,8 @@ function SuggestionChipsRow({
             <button
               key={`${suggestion.label}:${suggestion.value}`}
               type="button"
-              onMouseEnter={() => !suggestion.disabled && onSuggestionHover?.(suggestion.value)}
-              onClick={() => !suggestion.disabled && onSuggestionClick(suggestion.value)}
-              disabled={suggestion.disabled}
+              onMouseEnter={() => onSuggestionHover?.(suggestion.value)}
+              onClick={() => onSuggestionClick(suggestion.value)}
               className={baseClass}
             >
               {content}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/suggestion-row.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/suggestion-row.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { suggestionRowNavState, suggestionScrollStep } from './suggestion-row';
+
+describe('suggestionRowNavState', () => {
+  it('hides arrows when the row fits', () => {
+    expect(suggestionRowNavState(0, 400, 360)).toEqual({
+      overflow: false,
+      canPrev: false,
+      canNext: false,
+    });
+  });
+
+  it('enables next at the start of an overflowing row', () => {
+    expect(suggestionRowNavState(0, 400, 900)).toEqual({
+      overflow: true,
+      canPrev: false,
+      canNext: true,
+    });
+  });
+
+  it('enables prev at the end of an overflowing row', () => {
+    expect(suggestionRowNavState(500, 400, 900)).toEqual({
+      overflow: true,
+      canPrev: true,
+      canNext: false,
+    });
+  });
+
+  it('enables both arrows in the middle', () => {
+    expect(suggestionRowNavState(200, 400, 900)).toEqual({
+      overflow: true,
+      canPrev: true,
+      canNext: true,
+    });
+  });
+});
+
+describe('suggestionScrollStep', () => {
+  it('uses three quarters of the visible width, with a 160px floor', () => {
+    expect(suggestionScrollStep(400)).toBe(300);
+    expect(suggestionScrollStep(100)).toBe(160);
+  });
+});

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/suggestion-row.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/suggestion-row.test.ts
@@ -1,6 +1,26 @@
 import { describe, expect, it } from 'vitest';
 
-import { suggestionRowNavState, suggestionScrollStep } from './suggestion-row';
+import { activeSuggestions, suggestionRowNavState, suggestionScrollStep } from './suggestion-row';
+
+describe('activeSuggestions', () => {
+  it('returns an empty list when the input is missing', () => {
+    expect(activeSuggestions(undefined)).toEqual([]);
+    expect(activeSuggestions(null)).toEqual([]);
+  });
+
+  it('drops disabled chips and keeps the rest', () => {
+    expect(
+      activeSuggestions([
+        { label: 'Ask', value: 'ask' },
+        { label: 'Soon', value: 'soon', disabled: true },
+        { label: 'Apps', value: 'apps', disabled: false },
+      ]),
+    ).toEqual([
+      { label: 'Ask', value: 'ask' },
+      { label: 'Apps', value: 'apps', disabled: false },
+    ]);
+  });
+});
 
 describe('suggestionRowNavState', () => {
   it('hides arrows when the row fits', () => {

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/suggestion-row.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/suggestion-row.ts
@@ -1,5 +1,21 @@
 /** Nav state for a single-line suggestion scroller. */
 
+export type ChatSuggestion = {
+  label: string;
+  value: string;
+  description?: string;
+  disabled?: boolean;
+  cta?: string;
+};
+
+/** Active chips only. Drop grayed / coming-soon items so the row stays one line. */
+export function activeSuggestions<T extends { disabled?: boolean }>(
+  suggestions: T[] | undefined | null,
+): T[] {
+  if (!Array.isArray(suggestions)) return [];
+  return suggestions.filter((suggestion) => !suggestion.disabled);
+}
+
 export function suggestionRowNavState(
   scrollLeft: number,
   clientWidth: number,

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/suggestion-row.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/suggestion-row.ts
@@ -1,0 +1,18 @@
+/** Nav state for a single-line suggestion scroller. */
+
+export function suggestionRowNavState(
+  scrollLeft: number,
+  clientWidth: number,
+  scrollWidth: number,
+): { overflow: boolean; canPrev: boolean; canNext: boolean } {
+  const overflow = scrollWidth > clientWidth + 2;
+  return {
+    overflow,
+    canPrev: overflow && scrollLeft > 1,
+    canNext: overflow && scrollLeft + clientWidth < scrollWidth - 1,
+  };
+}
+
+export function suggestionScrollStep(clientWidth: number): number {
+  return Math.max(160, Math.floor(clientWidth * 0.75));
+}


### PR DESCRIPTION
## Summary
- Move empty-state suggestion chips from a stacked column to a single horizontal row immediately above the composer.
- Drop disabled / coming-soon chips so only the current agent's active suggestions render.
- Chips are one line: label only, no description subtitle.
- Small viewports scroll the row horizontally. Desktop shows prev/next when the row overflows, using the existing composer icon chrome.
- Enlarge the empty-state greeting avatar from 48px to 96px now that the stack is gone. It stays centered.
- Empty-state greeting sits under the avatar and uses the signed-in first name plus the current agent name: `Hello, {firstName}. {agentName} here, how can I help?`

## Test plan
- Open a new chat and confirm chips sit in one line above the composer, not as stacked bars.
- Confirm grayed or coming-soon chips do not appear.
- Confirm each chip is a single line (label only).
- Narrow the viewport: the row scrolls horizontally and prev/next stay hidden.
- Wide viewport with overflow: prev/next move along the row; prev is disabled at the start and next at the end.
- Confirm the greeting avatar is larger and still centered.
- Chip colors, fonts, and hover stay the existing Nexus styles.
- Open a new chat and confirm the greeting is below the avatar and reads `Hello, {firstName}. {agentName} here, how can I help?` with the real user first name and the selected agent.