### PR TITLE
feat(nexus): prefix sign-in email subjects on .dev frontends

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/invites/sign_in_email.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/invites/sign_in_email.py
@@ -17,11 +17,47 @@ from naas_abi_core.services.email.EmailService import EmailService
 logger = logging.getLogger(__name__)
 
 SIGN_IN_LOGO_CID = "sign-in-logo"
+DEV_SUBJECT_PREFIX = "[DEV] "
 
 
 class _SafeTemplateValues(dict[str, object]):
     def __missing__(self, key: str) -> str:
         return "{" + key + "}"
+
+
+def frontend_hostname(frontend_url: str) -> str:
+    """Hostname from a frontend URL, or a bare host if no scheme is given."""
+    raw = (frontend_url or "").strip()
+    if not raw:
+        return ""
+    parsed = urlparse(raw if "://" in raw else f"https://{raw}")
+    return (parsed.hostname or "").lower()
+
+
+def is_dev_frontend(
+    frontend_url: str | None = None,
+    nexus_env: str | None = None,
+) -> bool:
+    """True when this deployment is a dedicated .dev frontend.
+
+    Triggers: ``NEXUS_ENV=dev``, or a frontend host that contains ``.dev.``
+    or ends with ``.dev``. Generic on purpose: no product hostnames here.
+    """
+    env = nexus_env if nexus_env is not None else settings.nexus_env
+    if str(env or "").strip().lower() == "dev":
+        return True
+    url = settings.frontend_url if frontend_url is None else frontend_url
+    host = frontend_hostname(str(url or ""))
+    return ".dev." in host or host.endswith(".dev")
+
+
+def apply_dev_subject_prefix(subject: str) -> str:
+    """Prefix ``[DEV] `` on sign-in subjects for .dev frontends. Idempotent."""
+    if not is_dev_frontend():
+        return subject
+    if subject.startswith(DEV_SUBJECT_PREFIX):
+        return subject
+    return f"{DEV_SUBJECT_PREFIX}{subject}"
 
 
 def magic_link_url_for_token(token: str) -> str:
@@ -195,7 +231,9 @@ def render_sign_in_email(
         "tab_title": tenant.tab_title,
     }
     safe = _SafeTemplateValues(template_values)
