### PR TITLE
feat(nexus): unify workspace Header, Quick Open, and app embed

### DIFF
--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/apps/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/apps/page.tsx
@@ -5,7 +5,7 @@ import { useSearchParams, useRouter, useParams } from 'next/navigation';
 import { Header } from '@/components/shell/header';
 import { appsPath, nextAppsRestoreUrl, shouldSkipAppsRestore } from './lib/apps-route';
 import {
-  AppWindow, ExternalLink, RefreshCw, AlertTriangle, Info, PanelLeft, X,
+  AppWindow, ArrowLeft, ExternalLink, RefreshCw, AlertTriangle, Info,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { isBundledAppHtmlUrl, resolveAppEmbedUrl, resolveAppExternalUrl, appHtmlPathPrefix, pagesSsoAudience, withAppHtmlAccessToken, withPagesSsoToken } from '@/lib/app-html';
@@ -147,61 +147,60 @@ function EmbedView({ record, onBack }: { record: AppRecord; onBack: () => void }
 
   const externalHref = embedUrl || resolveAppExternalUrl(url);
 
+  const headerBtn = (active: boolean) =>
+    cn(
+      'flex h-8 w-8 items-center justify-center rounded-md transition-all',
+      'hover:bg-muted hover:text-foreground',
+      active ? 'bg-muted text-foreground' : 'text-muted-foreground',
+    );
+
   return (
     <div className="flex h-full flex-col">
-      {/* Top bar */}
-      <div className="flex h-12 flex-shrink-0 items-center gap-2 border-b border-border/50 bg-background px-3">
-        <button
-          onClick={() => setActivePanelSection(activePanelSection === 'apps' ? null : 'apps')}
-          title={activePanelSection === 'apps' ? 'Close panel' : 'Open panel'}
-          className={cn(
-            'flex h-7 w-7 flex-shrink-0 items-center justify-center rounded transition-colors',
-            activePanelSection === 'apps'
-              ? 'bg-muted text-foreground'
-              : 'text-muted-foreground hover:bg-muted hover:text-foreground',
-          )}
-        >
-          <PanelLeft size={15} />
-        </button>
-        <span className="flex-1 truncate text-sm font-medium">{record.name}</span>
-        <button
-          onClick={toggleDetail}
-          title={detailShown ? 'Hide details' : 'Show details'}
-          className={cn(
-            'rounded p-1.5 transition-colors',
-            detailShown
-              ? 'bg-muted text-foreground'
-              : 'text-muted-foreground hover:bg-muted hover:text-foreground',
-          )}
-        >
-          <Info size={13} />
-        </button>
-        <button
-          onClick={handleReload}
-          title="Reload"
-          className="rounded p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-        >
-          <RefreshCw size={13} />
-        </button>
-        <a
-          href={externalHref}
-          target="_blank"
-          rel="noopener noreferrer"
-          title="Open in new tab"
-          className="rounded p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-        >
-          <ExternalLink size={13} />
-        </a>
-        <button
-          onClick={onBack}
-          title="Close app"
-          className="rounded p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-        >
-          <X size={14} />
-        </button>
-      </div>
+      <Header
+        title={record.name}
+        nav={
+          <button
+            type="button"
+            onClick={onBack}
+            title="Back to apps"
+            className="flex min-w-0 items-center gap-1.5 rounded-md px-1.5 py-1 text-sm text-muted-foreground transition-all hover:bg-muted hover:text-foreground"
+          >
+            <ArrowLeft size={16} className="shrink-0" />
+            <span className="truncate font-medium text-foreground">{record.name}</span>
+          </button>
+        }
+        actions={
+          <>
+            <button
+              type="button"
+              onClick={toggleDetail}
+              title={detailShown ? 'Hide details' : 'Show details'}
+              className={headerBtn(detailShown)}
+            >
+              <Info size={16} />
+            </button>
+            <button
+              type="button"
+              onClick={handleReload}
+              title="Reload"
+              className={headerBtn(false)}
+            >
+              <RefreshCw size={16} />
+            </button>
+            <a
+              href={externalHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              title="Open in new tab"
+              className={headerBtn(false)}
+            >
+              <ExternalLink size={16} />
+            </a>
+          </>
+        }
+      />
 
-      {/* Body: full-width iframe — detail lives in the left section panel */}
+      {/* Body: full-width iframe. Detail lives in the left section panel. */}
       <div className="relative flex-1 overflow-hidden bg-muted/20">
         {embedError ? (
           <div className="flex h-full flex-col items-center justify-center gap-4 p-8 text-center">

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/home/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/home/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import { File, Folder, MessageSquare } from 'lucide-react';
 import { appsPath } from '@/app/workspace/[workspaceId]/apps/lib/apps-route';
 import { filesBrowsePath } from '@/app/workspace/[workspaceId]/files/lib/files-route';
-import { useRegisterShellTitle } from '@/components/shell/shell-title';
+import { Header } from '@/components/shell/header';
 import { getWorkspacePath } from '@/components/shell/sidebar/utils';
 import { useFeature } from '@/hooks/use-feature';
 import { useIsMobile } from '@/hooks/use-is-mobile';
@@ -31,8 +31,6 @@ export default function HomePage() {
   const setStarredNavigation = useFilesStore((s) => s.setStarredNavigation);
   const setActiveSource = useFilesStore((s) => s.setActiveSource);
 
-  useRegisterShellTitle(workspace?.name || 'Home');
-
   useEffect(() => {
     if (currentWorkspaceId) void fetchApps(currentWorkspaceId);
   }, [currentWorkspaceId, fetchApps]);
@@ -49,96 +47,99 @@ export default function HomePage() {
   };
 
   return (
-    <div className="relative h-full w-full overflow-hidden">
-      <div
-        className="absolute inset-0"
-        style={wallpaperStyle(
-          resolveDeskImageUrl(theme?.backgroundImageUrl),
-          theme?.backgroundColor,
-        )}
-      />
-      <div className="relative z-10 flex h-full w-full content-start flex-wrap items-start gap-x-7 gap-y-8 overflow-auto p-8">
-        {surfaceIcons.map((section) => (
-          <button
-            key={section}
-            type="button"
-            className="flex w-[88px] flex-col items-center gap-3 text-white"
-            onClick={() => openSurface(section)}
-            title={section === 'chat' ? 'Chat' : 'Files'}
-          >
-            <span className="flex h-14 w-14 items-center justify-center bg-black/35 shadow-lg">
-              {section === 'chat' ? <MessageSquare size={28} /> : <Folder size={28} />}
-            </span>
-            <span className="w-full truncate text-center text-[11px] font-medium leading-tight [text-shadow:0_1px_2px_rgba(0,0,0,0.8)]">
-              {section === 'chat' ? 'Chat' : 'Files'}
-            </span>
-          </button>
-        ))}
-        {desktopApps.map((app) => (
-          <button
-            key={app.app_id}
-            type="button"
-            className="flex w-[88px] flex-col items-center gap-3 text-white"
-            onClick={() => {
-              if (!currentWorkspaceId) return;
-              router.push(appsPath(currentWorkspaceId, app.app_id));
-            }}
-            title={app.name}
-          >
-            {app.avatar_url ? (
-              // eslint-disable-next-line @next/next/no-img-element
-              <span className="relative h-14 w-14 overflow-hidden p-0 shadow-lg">
-                <img
-                  src={app.avatar_url}
-                  alt=""
-                  className="absolute inset-0 h-full w-full object-cover"
-                />
+    <div className="flex h-full flex-col">
+      <Header title={workspace?.name || 'Home'} />
+      <div className="relative min-h-0 flex-1 overflow-hidden">
+        <div
+          className="absolute inset-0"
+          style={wallpaperStyle(
+            resolveDeskImageUrl(theme?.backgroundImageUrl),
+            theme?.backgroundColor,
+          )}
+        />
+        <div className="relative z-10 flex h-full w-full content-start flex-wrap items-start gap-x-7 gap-y-8 overflow-auto p-8">
+          {surfaceIcons.map((section) => (
+            <button
+              key={section}
+              type="button"
+              className="flex w-[88px] flex-col items-center gap-3 text-white"
+              onClick={() => openSurface(section)}
+              title={section === 'chat' ? 'Chat' : 'Files'}
+            >
+              <span className="flex h-14 w-14 items-center justify-center bg-black/35 shadow-lg">
+                {section === 'chat' ? <MessageSquare size={28} /> : <Folder size={28} />}
               </span>
-            ) : (
-              <span className="flex h-14 w-14 items-center justify-center bg-black/35 text-2xl shadow-lg">
-                {app.icon_emoji || app.name.slice(0, 1)}
+              <span className="w-full truncate text-center text-[11px] font-medium leading-tight [text-shadow:0_1px_2px_rgba(0,0,0,0.8)]">
+                {section === 'chat' ? 'Chat' : 'Files'}
               </span>
-            )}
-            <span className="w-full truncate text-center text-[11px] font-medium leading-tight [text-shadow:0_1px_2px_rgba(0,0,0,0.8)]">
-              {app.name}
-            </span>
-          </button>
-        ))}
-        {desktopFiles.map((item) => (
-          <button
-            key={`${item.workspaceId}:${item.source}:${item.path}`}
-            type="button"
-            className="flex w-[88px] flex-col items-center gap-3 text-white"
-            onClick={() => {
-              if (item.type === 'folder') {
-                setStarredNavigation({ source: item.source, path: item.path });
-              } else {
-                const parentPath = item.path.includes('/')
-                  ? item.path.substring(0, item.path.lastIndexOf('/'))
-                  : '';
-                setStarredNavigation({
-                  source: item.source,
-                  path: parentPath,
-                  previewPath: item.path,
-                });
-              }
-              setActivePanelSection('files');
-              router.push(
-                isMobile
-                  ? filesBrowsePath(currentWorkspaceId)
-                  : getWorkspacePath(currentWorkspaceId, '/files'),
-              );
-            }}
-            title={item.path}
-          >
-            <span className="flex h-14 w-14 items-center justify-center bg-black/35 shadow-lg">
-              {item.type === 'folder' ? <Folder size={28} /> : <File size={28} />}
-            </span>
-            <span className="w-full truncate text-center text-[11px] font-medium leading-tight [text-shadow:0_1px_2px_rgba(0,0,0,0.8)]">
-              {item.name}
-            </span>
-          </button>
-        ))}
+            </button>
+          ))}
+          {desktopApps.map((app) => (
+            <button
+              key={app.app_id}
+              type="button"
+              className="flex w-[88px] flex-col items-center gap-3 text-white"
+              onClick={() => {
+                if (!currentWorkspaceId) return;
+                router.push(appsPath(currentWorkspaceId, app.app_id));
+              }}
+              title={app.name}
+            >
+              {app.avatar_url ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <span className="relative h-14 w-14 overflow-hidden p-0 shadow-lg">
+                  <img
+                    src={app.avatar_url}
+                    alt=""
+                    className="absolute inset-0 h-full w-full object-cover"
+                  />
+                </span>
+              ) : (
+                <span className="flex h-14 w-14 items-center justify-center bg-black/35 text-2xl shadow-lg">
+                  {app.icon_emoji || app.name.slice(0, 1)}
+                </span>
+              )}
+              <span className="w-full truncate text-center text-[11px] font-medium leading-tight [text-shadow:0_1px_2px_rgba(0,0,0,0.8)]">
+                {app.name}
+              </span>
+            </button>
+          ))}
+          {desktopFiles.map((item) => (
+            <button
+              key={`${item.workspaceId}:${item.source}:${item.path}`}
+              type="button"
+              className="flex w-[88px] flex-col items-center gap-3 text-white"
+              onClick={() => {
+                if (item.type === 'folder') {
+                  setStarredNavigation({ source: item.source, path: item.path });
+                } else {
+                  const parentPath = item.path.includes('/')
+                    ? item.path.substring(0, item.path.lastIndexOf('/'))
+                    : '';
+                  setStarredNavigation({
+                    source: item.source,
+                    path: parentPath,
+                    previewPath: item.path,
+                  });
+                }
+                setActivePanelSection('files');
+                router.push(
+                  isMobile
+                    ? filesBrowsePath(currentWorkspaceId)
+                    : getWorkspacePath(currentWorkspaceId, '/files'),
+                );
+              }}
+              title={item.path}
+            >
+              <span className="flex h-14 w-14 items-center justify-center bg-black/35 shadow-lg">
+                {item.type === 'folder' ? <Folder size={28} /> : <File size={28} />}
+              </span>
+              <span className="w-full truncate text-center text-[11px] font-medium leading-tight [text-shadow:0_1px_2px_rgba(0,0,0,0.8)]">
+                {item.name}
+              </span>
+            </button>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/header.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/header.tsx
@@ -8,6 +8,7 @@ import {
 import { cn } from '@/lib/utils';
 import { useWorkspaceStore, isTransientPanelSection } from '@/stores/workspace';
 import { useIsMobile } from '@/hooks/use-is-mobile';
+import { QuickOpen } from './quick-open';
 import { useRegisterShellTitle } from './shell-title';
 
 interface HeaderProps {
@@ -46,6 +47,10 @@ export function Header({ title, subtitle, nav, actions }: HeaderProps = {}) {
   // Use defaults on server to prevent hydration mismatch
   const sidebarOpen = mounted ? !sidebarCollapsed : true;
   const panelOpen = mounted ? contextPanelOpen : false;
+  const sectionToToggle =
+    lastActivePanelSection && !isTransientPanelSection(lastActivePanelSection)
+      ? lastActivePanelSection
+      : 'chat';
 
   // Mobile shell owns chrome (back header + bottom nav). Desktop Header
   // (sidebar toggle, AI pane) is dead weight there. Branch + API live in
@@ -54,9 +59,8 @@ export function Header({ title, subtitle, nav, actions }: HeaderProps = {}) {
   if (isMobile) return null;
 
   return (
-    <header className="glass-nav relative z-[200] flex h-14 items-center justify-between border-b border-border/50 pl-2 pr-4">
-      {/* Left side */}
-      <div className="flex items-center gap-1">
+    <header className="glass-nav relative z-[200] flex h-14 items-center border-b border-border/50 pl-2 pr-4">
+      <div className="relative z-10 flex min-w-0 items-center gap-1">
         {!sidebarOpen && (
           <button
             onClick={toggleSidebar}
@@ -70,16 +74,18 @@ export function Header({ title, subtitle, nav, actions }: HeaderProps = {}) {
           </button>
         )}
 
-        {/* Section panel toggle: visible whenever a panel section has been opened */}
-        {mounted && lastActivePanelSection && !isTransientPanelSection(lastActivePanelSection) && (
+        {mounted && (
           <button
-            onClick={() => setActivePanelSection(activePanelSection ? null : lastActivePanelSection)}
+            type="button"
+            onClick={() => setActivePanelSection(activePanelSection ? null : sectionToToggle)}
             className={cn(
               'flex h-8 w-8 items-center justify-center rounded-md transition-all',
               'hover:bg-muted hover:text-foreground',
               activePanelSection ? 'text-foreground bg-muted' : 'text-muted-foreground'
             )}
             title={activePanelSection ? 'Close panel' : 'Open panel'}
+            aria-label={activePanelSection ? 'Close panel' : 'Open panel'}
+            aria-pressed={Boolean(activePanelSection)}
           >
             <PanelLeft size={16} />
           </button>
@@ -88,11 +94,15 @@ export function Header({ title, subtitle, nav, actions }: HeaderProps = {}) {
         {nav ? <div className="ml-1 flex min-w-0 items-center">{nav}</div> : null}
       </div>
 
-      {/* Right side: page actions + Abi pane. Account menu is on the dock. */}
-      <div className="flex items-center gap-1">
+      <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+        <div className="pointer-events-auto">
+          <QuickOpen />
+        </div>
+      </div>
+
+      <div className="relative z-10 ml-auto flex items-center gap-1">
         {actions}
 
-        {/* Right chat pane toggle: icon-only, mirrors left PanelLeft controls */}
         <button
           type="button"
           onClick={toggleContextPanel}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/quick-open.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/quick-open.tsx
@@ -1,0 +1,393 @@
+'use client';
+
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { usePathname, useRouter } from 'next/navigation';
+import { Search } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { markAppsSkipRestore } from '@/app/workspace/[workspaceId]/apps/lib/apps-route';
+import { getWorkspacePath } from '@/components/shell/sidebar/utils';
+import { useFeature } from '@/hooks/use-feature';
+import { getWorkspaceSwitchPath } from '@/lib/feature-access';
+import {
+  buildQuickOpenItems,
+  conversationUpdatedAtMs,
+  filterQuickOpenItems,
+  groupQuickOpenItems,
+  QUICK_OPEN_GROUP_LABEL,
+  QUICK_OPEN_SECTIONS,
+  type QuickOpenItem,
+} from '@/lib/quick-open';
+import { useAppsStore } from '@/stores/apps';
+import { useFilesStore } from '@/stores/files';
+import { useWorkspaceStore, type SidebarSection } from '@/stores/workspace';
+
+function modifierGlyph(): string {
+  if (typeof navigator !== 'undefined' && /Mac|iPhone|iPad/i.test(navigator.platform)) {
+    return '⌘';
+  }
+  return 'Ctrl+';
+}
+
+export function QuickOpen() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [mounted, setMounted] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const [listBox, setListBox] = useState<{ top: number; left: number; width: number } | null>(null);
+
+  const workspaces = useWorkspaceStore((s) => s.workspaces);
+  const currentWorkspaceId = useWorkspaceStore((s) => s.currentWorkspaceId);
+  const conversations = useWorkspaceStore((s) => s.conversations);
+  const setCurrentWorkspace = useWorkspaceStore((s) => s.setCurrentWorkspace);
+  const setActiveConversation = useWorkspaceStore((s) => s.setActiveConversation);
+  const setActivePanelSection = useWorkspaceStore((s) => s.setActivePanelSection);
+  const syncWorkspaceConversations = useWorkspaceStore((s) => s.syncWorkspaceConversations);
+  const workspace = workspaces.find((w) => w.id === currentWorkspaceId) || null;
+
+  const apps = useAppsStore((s) => s.apps);
+  const fetchApps = useAppsStore((s) => s.fetchApps);
+  const starredItems = useFilesStore((s) => s.starredItems);
+  const setStarredNavigation = useFilesStore((s) => s.setStarredNavigation);
+  const setActiveSource = useFilesStore((s) => s.setActiveSource);
+
+  const canMaps = useFeature('maps');
+  const canChat = useFeature('chat');
+  const canFiles = useFeature('files');
+  const canDatasets = useFeature('datasets');
+  const canAgents = useFeature('agents');
+  const canApps = useFeature('apps');
+  const canMarketplace = useFeature('marketplace');
+  const canSearch = useFeature('search');
+  const canOntology = useFeature('ontology');
+  const canGraph = useFeature('graph');
+  const canCode = useFeature('code');
+  const canSlides = useFeature('slides');
+  const canSettingsWorkspace = useFeature('settings.workspace');
+
+  const featureOn: Record<string, boolean> = {
+    apps: canApps,
+    agents: canAgents,
+    files: canFiles,
+    chat: canChat,
+    search: canSearch,
+    maps: canMaps,
+    ontology: canOntology,
+    graph: canGraph,
+    datasets: canDatasets,
+    slides: canSlides,
+    code: canCode,
+    marketplace: canMarketplace,
+    'settings.workspace': canSettingsWorkspace,
+  };
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const close = useCallback(() => {
+    setOpen(false);
+    setQuery('');
+    setActiveIndex(0);
+  }, []);
+
+  const openPalette = useCallback(() => {
+    setOpen(true);
+    setQuery('');
+    setActiveIndex(0);
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!open || !wrapRef.current) {
+      setListBox(null);
+      return;
+    }
+    const rect = wrapRef.current.getBoundingClientRect();
+    setListBox({ top: rect.bottom + 4, left: rect.left, width: rect.width });
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const id = requestAnimationFrame(() => inputRef.current?.focus());
+    return () => cancelAnimationFrame(id);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || !currentWorkspaceId) return;
+    void fetchApps(currentWorkspaceId);
+    void syncWorkspaceConversations(currentWorkspaceId);
+  }, [open, currentWorkspaceId, fetchApps, syncWorkspaceConversations]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey) || e.key.toLowerCase() !== 'p') return;
+      if (e.shiftKey) return;
+      e.preventDefault();
+      e.stopPropagation();
+      if (open) close();
+      else openPalette();
+    };
+    window.addEventListener('keydown', onKey, true);
+    return () => window.removeEventListener('keydown', onKey, true);
+  }, [open, openPalette, close]);
+
+  const catalog = useMemo(() => {
+    if (!currentWorkspaceId) return [];
+    const sections = QUICK_OPEN_SECTIONS.filter((section) => {
+      if (!section.feature) return true;
+      return featureOn[section.feature];
+    }).map((section) => ({
+      id: section.id,
+      label: section.label,
+      href: getWorkspacePath(currentWorkspaceId, section.href),
+    }));
+    const chats = conversations
+      .filter((c) => c.workspaceId === currentWorkspaceId && !c.archived)
+      .sort((a, b) => conversationUpdatedAtMs(b.updatedAt) - conversationUpdatedAtMs(a.updatedAt))
+      .slice(0, 20)
+      .map((c) => ({ id: c.id, title: c.title }));
+    const listedApps = apps
+      .filter((a) => a.enabled && a.installed && a.url)
+      .map((a) => ({ id: a.app_id, name: a.name }));
+    const files = starredItems
+      .filter((item) => item.workspaceId === currentWorkspaceId)
+      .map((item) => ({
+        source: item.source,
+        path: item.path,
+        name: item.name,
+        type: item.type,
+      }));
+    return buildQuickOpenItems({
+      workspaceId: currentWorkspaceId,
+      workspaces: workspaces.map((w) => ({ id: w.id, name: w.name })),
+      sections,
+      apps: listedApps,
+      chats,
+      files,
+    });
+    // Individual feature flags are listed below; featureOn is derived from them.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    currentWorkspaceId,
+    workspaces,
+    conversations,
+    apps,
+    starredItems,
+    canMaps,
+    canChat,
+    canFiles,
+    canDatasets,
+    canAgents,
+    canApps,
+    canMarketplace,
+    canSearch,
+    canOntology,
+    canGraph,
+    canCode,
+    canSlides,
+    canSettingsWorkspace,
+  ]);
+
+  const results = useMemo(() => filterQuickOpenItems(catalog, query), [catalog, query]);
+  const groups = useMemo(() => groupQuickOpenItems(results), [results]);
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [query]);
+
+  useEffect(() => {
+    if (!open) return;
+    const node = listRef.current?.querySelector<HTMLElement>(`[data-quick-open-index="${activeIndex}"]`);
+    node?.scrollIntoView({ block: 'nearest' });
+  }, [activeIndex, open]);
+
+  const run = useCallback(
+    (item: QuickOpenItem) => {
+      if (!currentWorkspaceId) return;
+      const action = item.action;
+      if (action.kind === 'workspace') {
+        if (action.workspaceId !== currentWorkspaceId) {
+          const target = workspaces.find((w) => w.id === action.workspaceId);
+          setActiveConversation(null);
+          markAppsSkipRestore();
+          setCurrentWorkspace(action.workspaceId);
+          router.push(
+            getWorkspaceSwitchPath({
+              pathname,
+              targetWorkspaceId: action.workspaceId,
+              role: target?.currentUserRole,
+              workspaceFlags: target?.featureFlags,
+            }),
+          );
+        }
+        close();
+        return;
+      }
+      if (action.kind === 'file') {
+        if (action.type === 'folder') {
+          setStarredNavigation({ source: action.source, path: action.path });
+        } else {
+          const parentPath = action.path.includes('/')
+            ? action.path.substring(0, action.path.lastIndexOf('/'))
+            : '';
+          setStarredNavigation({
+            source: action.source,
+            path: parentPath,
+            previewPath: action.path,
+          });
+        }
+        setActiveSource(action.source);
+        setActivePanelSection('files');
+        router.push(getWorkspacePath(currentWorkspaceId, '/files'));
+        close();
+        return;
+      }
+      if (action.panel === null) setActivePanelSection(null);
+      else if (action.panel) setActivePanelSection(action.panel as SidebarSection);
+      router.push(action.href);
+      close();
+    },
+    [
+      currentWorkspaceId,
+      workspaces,
+      pathname,
+      router,
+      setActiveConversation,
+      setCurrentWorkspace,
+      setActivePanelSection,
+      setStarredNavigation,
+      setActiveSource,
+      close,
+    ],
+  );
+
+  const onInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      close();
+      return;
+    }
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActiveIndex((i) => Math.min(i + 1, Math.max(results.length - 1, 0)));
+      return;
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIndex((i) => Math.max(i - 1, 0));
+      return;
+    }
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      const item = results[activeIndex];
+      if (item) run(item);
+    }
+  };
+
+  const workspaceName = workspace?.name || 'Search';
+  const shortcut = mounted ? `${modifierGlyph()}P` : '⌘P';
+
+  return (
+    <div ref={wrapRef} className="relative w-[min(32rem,calc(100vw-22rem))] max-w-[32rem]">
+      <button
+        type="button"
+        onClick={() => (open ? inputRef.current?.focus() : openPalette())}
+        className={cn(
+          'flex h-8 w-full items-center gap-2 rounded-md border px-2.5 text-left text-sm transition-colors',
+          open
+            ? 'border-workspace-accent/40 bg-background text-foreground shadow-sm'
+            : 'border-border/60 bg-muted/40 text-muted-foreground hover:border-border hover:bg-muted/70 hover:text-foreground',
+        )}
+        aria-label={`Search ${workspaceName}`}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        aria-controls="quick-open-list"
+      >
+        <Search size={14} className="shrink-0 opacity-70" />
+        {open ? (
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={onInputKeyDown}
+            onClick={(e) => e.stopPropagation()}
+            placeholder={workspaceName}
+            className="min-w-0 flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+            aria-autocomplete="list"
+          />
+        ) : (
+          <>
+            <span className="min-w-0 flex-1 truncate">{workspaceName}</span>
+            <kbd className="hidden shrink-0 rounded border border-border/70 bg-background/80 px-1.5 py-0.5 font-sans text-[10px] text-muted-foreground sm:inline">
+              {shortcut}
+            </kbd>
+          </>
+        )}
+      </button>
+
+      {open && mounted
+        ? createPortal(
+            <>
+              <div className="fixed inset-0 z-[250]" onMouseDown={close} />
+              <div
+                id="quick-open-list"
+                ref={listRef}
+                role="listbox"
+                className="fixed z-[260] max-h-[min(28rem,70vh)] overflow-y-auto border border-border bg-background shadow-xl"
+                style={{
+                  top: listBox?.top ?? 56,
+                  left: listBox?.left ?? 0,
+                  width: listBox?.width ?? 480,
+                }}
+              >
+                {groups.length === 0 ? (
+                  <p className="px-3 py-6 text-center text-sm text-muted-foreground">
+                    {query.trim() ? 'No matches' : 'Nothing to jump to yet'}
+                  </p>
+                ) : (
+                  groups.map((entry) => (
+                    <div key={entry.group}>
+                      <div className="px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                        {QUICK_OPEN_GROUP_LABEL[entry.group]}
+                      </div>
+                      {entry.items.map((item) => {
+                        const index = results.indexOf(item);
+                        const active = index === activeIndex;
+                        return (
+                          <button
+                            key={item.id}
+                            type="button"
+                            role="option"
+                            aria-selected={active}
+                            data-quick-open-index={index}
+                            onMouseEnter={() => setActiveIndex(index)}
+                            onMouseDown={(e) => e.preventDefault()}
+                            onClick={() => run(item)}
+                            className={cn(
+                              'flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm',
+                              active ? 'bg-muted text-foreground' : 'text-foreground/90 hover:bg-muted/70',
+                            )}
+                          >
+                            <span className="min-w-0 flex-1 truncate">{item.label}</span>
+                            {item.hint ? (
+                              <span className="shrink-0 text-[11px] text-muted-foreground">{item.hint}</span>
+                            ) : null}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  ))
+                )}
+              </div>
+            </>,
+            document.body,
+          )
+        : null}
+    </div>
+  );
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/quick-open.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/quick-open.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildQuickOpenItems,
+  conversationUpdatedAtMs,
+  filterQuickOpenItems,
+  groupQuickOpenItems,
+  scoreQuickOpen,
+  type QuickOpenItem,
+} from './quick-open';
+
+const item = (
+  id: string,
+  group: QuickOpenItem['group'],
+  label: string,
+  hint?: string,
+): QuickOpenItem => ({
+  id,
+  group,
+  label,
+  hint,
+  action: { kind: 'href', href: `/${id}` },
+});
+
+const catalog = [
+  item('home', 'navigate', 'Home'),
+  item('chat', 'navigate', 'Chat'),
+  item('acme', 'workspace', 'Acme'),
+  item('core', 'workspace', 'Core Team'),
+  item('proposal', 'app', 'Acme Portal'),
+  item('thread', 'chat', 'Q1 review', 'yesterday'),
+];
+
+describe('scoreQuickOpen', () => {
+  it('scores an exact label highest', () => {
+    expect(scoreQuickOpen(catalog[1], 'chat')).toBe(3);
+    expect(scoreQuickOpen(catalog[1], 'cha')).toBe(2);
+    expect(scoreQuickOpen(catalog[1], 'at')).toBe(1);
+  });
+
+  it('matches the hint when the label does not', () => {
+    expect(scoreQuickOpen(catalog[5], 'yesterday')).toBe(1);
+  });
+
+  it('returns 0 when nothing matches', () => {
+    expect(scoreQuickOpen(catalog[0], 'xyz')).toBe(0);
+  });
+});
+
+describe('filterQuickOpenItems', () => {
+  it('returns the catalog when the query is empty', () => {
+    expect(filterQuickOpenItems(catalog, '  ').map((row) => row.id)).toEqual(
+      catalog.map((row) => row.id),
+    );
+  });
+
+  it('keeps group order and prefers a prefix match inside a group', () => {
+    const rows = filterQuickOpenItems(
+      [item('team', 'workspace', 'Team Space'), item('acme', 'workspace', 'Acme')],
+      'a',
+    );
+    expect(rows.map((row) => row.id)).toEqual(['acme', 'team']);
+  });
+
+  it('is case-insensitive', () => {
+    expect(filterQuickOpenItems(catalog, 'ACME').map((row) => row.id)).toEqual([
+      'acme',
+      'proposal',
+    ]);
+  });
+});
+
+describe('groupQuickOpenItems', () => {
+  it('drops empty groups and keeps canonical order', () => {
+    expect(groupQuickOpenItems(catalog).map((entry) => entry.group)).toEqual([
+      'navigate',
+      'workspace',
+      'app',
+      'chat',
+    ]);
+  });
+});
+
+describe('conversationUpdatedAtMs', () => {
+  it('reads a Date', () => {
+    expect(conversationUpdatedAtMs(new Date('2026-03-15T12:00:00.000Z'))).toBe(
+      Date.parse('2026-03-15T12:00:00.000Z'),
+    );
+  });
+
+  it('reads an ISO string from persist rehydrate', () => {
+    expect(conversationUpdatedAtMs('2026-03-15T12:00:00.000Z')).toBe(
+      Date.parse('2026-03-15T12:00:00.000Z'),
+    );
+  });
+
+  it('reads a numeric timestamp', () => {
+    expect(conversationUpdatedAtMs(1_710_000_000_000)).toBe(1_710_000_000_000);
+  });
+
+  it('returns 0 for null, undefined, and invalid values', () => {
+    expect(conversationUpdatedAtMs(null)).toBe(0);
+    expect(conversationUpdatedAtMs(undefined)).toBe(0);
+    expect(conversationUpdatedAtMs('')).toBe(0);
+    expect(conversationUpdatedAtMs('not-a-date')).toBe(0);
+  });
+});
+
+describe('buildQuickOpenItems', () => {
+  it('builds hrefs and workspace actions from a catalog', () => {
+    const items = buildQuickOpenItems({
+      workspaceId: 'ws-1',
+      workspaces: [{ id: 'ws-1', name: 'Acme' }],
+      sections: [{ id: 'home', label: 'Home', href: '/workspace/ws-1/home' }],
+      apps: [{ id: 'acme-portal', name: 'Acme Portal' }],
+      chats: [{ id: 'c1', title: 'Kickoff' }],
+      files: [{ source: 'my-drive', path: 'notes.md', name: 'notes.md', type: 'file' }],
+    });
+    expect(items.map((row) => row.id)).toEqual([
+      'nav:home',
+      'ws:ws-1',
+      'app:acme-portal',
+      'chat:c1',
+      'file:my-drive:notes.md',
+    ]);
+    expect(items[0].action).toEqual({
+      kind: 'href',
+      href: '/workspace/ws-1/home',
+      panel: null,
+    });
+    expect(items[1].hint).toBe('Current');
+    expect(items[2].action).toEqual({
+      kind: 'href',
+      href: '/workspace/ws-1/apps?open=acme-portal',
+      panel: 'apps',
+    });
+  });
+});

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/quick-open.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/quick-open.ts
@@ -1,0 +1,172 @@
+export const QUICK_OPEN_GROUPS = ['navigate', 'workspace', 'app', 'chat', 'file'] as const;
+
+export type QuickOpenGroup = (typeof QUICK_OPEN_GROUPS)[number];
+
+export type QuickOpenAction =
+  | { kind: 'href'; href: string; panel?: string | null }
+  | { kind: 'workspace'; workspaceId: string }
+  | { kind: 'file'; source: string; path: string; type: 'file' | 'folder' };
+
+export type QuickOpenItem = {
+  id: string;
+  group: QuickOpenGroup;
+  label: string;
+  hint?: string;
+  action: QuickOpenAction;
+};
+
+export type QuickOpenSection = {
+  id: string;
+  label: string;
+  href: string;
+  feature?: string;
+};
+
+/** Surfaces the palette can jump to. Hrefs are workspace-relative. */
+export const QUICK_OPEN_SECTIONS: readonly QuickOpenSection[] = [
+  { id: 'home', label: 'Home', href: '/home' },
+  { id: 'apps', label: 'Apps', href: '/apps', feature: 'apps' },
+  { id: 'lab', label: 'Lab', href: '/lab', feature: 'agents' },
+  { id: 'files', label: 'Files', href: '/files', feature: 'files' },
+  { id: 'chat', label: 'Chat', href: '/chat', feature: 'chat' },
+  { id: 'search', label: 'Search', href: '/search', feature: 'search' },
+  { id: 'maps', label: 'Maps', href: '/maps/presence', feature: 'maps' },
+  { id: 'ontology', label: 'Ontology', href: '/ontology', feature: 'ontology' },
+  { id: 'graph', label: 'Knowledge Graph', href: '/graph/network', feature: 'graph' },
+  { id: 'datasets', label: 'Datasets', href: '/datasets', feature: 'datasets' },
+  { id: 'slides', label: 'Slides', href: '/slides', feature: 'slides' },
+  { id: 'code', label: 'Code', href: '/code/workspaces', feature: 'code' },
+  { id: 'marketplace', label: 'Marketplace', href: '/marketplace', feature: 'marketplace' },
+  { id: 'settings', label: 'Settings', href: '/settings', feature: 'settings.workspace' },
+];
+
+export const QUICK_OPEN_GROUP_LABEL: Record<QuickOpenGroup, string> = {
+  navigate: 'Navigate',
+  workspace: 'Workspaces',
+  app: 'Apps',
+  chat: 'Chats',
+  file: 'Files',
+};
+
+/** Persist rehydrate often stores Date fields as ISO strings. Never call .getTime() on them. */
+export function conversationUpdatedAtMs(
+  value: Date | string | number | null | undefined,
+): number {
+  if (value == null || value === '') return 0;
+  const ms = new Date(value).getTime();
+  return Number.isFinite(ms) ? ms : 0;
+}
+
+export function scoreQuickOpen(item: QuickOpenItem, query: string): number {
+  const q = query.trim().toLowerCase();
+  if (!q) return 1;
+  const label = item.label.toLowerCase();
+  const hint = (item.hint || '').toLowerCase();
+  if (label === q) return 3;
+  if (label.startsWith(q)) return 2;
+  if (label.includes(q) || hint.includes(q)) return 1;
+  return 0;
+}
+
+export function filterQuickOpenItems(
+  items: readonly QuickOpenItem[],
+  query: string,
+): QuickOpenItem[] {
+  const q = query.trim().toLowerCase();
+  const matched = q ? items.filter((item) => scoreQuickOpen(item, q) > 0) : [...items];
+  if (!q) return matched;
+  return matched.sort((a, b) => {
+    const group =
+      QUICK_OPEN_GROUPS.indexOf(a.group) - QUICK_OPEN_GROUPS.indexOf(b.group);
+    if (group) return group;
+    const score = scoreQuickOpen(b, q) - scoreQuickOpen(a, q);
+    if (score) return score;
+    return a.label.localeCompare(b.label);
+  });
+}
+
+export function groupQuickOpenItems(
+  items: readonly QuickOpenItem[],
+): { group: QuickOpenGroup; items: QuickOpenItem[] }[] {
+  const buckets = new Map<QuickOpenGroup, QuickOpenItem[]>();
+  for (const group of QUICK_OPEN_GROUPS) buckets.set(group, []);
+  for (const item of items) {
+    buckets.get(item.group)?.push(item);
+  }
+  return QUICK_OPEN_GROUPS
+    .map((group) => ({ group, items: buckets.get(group) ?? [] }))
+    .filter((entry) => entry.items.length > 0);
+}
+
+export function buildQuickOpenItems(input: {
+  workspaceId: string;
+  workspaces: { id: string; name: string }[];
+  sections: { id: string; label: string; href: string }[];
+  apps: { id: string; name: string }[];
+  chats: { id: string; title: string }[];
+  files: { source: string; path: string; name: string; type: 'file' | 'folder' }[];
+}): QuickOpenItem[] {
+  const items: QuickOpenItem[] = [];
+
+  for (const section of input.sections) {
+    items.push({
+      id: `nav:${section.id}`,
+      group: 'navigate',
+      label: section.label,
+      action: { kind: 'href', href: section.href, panel: section.id === 'home' ? null : section.id },
+    });
+  }
+
+  for (const workspace of input.workspaces) {
+    items.push({
+      id: `ws:${workspace.id}`,
+      group: 'workspace',
+      label: workspace.name,
+      hint: workspace.id === input.workspaceId ? 'Current' : undefined,
+      action: { kind: 'workspace', workspaceId: workspace.id },
+    });
+  }
+
+  for (const app of input.apps) {
+    items.push({
+      id: `app:${app.id}`,
+      group: 'app',
+      label: app.name,
+      action: {
+        kind: 'href',
+        href: `/workspace/${input.workspaceId}/apps?open=${encodeURIComponent(app.id)}`,
+        panel: 'apps',
+      },
+    });
+  }
+
+  for (const chat of input.chats) {
+    items.push({
+      id: `chat:${chat.id}`,
+      group: 'chat',
+      label: chat.title || 'Untitled chat',
+      action: {
+        kind: 'href',
+        href: `/workspace/${input.workspaceId}/chat/${chat.id}`,
+        panel: 'chat',
+      },
+    });
+  }
+
+  for (const file of input.files) {
+    items.push({
+      id: `file:${file.source}:${file.path}`,
+      group: 'file',
+      label: file.name,
+      hint: file.path,
+      action: {
+        kind: 'file',
+        source: file.source,
+        path: file.path,
+        type: file.type,
+      },
+    });
+  }
+
+  return items;
+}


### PR DESCRIPTION
## Summary
- Home mounts the shared Header, so the left section panel and the right Abi pane (Cmd+K) work from the desk.
- The Header always shows the left section-panel toggle. If there is no last section, it falls back to chat.
- A VS Code-style Quick Open sits in the center of the Header. It shows the current workspace name. Click or Cmd+P jumps to navigate, workspaces, apps, chats, or starred files.
- App embed uses the shared Header: back-to-apps in `nav`, Info / Reload / Open-in-new-tab in `actions`, Abi pane toggle on the right. The custom close bar is gone.

Fixes #1227

## Test plan
- [ ] Home shows Header; left toggle opens/closes section panel; right toggle opens Abi pane (Cmd+K)
- [ ] Center search shows workspace name; click or Cmd+P jumps to a page/workspace/app/chat
- [ ] Opening an app uses the same Header (back control, no X); Abi pane toggle still works
- [ ] Reload after visiting chat: Quick Open does not crash (persisted conversation dates)