-    subject = settings.magic_link_email_subject_template.format_map(safe)
+    subject = apply_dev_subject_prefix(
+        settings.magic_link_email_subject_template.format_map(safe)
+    )
     text_body = settings.magic_link_email_text_template.format_map(safe)
     html_body = settings.magic_link_email_html_template.format_map(safe)
     return subject, text_body, html_body, attachments

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/invites/sign_in_email_test.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/invites/sign_in_email_test.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from naas_abi.apps.nexus.apps.api.app.core.config import settings
+from naas_abi.apps.nexus.apps.api.app.core.config import TenantConfig, settings
 from naas_abi.apps.nexus.apps.api.app.services.auth.service import MagicLinkChallenge
 from naas_abi.apps.nexus.apps.api.app.services.invites import sign_in_email
 from naas_abi.apps.nexus.apps.api.app.services.invites.sign_in_email import (
@@ -126,3 +126,81 @@ def test_render_sign_in_email_embeds_private_host_logo_as_cid(monkeypatch, tmp_p
     assert attachments[0].is_inline is True
     assert attachments[0].content_id == "sign-in-logo"
     assert attachments[0].content.startswith(b"\x89PNG")
+
+
+def test_frontend_hostname_accepts_url_or_bare_host() -> None:
+    assert sign_in_email.frontend_hostname("https://App.Dev.Example.com/path") == (
+        "app.dev.example.com"
+    )
+    assert sign_in_email.frontend_hostname("app.dev.example.com") == "app.dev.example.com"
+    assert sign_in_email.frontend_hostname("") == ""
+
+
+def test_is_dev_frontend_from_hostname(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "nexus_env", "local")
+    monkeypatch.setattr(settings, "frontend_url", "https://app.dev.example.com")
+    assert sign_in_email.is_dev_frontend() is True
+
+    monkeypatch.setattr(settings, "frontend_url", "https://app.example.dev")
+    assert sign_in_email.is_dev_frontend() is True
+
+    monkeypatch.setattr(settings, "frontend_url", "https://app.example.com")
+    assert sign_in_email.is_dev_frontend() is False
+
+
+def test_is_dev_frontend_from_nexus_env(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "frontend_url", "https://app.example.com")
+    monkeypatch.setattr(settings, "nexus_env", "dev")
+    assert sign_in_email.is_dev_frontend() is True
+
+    monkeypatch.setattr(settings, "nexus_env", "local")
+    assert sign_in_email.is_dev_frontend() is False
+
+
+def test_render_sign_in_email_prefixes_dev_subject(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "frontend_url", "https://app.dev.example.com")
+    monkeypatch.setattr(settings, "nexus_env", "local")
+    monkeypatch.setattr(settings, "magic_link_email_app_name", "NEXUS")
+    monkeypatch.setattr(
+        settings, "magic_link_email_subject_template", "Your {app_name} sign-in link"
+    )
+    monkeypatch.setattr(settings, "magic_link_email_text_template", "{magic_link_url}")
+    monkeypatch.setattr(settings, "magic_link_email_html_template", "{magic_link_url}")
+    monkeypatch.setattr(settings, "tenant", TenantConfig())
+
+    subject, text, html, _attachments = sign_in_email.render_sign_in_email(
+        magic_link_url="https://app.dev.example.com/auth/magic-link?token=abc",
+        otp_code="123456",
+    )
+
+    assert subject == "[DEV] Your NEXUS sign-in link"
+    assert "https://app.dev.example.com/auth/magic-link?token=abc" in text
+    assert "https://app.dev.example.com/auth/magic-link?token=abc" in html
+
+
+def test_render_sign_in_email_skips_prefix_on_prod(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "frontend_url", "https://app.example.com")
+    monkeypatch.setattr(settings, "nexus_env", "local")
+    monkeypatch.setattr(settings, "magic_link_email_app_name", "NEXUS")
+    monkeypatch.setattr(
+        settings, "magic_link_email_subject_template", "Your {app_name} sign-in link"
+    )
+    monkeypatch.setattr(settings, "magic_link_email_text_template", "{magic_link_url}")
+    monkeypatch.setattr(settings, "magic_link_email_html_template", "{magic_link_url}")
+    monkeypatch.setattr(settings, "tenant", TenantConfig())
+
+    subject, text, _html, _attachments = sign_in_email.render_sign_in_email(
+        magic_link_url="https://app.example.com/auth/magic-link?token=abc",
+        otp_code="123456",
+    )
+
+    assert subject == "Your NEXUS sign-in link"
+    assert not subject.startswith("[DEV] ")
+    assert "https://app.example.com/auth/magic-link?token=abc" in text
+
+
+def test_apply_dev_subject_prefix_is_idempotent(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "frontend_url", "https://app.dev.example.com")
+    monkeypatch.setattr(settings, "nexus_env", "local")
+    once = sign_in_email.apply_dev_subject_prefix("[DEV] Already marked")
+    assert once == "[DEV] Already marked"


### PR DESCRIPTION
## Summary
- Sign-in emails (magic link and OTP) now prefix the subject with `[DEV] ` when the frontend host contains `.dev.` / ends with `.dev`, or when `NEXUS_ENV=dev`.
- The sign-in URL is unchanged: it still uses `settings.frontend_url`, so the link host matches the stack that sent the mail.
- The prefix is idempotent if a template already starts with `[DEV] `.
- Generic Nexus rule. No product-specific hostnames.

## Why
Shared SMTP From metadata makes two stacks look identical in the inbox. Operators need the subject line to declare which frontend issued the link.

## Test plan
- [x] `uv run pytest libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/invites/sign_in_email_test.py libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/auth/adapters/primary/auth__primary_adapter__FastAPI_test.py`
- [x] `uvx ruff check` on the touched files
- Request a sign-in email from a frontend whose host contains `.dev.`: subject starts with `[DEV] `, link stays on that host.
- Request one from a production frontend: no prefix, link stays on that host.
- Set `NEXUS_ENV=dev` with a non-`.dev` frontend URL: subject still gets the prefix.