### PR TITLE
feat(nexus): research-first Slides agent with a template rail

### DIFF
--- a/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
@@ -60,6 +60,7 @@ from naas_abi_core.services.agent.context import (
     agent_user_id,
     agent_workspace_id,
     coder_workspace_base,
+    slides_active_slug,
 )
 from naas_abi_core.services.agent.ontologies.modules.AgentEventOntology import (
     AgentAIMessageEmitted,
@@ -117,6 +118,33 @@ def _reset_shared_checkpointer_for_tests() -> None:
 
 
 atexit.register(_close_shared_checkpointer)
+
+
+def _friendly_model_invoke_error(exc: BaseException) -> str:
+    """One-line human error. Never dump raw provider JSON into the chat bubble."""
+    text = str(exc or "").strip()
+    lowered = text.lower()
+    if "recursion limit" in lowered:
+        return (
+            "The agent hit its step limit before finishing. "
+            "Open the deck and send the brief again."
+        )
+    if (
+        "429" in text
+        or "rate-limited" in lowered
+        or "rate limited" in lowered
+        or "temporarily rate-limited" in lowered
+    ):
+        return (
+            "This model is rate limited. Pick another model in the agent menu and try again."
+        )
+    if (
+        "error code:" in lowered
+        or "provider returned error" in lowered
+        or (len(text) > 160 and ("{" in text or "'error'" in text or '"error"' in text))
+    ):
+        return "The model provider failed. Pick another model and try again."
+    return text or "The model provider failed. Pick another model and try again."
 
 
 def create_checkpointer() -> BaseCheckpointSaver:
@@ -1455,7 +1483,7 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
                     **routing_update,
                     "messages": [
                         AIMessage(
-                            content=f"I'm sorry, I encountered an error while processing your request:\n\n{e}"
+                            content=_friendly_model_invoke_error(e)
                         )
                     ],
                 },
@@ -1954,9 +1982,16 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
 
         notified = {}
 
+        stream_config: dict[str, Any] = {
+            "configurable": {"thread_id": self._state.thread_id}
+        }
+        # Default LangGraph limit is 25. A slides research loop (search, then
+        # write 6-8 sections) needs more steps than a normal chat turn.
+        if (slides_active_slug.get() or "").strip():
+            stream_config["recursion_limit"] = 80
         for chunk in self.graph.stream(
             {"messages": [human_message]},
-            config={"configurable": {"thread_id": self._state.thread_id}},
+            config=stream_config,
             subgraphs=True,
         ):
             source, payload = chunk
@@ -2238,9 +2273,7 @@ Reformat the input into clean, readable Markdown. Preserve all meaning and detai
                 logger.opt(exception=True).error(
                     f"Agent invoke thread error for '{self._name}': {e}"
                 )
-                final_state = (
-                    f"I encountered an error while processing your request: {e}"
-                )
+                final_state = _friendly_model_invoke_error(e)
             self._event_queue.put(FinalStateEvent(payload=final_state))
 
         from threading import Thread

--- a/libs/naas-abi-core/naas_abi_core/services/agent/Agent_friendly_error_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/Agent_friendly_error_test.py
@@ -1,0 +1,19 @@
+from naas_abi_core.services.agent.Agent import _friendly_model_invoke_error
+
+
+def test_friendly_model_invoke_error_rewrites_429() -> None:
+    raw = (
+        "Error code: 429 - {'error': {'message': 'Provider returned error', "
+        "'code': 429, 'metadata': {'raw': "
+        "'google/gemma-4-26b-a4b-it:free is temporarily rate-limited upstream.'}}}"
+    )
+    assert _friendly_model_invoke_error(Exception(raw)) == (
+        "This model is rate limited. Pick another model in the agent menu and try again."
+    )
+
+
+def test_friendly_model_invoke_error_hides_json_dump() -> None:
+    raw = "Error code: 500 - {'error': {'message': 'Provider returned error', 'code': 500}}"
+    assert _friendly_model_invoke_error(Exception(raw)) == (
+        "The model provider failed. Pick another model and try again."
+    )

--- a/libs/naas-abi-core/naas_abi_core/services/agent/context.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/context.py
@@ -56,3 +56,13 @@ slides_active_title: ContextVar[str | None] = ContextVar(
 slides_active_mode: ContextVar[str | None] = ContextVar(
     "slides_active_mode", default=None
 )
+
+# Research gate for Slides briefs. Set at the chat stream boundary when the
+# open deck needs web_search before HTML writes. web_search appends queries;
+# write tools refuse until at least one query is recorded.
+slides_research_required: ContextVar[bool] = ContextVar(
+    "slides_research_required", default=False
+)
+slides_research_queries: ContextVar[list[str] | None] = ContextVar(
+    "slides_research_queries", default=None
+)

--- a/libs/naas-abi/naas_abi/__init__.py
+++ b/libs/naas-abi/naas_abi/__init__.py
@@ -594,6 +594,11 @@ class ABIModule(BaseModule):
         # whichever provider registered first.
         abi_agent_provider: str | None = None
 
+        # Slides-only override. Nexus Slides briefs use this instead of
+        # ``abi_agent_model`` so general chat can stay on a cheaper default.
+        # Must be a reasoning-capable registry id, not mini or a free Gemma.
+        abi_slides_agent_model: str = "anthropic/claude-sonnet-5"
+
         # Canonical model id used by OntologyEngineerAgent. Same registry
         # semantics as ``abi_agent_model``.
         ontology_engineer_model: str = "claude-sonnet-5"

--- a/libs/naas-abi/naas_abi/agents/AbiAgent.py
+++ b/libs/naas-abi/naas_abi/agents/AbiAgent.py
@@ -38,17 +38,27 @@ Respond only based on what your available agents and tools can actually deliver.
 1. Match the user request to the best available agent or tool.
 2. If a match is found, delegate to that agent or tool with full context and report the result back verbatim.
 3. For organization/workspace/user admin requests (list orgs, create workspaces, invite or remove members, update roles or your own profile), use the Nexus admin tools directly. Do not invent success.
-4. For Slides edits (deck.html), use the Slides tools surgically. Never dump or rewrite the full deck for a small text change. When a deck is open in the Slides UI, you are already editing that presentation: do not ask which deck.
-5. If no match is found, tell the user you do not have the capabilities to handle its request and propose alternatives based on your available agents and tools.
+        4. For Slides edits (deck.html), use the Slides tools surgically. Never dump or rewrite the full deck for a small text change. When a deck is open in the Slides UI, you are already editing that presentation: do not ask which deck. For a new seed brief that needs facts, call web_search first, then write the open HTML.
+        5. If no match is found, tell the user you do not have the capabilities to handle its request and propose alternatives based on your available agents and tools.
 </tasks>
 
 <slides_guidelines>
-- You edit the open presentation in the user's Slides overlay (Coder workspace files via sidecar when available; Forgejo for version history).
-- Never ask which deck, slug, or file when open-deck context is present (slug, path, title, mode). Omit slug on tool calls; tools default to the open deck.
-- Prefer replace_in_slides_deck for copy edits (matches plain text and HTML entities like &amp; so cover titles update with script strings).
+- You edit the open presentation HTML only (Coder workspace files via sidecar when available; Forgejo for version history). Preview is that HTML. PPTX is an export reconstructed from the live .slide DOM at 1280x720. Do not edit buildPptx, FOOTER_TXT, or other script strings.
+- Never ask which deck, slug, file, or template when open-deck context is present. Omit slug on tool calls; tools default to the open deck.
+- A new deck is already a seed. The user's first message is the brief for that open deck.html. Do not ask which file to edit. Default to 6-8 slides after research unless they specified length.
+- Research loop (required, not optional) for news, current events, "what is going on", country or company briefings, or any factual deck:
+  1. Call web_search first. Run 2 to 4 queries (latest developments, context, key actors, dates). Include the current year. Stop searching after 4 queries.
+  2. Optionally one second-pass query to contradict or confirm named sources, still within the 4-query budget.
+  3. Outline 6-8 sections against the open template.
+  4. Then write or replace HTML in the open deck.html with real claims, dates, and named sources. Do not keep searching instead of writing.
+- Do not write slides from training data alone when the brief is time-sensitive. Slides write tools will reject the edit until web_search has run.
+- Do not leave template filler (Presentation Title, Agenda: Context / Approach / Plan, lorem). Keep the seed template CSS and structure (Minimal Light, Pitch Dark, or Executive). Replace section titles and body copy only. Do not invent a new design system.
+- Cite sources in speaker-visible lines or footer/source lines if the template allows, without wrecking layout.
+- Tiny copy edits (title typo, color tweak) may skip search. A first-message create/brief may not.
+- Prefer replace_in_slides_deck for copy edits (matches plain text and HTML entities like &amp; so cover &lt;h1&gt; and body copy update in Preview and PPTX).
 - For cover / title / slide 1 edits: call replace_in_slides_deck with section_index=0 and occurrence=0. Never use occurrence=1 for the title (that hits &lt;title&gt;/menubar before the cover &lt;h1&gt; Preview shows). Confirm cover_h1_updated is true in the tool result.
 - Use list_slides_sections then read_slides_section for targeted inspection.
-- Use write_slides_section to replace one &lt;section&gt; only.
+- Use write_slides_section to replace one &lt;section&gt; only. Keep .deck / .slide 1280x720, cover h1, and theme CSS variables.
 - Avoid read_slides_deck with include_assets=true. Default reads redact embedded data-URLs on purpose.
 - Avoid write_slides_deck unless creating or restructuring the whole presentation.
 </slides_guidelines>
@@ -171,6 +181,18 @@ Respond only based on what your available agents and tools can actually deliver.
             logger = __import__("logging").getLogger(__name__)
             logger.debug("slides tools unavailable: %s", exc)
 
+        try:
+            from naas_abi.agents.slides_policy import attach_slides_research_note
+            from zen.tools.WebTools import make_web_fetch_tool, make_web_search_tool
+
+            tools += [
+                attach_slides_research_note(make_web_search_tool()),
+                make_web_fetch_tool(),
+            ]
+        except Exception as exc:  # noqa: BLE001
+            logger = __import__("logging").getLogger(__name__)
+            logger.debug("web search tools unavailable: %s", exc)
+
         # NOTE: coding-workspace filesystem tools (write_file/read_file/list_dir)
         # are injected generically for every agent via default_tools, so the
         # supervisor and all sub-agents can act on the caller's workspace.
@@ -287,18 +309,28 @@ Respond only based on what your available agents and tools can actually deliver.
         return intents
 
     @classmethod
+    def get_chat_model_id(cls) -> str:
+        from naas_abi import ABIModule
+
+        return str(ABIModule.get_instance().configuration.abi_agent_model)
+
+    @classmethod
     def New(
         cls,
         agent_shared_state: AgentSharedState | None = None,
         agent_configuration: AgentConfiguration | None = None,
+        model_id: str | None = None,
     ) -> "AbiAgent":
         from naas_abi import ABIModule
+        from naas_abi.agents.slides_policy import bind_slides_reasoning
 
         abi_module = ABIModule.get_instance()
+        resolved_model = model_id or abi_module.configuration.abi_agent_model
         chat_model = abi_module.engine.services.model_registry.get_chat_model(
-            abi_module.configuration.abi_agent_model,
+            resolved_model,
             provider=abi_module.configuration.abi_agent_provider,
         )
+        chat_model = bind_slides_reasoning(chat_model, resolved_model)
 
         tools = cls.get_tools()
 

--- a/libs/naas-abi/naas_abi/agents/AbiAgent_slides_test.py
+++ b/libs/naas-abi/naas_abi/agents/AbiAgent_slides_test.py
@@ -1,0 +1,15 @@
+import inspect
+
+from naas_abi.agents.AbiAgent import AbiAgent
+
+
+def test_slides_guidelines_require_research_before_write() -> None:
+    prompt = AbiAgent.system_prompt
+    assert "web_search" in prompt
+    assert "Research loop" in prompt
+    assert "start writing immediately" not in prompt
+    assert "Context / Approach / Plan" in prompt
+
+
+def test_new_accepts_model_id() -> None:
+    assert "model_id" in inspect.signature(AbiAgent.New).parameters

--- a/libs/naas-abi/naas_abi/agents/slides_policy.py
+++ b/libs/naas-abi/naas_abi/agents/slides_policy.py
@@ -1,0 +1,317 @@
+"""Slides chat policy: research first, then write; stronger model than mini.
+
+Used by AbiAgent, slides tools, and Nexus chat so a current-events brief cannot
+skip web_search and dump template filler into deck.html.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from naas_abi_core.services.agent.context import (
+    slides_active_slug,
+    slides_research_queries,
+    slides_research_required,
+)
+
+# OpenRouter id. This environment's OPENAI_API_KEY is an OpenRouter key, so
+# a native Anthropic / ChatGPT registry id (api.anthropic.com / api.openai.com)
+# 401s. Route slides through OpenRouter instead.
+DEFAULT_SLIDES_MODEL = "anthropic/claude-sonnet-5"
+
+# Mini / free models skip tools and invent filler. Do not use them for slides
+# creation even if the UI still has them selected from an earlier turn.
+_WEAK_SLIDES_MODEL_IDS = frozenset(
+    {
+        "gpt-4.1-mini",
+        "openai/gpt-4.1-mini",
+        "gpt-5-mini",
+        "openai/gpt-5-mini",
+        "gpt-5-nano",
+        "openai/gpt-5-nano",
+        "google/gemma-4-26b-a4b-it:free",
+        "google/gemma-4-31b-it:free",
+        "gemma-4-26b-a4b-it",
+        "gemma-4-31b-it",
+    }
+)
+
+_COPY_EDIT_RE = re.compile(
+    r"\b("
+    r"rename|retitle|fix typo|change the title|tweak|"
+    r"make it (darker|lighter|dark|light)|"
+    r"change (the )?(color|font|theme)"
+    r")\b",
+    re.IGNORECASE,
+)
+_RESEARCH_RE = re.compile(
+    r"\b("
+    r"what'?s going on|going on in|current events?|today|now|"
+    r"news|latest|briefing|situation|update|developments?|"
+    r"who is|what happened"
+    r")\b",
+    re.IGNORECASE,
+)
+_CREATE_RE = re.compile(
+    r"\b("
+    r"create|make|build|write|draft|generate|"
+    r"presentation|deck|slides|brief"
+    r")\b",
+    re.IGNORECASE,
+)
+
+_UNRESEARCHED_WRITE_ERROR = (
+    "Research required before editing this deck. Call web_search first with "
+    "2 to 4 queries (latest developments, context, key actors, dates). "
+    "Then retry this write."
+)
+
+MAX_SLIDES_SEARCHES = 4
+_SEARCH_BUDGET_MESSAGE = (
+    "Search budget reached (4 queries). Do not call web_search or web_fetch "
+    "again. Outline 6-8 slides against the open template and write the open "
+    "deck.html now with researched claims, dates, actors, and sources."
+)
+
+
+def is_weak_slides_model(model_id: str | None) -> bool:
+    raw = (model_id or "").strip().lower()
+    if not raw:
+        return True
+    if raw in _WEAK_SLIDES_MODEL_IDS:
+        return True
+    if raw.endswith(":free"):
+        return True
+    return raw.endswith("/gpt-4.1-mini")
+
+
+def configured_slides_model() -> str:
+    try:
+        from naas_abi import ABIModule
+
+        configured = getattr(
+            ABIModule.get_instance().configuration,
+            "abi_slides_agent_model",
+            None,
+        )
+        if configured and str(configured).strip():
+            return str(configured).strip()
+    except Exception:  # noqa: BLE001
+        pass
+    return DEFAULT_SLIDES_MODEL
+
+
+def resolve_slides_llm_model(
+    incoming: str | None,
+    slides_default: str | None = None,
+) -> str:
+    """Pick a reasoning model for slides. Ignore mini/free selections."""
+    default = (slides_default or "").strip() or configured_slides_model()
+    raw = (incoming or "").strip()
+    if raw and not is_weak_slides_model(raw):
+        return raw
+    return default
+
+
+def open_slides_slug(client_context: dict | None) -> str:
+    if not isinstance(client_context, dict):
+        return ""
+    slides = client_context.get("slides")
+    if not isinstance(slides, dict):
+        return ""
+    return str(slides.get("slug") or "").strip()
+
+
+def apply_slides_model_override(
+    incoming: str | None,
+    client_context: dict | None,
+) -> str | None:
+    if not open_slides_slug(client_context):
+        return incoming
+    return resolve_slides_llm_model(incoming)
+
+
+def slides_brief_requires_research(message: str, has_prior_assistant: bool) -> bool:
+    """True when the model must call web_search before writing HTML."""
+    text = (message or "").strip()
+    if not text:
+        return False
+    copy_edit = bool(_COPY_EDIT_RE.search(text))
+    researchy = bool(_RESEARCH_RE.search(text))
+    createy = bool(_CREATE_RE.search(text))
+    if copy_edit and not researchy and not createy:
+        return False
+    if not has_prior_assistant:
+        return True
+    # Follow-up "write the deck now" must not reset the research gate.
+    return researchy
+
+
+def bind_slides_research_policy(
+    message: str,
+    has_prior_assistant: bool,
+    client_context: dict | None,
+) -> bool:
+    """Set request-scoped research gates. Returns whether search is required."""
+    slug = open_slides_slug(client_context) or (slides_active_slug.get() or "").strip()
+    if not slug:
+        slides_research_required.set(False)
+        return False
+    slides_active_slug.set(slug)
+    required = slides_brief_requires_research(message, has_prior_assistant)
+    slides_research_required.set(required)
+    if required:
+        slides_research_queries.set([])
+    return required
+
+
+def note_slides_web_search(query: str) -> None:
+    """Record that web_search ran this turn (unlocks slides writes)."""
+    if not slides_research_required.get():
+        return
+    text = (query or "").strip()
+    if not text:
+        return
+    bucket = slides_research_queries.get()
+    if bucket is None:
+        slides_research_queries.set([text])
+        return
+    bucket.append(text)
+
+
+def reject_unresearched_slides_write() -> dict[str, Any] | None:
+    """Block deck writes until web_search has run for a research brief."""
+    if not slides_research_required.get():
+        return None
+    queries = slides_research_queries.get()
+    if queries:
+        return None
+    return {"error": _UNRESEARCHED_WRITE_ERROR}
+
+
+def slides_search_budget_remaining() -> int:
+    queries = slides_research_queries.get() or []
+    return max(0, MAX_SLIDES_SEARCHES - len(queries))
+
+
+def attach_slides_research_note(tool: Any) -> Any:
+    """Wrap a web_search tool so successful calls unlock slides writes."""
+    original = getattr(tool, "func", None)
+    if original is None:
+        return tool
+
+    def wrapped(*args: Any, **kwargs: Any) -> Any:
+        if slides_research_required.get() and slides_search_budget_remaining() <= 0:
+            return _SEARCH_BUDGET_MESSAGE
+        query = kwargs.get("query")
+        if query is None and args:
+            query = args[0]
+        if isinstance(query, str) and query.strip():
+            note_slides_web_search(query)
+        return original(*args, **kwargs)
+
+    tool.func = wrapped
+    return tool
+
+
+def _openrouter_api_key(abi: Any) -> str | None:
+    """Prefer the OpenRouter module key; this env often stores it as OPENAI_API_KEY."""
+    import os
+
+    for name, module in (getattr(getattr(abi, "engine", None), "modules", {}) or {}).items():
+        if "openrouter" not in str(name).lower():
+            continue
+        key = getattr(getattr(module, "configuration", None), "openrouter_api_key", None)
+        if key:
+            return str(key)
+    for env_name in ("OPENROUTER_API_KEY", "OPENAI_API_KEY"):
+        raw = (os.environ.get(env_name) or "").strip()
+        if raw.startswith("sk-or-"):
+            return raw
+    routed = (os.environ.get("OPENROUTER_API_KEY") or "").strip()
+    return routed or None
+
+
+def openrouter_slides_model_id(model_id: str) -> str:
+    """Map a slides model id onto an OpenRouter provider/model slug.
+
+    Bare GPT ids stay ``openai/...``. Bare Claude / Sonnet / Opus / Haiku ids
+    become ``anthropic/...``. Never rewrite ``claude-sonnet-5`` to
+    ``openai/claude-sonnet-5``.
+    """
+    raw = (model_id or "").strip()
+    if not raw:
+        return DEFAULT_SLIDES_MODEL
+    if "/" in raw:
+        return raw
+    hay = raw.lower()
+    if hay.startswith(("claude", "anthropic")) or any(
+        token in hay for token in ("sonnet", "opus", "haiku")
+    ):
+        return f"anthropic/{raw}"
+    return f"openai/{raw}"
+
+
+def slides_reasoning_extra_body(model_id: str) -> dict[str, Any] | None:
+    """OpenRouter unified ``reasoning.effort`` for GPT-5 and Claude Sonnet 5.
+
+    Both families accept this payload on OpenRouter. Skip it for unknown ids
+    so we do not send an invalid body.
+    """
+    hay = (model_id or "").lower()
+    if not any(token in hay for token in ("gpt-5", "o3", "o4", "sonnet", "opus", "gemini")):
+        return None
+    return {"reasoning": {"effort": "high"}}
+
+
+def load_slides_chat_model(model_id: str | None = None) -> Any:
+    """Build the slides chat model via OpenRouter, not api.openai.com."""
+    from langchain_openai import ChatOpenAI
+    from naas_abi import ABIModule
+    from naas_abi_core.models.Model import ChatModel
+    from pydantic import SecretStr
+
+    resolved = resolve_slides_llm_model(model_id)
+    or_id = openrouter_slides_model_id(resolved)
+    abi = ABIModule.get_instance()
+    api_key = _openrouter_api_key(abi)
+    if not api_key:
+        return abi.engine.services.model_registry.get_chat_model(
+            resolved,
+            provider=abi.configuration.abi_agent_provider,
+        )
+    extra = slides_reasoning_extra_body(or_id)
+    chat = ChatModel(
+        model_id=or_id,
+        provider="openrouter",
+        model=ChatOpenAI(
+            model=or_id,
+            api_key=SecretStr(str(api_key)),
+            base_url="https://openrouter.ai/api/v1",
+            timeout=180,
+            **({"extra_body": extra} if extra else {}),
+        ),
+    )
+    return bind_slides_reasoning(chat, or_id)
+
+
+def bind_slides_reasoning(chat_model: Any, model_id: str) -> Any:
+    """Turn on high reasoning effort without replacing the LangChain chat class.
+
+    ``model.bind(...)`` returns a RunnableBinding, which Agent rejects. Set the
+    attribute on the live ChatOpenAI (or equivalent) instead.
+    """
+    if not (slides_active_slug.get() or "").strip():
+        return chat_model
+    hay = (model_id or "").lower()
+    if not any(token in hay for token in ("gpt-5", "o3", "o4", "sonnet", "opus", "gemini")):
+        return chat_model
+    lc = getattr(chat_model, "model", chat_model)
+    if not hasattr(lc, "reasoning_effort"):
+        return chat_model
+    try:
+        lc.reasoning_effort = "high"
+    except Exception:  # noqa: BLE001
+        return chat_model
+    return chat_model

--- a/libs/naas-abi/naas_abi/agents/slides_policy_test.py
+++ b/libs/naas-abi/naas_abi/agents/slides_policy_test.py
@@ -1,0 +1,171 @@
+from naas_abi.agents.slides_policy import (
+    DEFAULT_SLIDES_MODEL,
+    MAX_SLIDES_SEARCHES,
+    apply_slides_model_override,
+    attach_slides_research_note,
+    bind_slides_research_policy,
+    is_weak_slides_model,
+    note_slides_web_search,
+    openrouter_slides_model_id,
+    reject_unresearched_slides_write,
+    resolve_slides_llm_model,
+    slides_brief_requires_research,
+    slides_reasoning_extra_body,
+    slides_search_budget_remaining,
+)
+from naas_abi_core.services.agent.context import (
+    slides_active_slug,
+    slides_research_queries,
+    slides_research_required,
+)
+
+
+def test_weak_models_include_mini_and_free_gemma() -> None:
+    assert is_weak_slides_model("gpt-4.1-mini")
+    assert is_weak_slides_model("openai/gpt-4.1-mini")
+    assert is_weak_slides_model("google/gemma-4-26b-a4b-it:free")
+    assert is_weak_slides_model("")
+    assert not is_weak_slides_model("gpt-5")
+    assert not is_weak_slides_model("openai/gpt-5")
+    assert not is_weak_slides_model("gpt-5.2")
+    assert not is_weak_slides_model("claude-sonnet-5")
+    assert not is_weak_slides_model("anthropic/claude-sonnet-5")
+
+
+def test_default_slides_model_is_claude_sonnet_5() -> None:
+    assert DEFAULT_SLIDES_MODEL == "anthropic/claude-sonnet-5"
+
+
+def test_openrouter_slides_model_id_keeps_anthropic_prefix() -> None:
+    assert openrouter_slides_model_id("anthropic/claude-sonnet-5") == (
+        "anthropic/claude-sonnet-5"
+    )
+    assert openrouter_slides_model_id("claude-sonnet-5") == "anthropic/claude-sonnet-5"
+    assert openrouter_slides_model_id("gpt-5") == "openai/gpt-5"
+    assert openrouter_slides_model_id("openai/gpt-5") == "openai/gpt-5"
+
+
+def test_slides_reasoning_extra_body_for_sonnet_and_gpt5() -> None:
+    assert slides_reasoning_extra_body("anthropic/claude-sonnet-5") == {
+        "reasoning": {"effort": "high"}
+    }
+    assert slides_reasoning_extra_body("openai/gpt-5") == {
+        "reasoning": {"effort": "high"}
+    }
+    assert slides_reasoning_extra_body("gpt-4.1-mini") is None
+
+
+def test_resolve_slides_llm_model_upgrades_mini() -> None:
+    assert resolve_slides_llm_model("gpt-4.1-mini", slides_default="gpt-5") == "gpt-5"
+    assert (
+        resolve_slides_llm_model("google/gemma-4-26b-a4b-it:free", slides_default="gpt-5")
+        == "gpt-5"
+    )
+    assert resolve_slides_llm_model("gpt-5.2", slides_default="gpt-5") == "gpt-5.2"
+    assert resolve_slides_llm_model(None, slides_default="gpt-5") == "gpt-5"
+    assert resolve_slides_llm_model(None, slides_default=None) == DEFAULT_SLIDES_MODEL
+
+
+def test_apply_slides_model_override_only_when_deck_open() -> None:
+    assert apply_slides_model_override("gpt-4.1-mini", None) == "gpt-4.1-mini"
+    assert apply_slides_model_override("gpt-4.1-mini", {"slides": {}}) == "gpt-4.1-mini"
+    assert (
+        apply_slides_model_override(
+            "gpt-4.1-mini",
+            {"slides": {"slug": "iran-now"}},
+        )
+        == DEFAULT_SLIDES_MODEL
+    )
+    assert (
+        apply_slides_model_override(
+            "gpt-5.2",
+            {"slides": {"slug": "iran-now"}},
+        )
+        == "gpt-5.2"
+    )
+
+
+def test_first_create_brief_requires_research() -> None:
+    assert slides_brief_requires_research(
+        "create a presentation about what's going on in iran now",
+        has_prior_assistant=False,
+    )
+    assert slides_brief_requires_research(
+        "Iran situation briefing",
+        has_prior_assistant=False,
+    )
+
+
+def test_copy_edit_does_not_require_research() -> None:
+    assert not slides_brief_requires_research(
+        "change the title to Q3 Review",
+        has_prior_assistant=True,
+    )
+    assert not slides_brief_requires_research(
+        "fix typo on slide 2",
+        has_prior_assistant=False,
+    )
+
+
+def test_followup_news_brief_still_requires_research() -> None:
+    assert slides_brief_requires_research(
+        "add the latest news from today",
+        has_prior_assistant=True,
+    )
+
+
+def test_followup_write_now_does_not_require_another_search() -> None:
+    assert not slides_brief_requires_research(
+        "Insert the drafted copy into the open file. Do not search.",
+        has_prior_assistant=True,
+    )
+
+
+def test_write_gate_blocks_until_web_search() -> None:
+    slides_research_required.set(True)
+    slides_research_queries.set([])
+    blocked = reject_unresearched_slides_write()
+    assert blocked is not None
+    assert "web_search" in blocked["error"]
+
+    note_slides_web_search("Iran latest developments 2026")
+    assert reject_unresearched_slides_write() is None
+    slides_research_required.set(False)
+    slides_research_queries.set(None)
+
+
+def test_bind_policy_sets_gate_for_open_deck() -> None:
+    required = bind_slides_research_policy(
+        "create a presentation about what's going on in iran now",
+        has_prior_assistant=False,
+        client_context={"slides": {"slug": "iran-now"}},
+    )
+    assert required is True
+    assert slides_research_required.get() is True
+    assert slides_research_queries.get() == []
+    assert slides_active_slug.get() == "iran-now"
+    slides_research_required.set(False)
+    slides_research_queries.set(None)
+    slides_active_slug.set(None)
+
+
+def test_search_budget_stops_after_four_queries() -> None:
+    slides_research_required.set(True)
+    slides_research_queries.set([])
+
+    class _Tool:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def func(self, query: str, max_results: int = 8) -> str:
+            self.calls += 1
+            return f"ok:{query}"
+
+    wrapped = attach_slides_research_note(_Tool())
+    for i in range(MAX_SLIDES_SEARCHES):
+        assert wrapped.func(f"q{i}").startswith("ok:")
+    blocked = wrapped.func("one more")
+    assert "Search budget reached" in blocked
+    assert slides_search_budget_remaining() == 0
+    slides_research_required.set(False)
+    slides_research_queries.set(None)

--- a/libs/naas-abi/naas_abi/agents/tools/slides_tools.py
+++ b/libs/naas-abi/naas_abi/agents/tools/slides_tools.py
@@ -8,10 +8,12 @@ user has a deck open in Nexus, ``slides_active_slug`` is set so tools default
 to that deck and Abi must not ask which presentation to edit.
 
 Template decks keep slide markup in ``<main>`` (~tens of KB) but also ship
-inline PPTX/asset ``<script>`` blobs (~1MB with base64 images). Tools therefore:
+inline asset ``<script>`` blobs (~1MB with base64 images). PPTX export walks
+the live ``.slide`` DOM; tools therefore:
 
 - expose section-scoped read/write and surgical string replace
 - redact heavy scripts / data-URLs on full-deck reads
+- never require the model to edit ``buildPptx`` or ``FOOTER_TXT``
 """
 
 from __future__ import annotations
@@ -22,6 +24,7 @@ import re
 from typing import Any
 
 from langchain_core.tools import BaseTool, tool
+from naas_abi.agents.slides_policy import reject_unresearched_slides_write
 from naas_abi_core.services.agent.context import (
     agent_user_id,
     agent_workspace_id,
@@ -31,7 +34,10 @@ from naas_abi_core.services.agent.context import (
     slides_active_title,
 )
 from naas_abi_core.services.agent.tools.workspace_tools import _call as _sidecar_call
-from naas_abi_core.services.source_control.SourceControlPorts import SourceControlError
+from naas_abi_core.services.source_control.SourceControlPorts import (
+    BranchNameConflictError,
+    SourceControlError,
+)
 
 _SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 _BRANCH_PREFIX = "slides/"
@@ -49,6 +55,8 @@ _H1_RE = re.compile(r"<h1\b[^>]*>(.*?)</h1>", re.IGNORECASE | re.DOTALL)
 _TAG_RE = re.compile(r"<[^>]+>")
 _REDACTED_PLACEHOLDER = "[REDACTED_DATA_URL]"
 _SCRIPT_PLACEHOLDER = "<!-- REDACTED_SCRIPT -->"
+_REPO_ID_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$")
+_WIPED_DECK_ERROR = "API restart wiped this deck. Click New, then retry."
 
 
 def _get_source_control():
@@ -64,6 +72,134 @@ def _repo_id() -> str:
         return settings.coding_repo_id or "abi/monorepo"
     except Exception:  # noqa: BLE001
         return "abi/monorepo"
+
+
+def _ensure_coding_repo() -> str:
+    """Seed CODING_REPO_ID. Local in_memory starts empty; UI create already does this."""
+    repo_id = _repo_id()
+    owner, sep, name = repo_id.partition("/")
+    if not sep or not owner or not name or "/" in name:
+        return repo_id
+    try:
+        _get_source_control().ensure_repo(owner=owner, name=name)
+    except SourceControlError:
+        pass
+    return repo_id
+
+
+def _is_repo_id_message(text: str) -> bool:
+    raw = (text or "").strip()
+    if not raw:
+        return False
+    repo_id = _repo_id()
+    if raw == repo_id or _REPO_ID_RE.fullmatch(raw):
+        return True
+    if raw.startswith(f"{repo_id}:") or raw.startswith(f"{repo_id}@"):
+        return True
+    return raw.endswith(f": {repo_id}")
+
+
+def _friendly_sc_error(exc: BaseException) -> str:
+    """Never return a raw owner/name (InMemory RepoNotFoundError)."""
+    text = str(exc).strip() or type(exc).__name__
+    lowered = text.lower()
+    if any(
+        marker in lowered
+        for marker in (
+            "connection refused",
+            "failed to establish",
+            "timed out",
+            "timeout",
+            "connection reset",
+            "network is unreachable",
+        )
+    ):
+        return "Forgejo is not reachable. Slides needs git storage."
+    if _is_repo_id_message(text) or "deck.html" in lowered:
+        return _WIPED_DECK_ERROR
+    return text
+
+
+def _tool_error(exc: BaseException) -> dict[str, Any]:
+    return {"error": _friendly_sc_error(exc)}
+
+
+def _load_seed_deck_html() -> str | None:
+    """Same Minimal Light seed the UI New path writes."""
+    try:
+        from importlib import resources
+
+        root = resources.files("naas_abi.apps.nexus.assets.slides.templates")
+        text = (root / "minimal-light-v1.html").read_text(encoding="utf-8")
+        return text if text.strip() else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _looks_like_missing_deck(exc: BaseException, paths: dict[str, str]) -> bool:
+    text = str(exc)
+    deck = paths.get("deck_path") or ""
+    if deck and deck in text:
+        return True
+    return _is_repo_id_message(text)
+
+
+def _ensure_project_json(
+    sc: Any, repo_id: str, paths: dict[str, str], slug: str
+) -> None:
+    """Preview GET resolves the project via project.json; writes must seed it."""
+    try:
+        existing = sc.get_file(
+            repo_id=repo_id, path=paths["project_path"], ref=paths["branch"]
+        )
+        if existing.text:
+            return
+    except SourceControlError:
+        pass
+    ws = _workspace_id()
+    title = (slides_active_title.get() or "").strip() or slug.replace("-", " ").title()
+    meta = {
+        "slug": slug,
+        "workspace_id": ws or "",
+        "title": title,
+        "template_id": "minimal-light-v1",
+    }
+    try:
+        sc.upsert_file(
+            repo_id=repo_id,
+            path=paths["project_path"],
+            content=json.dumps(meta, indent=2) + "\n",
+            message=f"Seed slides project {slug}",
+            branch=paths["branch"],
+        )
+    except SourceControlError:
+        pass
+
+
+def _ensure_slides_write_paths(slug: str) -> dict[str, str]:
+    """Repo + slides branch + project.json, matching the UI create path."""
+    paths = _resolve_paths(slug)
+    if paths.get("error"):
+        return paths
+    sc = _get_source_control()
+    repo_id = _ensure_coding_repo()
+    try:
+        names = {b.name for b in sc.list_branches(repo_id=repo_id)}
+    except SourceControlError as exc:
+        return {"error": _friendly_sc_error(exc)}
+    branch = paths["branch"]
+    if branch not in names:
+        default = "main" if "main" in names else (next(iter(names)) if names else "main")
+        if default not in names:
+            return {"error": _WIPED_DECK_ERROR}
+        try:
+            sc.create_branch(repo_id=repo_id, name=branch, from_ref=default)
+        except BranchNameConflictError:
+            pass
+        except SourceControlError as exc:
+            return {"error": _friendly_sc_error(exc)}
+    _ensure_project_json(sc, repo_id, paths, slug)
+    return paths
 
 
 def _workspace_id() -> str | None:
@@ -112,8 +248,11 @@ def _resolve_paths(slug: str) -> dict[str, str]:
     """Prefer namespaced paths; fall back to legacy when that branch exists."""
     ws = _workspace_id()
     sc = _get_source_control()
-    repo_id = _repo_id()
-    names = {b.name for b in sc.list_branches(repo_id=repo_id)}
+    repo_id = _ensure_coding_repo()
+    try:
+        names = {b.name for b in sc.list_branches(repo_id=repo_id)}
+    except SourceControlError as exc:
+        return {"error": _friendly_sc_error(exc)}
     if ws:
         ns_branch = _branch(slug, ws)
         if ns_branch in names:
@@ -233,29 +372,41 @@ def _load_deck_via_forgejo(slug: str) -> str | dict[str, Any]:
     if paths.get("error"):
         return {"error": paths["error"], "source": "forgejo"}
     sc = _get_source_control()
-    file = sc.get_file(
-        repo_id=_repo_id(), path=paths["deck_path"], ref=paths["branch"]
-    )
+    try:
+        file = sc.get_file(
+            repo_id=_repo_id(), path=paths["deck_path"], ref=paths["branch"]
+        )
+    except SourceControlError as exc:
+        if _looks_like_missing_deck(exc, paths):
+            seed = _load_seed_deck_html()
+            if seed:
+                return seed
+            return {"error": _WIPED_DECK_ERROR, "source": "forgejo"}
+        return {"error": _friendly_sc_error(exc), "source": "forgejo"}
     if file.is_binary or file.text is None:
         return {"error": "Deck is not UTF-8 text", "source": "forgejo"}
     return file.text
 
 
 def _commit_deck_forgejo(slug: str, html: str, message: str) -> dict[str, Any]:
-    paths = _resolve_paths(slug)
+    paths = _ensure_slides_write_paths(slug)
     if paths.get("error"):
         return {"error": paths["error"], "source": "forgejo"}
     sc = _get_source_control()
-    commit = sc.upsert_file(
-        repo_id=_repo_id(),
-        path=paths["deck_path"],
-        content=html,
-        message=message,
-        branch=paths["branch"],
-    )
+    try:
+        commit = sc.upsert_file(
+            repo_id=_repo_id(),
+            path=paths["deck_path"],
+            content=html,
+            message=message,
+            branch=paths["branch"],
+        )
+    except SourceControlError as exc:
+        return {"error": _friendly_sc_error(exc), "source": "forgejo"}
     return {
         "slug": slug,
         "path": paths["deck_path"],
+        "branch": paths["branch"],
         "commit_sha": commit.sha,
         "message": commit.message,
         "source": "forgejo",
@@ -296,13 +447,25 @@ def _persist_deck(slug: str, html: str, message: str) -> dict[str, Any]:
             sources.append("sidecar-failed")
     try:
         forgejo = _commit_deck_forgejo(slug, html, message)
+        if forgejo.get("error"):
+            if sidecar_result and sidecar_result.get("ok"):
+                return {
+                    **sidecar_result,
+                    "sources": sources,
+                    "forgejo_error": forgejo.get("error"),
+                    "note": (
+                        "Updated Coder workspace (live edit); Forgejo snapshot failed. "
+                        "Preview should follow sidecar. Use File → Save later for history."
+                    ),
+                }
+            return {**forgejo, "sources": sources}
         sources.append("forgejo")
         result = {**forgejo, "sources": sources}
         if sidecar_result and not sidecar_result.get("ok"):
             result["sidecar_error"] = sidecar_result.get("error")
             result["note"] = (
-                "Wrote Forgejo snapshot only; Coder sidecar write failed. "
-                "Runtime may still be starting. Preview may lag until sidecar is ready."
+                "Wrote git snapshot only; Coder sidecar write failed. "
+                "Preview should refresh from the git copy."
             )
         elif "sidecar" in sources:
             result["note"] = (
@@ -314,13 +477,13 @@ def _persist_deck(slug: str, html: str, message: str) -> dict[str, Any]:
             return {
                 **sidecar_result,
                 "sources": sources,
-                "forgejo_error": str(exc),
+                "forgejo_error": _friendly_sc_error(exc),
                 "note": (
                     "Updated Coder workspace (live edit); Forgejo snapshot failed. "
                     "Preview should follow sidecar. Use File → Save later for history."
                 ),
             }
-        return {"error": str(exc), "sources": sources}
+        return {"error": _friendly_sc_error(exc), "sources": sources}
 
 
 def _replace_string_pairs(old: str, new: str) -> list[tuple[str, str]]:
@@ -676,9 +839,10 @@ def _view_for_llm(html: str) -> dict[str, Any]:
         "redacted_scripts": n_scripts,
         "redacted_assets": n_assets,
         "note": (
-            "Heavy <script> blocks (PPTX/assets) and data-URLs are redacted. "
+            "Heavy <script> blocks (assets / export) and data-URLs are redacted. "
             "Prefer list_slides_sections + replace_in_slides_deck / "
-            "write_slides_section for edits. Do not rewrite the whole file. "
+            "write_slides_section for HTML edits. Do not rewrite the whole file "
+            "or edit buildPptx. Preview is HTML; PPTX is derived at export. "
             "You are editing the open presentation; do not ask which deck."
         ),
     }
@@ -697,7 +861,7 @@ def slides_tools() -> list[BaseTool]:
         open_slug = slides_active_slug.get()
         try:
             sc = _get_source_control()
-            repo_id = _repo_id()
+            repo_id = _ensure_coding_repo()
             ws = _workspace_id()
             ws_seg = _workspace_segment(ws) if ws else None
             ns_prefix = f"{_BRANCH_PREFIX}{ws_seg}/" if ws_seg else None
@@ -760,7 +924,7 @@ def slides_tools() -> list[BaseTool]:
                 )
             return out
         except Exception as exc:  # noqa: BLE001
-            return {"error": str(exc)}
+            return _tool_error(exc)
 
     @tool
     def list_slides_sections(slug: str = "") -> dict[str, Any]:
@@ -788,7 +952,7 @@ def slides_tools() -> list[BaseTool]:
                 "sections": [_section_meta(i, sec) for i, sec in enumerate(sections)],
             }
         except Exception as exc:  # noqa: BLE001
-            return {"error": str(exc)}
+            return _tool_error(exc)
 
     @tool
     def read_slides_section(
@@ -830,7 +994,7 @@ def slides_tools() -> list[BaseTool]:
                 ),
             }
         except Exception as exc:  # noqa: BLE001
-            return {"error": str(exc)}
+            return _tool_error(exc)
 
     @tool
     def write_slides_section(
@@ -845,7 +1009,13 @@ def slides_tools() -> list[BaseTool]:
         Omit slug when a deck is open. Pass the full ``<section>...</section>``
         for that slide. If html still contains ``[REDACTED_DATA_URL]`` placeholders
         from a prior read, original embedded assets are restored automatically.
+
+        For news, current events, or factual briefs: call web_search first.
+        This tool rejects the write until search has run this turn.
         """
+        blocked = reject_unresearched_slides_write()
+        if blocked:
+            return blocked
         if not agent_user_id.get():
             return {"error": "No authenticated user on this agent session."}
         resolved = _resolve_slug(slug)
@@ -875,7 +1045,7 @@ def slides_tools() -> list[BaseTool]:
             result.update(_open_deck_note(resolved))
             return result
         except Exception as exc:  # noqa: BLE001
-            return {"error": str(exc)}
+            return _tool_error(exc)
 
     @tool
     def replace_in_slides_deck(
@@ -892,15 +1062,22 @@ def slides_tools() -> list[BaseTool]:
         Omit slug when a deck is open in the Slides UI. occurrence: 0 replaces all
         matches; 1 replaces the first, 2 the second, etc. Matches HTML entities
         flexibly (``&``/``&amp;``, ``—``/``&mdash;``/``&#8212;``, ``–``/``&ndash;``)
-        so cover ``<h1>`` / subtitle text updates with PPTX script strings.
+        so cover ``<h1>`` / subtitle HTML updates. PPTX export reads that live
+        DOM; do not edit ``buildPptx`` or ``FOOTER_TXT``.
 
         For cover / title / \"slide 1\" edits: pass section_index=0 (or
         section_id of the cover) and occurrence=0. Do not use occurrence=1 for
         \"the title\": document order hits ``<title>`` / menubar before the cover
         ``<h1>`` that Preview shows. Confirm ``cover_h1_updated`` /
         ``cover_subtitle_updated`` in the tool result before claiming Preview
-        changed.
+        and PPTX changed.
+
+        For news, current events, or factual briefs: call web_search first.
+        This tool rejects the write until search has run this turn.
         """
+        blocked = reject_unresearched_slides_write()
+        if blocked:
+            return blocked
         if not agent_user_id.get():
             return {"error": "No authenticated user on this agent session."}
         resolved = _resolve_slug(slug)
@@ -977,7 +1154,7 @@ def slides_tools() -> list[BaseTool]:
             result.update(_open_deck_note(resolved))
             return result
         except Exception as exc:  # noqa: BLE001
-            return {"error": str(exc)}
+            return _tool_error(exc)
 
     @tool
     def read_slides_deck(slug: str = "", include_assets: bool = False) -> dict[str, Any]:
@@ -1018,7 +1195,7 @@ def slides_tools() -> list[BaseTool]:
                 **view,
             }
         except Exception as exc:  # noqa: BLE001
-            return {"error": str(exc)}
+            return _tool_error(exc)
 
     @tool
     def write_slides_deck(
@@ -1030,7 +1207,13 @@ def slides_tools() -> list[BaseTool]:
 
         Omit slug when a deck is open. Prefer replace_in_slides_deck or
         write_slides_section.
+
+        For news, current events, or factual briefs: call web_search first.
+        This tool rejects the write until search has run this turn.
         """
+        blocked = reject_unresearched_slides_write()
+        if blocked:
+            return blocked
         if not agent_user_id.get():
             return {"error": "No authenticated user on this agent session."}
         resolved = _resolve_slug(slug)
@@ -1063,7 +1246,7 @@ def slides_tools() -> list[BaseTool]:
             result.update(_open_deck_note(resolved))
             return result
         except Exception as exc:  # noqa: BLE001
-            return {"error": str(exc)}
+            return _tool_error(exc)
 
     @tool
     def slides_history(slug: str = "", limit: int = 10) -> dict[str, Any]:
@@ -1095,7 +1278,7 @@ def slides_tools() -> list[BaseTool]:
                 ],
             }
         except Exception as exc:  # noqa: BLE001
-            return {"error": str(exc)}
+            return _tool_error(exc)
 
     return [
         list_slides_projects,

--- a/libs/naas-abi/naas_abi/agents/tools/slides_tools_test.py
+++ b/libs/naas-abi/naas_abi/agents/tools/slides_tools_test.py
@@ -7,10 +7,15 @@ from pathlib import Path
 from naas_abi.agents.tools.slides_tools import (
     _DATA_URL_RE,
     _REDACTED_PLACEHOLDER,
+    _WIPED_DECK_ERROR,
     _apply_replacements,
     _apply_replacements_in_section,
     _cover_h1_text,
     _cover_subtitle_text,
+    _deck_path,
+    _ensure_coding_repo,
+    _friendly_sc_error,
+    _persist_deck,
     _redact_data_urls,
     _replace_string_pairs,
     _resolve_slug,
@@ -18,8 +23,22 @@ from naas_abi.agents.tools.slides_tools import (
     _section_meta,
     _split_sections,
     _view_for_llm,
+    slides_tools,
 )
-from naas_abi_core.services.agent.context import slides_active_slug
+from naas_abi_core.services.agent.context import (
+    agent_user_id,
+    agent_workspace_id,
+    slides_active_slug,
+    slides_research_queries,
+    slides_research_required,
+)
+from naas_abi_core.services.source_control.adapters.secondary.InMemoryAdapter import (
+    InMemoryAdapter,
+)
+from naas_abi_core.services.source_control.SourceControlPorts import RepoNotFoundError
+from naas_abi_core.services.source_control.SourceControlService import (
+    SourceControlService,
+)
 
 _SAMPLE = """<!DOCTYPE html>
 <html><head></head><body>
@@ -278,3 +297,173 @@ def test_apply_replacements_real_template_cover_title():
     assert replaced == found
     assert "<h1>Presentation Title test</h1>" in updated
     assert _cover_h1_text(updated) == "Presentation Title test"
+
+
+def _bind_in_memory_git(monkeypatch):
+    sc = SourceControlService(InMemoryAdapter())
+    monkeypatch.setattr(
+        "naas_abi.agents.tools.slides_tools._get_source_control", lambda: sc
+    )
+    monkeypatch.setattr(
+        "naas_abi.agents.tools.slides_tools._repo_id", lambda: "abi/monorepo"
+    )
+    return sc
+
+
+def _slides_context(*, workspace: str = "ws-test", slug: str = "untitled-local"):
+    tokens = [
+        agent_workspace_id.set(workspace),
+        slides_active_slug.set(slug),
+        agent_user_id.set("user-1"),
+        slides_research_required.set(False),
+        slides_research_queries.set(None),
+    ]
+    return tokens
+
+
+def _reset_tokens(tokens) -> None:
+    agent_workspace_id.reset(tokens[0])
+    slides_active_slug.reset(tokens[1])
+    agent_user_id.reset(tokens[2])
+    slides_research_required.reset(tokens[3])
+    slides_research_queries.reset(tokens[4])
+
+
+def test_friendly_sc_error_never_returns_raw_repo_id():
+    assert _friendly_sc_error(RepoNotFoundError("abi/monorepo")) == _WIPED_DECK_ERROR
+    assert (
+        _friendly_sc_error(
+            RepoNotFoundError("abi/monorepo:slides/ws-test/untitled-local/deck.html")
+        )
+        == _WIPED_DECK_ERROR
+    )
+    assert (
+        _friendly_sc_error(RepoNotFoundError("abi/monorepo@slides/ws-test/untitled-local"))
+        == _WIPED_DECK_ERROR
+    )
+    assert _friendly_sc_error(RepoNotFoundError("abi/monorepo")) != "abi/monorepo"
+
+
+def test_ensure_coding_repo_seeds_empty_in_memory_on_write(monkeypatch):
+    sc = _bind_in_memory_git(monkeypatch)
+    try:
+        sc.list_branches(repo_id="abi/monorepo")
+        raise AssertionError("empty in_memory should not have the coding repo")
+    except RepoNotFoundError as exc:
+        assert str(exc) == "abi/monorepo"
+    tokens = _slides_context()
+    try:
+        assert _ensure_coding_repo() == "abi/monorepo"
+        assert [b.name for b in sc.list_branches(repo_id="abi/monorepo")]
+        result = _persist_deck(
+            "untitled-local",
+            "<html><body><main><section class='slide'>"
+            "<h1>Iran now</h1></section></main></body></html>",
+            "Write via Abi",
+        )
+        assert result.get("error") != "abi/monorepo"
+        assert "error" not in result, result
+        assert result["path"] == "slides/ws-test/untitled-local/deck.html"
+        assert result["branch"] == "slides/ws-test/untitled-local"
+        deck = sc.get_file(
+            repo_id="abi/monorepo",
+            path="slides/ws-test/untitled-local/deck.html",
+            ref="slides/ws-test/untitled-local",
+        )
+        assert "Iran now" in (deck.text or "")
+        meta = sc.get_file(
+            repo_id="abi/monorepo",
+            path="slides/ws-test/untitled-local/project.json",
+            ref="slides/ws-test/untitled-local",
+        )
+        assert "ws-test" in (meta.text or "")
+    finally:
+        _reset_tokens(tokens)
+
+
+def test_replace_write_path_matches_ui_create(monkeypatch):
+    """UI create seeds namespaced deck.html; replace must edit that file."""
+    sc = _bind_in_memory_git(monkeypatch)
+    sc.ensure_repo(owner="abi", name="monorepo")
+    sc.create_branch(
+        repo_id="abi/monorepo",
+        name="slides/ws-test/untitled-local",
+        from_ref="main",
+    )
+    seed = (
+        "<!DOCTYPE html><html><body><main>"
+        '<section id="slide-cover" class="slide cover">'
+        "<h1>Presentation Title</h1>"
+        "</section></main></body></html>"
+    )
+    sc.upsert_file(
+        repo_id="abi/monorepo",
+        path="slides/ws-test/untitled-local/deck.html",
+        content=seed,
+        message="Seed deck",
+        branch="slides/ws-test/untitled-local",
+    )
+    sc.upsert_file(
+        repo_id="abi/monorepo",
+        path="slides/ws-test/untitled-local/project.json",
+        content='{"slug":"untitled-local","workspace_id":"ws-test"}\n',
+        message="Seed project",
+        branch="slides/ws-test/untitled-local",
+    )
+    tokens = _slides_context()
+    try:
+        assert _deck_path("untitled-local") == "slides/ws-test/untitled-local/deck.html"
+        replace = next(
+            t for t in slides_tools() if t.name == "replace_in_slides_deck"
+        )
+        result = replace.invoke(
+            {
+                "old": "Presentation Title",
+                "new": "Iran briefing",
+                "section_index": 0,
+                "occurrence": 0,
+            }
+        )
+        assert result.get("error") != "abi/monorepo"
+        assert "error" not in result, result
+        assert result["path"] == "slides/ws-test/untitled-local/deck.html"
+        assert result.get("cover_h1_updated") is True
+        deck = sc.get_file(
+            repo_id="abi/monorepo",
+            path="slides/ws-test/untitled-local/deck.html",
+            ref="slides/ws-test/untitled-local",
+        )
+        assert _cover_h1_text(deck.text or "") == "Iran briefing"
+    finally:
+        _reset_tokens(tokens)
+
+
+def test_missing_repo_error_is_wipe_message(monkeypatch):
+    class _MissingRepo:
+        def ensure_repo(self, **_kwargs):
+            raise RepoNotFoundError("abi/monorepo")
+
+        def list_branches(self, **_kwargs):
+            raise RepoNotFoundError("abi/monorepo")
+
+        def upsert_file(self, **_kwargs):
+            raise RepoNotFoundError("abi/monorepo")
+
+    monkeypatch.setattr(
+        "naas_abi.agents.tools.slides_tools._get_source_control",
+        lambda: _MissingRepo(),
+    )
+    monkeypatch.setattr(
+        "naas_abi.agents.tools.slides_tools._repo_id", lambda: "abi/monorepo"
+    )
+    tokens = _slides_context()
+    try:
+        result = _persist_deck(
+            "untitled-local",
+            "<html><body><main><section><h1>X</h1></section></main></body></html>",
+            "Write via Abi",
+        )
+        assert result.get("error") == _WIPED_DECK_ERROR
+        assert result.get("error") != "abi/monorepo"
+    finally:
+        _reset_tokens(tokens)

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__streaming.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__streaming.py
@@ -231,6 +231,7 @@ async def stream_chat_response(
         return StreamingResponse(unsupported_stream(), media_type="text/event-stream")
 
     now = datetime.now(UTC).replace(tzinfo=None)
+    client_ctx = request.context if isinstance(request.context, dict) else {}
 
     async with AsyncSessionLocal() as db:
         try:
@@ -274,6 +275,19 @@ async def stream_chat_response(
                             slides_active_title.set(title)
                         if mode:
                             slides_active_mode.set(mode)
+                        from naas_abi.agents.slides_policy import (  # noqa: PLC0415
+                            bind_slides_research_policy,
+                        )
+
+                        has_prior_assistant = any(
+                            getattr(m, "role", None) == "assistant"
+                            for m in (request.messages or [])
+                        )
+                        bind_slides_research_policy(
+                            request.message,
+                            has_prior_assistant,
+                            client_ctx,
+                        )
                         if request.workspace_id:
                             try:
                                 from naas_abi.apps.nexus.apps.api.app.services.slides.adapters.primary.slides__primary_adapter__FastAPI import (  # noqa: PLC0415
@@ -343,6 +357,9 @@ async def stream_chat_response(
     #             )
     #             break
 
+    from naas_abi.agents.slides_policy import apply_slides_model_override
+
+    incoming_llm = getattr(provider, "llm_model", None) or request.llm_model
     provider_config = ProviderConfig(
         id=provider.id,
         name=provider.name,
@@ -352,7 +369,7 @@ async def stream_chat_response(
         api_key=provider.api_key,
         account_id=provider.account_id,
         model=provider.model,
-        llm_model=getattr(provider, "llm_model", None) or request.llm_model,
+        llm_model=apply_slides_model_override(incoming_llm, client_ctx),
     )
 
     assistant_msg_id = ""

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/service.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/service.py
@@ -169,7 +169,7 @@ _SKILLS_CATALOG_HEADER = (
 
 
 def _render_slides_context_block(client_context: dict | None) -> str:
-    """Inject open Slides deck so Abi edits that file and never asks which deck."""
+    """Inject open Slides deck so Abi researches, then edits that file."""
     if not isinstance(client_context, dict):
         return ""
     slides = client_context.get("slides")
@@ -182,10 +182,13 @@ def _render_slides_context_block(client_context: dict | None) -> str:
     branch = str(slides.get("branch") or f"slides/{slug}").strip()
     title = str(slides.get("title") or "").strip()
     mode = str(slides.get("mode") or "").strip()
+    today = datetime.now().date().isoformat()
+    year = today[:4]
     lines = [
         f"- slug: {slug}",
         f"- path: {path}",
         f"- branch: {branch}",
+        f"- today: {today}",
     ]
     if title:
         lines.append(f"- title: {title}")
@@ -196,11 +199,28 @@ def _render_slides_context_block(client_context: dict | None) -> str:
         "The user is editing this presentation in the Slides overlay right now. "
         "You are operating on its Coder workspace files (sidecar) when available; "
         "Forgejo remains the Save/history snapshot. Preview loads from sidecar when "
-        "ready. Do not ask which deck, slug, or file. "
-        "Omit slug on Slides tool calls; tools default to this open deck. "
-        "For a small copy edit (e.g. replace the title), call replace_in_slides_deck "
-        "immediately with section_index=0 and occurrence=0 (matches &amp; on cover "
-        "h1; do not use occurrence=1 for the title).\n"
+        "ready. Do not ask which deck, slug, file, or template. "
+        "Omit slug on Slides tool calls; tools default to this open deck.\n"
+        "Research first, then write. For news, current events, "
+        '"what is going on", country or company briefings, or any factual deck:\n'
+        f"1. Call web_search before any replace_in_slides_deck, write_slides_section, "
+        f"or write_slides_deck. Use 2 to 4 queries (latest developments, context, "
+        f"key actors, dates). Include {year} in the queries. Stop after 4 searches.\n"
+        "2. Optionally one second-pass query to check named sources, still within "
+        "the 4-query budget.\n"
+        "3. Outline 6-8 slides against the open template.\n"
+        "4. Then rewrite the open HTML sections with researched claims, dates, "
+        "actors, and sources. Do not keep searching instead of writing. No lorem. "
+        "No Context / Approach / Plan filler when the user asked for a situation brief.\n"
+        "Keep the seed template CSS and structure. Cite sources in footer or "
+        "source lines if the layout allows. "
+        "A tiny copy edit (title typo, color tweak) may skip search. "
+        "Edit HTML sections only. Preview is the HTML stage. PPTX export "
+        "reconstructs the live .slide DOM at 1280x720; do not edit buildPptx or "
+        "FOOTER_TXT. For a small copy edit after research (or a title-only tweak), "
+        "call replace_in_slides_deck with section_index=0 and "
+        "occurrence=0 (matches &amp; on cover h1; do not use occurrence=1 "
+        "for the title).\n"
         + "\n".join(lines)
         + "\n"
     )
@@ -943,6 +963,23 @@ class ChatService:
                         client_context=request.context,
                     )
 
+                from naas_abi.agents.slides_policy import (
+                    apply_slides_model_override,
+                    bind_slides_research_policy,
+                )
+
+                has_prior_assistant = any(
+                    getattr(m, "role", None) == "assistant" for m in prior_messages
+                )
+                bind_slides_research_policy(
+                    request.message,
+                    has_prior_assistant,
+                    request.context,
+                )
+                llm_model = apply_slides_model_override(
+                    provider.llm_model, request.context
+                )
+
                 response_content = await complete_with_provider(
                     messages=provider_messages,
                     config=ProviderConfig(
@@ -954,6 +991,7 @@ class ChatService:
                         api_key=provider.api_key,
                         account_id=provider.account_id,
                         model=provider.model,
+                        llm_model=llm_model,
                     ),
                     system_prompt=system_prompt,
                     thread_id=conversation_id,

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/service_test.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/service_test.py
@@ -996,6 +996,12 @@ async def test_build_abi_injection_preamble_includes_open_slides_deck() -> None:
     assert "Open Slides presentation" in preamble
     assert "q3-br" in preamble
     assert "Do not ask which deck" in preamble
+    assert "Edit HTML sections only" in preamble
+    assert "buildPptx" in preamble
+    assert "Research first, then write" in preamble
+    assert "web_search" in preamble
+    assert "start editing immediately" not in preamble
+    assert "today:" in preamble
 
 
 @pytest.mark.asyncio

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/provider_runtime.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/provider_runtime.py
@@ -750,7 +750,10 @@ async def complete_with_abi(
             latest_user_message = f"{injection_preamble.strip()}\n\n{latest_user_message}"
 
         # Per-request isolation: never execute against the cached singleton.
+        llm_model = (getattr(config, "llm_model", None) or "").strip() or None
         agent = _duplicate_inprocess_agent(template_agent, thread_id)
+        if llm_model:
+            _retarget_inprocess_chat_model(agent, llm_model)
 
         if hasattr(agent, "ainvoke"):
             return await agent.ainvoke(latest_user_message, thread_id=thread_id)
@@ -1301,10 +1304,46 @@ def _resolve_inprocess_abi_agent(agent_name: str):
         try:
             instance = factory()
         except Exception:
+            from naas_abi_core import logger
+
+            logger.exception("In-process ABI agent factory failed for %s", raw_target)
             return None
 
         _INPROCESS_AGENT_INSTANCES[factory_key] = instance
         return instance
+
+
+def _retarget_inprocess_chat_model(agent: Any, model_id: str) -> None:
+    """Swap the chat model on a duplicated agent without rebuilding intents.
+
+    ``Agent.New(model_id=...)`` reconstructs IntentMapper and re-embeds, which
+    401s when OPENAI_API_KEY is actually an OpenRouter key. Keep the cached
+    mapper; only rebind tools onto the slides model.
+    """
+    from naas_abi.agents.slides_policy import load_slides_chat_model
+    from naas_abi_core.services.agent.tools.utils import can_bind_tools
+
+    chat_model = load_slides_chat_model(model_id)
+    base = getattr(chat_model, "model", chat_model)
+    agent._chat_model = base
+    tools_to_bind: list[Any] = []
+    tools_to_bind.extend(getattr(agent, "_structured_tools", []) or [])
+    tools_to_bind.extend(getattr(agent, "_native_tools", []) or [])
+    if tools_to_bind and can_bind_tools(base):
+        agent._chat_model_with_tools = base.bind_tools(tools_to_bind)
+        requires_ws = getattr(type(agent), "_requires_workspace", None)
+        if callable(requires_ws):
+            gated = [t for t in tools_to_bind if not requires_ws(t)]
+            agent._chat_model_without_workspace_tools = (
+                base.bind_tools(gated)
+                if len(gated) != len(tools_to_bind)
+                else agent._chat_model_with_tools
+            )
+        else:
+            agent._chat_model_without_workspace_tools = agent._chat_model_with_tools
+        return
+    agent._chat_model_with_tools = base
+    agent._chat_model_without_workspace_tools = base
 
 
 def _duplicate_inprocess_agent(template: Any, thread_id: str | None) -> Any:
@@ -1440,21 +1479,17 @@ async def stream_with_abi_inprocess(
     # (the previous behaviour) caused cross-conversation response leakage when
     # two requests overlapped — see jupyter-naas/abi#991.
     assert thread_id is not None, "thread_id is required"
-    agent = None
+    agent = _duplicate_inprocess_agent(template_agent, thread_id)
     if llm_model:
-        new_fn = getattr(type(template_agent), "New", None)
-        if callable(new_fn):
-            try:
-                from naas_abi_core.services.agent.Agent import AgentSharedState
-
-                agent = new_fn(
-                    agent_shared_state=AgentSharedState(thread_id=str(thread_id)),
-                    model_id=llm_model,
-                )
-            except TypeError:
-                agent = None
-    if agent is None:
-        agent = _duplicate_inprocess_agent(template_agent, thread_id)
+        try:
+            _retarget_inprocess_chat_model(agent, llm_model)
+        except Exception:
+            logger.exception("Failed to retarget in-process agent to %s", llm_model)
+            yield (
+                f"\n\n**Error:** Could not switch slides chat to {llm_model}. "
+                "Check the API logs and retry."
+            )
+            return
 
     logger.debug(
         f"Agent.state.thread_id: {getattr(getattr(agent, 'state', None), 'thread_id', None)}"
@@ -1502,6 +1537,8 @@ async def stream_with_abi_inprocess(
         return
 
     stream_iter = iter(agent.stream_invoke(latest_user_message))
+    emitted = False
+    final_replay: list[str] = []
 
     while True:
         try:
@@ -1521,11 +1558,14 @@ async def stream_with_abi_inprocess(
             if text == "[DONE]" or event_name == "done":
                 break
 
-            # Only forward the real-time ai_message events.
-            # Skip "message" events - those are a post-hoc replay of the final
-            # state and would duplicate the content already streamed via ai_message.
+            # Prefer live ai_message deltas. The closing "message" replay is the
+            # only text when the graph errors before an assistant token (for
+            # example a recursion-limit stop).
             if event_name == "ai_message" and text.strip():
+                emitted = True
                 yield text
+            elif event_name == "message" and text.strip():
+                final_replay.append(text.strip())
             elif event_name == "tool_usage" and text.strip():
                 yield {"event": "tool_usage", "tool": text}
             elif event_name == "tool_response" and text.strip():
@@ -1535,4 +1575,8 @@ async def stream_with_abi_inprocess(
             elif event_name == "agent_routing" and text.strip():
                 yield {"event": "agent_routing", "agent": text}
         elif isinstance(event, str) and event.strip():
+            emitted = True
             yield event
+
+    if not emitted and final_replay:
+        yield "\n".join(final_replay)

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/slides/adapters/primary/slides__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/slides/adapters/primary/slides__primary_adapter__FastAPI.py
@@ -12,6 +12,7 @@ Coder.
 from __future__ import annotations
 
 import hashlib
+import html as html_lib
 import json
 import logging
 import re
@@ -88,7 +89,7 @@ def _get_source_control(request: Request) -> SourceControlService:
     except Exception as exc:
         raise HTTPException(
             status_code=503,
-            detail="Source control (Forgejo) is not configured. Slides requires git storage.",
+            detail="Forgejo is not configured. Slides needs git storage.",
         ) from exc
 
 
@@ -108,6 +109,77 @@ def _get_coding_environment(request: Request) -> CodingEnvironmentService | None
 
 def _repo_id() -> str:
     return settings.coding_repo_id or "abi/monorepo"
+
+
+_REPO_ID_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$")
+_FORGEJO_NOT_CONFIGURED = "Forgejo is not configured. Slides needs git storage."
+_FORGEJO_UNREACHABLE = "Forgejo is not reachable. Slides needs git storage."
+
+
+def _is_repo_id_message(text: str) -> bool:
+    """True when the exception is just owner/name (InMemory RepoNotFoundError)."""
+    return bool(_REPO_ID_RE.fullmatch((text or "").strip()))
+
+
+def _repo_missing_detail(repo_id: str) -> str:
+    return (
+        f"Git repo '{repo_id}' is missing. Forgejo is not configured, "
+        "or coding-init did not seed it."
+    )
+
+
+def _is_forgejo_unreachable(exc: BaseException | str) -> bool:
+    text = str(exc or "").lower()
+    return any(
+        marker in text
+        for marker in (
+            "connection refused",
+            "failed to establish",
+            "name or service not known",
+            "nodename nor servname",
+            "timed out",
+            "timeout",
+            "connection reset",
+            "max retries",
+            "temporarily unavailable",
+            "network is unreachable",
+            "connectionerror",
+            "connecterror",
+        )
+    )
+
+
+def _source_control_http_error(exc: BaseException) -> HTTPException:
+    """Map forge failures: missing/down git is 503; transient writes stay 502."""
+    text = str(exc or "").strip()
+    repo_hint = text.split(":", 1)[0].strip() if text else ""
+    if isinstance(exc, RepoNotFoundError) and _is_repo_id_message(repo_hint):
+        return HTTPException(status_code=503, detail=_repo_missing_detail(repo_hint))
+    if _is_repo_id_message(text):
+        return HTTPException(status_code=503, detail=_repo_missing_detail(text))
+    if _is_forgejo_unreachable(exc):
+        return HTTPException(status_code=503, detail=_FORGEJO_UNREACHABLE)
+    return HTTPException(status_code=502, detail=_friendly_git_detail(exc))
+
+
+def _ensure_coding_repo(sc: SourceControlService) -> str:
+    """Idempotently seed CODING_REPO_ID (local in_memory starts empty)."""
+    repo_id = _repo_id()
+    owner, sep, name = repo_id.partition("/")
+    if not sep or not owner or not name or "/" in name:
+        raise HTTPException(status_code=503, detail=_FORGEJO_NOT_CONFIGURED)
+    try:
+        sc.ensure_repo(owner=owner, name=name)
+    except SourceControlError as exc:
+        raise _source_control_http_error(exc) from exc
+    except (OSError, TimeoutError) as exc:
+        raise HTTPException(status_code=503, detail=_FORGEJO_UNREACHABLE) from exc
+    return repo_id
+
+
+def _slides_sc(request: Request) -> tuple[SourceControlService, str]:
+    sc = _get_source_control(request)
+    return sc, _ensure_coding_repo(sc)
 
 
 def _forge_username(name: str, email: str) -> str:
@@ -310,6 +382,70 @@ def _count_embedded_images(html: str) -> int:
     return len(re.findall(r"data:image/[^;]+;base64,", html))
 
 
+_SECTION_SLIDE_RE = re.compile(
+    r"<section\b([^>]*)>(.*?)</section>",
+    re.IGNORECASE | re.DOTALL,
+)
+_SLIDE_CLASS_RE = re.compile(r"""\bclass\s*=\s*["'][^"']*\bslide\b""", re.IGNORECASE)
+_SECTION_ID_RE = re.compile(r"""\bid\s*=\s*["']([^"']+)["']""", re.IGNORECASE)
+_EYEBROW_RE = re.compile(
+    r"""<div\b[^>]*class=["'][^"']*\b(?:eyebrow|divider-eyebrow)\b[^"']*["'][^>]*>(.*?)</div>""",
+    re.IGNORECASE | re.DOTALL,
+)
+_H1_RE = re.compile(r"<h1\b[^>]*>(.*?)</h1>", re.IGNORECASE | re.DOTALL)
+_DIVIDER_TITLE_RE = re.compile(
+    r"""<div\b[^>]*class=["'][^"']*\bdivider-title\b[^"']*["'][^>]*>(.*?)</div>""",
+    re.IGNORECASE | re.DOTALL,
+)
+_TAG_RE = re.compile(r"<[^>]+>")
+_IMG_CONST_RE = re.compile(r"const IMG\s*=\s*\{(.*?)\n\s*\};", re.DOTALL)
+_IMG_KEY_RE = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*:", re.MULTILINE)
+
+
+def _strip_html_text(raw: str) -> str:
+    return html_lib.unescape(_TAG_RE.sub("", raw or "")).strip()
+
+
+def _parse_slide_outline(html: str) -> list[dict]:
+    """h1 / eyebrow (or divider title) per ``<section class="slide">``."""
+    slides: list[dict] = []
+    index = 0
+    for match in _SECTION_SLIDE_RE.finditer(html or ""):
+        attrs = match.group(1) or ""
+        if not _SLIDE_CLASS_RE.search(attrs):
+            continue
+        body = match.group(2) or ""
+        id_m = _SECTION_ID_RE.search(attrs)
+        eyebrow_m = _EYEBROW_RE.search(body)
+        h1_m = _H1_RE.search(body)
+        divider_m = _DIVIDER_TITLE_RE.search(body)
+        title = (
+            _strip_html_text(h1_m.group(1))
+            if h1_m
+            else (_strip_html_text(divider_m.group(1)) if divider_m else "")
+        )
+        slides.append(
+            {
+                "index": index,
+                "id": id_m.group(1) if id_m else None,
+                "eyebrow": _strip_html_text(eyebrow_m.group(1)) if eyebrow_m else "",
+                "title": title,
+            }
+        )
+        index += 1
+    return slides
+
+
+def _parse_template_assets(html: str) -> list[dict[str, str]]:
+    """Embedded seed assets (``const IMG`` keys, else numbered data-URLs)."""
+    block = _IMG_CONST_RE.search(html or "")
+    if block:
+        keys = _IMG_KEY_RE.findall(block.group(1))
+        return [{"name": key, "kind": "embedded"} for key in keys]
+    count = _count_embedded_images(html or "")
+    return [{"name": f"embedded-{i + 1}", "kind": "embedded"} for i in range(count)]
+
+
 def _slugify(title: str) -> str:
     raw = re.sub(r"[^a-z0-9]+", "-", title.strip().lower()).strip("-")
     return raw[:48] or "deck"
@@ -443,8 +579,18 @@ def _seed_template_meta(template_id: str) -> dict[str, str]:
     }
 
 
-def _list_seed_template_records() -> list[dict[str, str]]:
-    return [_seed_template_meta(tid) for tid in _discover_seed_ids()]
+def _list_seed_template_records() -> list[dict]:
+    rows: list[dict] = []
+    for tid in _discover_seed_ids():
+        meta = _seed_template_meta(tid)
+        try:
+            seed = _load_seed_html(tid)
+        except HTTPException:
+            seed = ""
+        meta["slides"] = _parse_slide_outline(seed) if seed else []
+        meta["assets"] = _parse_template_assets(seed) if seed else []
+        rows.append(meta)
+    return rows
 
 
 def _known_template_ids() -> set[str]:
@@ -511,6 +657,12 @@ class DeckUpdateRequest(BaseModel):
     workspace_id: str = Field(..., min_length=1, max_length=100)
     html: str = Field(..., min_length=1)
     message: str = Field(default="Update slides deck", max_length=200)
+    template_id: str | None = Field(default=None, max_length=64)
+
+
+class ApplyTemplateRequest(BaseModel):
+    workspace_id: str = Field(..., min_length=1, max_length=100)
+    template_id: str = Field(..., min_length=1, max_length=64)
 
 
 class CommitResponse(BaseModel):
@@ -718,7 +870,14 @@ def _friendly_git_detail(exc: BaseException) -> str:
     """Human detail for Forgejo failures; never dump raw forge JSON."""
     if _is_git_write_race(exc):
         return "Git write raced on the deck branch; retrying is safe"
+    if _is_forgejo_unreachable(exc):
+        return _FORGEJO_UNREACHABLE
     text = str(exc or "").strip()
+    repo_hint = text.split(":", 1)[0].strip() if text else ""
+    if _is_repo_id_message(text) or (
+        isinstance(exc, RepoNotFoundError) and _is_repo_id_message(repo_hint)
+    ):
+        return _repo_missing_detail(repo_hint or _repo_id())
     if (
         len(text) > 180
         or text.startswith("{")
@@ -804,8 +963,7 @@ async def list_projects(
     current_user: User = Depends(get_current_user_required),
 ) -> list[ProjectResponse]:
     await require_workspace_access(current_user.id, workspace_id)
-    sc = _get_source_control(request)
-    repo_id = _repo_id()
+    sc, repo_id = _slides_sc(request)
     ws_seg = _workspace_segment(workspace_id)
     ns_prefix = f"{_BRANCH_PREFIX}{ws_seg}/"
 
@@ -856,7 +1014,7 @@ async def list_projects(
     try:
         return await run_in_threadpool(_list)
     except SourceControlError as exc:
-        raise HTTPException(status_code=502, detail=str(exc)) from exc
+        raise _source_control_http_error(exc) from exc
 
 
 @router.post("/projects", response_model=ProjectResponse)
@@ -878,8 +1036,7 @@ async def create_project(
             status_code=422,
             detail=f"Unknown template_id '{body.template_id}'.",
         )
-    sc = _get_source_control(request)
-    repo_id = _repo_id()
+    sc, repo_id = _slides_sc(request)
     paths = _paths_for(body.workspace_id, slug, legacy=False)
     branch = paths["branch"]
     username = _forge_username(current_user.name or "", str(current_user.email))
@@ -994,9 +1151,7 @@ async def create_project(
     except BranchNameConflictError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     except SourceControlError as exc:
-        raise HTTPException(
-            status_code=502, detail=_friendly_git_detail(exc)
-        ) from exc
+        raise _source_control_http_error(exc) from exc
 
     try:
         runtime = await _ensure_runtime_impl(
@@ -1026,8 +1181,7 @@ async def get_project(
     await require_workspace_access(current_user.id, workspace_id)
     if not _SLUG_RE.match(slug):
         raise HTTPException(status_code=422, detail="Invalid slug")
-    sc = _get_source_control(request)
-    repo_id = _repo_id()
+    sc, repo_id = _slides_sc(request)
 
     def _get() -> ProjectResponse:
         paths = _resolve_project_paths(
@@ -1056,9 +1210,7 @@ async def get_project(
     except RepoNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except SourceControlError as exc:
-        raise HTTPException(
-            status_code=502, detail=_friendly_git_detail(exc)
-        ) from exc
+        raise _source_control_http_error(exc) from exc
 
 
 @router.get("/projects/{slug}/deck", response_model=DeckResponse)
@@ -1077,8 +1229,7 @@ async def get_deck(
     await require_workspace_access(current_user.id, workspace_id)
     if not _SLUG_RE.match(slug):
         raise HTTPException(status_code=422, detail="Invalid slug")
-    sc = _get_source_control(request)
-    repo_id = _repo_id()
+    sc, repo_id = _slides_sc(request)
 
     def _resolve() -> dict[str, str]:
         paths = _resolve_project_paths(
@@ -1095,9 +1246,7 @@ async def get_deck(
     except RepoNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except SourceControlError as exc:
-        raise HTTPException(
-            status_code=502, detail=_friendly_git_detail(exc)
-        ) from exc
+        raise _source_control_http_error(exc) from exc
 
     sidecar_base, sidecar_secret = await lookup_slides_sidecar(
         db,
@@ -1142,9 +1291,7 @@ async def get_deck(
     except ValidationError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
     except SourceControlError as exc:
-        raise HTTPException(
-            status_code=502, detail=_friendly_git_detail(exc)
-        ) from exc
+        raise _source_control_http_error(exc) from exc
 
 
 @router.put("/projects/{slug}/deck", response_model=DeckResponse)
@@ -1159,8 +1306,7 @@ async def put_deck(
     await require_workspace_access(current_user.id, body.workspace_id)
     if not _SLUG_RE.match(slug):
         raise HTTPException(status_code=422, detail="Invalid slug")
-    sc = _get_source_control(request)
-    repo_id = _repo_id()
+    sc, repo_id = _slides_sc(request)
     username = _forge_username(current_user.name or "", str(current_user.email))
     author_name = current_user.name or username
     author_email = str(current_user.email)
@@ -1208,6 +1354,8 @@ async def put_deck(
 
                 data["workspace_id"] = body.workspace_id
                 data["updated_at"] = datetime.now(UTC).isoformat()
+                if body.template_id:
+                    data["template_id"] = body.template_id
                 sc.upsert_file(
                     repo_id=repo_id,
                     path=paths["project_path"],
@@ -1232,9 +1380,36 @@ async def put_deck(
     except RepoNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except SourceControlError as exc:
+        raise _source_control_http_error(exc) from exc
+
+
+@router.post("/projects/{slug}/apply-template", response_model=DeckResponse)
+async def apply_template(
+    slug: str,
+    body: ApplyTemplateRequest,
+    request: Request,
+    current_user: User = Depends(get_current_user_required),
+    db: AsyncSession = Depends(get_db),
+) -> DeckResponse:
+    """Rewrite the open deck from a seed template (HTML source of truth)."""
+    if body.template_id not in _known_template_ids():
         raise HTTPException(
-            status_code=502, detail=_friendly_git_detail(exc)
-        ) from exc
+            status_code=422,
+            detail=f"Unknown template_id '{body.template_id}'.",
+        )
+    seed = _load_seed_html(body.template_id)
+    return await put_deck(
+        slug,
+        DeckUpdateRequest(
+            workspace_id=body.workspace_id,
+            html=seed,
+            message=f"Apply template {body.template_id}",
+            template_id=body.template_id,
+        ),
+        request,
+        current_user,
+        db,
+    )
 
 
 @router.get("/projects/{slug}/history", response_model=list[CommitResponse])
@@ -1248,8 +1423,7 @@ async def list_history(
     await require_workspace_access(current_user.id, workspace_id)
     if not _SLUG_RE.match(slug):
         raise HTTPException(status_code=422, detail="Invalid slug")
-    sc = _get_source_control(request)
-    repo_id = _repo_id()
+    sc, repo_id = _slides_sc(request)
 
     def _hist() -> list[CommitResponse]:
         paths = _resolve_project_paths(
@@ -1272,7 +1446,7 @@ async def list_history(
     except RepoNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except SourceControlError as exc:
-        raise HTTPException(status_code=502, detail=str(exc)) from exc
+        raise _source_control_http_error(exc) from exc
 
 
 def _build_sidecar_base(*, coder_username: str | None, name: str) -> str | None:
@@ -1289,7 +1463,7 @@ async def lookup_slides_sidecar(
     slug: str,
 ) -> tuple[str | None, str | None]:
     """Return (sidecar_base, sidecar_secret) for an open Slides deck, if bound."""
-    if not workspace_id or not user_id or not slug or not _SLUG_RE.match(slug):
+    if db is None or not workspace_id or not user_id or not slug or not _SLUG_RE.match(slug):
         return None, None
     labels = _runtime_labels(workspace_id, slug)
     result = await db.execute(
@@ -1318,8 +1492,7 @@ async def _ensure_runtime_impl(
     db: AsyncSession | None,
 ) -> RuntimeResponse:
     # Ownership gate before provisioning compute.
-    sc_gate = _get_source_control(request)
-    repo_gate = _repo_id()
+    sc_gate, repo_gate = _slides_sc(request)
 
     def _owned() -> dict[str, str] | None:
         return _resolve_project_paths(
@@ -1360,8 +1533,8 @@ async def _ensure_runtime_impl(
             coder_workspace=name,
             branch=branch,
         )
-    sc = _get_source_control(request)
-    repo_id = _repo_id()
+    sc = sc_gate
+    repo_id = repo_gate
 
     def _pick_template() -> tuple[str, str] | None:
         templates = coding.list_templates()
@@ -1751,8 +1924,7 @@ async def get_project_tree(
     await require_workspace_access(current_user.id, workspace_id)
     if not _SLUG_RE.match(slug):
         raise HTTPException(status_code=422, detail="Invalid slug")
-    sc = _get_source_control(request)
-    repo_id = _repo_id()
+    sc, repo_id = _slides_sc(request)
 
     def _tree() -> ProjectTreeResponse:
         paths = _resolve_project_paths(
@@ -1849,7 +2021,19 @@ async def get_project_tree(
     except RepoNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except SourceControlError as exc:
-        raise HTTPException(status_code=502, detail=str(exc)) from exc
+        raise _source_control_http_error(exc) from exc
+
+
+class SlideOutlineItem(BaseModel):
+    index: int
+    id: str | None = None
+    eyebrow: str = ""
+    title: str = ""
+
+
+class TemplateAssetItem(BaseModel):
+    name: str
+    kind: str = "embedded"
 
 
 class SeedTemplateResponse(BaseModel):
@@ -1860,6 +2044,8 @@ class SeedTemplateResponse(BaseModel):
     preview_panel: str = "#ffffff"
     preview_accent: str = "#0072ce"
     preview_ink: str = "#2d2d2d"
+    slides: list[SlideOutlineItem] = Field(default_factory=list)
+    assets: list[TemplateAssetItem] = Field(default_factory=list)
 
 
 @router.get("/templates", response_model=list[SeedTemplateResponse])
@@ -1867,6 +2053,6 @@ async def list_seed_templates(
     workspace_id: str,
     current_user: User = Depends(get_current_user_required),
 ) -> list[SeedTemplateResponse]:
-    """List Nexus seed templates available for New Presentation."""
+    """List seed templates with slide outlines for the Slides sidebar."""
     await require_workspace_access(current_user.id, workspace_id)
     return [SeedTemplateResponse(**row) for row in _list_seed_template_records()]

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/slides/adapters/primary/slides__primary_adapter__FastAPI_test.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/slides/adapters/primary/slides__primary_adapter__FastAPI_test.py
@@ -2,6 +2,13 @@
 
 from __future__ import annotations
 
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from naas_abi.apps.nexus.apps.api.app.api.endpoints.auth import (
+    User,
+    get_current_user_required,
+)
+from naas_abi.apps.nexus.apps.api.app.core.database import get_db
 from naas_abi.apps.nexus.apps.api.app.services.slides.adapters.primary.slides__primary_adapter__FastAPI import (
     _assets_dir,
     _assets_gitkeep_path,
@@ -9,6 +16,7 @@ from naas_abi.apps.nexus.apps.api.app.services.slides.adapters.primary.slides__p
     _coder_workspace_name,
     _deck_path,
     _discover_seed_ids,
+    _ensure_coding_repo,
     _friendly_coding_detail,
     _friendly_git_detail,
     _is_git_write_race,
@@ -16,18 +24,32 @@ from naas_abi.apps.nexus.apps.api.app.services.slides.adapters.primary.slides__p
     _legacy_deck_path,
     _list_seed_template_records,
     _load_seed_html,
+    _parse_slide_outline,
+    _parse_template_assets,
     _paths_for,
     _probe_sidecar,
     _project_path,
     _read_deck_via_sidecar,
+    _repo_id,
     _runtime_label,
     _sidecar_tool_call,
     _slugify,
+    _source_control_http_error,
     _wait_for_sidecar,
     _write_deck_via_sidecar,
 )
+from naas_abi.apps.nexus.apps.api.app.services.slides.adapters.primary import (
+    slides__primary_adapter__FastAPI as slides_api,
+)
 from naas_abi_core.services.coding_environment.CodingEnvironmentPorts import (
     WorkspaceNameConflictError,
+)
+from naas_abi_core.services.source_control.adapters.secondary.InMemoryAdapter import (
+    InMemoryAdapter,
+)
+from naas_abi_core.services.source_control.SourceControlPorts import RepoNotFoundError
+from naas_abi_core.services.source_control.SourceControlService import (
+    SourceControlService,
 )
 
 
@@ -48,11 +70,40 @@ def test_slugify_and_paths() -> None:
     assert legacy["branch"] == "slides/demo"
 
 
+def test_parse_slide_outline_reads_eyebrow_and_h1() -> None:
+    html = """
+    <main class="deck">
+      <section id="slide-cover" class="slide cover">
+        <div class="eyebrow">Confidential</div>
+        <h1>Presentation Title</h1>
+      </section>
+      <section class="slide section-divider">
+        <div class="divider-eyebrow">Section 01</div>
+        <div class="divider-title">Context</div>
+      </section>
+    </main>
+    """
+    slides = _parse_slide_outline(html)
+    assert len(slides) == 2
+    assert slides[0]["id"] == "slide-cover"
+    assert slides[0]["eyebrow"] == "Confidential"
+    assert slides[0]["title"] == "Presentation Title"
+    assert slides[1]["eyebrow"] == "Section 01"
+    assert slides[1]["title"] == "Context"
+    assets = _parse_template_assets(
+        'const IMG = {\n  hero: "data:image/svg+xml,x",\n  logo: "data:image/svg+xml,y",\n};'
+    )
+    assert [a["name"] for a in assets] == ["hero", "logo"]
+
+
 def test_seed_template_includes_build_pptx() -> None:
     html = _load_seed_html("minimal-light-v1")
     assert "function buildPptx" in html
     assert "PptxGenJS" in html or "pptxgen" in html.lower()
     assert "data:image/" in html
+    assert "NEXUS_SLIDES_PPTX_FROM_DOM_V1" in html
+    assert 'querySelectorAll("main.deck > section.slide' in html
+    assert '[["1","Context"],["2","Approach"]' not in html
 
 
 def test_seed_catalog_lists_all_templates() -> None:
@@ -66,9 +117,16 @@ def test_seed_catalog_lists_all_templates() -> None:
     by_id = {r["id"]: r for r in records}
     assert by_id["minimal-light-v1"]["name"] == "Minimal Light"
     assert by_id["pitch-dark-v1"]["preview_bg"].startswith("#")
+    light_slides = by_id["minimal-light-v1"]["slides"]
+    titles = [s["title"] for s in light_slides]
+    assert "Presentation Title" in titles
+    assert "What we will cover" in titles
+    assert any(s.get("eyebrow") == "Agenda" for s in light_slides)
+    assert by_id["minimal-light-v1"]["assets"]
     for tid in ("pitch-dark-v1", "minimal-light-v1", "executive-v1"):
         html = _load_seed_html(tid)
         assert "function buildPptx" in html
+        assert "NEXUS_SLIDES_PPTX_FROM_DOM_V1" in html
         assert 'class="deck"' in html
         assert 'class="slide' in html
         assert "deck-menubar" in html
@@ -86,6 +144,109 @@ def test_friendly_coding_detail_hides_raw_coder_json() -> None:
     assert _friendly_coding_detail(Exception(raw)) == (
         "Reconnecting to existing runtime…"
     )
+
+
+def test_friendly_git_detail_rewrites_raw_repo_id() -> None:
+    err = RepoNotFoundError("abi/monorepo")
+    detail = _friendly_git_detail(err)
+    assert "abi/monorepo" in detail
+    assert "missing" in detail.lower()
+    http = _source_control_http_error(err)
+    assert http.status_code == 503
+    assert "Forgejo is not configured" in str(http.detail)
+
+
+def test_source_control_http_error_unreachable() -> None:
+    http = _source_control_http_error(OSError("Connection refused"))
+    assert http.status_code == 503
+    assert "not reachable" in str(http.detail).lower()
+
+
+def test_ensure_coding_repo_seeds_empty_in_memory() -> None:
+    sc = SourceControlService(InMemoryAdapter())
+    repo_id = _repo_id()
+    assert repo_id.count("/") == 1
+    try:
+        sc.list_branches(repo_id=repo_id)
+        raise AssertionError("empty in_memory should not have the coding repo")
+    except RepoNotFoundError:
+        pass
+    assert _ensure_coding_repo(sc) == repo_id
+    assert [b.name for b in sc.list_branches(repo_id=repo_id)]
+
+
+def _slides_client(monkeypatch, source_control: SourceControlService) -> TestClient:
+    app = FastAPI()
+    app.state.source_control = source_control
+    app.include_router(slides_api.router, prefix="/slides")
+    app.dependency_overrides[get_current_user_required] = lambda: User.model_construct(
+        id="user-1", email="admin@example.com", name="Zen Admin"
+    )
+
+    async def _fake_db():
+        yield None
+
+    app.dependency_overrides[get_db] = _fake_db
+
+    async def _allow(user_id: str, workspace_id: str) -> str:
+        return "owner"
+
+    monkeypatch.setattr(slides_api, "require_workspace_access", _allow)
+    monkeypatch.setattr(slides_api, "_get_coding_environment", lambda _request: None)
+    return TestClient(app)
+
+
+def test_list_and_create_projects_seed_in_memory_repo(monkeypatch) -> None:
+    sc = SourceControlService(InMemoryAdapter())
+    client = _slides_client(monkeypatch, sc)
+    listed = client.get("/slides/projects", params={"workspace_id": "ws-test"})
+    assert listed.status_code == 200, listed.text
+    assert listed.json() == []
+    created = client.post(
+        "/slides/projects",
+        json={
+            "workspace_id": "ws-test",
+            "title": "Untitled presentation",
+            "slug": "untitled-local",
+            "template_id": "minimal-light-v1",
+        },
+    )
+    assert created.status_code == 200, created.text
+    body = created.json()
+    assert body["slug"] == "untitled-local"
+    assert body["deck_path"] == "slides/ws-test/untitled-local/deck.html"
+    listed2 = client.get("/slides/projects", params={"workspace_id": "ws-test"})
+    assert listed2.status_code == 200, listed2.text
+    assert "untitled-local" in [p["slug"] for p in listed2.json()]
+    templates = client.get("/slides/templates", params={"workspace_id": "ws-test"})
+    assert templates.status_code == 200, templates.text
+    catalog = templates.json()
+    assert {t["id"] for t in catalog} >= {
+        "minimal-light-v1",
+        "pitch-dark-v1",
+        "executive-v1",
+    }
+    light = next(t for t in catalog if t["id"] == "minimal-light-v1")
+    assert light["name"] == "Minimal Light"
+    assert any(s["title"] == "What we will cover" for s in light["slides"])
+    applied = client.post(
+        "/slides/projects/untitled-local/apply-template",
+        json={"workspace_id": "ws-test", "template_id": "pitch-dark-v1"},
+    )
+    assert applied.status_code == 200, applied.text
+    deck = client.get(
+        "/slides/projects/untitled-local/deck",
+        params={"workspace_id": "ws-test"},
+    )
+    assert deck.status_code == 200, deck.text
+    html = deck.json()["html"]
+    assert 'content="pitch-dark-v1"' in html
+    proj = client.get(
+        "/slides/projects/untitled-local",
+        params={"workspace_id": "ws-test"},
+    )
+    assert proj.status_code == 200, proj.text
+    assert proj.json()["template_id"] == "pitch-dark-v1"
 
 
 def test_friendly_git_detail_hides_pushrejected_dump() -> None:

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/slides/[slug]/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/slides/[slug]/page.tsx
@@ -11,6 +11,11 @@ import {
   type SlidesPreviewFrameHandle,
 } from '@/components/slides/slides-preview-frame';
 import { SlidesStatusBar } from '@/components/slides/slides-status-bar';
+import {
+  openSlidesAgentPane,
+  slidesApiErrorMessage,
+  startNewPresentation,
+} from '@/lib/create-slides-project';
 import { authFetch } from '@/stores/auth';
 import {
   SLIDES_DECK_UPDATED_EVENT,
@@ -166,6 +171,7 @@ export default function SlidesEditorPage() {
   const runtimeStatus = useSlidesStore((s) => s.runtimeStatus);
   const runtimeDetail = useSlidesStore((s) => s.runtimeDetail);
   const refreshToken = useSlidesStore((s) => s.refreshToken);
+  const agentWriting = useSlidesStore((s) => s.agentWriting);
 
   const [title, setTitle] = useState(slug);
   const [html, setHtml] = useState('');
@@ -186,7 +192,9 @@ export default function SlidesEditorPage() {
   const saveRef = useRef<() => Promise<void>>(async () => {});
   const refreshRef = useRef<() => Promise<void>>(async () => {});
 
-  const newPresentationHref = `/workspace/${workspaceId}/slides/new`;
+  useEffect(() => {
+    openSlidesAgentPane();
+  }, []);
 
   useEffect(() => {
     dirtyRef.current = dirty;
@@ -253,8 +261,8 @@ export default function SlidesEditorPage() {
         if (!projRes.ok || !deckRes.ok) {
           const body = (await (projRes.ok ? deckRes : projRes)
             .json()
-            .catch(() => ({}))) as { detail?: string };
-          throw new Error(body.detail || 'Failed to load deck');
+            .catch(() => ({}))) as { detail?: unknown };
+          throw new Error(slidesApiErrorMessage(body.detail, 'Failed to load deck'));
         }
         const proj = (await projRes.json()) as {
           title: string;
@@ -284,6 +292,8 @@ export default function SlidesEditorPage() {
                 : null;
           setStatus(src ? `Preview refreshed (${src})` : 'Preview refreshed');
         }
+        setLoading(false);
+        setRefreshing(false);
         if (ensureRuntime) {
           const runtime = await ensureSlidesRuntime(workspaceId, slug, quiet ? 2 : 6);
           if (gen !== loadGenRef.current) return;
@@ -388,8 +398,8 @@ export default function SlidesEditorPage() {
         }),
       });
       if (!res.ok) {
-        const body = (await res.json().catch(() => ({}))) as { detail?: string };
-        throw new Error(body.detail || `Save failed (${res.status})`);
+        const body = (await res.json().catch(() => ({}))) as { detail?: unknown };
+        throw new Error(slidesApiErrorMessage(body.detail, `Save failed (${res.status})`));
       }
       const body = (await res.json()) as { commit_sha?: string };
       setDirty(false);
@@ -442,7 +452,9 @@ export default function SlidesEditorPage() {
     setStatus(null);
     try {
       await previewRef.current.exportPptx();
-      setStatus('PPTX export started (best-effort vs preview)');
+      setStatus(
+        'PPTX started from live HTML (closest fit; fonts and wrap will differ from preview)',
+      );
     } catch (e) {
       setError(`PPTX export failed: ${(e as Error).message}`);
     } finally {
@@ -452,7 +464,12 @@ export default function SlidesEditorPage() {
 
   const menuBar = (
     <SlidesMenuBar
-      onNewPresentation={() => router.push(newPresentationHref)}
+      onNewPresentation={() => {
+        if (!workspaceId) return;
+        void startNewPresentation(workspaceId, (href) => router.push(href)).catch((e) => {
+          setError(slidesApiErrorMessage((e as Error).message, 'Could not create the deck.'));
+        });
+      }}
       onCommit={() => void save()}
       commitDisabled={saving || !dirty || loading}
       onExportPptx={() => void exportPptx()}
@@ -496,13 +513,19 @@ export default function SlidesEditorPage() {
     <div className="flex h-full flex-col">
       <Header
         title={title}
-        subtitle={`slides/${slug}/deck.html · PPTX export is best-effort vs preview`}
+        subtitle={`HTML source · PPTX is a 1280x720 reconstruction (closest fit)`}
         nav={menuBar}
       />
 
       {error && (
         <div className="border-b border-red-500/20 bg-red-500/10 px-4 py-2 text-xs text-red-600">
           {error}
+        </div>
+      )}
+
+      {agentWriting && (
+        <div className="border-b border-workspace-accent/20 bg-workspace-accent-10 px-4 py-2 text-xs text-foreground">
+          Abi is updating the deck…
         </div>
       )}
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/slides/new/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/slides/new/page.tsx
@@ -1,132 +1,28 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
-import { Check, Loader2 } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 import { Header } from '@/components/shell/header';
 import { SlidesMenuBar } from '@/components/slides/slides-menu-bar';
 import { SlidesStatusBar } from '@/components/slides/slides-status-bar';
-import { authFetch } from '@/stores/auth';
-import { useSlidesStore } from '@/stores/slides';
-
-type SeedTemplate = {
-  id: string;
-  name: string;
-  description: string;
-  preview_bg: string;
-  preview_panel: string;
-  preview_accent: string;
-  preview_ink: string;
-};
-
-function TemplateThumb({ t }: { t: SeedTemplate }) {
-  return (
-    <div
-      className="relative aspect-video w-full overflow-hidden rounded-sm border border-black/10"
-      style={{ background: t.preview_bg }}
-      aria-hidden
-    >
-      <div
-        className="absolute inset-[10%] flex flex-col rounded-[2px] shadow-sm"
-        style={{ background: t.preview_panel, border: `1px solid ${t.preview_accent}33` }}
-      >
-        <div className="h-[28%]" style={{ background: t.preview_accent }} />
-        <div className="flex flex-1 flex-col justify-center gap-1.5 px-[8%]">
-          <div className="h-1.5 w-[18%] rounded-full" style={{ background: t.preview_accent }} />
-          <div className="h-2 w-[72%] rounded-full" style={{ background: t.preview_ink, opacity: 0.85 }} />
-          <div className="h-1.5 w-[48%] rounded-full" style={{ background: t.preview_ink, opacity: 0.35 }} />
-        </div>
-      </div>
-    </div>
-  );
-}
+import { slidesApiErrorMessage, startNewPresentation } from '@/lib/create-slides-project';
 
 export default function NewSlidesProjectPage() {
   const params = useParams();
   const router = useRouter();
   const workspaceId = typeof params?.workspaceId === 'string' ? params.workspaceId : '';
   const base = `/workspace/${workspaceId}/slides`;
-  const setSelectedSlug = useSlidesStore((s) => s.setSelectedSlug);
-
-  const [templates, setTemplates] = useState<SeedTemplate[]>([]);
-  const [templatesLoading, setTemplatesLoading] = useState(true);
-  const [templateId, setTemplateId] = useState('minimal-light-v1');
-  const [title, setTitle] = useState('');
-  const [slug, setSlug] = useState('');
-  const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  const slugValid = !slug || /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug);
+  const started = useRef(false);
 
   useEffect(() => {
-    if (!workspaceId) return;
-    let cancelled = false;
-    setTemplatesLoading(true);
-    void (async () => {
-      try {
-        const res = await authFetch(
-          `/api/slides/templates?workspace_id=${encodeURIComponent(workspaceId)}`,
-        );
-        if (!res.ok) {
-          const body = (await res.json().catch(() => ({}))) as { detail?: string };
-          throw new Error(body?.detail || `Templates failed (${res.status})`);
-        }
-        const rows = (await res.json()) as SeedTemplate[];
-        if (cancelled) return;
-        setTemplates(rows);
-        setTemplateId((current) =>
-          rows.some((r) => r.id === current) ? current : rows[0]?.id || 'minimal-light-v1',
-        );
-      } catch (e) {
-        if (cancelled) return;
-        setError((e as Error).message);
-        setTemplates([
-          {
-            id: 'minimal-light-v1',
-            name: 'Minimal Light',
-            description: 'Quiet light deck with generous whitespace and a single accent.',
-            preview_bg: '#f7f6f3',
-            preview_panel: '#ffffff',
-            preview_accent: '#1a1a1a',
-            preview_ink: '#1a1a1a',
-          },
-        ]);
-      } finally {
-        if (!cancelled) setTemplatesLoading(false);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [workspaceId]);
-
-  const create = async () => {
-    if (!title.trim() || !slugValid || !templateId) return;
-    setBusy(true);
-    setError(null);
-    try {
-      const res = await authFetch('/api/slides/projects', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          workspace_id: workspaceId,
-          title: title.trim(),
-          slug: slug.trim() || undefined,
-          template_id: templateId,
-        }),
-      });
-      if (!res.ok) {
-        const body = (await res.json().catch(() => ({}))) as { detail?: string };
-        throw new Error(body?.detail || `Failed (${res.status})`);
-      }
-      const created = (await res.json()) as { slug: string };
-      setSelectedSlug(created.slug);
-      router.push(`${base}/${created.slug}`);
-    } catch (e) {
-      setError((e as Error).message);
-      setBusy(false);
-    }
-  };
+    if (!workspaceId || started.current) return;
+    started.current = true;
+    void startNewPresentation(workspaceId, (href) => router.replace(href)).catch((e) => {
+      setError(slidesApiErrorMessage((e as Error).message, 'Could not create the deck.'));
+    });
+  }, [workspaceId, router]);
 
   return (
     <div className="flex h-full flex-col">
@@ -134,121 +30,14 @@ export default function NewSlidesProjectPage() {
         title="New Presentation"
         nav={<SlidesMenuBar onNewPresentation={() => router.push(`${base}/new`)} />}
       />
-
       {error && (
         <div className="border-b border-red-500/20 bg-red-500/10 px-4 py-2 text-xs text-red-600">
           {error}
         </div>
       )}
-
-      <div className="flex-1 overflow-auto p-6">
-        <div className="mx-auto max-w-4xl space-y-8">
-          <section className="space-y-3">
-            <div className="flex items-baseline justify-between gap-3">
-              <div>
-                <h2 className="text-sm font-medium">Templates</h2>
-                <p className="text-xs text-muted-foreground">
-                  Show all templates. Pick a seed, then name the deck. Abi customizes after create.
-                </p>
-              </div>
-              <span className="text-xs text-muted-foreground">
-                {templatesLoading ? 'Loading…' : `${templates.length} templates`}
-              </span>
-            </div>
-
-            {templatesLoading ? (
-              <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                <Loader2 size={16} className="animate-spin" />
-                Loading templates…
-              </div>
-            ) : (
-              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
-                {templates.map((t) => {
-                  const selected = t.id === templateId;
-                  return (
-                    <button
-                      key={t.id}
-                      type="button"
-                      onClick={() => setTemplateId(t.id)}
-                      className={`group relative rounded-md border p-2.5 text-left transition ${
-                        selected
-                          ? 'border-workspace-accent bg-workspace-accent-10 ring-1 ring-workspace-accent'
-                          : 'border-border hover:border-workspace-accent/50'
-                      }`}
-                    >
-                      <TemplateThumb t={t} />
-                      <div className="mt-2.5 space-y-0.5">
-                        <div className="flex items-center justify-between gap-2">
-                          <span className="text-sm font-medium">{t.name}</span>
-                          {selected && (
-                            <Check size={14} className="shrink-0 text-workspace-accent" />
-                          )}
-                        </div>
-                        <p className="line-clamp-2 text-xs text-muted-foreground">
-                          {t.description}
-                        </p>
-                      </div>
-                    </button>
-                  );
-                })}
-              </div>
-            )}
-          </section>
-
-          <section className="mx-auto max-w-xl space-y-5">
-            <label className="block space-y-1">
-              <span className="text-sm font-medium">Title</span>
-              <input
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-                placeholder="Q3 Business Review"
-                autoFocus
-                className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm outline-none focus:border-workspace-accent"
-              />
-            </label>
-
-            <label className="block space-y-1">
-              <span className="text-sm font-medium">Slug (optional)</span>
-              <input
-                value={slug}
-                onChange={(e) => setSlug(e.target.value.toLowerCase())}
-                placeholder="q3-business-review"
-                className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm outline-none focus:border-workspace-accent"
-              />
-              <span className="text-xs text-muted-foreground">
-                Stored on branch slides/&lt;slug&gt; as slides/&lt;slug&gt;/deck.html
-              </span>
-              {slug && !slugValid && (
-                <span className="block text-xs text-red-600">Use lowercase kebab-case</span>
-              )}
-            </label>
-
-            <div className="rounded-md border border-border px-3 py-2 text-xs text-muted-foreground">
-              Template: {templates.find((t) => t.id === templateId)?.name || templateId} (
-              {templateId}). A hidden slides runtime may start in the background; you will never
-              see the Coder UI.
-            </div>
-
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                onClick={() => void create()}
-                disabled={busy || !title.trim() || !slugValid || !templateId}
-                className="inline-flex items-center gap-1.5 rounded-md bg-workspace-accent px-3 py-1.5 text-xs font-medium text-white hover:opacity-90 disabled:opacity-50"
-              >
-                {busy && <Loader2 size={14} className="animate-spin" />}
-                Create project
-              </button>
-              <button
-                type="button"
-                onClick={() => router.push(base)}
-                className="rounded-md px-3 py-1.5 text-xs text-muted-foreground hover:bg-workspace-accent-10"
-              >
-                Cancel
-              </button>
-            </div>
-          </section>
-        </div>
+      <div className="flex flex-1 items-center justify-center gap-2 text-sm text-muted-foreground">
+        {!error && <Loader2 size={16} className="animate-spin" />}
+        {error || 'Opening Minimal Light…'}
       </div>
       <SlidesStatusBar />
     </div>

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/slides/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/slides/page.tsx
@@ -2,10 +2,11 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
-import { Loader2, Plus, Presentation } from 'lucide-react';
+import { Loader2, Presentation } from 'lucide-react';
 import { Header } from '@/components/shell/header';
 import { SlidesMenuBar } from '@/components/slides/slides-menu-bar';
 import { SlidesStatusBar } from '@/components/slides/slides-status-bar';
+import { slidesApiErrorMessage, startNewPresentation } from '@/lib/create-slides-project';
 import { authFetch } from '@/stores/auth';
 import { useSlidesStore, type SlidesProject } from '@/stores/slides';
 
@@ -16,8 +17,21 @@ export default function SlidesIndexPage() {
   const base = `/workspace/${workspaceId}/slides`;
   const [projects, setProjects] = useState<SlidesProject[]>([]);
   const [loading, setLoading] = useState(true);
+  const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const setSelectedSlug = useSlidesStore((s) => s.setSelectedSlug);
+
+  const onNewPresentation = useCallback(async () => {
+    if (!workspaceId || creating) return;
+    setCreating(true);
+    setError(null);
+    try {
+      await startNewPresentation(workspaceId, (href) => router.push(href));
+    } catch (e) {
+      setError(slidesApiErrorMessage((e as Error).message, 'Could not create the deck.'));
+      setCreating(false);
+    }
+  }, [workspaceId, creating, router]);
 
   const load = useCallback(async () => {
     if (!workspaceId) return;
@@ -28,8 +42,8 @@ export default function SlidesIndexPage() {
         `/api/slides/projects?workspace_id=${encodeURIComponent(workspaceId)}`,
       );
       if (!res.ok) {
-        const body = (await res.json().catch(() => ({}))) as { detail?: string };
-        throw new Error(body.detail || `Failed (${res.status})`);
+        const body = (await res.json().catch(() => ({}))) as { detail?: unknown };
+        throw new Error(slidesApiErrorMessage(body.detail, `Failed (${res.status})`));
       }
       setProjects((await res.json()) as SlidesProject[]);
     } catch (e) {
@@ -47,19 +61,7 @@ export default function SlidesIndexPage() {
     <div className="flex h-full flex-col">
       <Header
         title="Slides"
-        nav={
-          <SlidesMenuBar onNewPresentation={() => router.push(`${base}/new`)} />
-        }
-        actions={
-          <button
-            type="button"
-            onClick={() => router.push(`${base}/new`)}
-            className="inline-flex items-center gap-1.5 rounded-md bg-workspace-accent px-3 py-1.5 text-xs font-medium text-white hover:opacity-90"
-          >
-            <Plus size={14} />
-            New Presentation
-          </button>
-        }
+        nav={<SlidesMenuBar onNewPresentation={() => void onNewPresentation()} />}
       />
 
       {error && (
@@ -79,17 +81,11 @@ export default function SlidesIndexPage() {
             <Presentation size={32} className="mx-auto text-muted-foreground" />
             <h2 className="text-base font-medium">Create your first deck</h2>
             <p className="text-sm text-muted-foreground">
-              New projects seed from the generic default template into git. Edit in the
-              browser, preview live, ask Abi to revise, then export PPTX.
+              Use File → New or New in the Slides column. That opens Minimal Light and
+              Abi. Talk through the deck; the preview updates as tools run. File →
+              Export PPTX rebuilds the current HTML at 1280x720 (closest fit, not
+              pixel-perfect).
             </p>
-            <button
-              type="button"
-              onClick={() => router.push(`${base}/new`)}
-              className="inline-flex items-center gap-1.5 rounded-md bg-workspace-accent px-3 py-1.5 text-xs font-medium text-white hover:opacity-90"
-            >
-              <Plus size={14} />
-              New Presentation
-            </button>
           </div>
         ) : (
           <div className="mx-auto grid max-w-3xl gap-2">

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
@@ -16,7 +16,7 @@ import { useAgentsStore } from '@/stores/agents';
 import { useModelsStore, modelDisplayName } from '@/stores/models';
 import { useSkillsStore, type Skill, type SkillScope } from '@/stores/skills';
 import { useSecretsStore } from '@/stores/secrets';
-import { dispatchSlidesDeckUpdated, useSlidesStore } from '@/stores/slides';
+import { dispatchSlidesDeckUpdated, isSlidesWriteTool, useSlidesStore } from '@/stores/slides';
 import { useAuthStore, authFetch } from '@/stores/auth';
 import { useWebSocket } from '@/contexts/websocket-context';
 import { useTenant } from '@/contexts/tenant-context';
@@ -25,6 +25,7 @@ import '@/app/workspace/[workspaceId]/chat/components/chat-agent-selector.css';
 import { TypingIndicator } from '@/components/typing-indicator';
 import { PdfViewer } from '@/components/files/pdf-viewer';
 
+import { humanizeChatProviderError } from '@/lib/chat-provider-error';
 import { getApiUrl, getOllamaUrl } from '@/lib/config';
 import { getLogoUrl } from '@/lib/logo-url';
 import {
@@ -2049,6 +2050,9 @@ export function ChatInterface({
           });
           streamActivityLine = prefix === 'Routing to' ? `${prefix} ${name}` : name;
           hasDetailedActivity = true;
+          if (isSlidesWriteTool(rawTool)) {
+            useSlidesStore.getState().setAgentWriting(true);
+          }
         };
 
         const handleToolResponseEvent = (output: string) => {
@@ -2073,18 +2077,20 @@ export function ChatInterface({
 
           // After Abi writes a Slides deck, nudge the open preview to reload.
           const raw = (target.rawName || target.toolName || '').toLowerCase();
-          if (
-            raw.includes('write_slides') ||
-            raw.includes('replace_in_slides')
-          ) {
+          if (isSlidesWriteTool(raw)) {
             let slug: string | undefined;
+            let writeFailed = false;
             try {
-              const parsed = JSON.parse(output) as { slug?: string };
+              const parsed = JSON.parse(output) as { slug?: string; error?: unknown };
               if (typeof parsed?.slug === 'string') slug = parsed.slug;
+              if (parsed && parsed.error) writeFailed = true;
             } catch {
               /* tool output may be plain text */
             }
-            dispatchSlidesDeckUpdated({ slug, source: target.rawName || target.toolName });
+            useSlidesStore.getState().setAgentWriting(false);
+            if (!writeFailed) {
+              dispatchSlidesDeckUpdated({ slug, source: target.rawName || target.toolName });
+            }
           }
 
           const toolUrls = extractUrlsFromContent(output);
@@ -2426,6 +2432,7 @@ export function ChatInterface({
       } finally {
         setIsStreaming(false);
         setStreamingMessageId(null);
+        useSlidesStore.getState().setAgentWriting(false);
         if (connectingTimerRef.current) clearTimeout(connectingTimerRef.current);
         setShowConnecting(false);
         streamControllerRef.current = null;
@@ -2564,6 +2571,7 @@ export function ChatInterface({
       setIsLoading(false);
       setIsStreaming(false);
       isSubmittingRef.current = false;
+      useSlidesStore.getState().setAgentWriting(false);
     }
   };
 
@@ -2646,6 +2654,7 @@ export function ChatInterface({
           <EmptyState
             selectedAgentName={selectedAgentData?.name || selectedAgent}
             logoUrl={selectedAgentData?.logoUrl ?? undefined}
+            slidesOpen={Boolean(slidesChatContext)}
           />
         ) : (
           <div className="mx-auto max-w-3xl space-y-6">
@@ -2958,7 +2967,13 @@ export function ChatInterface({
                     }
                   }}
                   placeholder={
-                    attachedImages.length > 0 ? 'Ask about the image...' : pendingFileAttachments.length > 0 ? 'Ask about the file...' : 'Send a message...'
+                    attachedImages.length > 0
+                      ? 'Ask about the image...'
+                      : pendingFileAttachments.length > 0
+                        ? 'Ask about the file...'
+                        : slidesChatContext
+                          ? 'Describe the deck: topic, audience, how many slides...'
+                          : 'Send a message...'
                   }
                   // placeholder={searchEnabled ? "Search the web..." : attachedImages.length > 0 ? "Ask about the image..." : "Send a message..."}
                   className="chat-composer-input max-h-36 min-h-[24px] w-full resize-none overflow-y-hidden bg-transparent outline-none ring-0 focus:ring-0 focus:outline-none placeholder:text-muted-foreground"
@@ -3320,9 +3335,11 @@ function SuggestionChipsRow({
 function EmptyState({
   selectedAgentName,
   logoUrl,
+  slidesOpen,
 }: {
   selectedAgentName: string;
   logoUrl?: string | null;
+  slidesOpen?: boolean;
 }) {
   const { user } = useAuthStore();
   const resolvedLogoUrl = logoUrl ? getLogoUrl(logoUrl) : undefined;
@@ -3333,7 +3350,9 @@ function EmptyState({
     <div className="flex h-full flex-col items-center justify-center px-4">
       <EmptyStateLogo src={resolvedLogoUrl} name={selectedAgentName} />
       <p className="mb-6 text-center text-muted-foreground">
-        {greeting} {selectedAgentName} here, how can I help?
+        {slidesOpen
+          ? `${greeting} This is a Minimal Light deck. Tell me the topic and I will write the slides.`
+          : `${greeting} ${selectedAgentName} here, how can I help?`}
       </p>
     </div>
   );
@@ -3927,7 +3946,7 @@ const MessageBubble = React.memo(function MessageBubble({
   // collapsible panel below handles display.
   const responseForRender = useMemo(() => {
     if (isUser || typeof responseForDisplay !== 'string') return responseForDisplay;
-    return stripTrailingSources(responseForDisplay);
+    return humanizeChatProviderError(stripTrailingSources(responseForDisplay));
   }, [isUser, responseForDisplay]);
 
   const handleCopyCode = useCallback(async (code: string, key: string) => {

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/header.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/header.tsx
@@ -94,8 +94,8 @@ export function Header({ title, subtitle, nav, actions }: HeaderProps = {}) {
         {nav ? <div className="ml-1 flex min-w-0 items-center">{nav}</div> : null}
       </div>
 
-      <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-        <div className="pointer-events-auto">
+      <div className="pointer-events-none absolute inset-0 flex items-center justify-center px-8">
+        <div className="pointer-events-auto w-full max-w-[32rem]">
           <QuickOpen />
         </div>
       </div>

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/quick-open.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/quick-open.tsx
@@ -14,6 +14,7 @@ import {
   conversationUpdatedAtMs,
   filterQuickOpenItems,
   groupQuickOpenItems,
+  QUICK_OPEN_EVENT,
   QUICK_OPEN_GROUP_LABEL,
   QUICK_OPEN_SECTIONS,
   type QuickOpenItem,
@@ -113,8 +114,9 @@ export function QuickOpen() {
 
   useEffect(() => {
     if (!open) return;
-    const id = requestAnimationFrame(() => inputRef.current?.focus());
-    return () => cancelAnimationFrame(id);
+    // Timeout beats the dock button keeping focus after pointerup.
+    const id = window.setTimeout(() => inputRef.current?.focus(), 0);
+    return () => window.clearTimeout(id);
   }, [open]);
 
   useEffect(() => {
@@ -124,7 +126,30 @@ export function QuickOpen() {
   }, [open, currentWorkspaceId, fetchApps, syncWorkspaceConversations]);
 
   useEffect(() => {
+    const onRequest = () => openPalette();
+    window.addEventListener(QUICK_OPEN_EVENT, onRequest);
+    return () => window.removeEventListener(QUICK_OPEN_EVENT, onRequest);
+  }, [openPalette]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (wrapRef.current?.contains(target) || listRef.current?.contains(target)) return;
+      close();
+    };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [open, close]);
+
+  useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
+      if (open && e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
+        close();
+        return;
+      }
       if (!(e.metaKey || e.ctrlKey) || e.key.toLowerCase() !== 'p') return;
       if (e.shiftKey) return;
       e.preventDefault();
@@ -293,98 +318,97 @@ export function QuickOpen() {
   const shortcut = mounted ? `${modifierGlyph()}P` : '⌘P';
 
   return (
-    <div ref={wrapRef} className="relative w-[min(32rem,calc(100vw-22rem))] max-w-[32rem]">
-      <button
-        type="button"
-        onClick={() => (open ? inputRef.current?.focus() : openPalette())}
-        className={cn(
-          'flex h-8 w-full items-center gap-2 rounded-md border px-2.5 text-left text-sm transition-colors',
-          open
-            ? 'border-workspace-accent/40 bg-background text-foreground shadow-sm'
-            : 'border-border/60 bg-muted/40 text-muted-foreground hover:border-border hover:bg-muted/70 hover:text-foreground',
-        )}
-        aria-label={`Search ${workspaceName}`}
-        aria-expanded={open}
-        aria-haspopup="listbox"
-        aria-controls="quick-open-list"
-      >
-        <Search size={14} className="shrink-0 opacity-70" />
-        {open ? (
+    <div ref={wrapRef} className="relative w-full">
+      {open ? (
+        <div
+          className="flex h-8 w-full items-center gap-2 rounded-md border border-workspace-accent/40 bg-background px-2.5 text-sm text-foreground shadow-sm"
+          role="combobox"
+          aria-expanded
+          aria-haspopup="listbox"
+          aria-owns="quick-open-list"
+        >
+          <Search size={14} className="shrink-0 opacity-70" />
           <input
             ref={inputRef}
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             onKeyDown={onInputKeyDown}
-            onClick={(e) => e.stopPropagation()}
             placeholder={workspaceName}
             className="min-w-0 flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+            aria-label={`Search ${workspaceName}`}
             aria-autocomplete="list"
+            aria-controls="quick-open-list"
           />
-        ) : (
-          <>
-            <span className="min-w-0 flex-1 truncate">{workspaceName}</span>
-            <kbd className="hidden shrink-0 rounded border border-border/70 bg-background/80 px-1.5 py-0.5 font-sans text-[10px] text-muted-foreground sm:inline">
-              {shortcut}
-            </kbd>
-          </>
-        )}
-      </button>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={openPalette}
+          className="flex h-8 w-full items-center gap-2 rounded-md border border-border/60 bg-muted/40 px-2.5 text-left text-sm text-muted-foreground transition-colors hover:border-border hover:bg-muted/70 hover:text-foreground"
+          aria-label={`Search ${workspaceName}`}
+          aria-expanded={false}
+          aria-haspopup="listbox"
+        >
+          <Search size={14} className="shrink-0 opacity-70" />
+          <span className="min-w-0 flex-1 truncate">{workspaceName}</span>
+          <kbd className="hidden shrink-0 rounded border border-border/70 bg-background/80 px-1.5 py-0.5 font-sans text-[10px] text-muted-foreground sm:inline">
+            {shortcut}
+          </kbd>
+        </button>
+      )}
 
       {open && mounted
         ? createPortal(
-            <>
-              <div className="fixed inset-0 z-[250]" onMouseDown={close} />
-              <div
-                id="quick-open-list"
-                ref={listRef}
-                role="listbox"
-                className="fixed z-[260] max-h-[min(28rem,70vh)] overflow-y-auto border border-border bg-background shadow-xl"
-                style={{
-                  top: listBox?.top ?? 56,
-                  left: listBox?.left ?? 0,
-                  width: listBox?.width ?? 480,
-                }}
-              >
-                {groups.length === 0 ? (
-                  <p className="px-3 py-6 text-center text-sm text-muted-foreground">
-                    {query.trim() ? 'No matches' : 'Nothing to jump to yet'}
-                  </p>
-                ) : (
-                  groups.map((entry) => (
-                    <div key={entry.group}>
-                      <div className="px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-                        {QUICK_OPEN_GROUP_LABEL[entry.group]}
-                      </div>
-                      {entry.items.map((item) => {
-                        const index = results.indexOf(item);
-                        const active = index === activeIndex;
-                        return (
-                          <button
-                            key={item.id}
-                            type="button"
-                            role="option"
-                            aria-selected={active}
-                            data-quick-open-index={index}
-                            onMouseEnter={() => setActiveIndex(index)}
-                            onMouseDown={(e) => e.preventDefault()}
-                            onClick={() => run(item)}
-                            className={cn(
-                              'flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm',
-                              active ? 'bg-muted text-foreground' : 'text-foreground/90 hover:bg-muted/70',
-                            )}
-                          >
-                            <span className="min-w-0 flex-1 truncate">{item.label}</span>
-                            {item.hint ? (
-                              <span className="shrink-0 text-[11px] text-muted-foreground">{item.hint}</span>
-                            ) : null}
-                          </button>
-                        );
-                      })}
+            <div
+              id="quick-open-list"
+              ref={listRef}
+              role="listbox"
+              className="fixed z-[260] max-h-[min(28rem,70vh)] overflow-y-auto border border-border bg-background shadow-xl"
+              style={{
+                top: listBox?.top ?? 56,
+                left: listBox?.left ?? 0,
+                width: listBox?.width ?? 480,
+              }}
+            >
+              {groups.length === 0 ? (
+                <p className="px-3 py-6 text-center text-sm text-muted-foreground">
+                  {query.trim() ? 'No matches' : 'Nothing to jump to yet'}
+                </p>
+              ) : (
+                groups.map((entry) => (
+                  <div key={entry.group}>
+                    <div className="px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                      {QUICK_OPEN_GROUP_LABEL[entry.group]}
                     </div>
-                  ))
-                )}
-              </div>
-            </>,
+                    {entry.items.map((item) => {
+                      const index = results.indexOf(item);
+                      const active = index === activeIndex;
+                      return (
+                        <button
+                          key={item.id}
+                          type="button"
+                          role="option"
+                          aria-selected={active}
+                          data-quick-open-index={index}
+                          onMouseEnter={() => setActiveIndex(index)}
+                          onMouseDown={(e) => e.preventDefault()}
+                          onClick={() => run(item)}
+                          className={cn(
+                            'flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm',
+                            active ? 'bg-muted text-foreground' : 'text-foreground/90 hover:bg-muted/70',
+                          )}
+                        >
+                          <span className="min-w-0 flex-1 truncate">{item.label}</span>
+                          {item.hint ? (
+                            <span className="shrink-0 text-[11px] text-muted-foreground">{item.hint}</span>
+                          ) : null}
+                        </button>
+                      );
+                    })}
+                  </div>
+                ))
+              )}
+            </div>,
             document.body,
           )
         : null}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/index.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/index.tsx
@@ -21,6 +21,7 @@ import {
   moveNavItem,
   shiftForReorder,
 } from '@/lib/sidebar-nav';
+import { requestQuickOpen } from '@/lib/quick-open';
 import { getWorkspacePath } from './utils';
 import { WorkspaceMark, WorkspaceMarkFrame } from '../workspace-mark';
 import { clearAppsSkipRestore } from '@/app/workspace/[workspaceId]/apps/lib/apps-route';
@@ -231,6 +232,10 @@ export function Sidebar() {
 
   const handleSectionClick = (section: SectionDef) => {
     clearAppsSkipRestore();
+    if (section.id === 'search') {
+      requestQuickOpen();
+      return;
+    }
     if (section.id === 'home') {
       setActivePanelSection(null);
       router.push(getDefaultPath(section.id));

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/slides-section.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/slides-section.tsx
@@ -7,21 +7,24 @@ import {
   FileCode2,
   Folder,
   Image as ImageIcon,
-  Plus,
+  LayoutTemplate,
   Presentation,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import {
+  applySlidesTemplate,
+  slidesApiErrorMessage,
+  startNewPresentation,
+} from '@/lib/create-slides-project';
+import {
+  templateAssetLabel,
+  templateSlideLabel,
+  type SlidesSeedTemplate,
+} from '@/lib/slides-templates';
 import { authFetch } from '@/stores/auth';
 import { useSlidesStore, type SlidesProject } from '@/stores/slides';
 import { CollapsibleSection } from './collapsible-section';
 import { getWorkspacePath } from './utils';
-
-interface TreeEntry {
-  name: string;
-  path: string;
-  type: 'file' | 'dir';
-  size?: number;
-}
 
 export function SlidesSection({
   collapsed,
@@ -37,11 +40,15 @@ export function SlidesSection({
   const routeSlug = typeof params?.slug === 'string' ? params.slug : '';
   const slidesBase = getWorkspacePath(workspaceId, '/slides');
   const [projects, setProjects] = useState<SlidesProject[]>([]);
-  const [tree, setTree] = useState<TreeEntry[]>([]);
-  const [assets, setAssets] = useState<TreeEntry[]>([]);
-  const [assetsOpen, setAssetsOpen] = useState(true);
+  const [templates, setTemplates] = useState<SlidesSeedTemplate[]>([]);
+  const [expandedIds, setExpandedIds] = useState<string[]>([]);
+  const [creating, setCreating] = useState(false);
+  const [applyingId, setApplyingId] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
   const selectedSlug = useSlidesStore((s) => s.selectedSlug);
+  const selectedTitle = useSlidesStore((s) => s.selectedTitle);
   const setSelectedSlug = useSlidesStore((s) => s.setSelectedSlug);
+  const deckDirty = useSlidesStore((s) => s.deckDirty);
 
   const openSlug = routeSlug || selectedSlug;
   const openProject = projects.find((p) => p.slug === openSlug) ?? null;
@@ -58,65 +65,94 @@ export function SlidesSection({
     }
   }, [workspaceId]);
 
-  const fetchTree = useCallback(async () => {
-    if (!workspaceId || !openSlug) {
-      setTree([]);
-      setAssets([]);
-      return;
-    }
+  const fetchTemplates = useCallback(async () => {
+    if (!workspaceId) return;
     try {
       const res = await authFetch(
-        `/api/slides/projects/${encodeURIComponent(openSlug)}/tree?workspace_id=${encodeURIComponent(workspaceId)}`,
+        `/api/slides/templates?workspace_id=${encodeURIComponent(workspaceId)}`,
       );
-      if (!res.ok) {
-        // Fallback shape when tree API unavailable (older pin).
-        setTree([
-          { name: 'deck.html', path: `slides/${openSlug}/deck.html`, type: 'file' },
-          { name: 'assets', path: `slides/${openSlug}/assets`, type: 'dir' },
-        ]);
-        setAssets([]);
-        return;
-      }
-      const body = (await res.json()) as {
-        entries?: TreeEntry[];
-        assets?: TreeEntry[];
-      };
-      setTree(body.entries ?? []);
-      setAssets(body.assets ?? []);
+      if (!res.ok) return;
+      const body = (await res.json()) as SlidesSeedTemplate[];
+      setTemplates(
+        body.map((row) => ({
+          ...row,
+          slides: row.slides ?? [],
+          assets: row.assets ?? [],
+        })),
+      );
     } catch {
-      setTree([
-        { name: 'deck.html', path: `slides/${openSlug}/deck.html`, type: 'file' },
-        { name: 'assets', path: `slides/${openSlug}/assets`, type: 'dir' },
-      ]);
-      setAssets([]);
+      // ignore
     }
-  }, [workspaceId, openSlug]);
+  }, [workspaceId]);
 
   useEffect(() => {
     void fetchProjects();
-  }, [fetchProjects, pathname]);
-
-  useEffect(() => {
-    void fetchTree();
-  }, [fetchTree]);
+    void fetchTemplates();
+  }, [fetchProjects, fetchTemplates, pathname]);
 
   useEffect(() => {
     if (routeSlug) setSelectedSlug(routeSlug);
   }, [routeSlug, setSelectedSlug]);
 
-  const folderLabel = openProject?.title || openSlug || 'Presentation';
+  const folderLabel = openProject?.title || selectedTitle || openSlug || 'Presentation';
+  const appliedTemplateId = openProject?.template_id || null;
+
+  const toggleTemplate = (id: string) => {
+    setExpandedIds((current) =>
+      current.includes(id) ? current.filter((item) => item !== id) : [...current, id],
+    );
+  };
+
+  const createNew = () => {
+    if (!workspaceId || creating) return;
+    setCreating(true);
+    setActionError(null);
+    void startNewPresentation(workspaceId, (href) => router.push(href))
+      .catch((e) => {
+        setActionError(
+          slidesApiErrorMessage((e as Error).message, 'Could not create the deck.'),
+        );
+      })
+      .finally(() => {
+        setCreating(false);
+      });
+  };
+
+  const applyTemplate = (template: SlidesSeedTemplate) => {
+    if (!workspaceId || creating || applyingId) return;
+    if (openSlug && deckDirty) {
+      const ok = window.confirm(
+        'Replace the open deck with this template? Unsaved edits will be lost.',
+      );
+      if (!ok) return;
+    }
+    setApplyingId(template.id);
+    setActionError(null);
+    void applySlidesTemplate(workspaceId, template.id, openSlug || null, (href) =>
+      router.push(href),
+    )
+      .then(() => {
+        void fetchProjects();
+      })
+      .catch((e) => {
+        setActionError(slidesApiErrorMessage((e as Error).message, 'Could not apply the template.'));
+      })
+      .finally(() => {
+        setApplyingId(null);
+      });
+  };
 
   return (
     <CollapsibleSection
       id="slides"
       icon={<Presentation size={18} />}
       label="Slides"
-      description="Presentation projects"
+      description="Templates and open deck"
       href={slidesBase}
       collapsed={collapsed}
       detailOnly={detailOnly}
     >
-      <div className="flex items-center justify-between px-1 pb-1">
+      <div className="px-1 pb-1">
         <button
           onClick={() => router.push(slidesBase)}
           className={cn(
@@ -126,18 +162,11 @@ export function SlidesSection({
         >
           All projects
         </button>
-        <button
-          onClick={() => router.push(`${slidesBase}/new`)}
-          title="New Presentation"
-          aria-label="New Presentation"
-          className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-workspace-accent-10 hover:text-workspace-accent"
-        >
-          <Plus size={13} />
-        </button>
       </div>
+      {actionError ? <p className="px-3 pb-1 text-xs text-red-600">{actionError}</p> : null}
 
       {openSlug ? (
-        <div className="space-y-0.5 px-1">
+        <div className="space-y-0.5 px-1 pb-2">
           <div className="px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
             Open presentation
           </div>
@@ -157,117 +186,147 @@ export function SlidesSection({
             <Folder size={12} className="flex-shrink-0 text-muted-foreground" />
             <span className="truncate">{folderLabel}</span>
           </button>
-
-          <div className="ml-3 space-y-0.5 border-l border-border/60 pl-2">
-            {(tree.length
-              ? tree.filter((e) => e.type === 'file' && e.name !== 'project.json')
-              : [{ name: 'deck.html', path: '', type: 'file' as const }]
-            ).map((entry) => (
-              <button
-                key={entry.name}
-                type="button"
-                onClick={() => router.push(`${slidesBase}/${openSlug}`)}
-                className={cn(
-                  'flex w-full items-center gap-2 rounded-md px-2 py-1 text-xs transition-colors hover:bg-workspace-accent-10',
-                  entry.name === 'deck.html' &&
-                    pathname.startsWith(`${slidesBase}/${openSlug}`) &&
-                    'bg-workspace-accent-10 font-medium text-workspace-accent',
-                )}
-              >
-                <FileCode2 size={11} className="flex-shrink-0 text-muted-foreground" />
-                <span className="truncate">{entry.name}</span>
-              </button>
-            ))}
-
+          <div className="ml-3 border-l border-border/60 pl-2">
             <button
               type="button"
-              onClick={() => setAssetsOpen((v) => !v)}
-              className="flex w-full items-center gap-1 rounded-md px-2 py-1 text-xs text-foreground hover:bg-workspace-accent-10"
+              onClick={() => router.push(`${slidesBase}/${openSlug}`)}
+              className="flex w-full items-center gap-2 rounded-md px-2 py-1 text-xs font-medium text-workspace-accent hover:bg-workspace-accent-10"
             >
-              <ChevronRight
-                size={11}
-                className={cn('transition-transform', assetsOpen && 'rotate-90')}
-              />
-              <Folder size={11} className="flex-shrink-0 text-muted-foreground" />
-              <span className="truncate">assets</span>
+              <FileCode2 size={11} className="flex-shrink-0 text-muted-foreground" />
+              <span className="truncate">deck.html</span>
             </button>
-            {assetsOpen && (
-              <div className="ml-4 space-y-0.5">
-                {assets.length === 0 ? (
-                  <p className="px-2 py-0.5 text-[10px] text-muted-foreground">
-                    Empty (template images still embedded in deck.html)
-                  </p>
-                ) : (
-                  assets.map((entry) => (
-                    <div
-                      key={entry.path}
-                      className="flex items-center gap-2 px-2 py-0.5 text-[11px] text-muted-foreground"
-                    >
-                      <ImageIcon size={10} className="flex-shrink-0" />
-                      <span className="truncate">{entry.name}</span>
-                    </div>
-                  ))
-                )}
-              </div>
-            )}
           </div>
+        </div>
+      ) : null}
 
-          {projects.length > 1 && (
-            <>
-              <div className="mt-2 px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-                Other projects
-              </div>
-              {projects
-                .filter((p) => p.slug !== openSlug)
-                .map((p) => (
-                  <button
-                    key={p.slug}
-                    onClick={() => {
-                      setSelectedSlug(p.slug);
-                      router.push(`${slidesBase}/${p.slug}`);
-                    }}
-                    className="flex w-full items-center gap-2 rounded-md px-2 py-1 text-xs transition-colors hover:bg-workspace-accent-10"
-                  >
-                    <Presentation size={11} className="flex-shrink-0 text-muted-foreground" />
-                    <span className="truncate">{p.title}</span>
-                  </button>
-                ))}
-            </>
-          )}
-        </div>
-      ) : (
-        <div className="space-y-0.5 px-1">
-          <div className="px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-            Projects
+      <div className="space-y-0.5 px-1">
+        <div className="flex items-center justify-between px-2 py-1">
+          <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            Templates
           </div>
-          {projects.length === 0 ? (
-            <p className="px-2 py-1 text-xs text-muted-foreground">No slides projects yet</p>
-          ) : (
-            projects.map((p) => {
-              const href = `${slidesBase}/${p.slug}`;
-              const active = pathname.startsWith(href);
-              return (
-                <button
-                  key={p.slug}
-                  onClick={() => {
-                    setSelectedSlug(p.slug);
-                    router.push(href);
-                  }}
-                  className={cn(
-                    'flex w-full items-center gap-2 rounded-md px-2 py-1 text-xs transition-colors hover:bg-workspace-accent-10',
-                    active
-                      ? 'bg-workspace-accent-10 font-medium text-workspace-accent'
-                      : 'text-foreground',
-                  )}
-                >
-                  <Presentation size={11} className="flex-shrink-0 text-muted-foreground" />
-                  <span className="truncate">{p.title}</span>
-                </button>
-              );
-            })
-          )}
+          <button
+            type="button"
+            onClick={createNew}
+            disabled={creating}
+            title="New"
+            aria-label="New"
+            className="rounded px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground transition-colors hover:bg-workspace-accent-10 hover:text-workspace-accent disabled:opacity-50"
+          >
+            New
+          </button>
         </div>
-      )}
+        {templates.length === 0 ? (
+          <p className="px-2 py-1 text-xs text-muted-foreground">No templates loaded</p>
+        ) : (
+          templates.map((template) => {
+            const expanded = expandedIds.includes(template.id);
+            const applying = applyingId === template.id;
+            const active = appliedTemplateId === template.id && Boolean(openSlug);
+            return (
+              <div key={template.id} className="space-y-0.5">
+                <div className="flex items-center gap-0.5">
+                  <button
+                    type="button"
+                    onClick={() => toggleTemplate(template.id)}
+                    aria-expanded={expanded}
+                    aria-label={`Expand ${template.name}`}
+                    className="rounded p-1 text-muted-foreground hover:bg-workspace-accent-10 hover:text-foreground"
+                  >
+                    <ChevronRight
+                      size={11}
+                      className={cn('transition-transform', expanded && 'rotate-90')}
+                    />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => applyTemplate(template)}
+                    disabled={Boolean(applyingId)}
+                    title={`Apply ${template.name}`}
+                    className={cn(
+                      'flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1 text-xs transition-colors hover:bg-workspace-accent-10 disabled:opacity-50',
+                      active
+                        ? 'bg-workspace-accent-10 font-medium text-workspace-accent'
+                        : 'text-foreground',
+                    )}
+                  >
+                    <span
+                      className="h-2.5 w-2.5 flex-shrink-0 rounded-sm border border-border/70"
+                      style={{ background: template.preview_accent || template.preview_bg }}
+                      aria-hidden
+                    />
+                    <LayoutTemplate size={11} className="flex-shrink-0 text-muted-foreground" />
+                    <span className="truncate">{template.name}</span>
+                    {applying ? (
+                      <span className="ml-auto text-[10px] text-muted-foreground">Applying</span>
+                    ) : null}
+                  </button>
+                </div>
+                {expanded ? (
+                  <div className="ml-6 space-y-1 border-l border-border/60 pl-2">
+                    <div className="px-2 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                      Slides
+                    </div>
+                    {template.slides.length === 0 ? (
+                      <p className="px-2 py-0.5 text-[10px] text-muted-foreground">No slides in seed</p>
+                    ) : (
+                      template.slides.map((slide) => (
+                        <div
+                          key={`${template.id}-${slide.index}`}
+                          className="flex items-center gap-2 px-2 py-0.5 text-[11px] text-muted-foreground"
+                        >
+                          <Presentation size={10} className="flex-shrink-0" />
+                          <span className="truncate">{templateSlideLabel(slide)}</span>
+                        </div>
+                      ))
+                    )}
+                    <div className="px-2 pt-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                      Assets
+                    </div>
+                    {template.assets.length === 0 ? (
+                      <p className="px-2 py-0.5 text-[10px] text-muted-foreground">
+                        None (images stay inside deck.html)
+                      </p>
+                    ) : (
+                      template.assets.map((asset) => (
+                        <div
+                          key={`${template.id}-${asset.name}`}
+                          className="flex items-center gap-2 px-2 py-0.5 text-[11px] text-muted-foreground"
+                        >
+                          <ImageIcon size={10} className="flex-shrink-0" />
+                          <span className="truncate">{templateAssetLabel(asset)}</span>
+                        </div>
+                      ))
+                    )}
+                  </div>
+                ) : null}
+              </div>
+            );
+          })
+        )}
+      </div>
+
+      {projects.filter((p) => p.slug !== openSlug).length > 0 ? (
+        <div className="mt-2 space-y-0.5 px-1">
+          <div className="px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            Other projects
+          </div>
+          {projects
+            .filter((p) => p.slug !== openSlug)
+            .map((p) => (
+              <button
+                key={p.slug}
+                onClick={() => {
+                  setSelectedSlug(p.slug);
+                  router.push(`${slidesBase}/${p.slug}`);
+                }}
+                className="flex w-full items-center gap-2 rounded-md px-2 py-1 text-xs transition-colors hover:bg-workspace-accent-10"
+              >
+                <Presentation size={11} className="flex-shrink-0 text-muted-foreground" />
+                <span className="truncate">{p.title}</span>
+              </button>
+            ))}
+        </div>
+      ) : null}
     </CollapsibleSection>
   );
 }

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/slides/slides-pptx-from-dom.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/slides/slides-pptx-from-dom.test.ts
@@ -1,0 +1,135 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { SLIDES_STAGE_HEIGHT, SLIDES_STAGE_WIDTH } from './slides-preview-fit';
+import {
+  planSlidesPptxFromHtml,
+  SLIDES_PPTX_FROM_DOM_FINGERPRINT,
+  SLIDES_PPTX_FROM_DOM_FN,
+  SLIDES_PPTX_FROM_DOM_SCRIPT,
+  SLIDES_PPTX_FROM_DOM_SCRIPT_ID,
+  SLIDES_PPTX_HEIGHT_IN,
+  SLIDES_PPTX_STAGE_HEIGHT_PX,
+  SLIDES_PPTX_STAGE_WIDTH_PX,
+  SLIDES_PPTX_WIDTH_IN,
+} from './slides-pptx-from-dom';
+
+const FIXTURE = `<!doctype html>
+<html><head><style>
+:root {
+  --panel: #ffffff;
+  --ink: #1a1a1a;
+  --muted: #6b6b6b;
+  --accent: #1a1a1a;
+  --card: #fafaf8;
+}
+</style></head>
+<body>
+<main class="deck">
+<section id="slide-cover" class="slide cover">
+  <h1>Q3 Review</h1>
+  <p class="subtitle">Exec team readout</p>
+  <div class="hook">30 min</div>
+</section>
+<section class="slide">
+  <div class="eyebrow">Agenda</div>
+  <h1>What we will cover</h1>
+  <div class="agenda-row"><h2>Context</h2><p>Why now</p></div>
+</section>
+<section class="slide">
+  <div class="eyebrow">Context</div>
+  <h1>Shared problem</h1>
+  <div class="card"><h2>Current state</h2><ul><li>Gap one</li></ul></div>
+</section>
+</main>
+<script>const FOOTER_TXT = "Presentation Title"; function buildPptx(){ /* seed strings */ }</script>
+</body></html>`;
+
+function seedHtml(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const path = resolve(
+    here,
+    '../../../../../assets/slides/templates/minimal-light-v1.html',
+  );
+  return readFileSync(path, 'utf8');
+}
+
+describe('planSlidesPptxFromHtml', () => {
+  it('uses the 1280x720 / 13.333x7.5 stage', () => {
+    const plan = planSlidesPptxFromHtml(FIXTURE);
+    expect(plan.stage.widthPx).toBe(SLIDES_STAGE_WIDTH);
+    expect(plan.stage.heightPx).toBe(SLIDES_STAGE_HEIGHT);
+    expect(plan.stage.widthPx).toBe(SLIDES_PPTX_STAGE_WIDTH_PX);
+    expect(plan.stage.heightPx).toBe(SLIDES_PPTX_STAGE_HEIGHT_PX);
+    expect(plan.stage.widthIn).toBe(SLIDES_PPTX_WIDTH_IN);
+    expect(plan.stage.heightIn).toBe(SLIDES_PPTX_HEIGHT_IN);
+  });
+
+  it('reads live HTML: slide count, cover h1, colors, not script strings', () => {
+    const plan = planSlidesPptxFromHtml(FIXTURE);
+    expect(plan.slideCount).toBe(3);
+    expect(plan.coverH1).toBe('Q3 Review');
+    expect(plan.coverSubtitle).toBe('Exec team readout');
+    expect(plan.colors.panel).toBe('ffffff');
+    expect(plan.colors.ink).toBe('1a1a1a');
+    expect(plan.slides.map((s) => s.kind)).toEqual(['cover', 'agenda', 'cards']);
+    expect(plan.slides[0].texts).toContain('Q3 Review');
+    expect(plan.coverH1).not.toBe('Presentation Title');
+  });
+
+  it('picks up an agent cover h1 edit', () => {
+    const edited = FIXTURE.replace('<h1>Q3 Review</h1>', '<h1>Q3 Review for execs</h1>');
+    const plan = planSlidesPptxFromHtml(edited);
+    expect(plan.coverH1).toBe('Q3 Review for execs');
+    expect(plan.slideCount).toBe(3);
+  });
+
+  it('plans every section when the agent adds slides (not a 4-slide script)', () => {
+    const extra = FIXTURE.replace(
+      '</main>',
+      `<section class="slide"><h1>Roadmap</h1></section>
+<section class="slide"><h1>Next</h1></section></main>`,
+    );
+    const plan = planSlidesPptxFromHtml(extra);
+    expect(plan.slideCount).toBe(5);
+    expect(plan.slides[3].title).toBe('Roadmap');
+    expect(plan.slides[4].title).toBe('Next');
+  });
+});
+
+describe('seed template contract', () => {
+  it('plans all Minimal Light slides and the cover h1 from HTML', () => {
+    const html = seedHtml();
+    const plan = planSlidesPptxFromHtml(html);
+    expect(plan.slideCount).toBe(10);
+    expect(plan.coverH1).toBe('Presentation Title');
+    expect(plan.colors.panel).toBe('ffffff');
+    expect(plan.slides[0].kind).toBe('cover');
+    expect(plan.slides.some((s) => s.kind === 'divider')).toBe(true);
+    const edited = html.replace(
+      '<h1>Presentation Title</h1>',
+      '<h1>Board update</h1>',
+    );
+    expect(planSlidesPptxFromHtml(edited).coverH1).toBe('Board update');
+  });
+
+  it('ships the DOM walker instead of a 4-slide hardcoded export', () => {
+    const html = seedHtml();
+    expect(html).toContain(SLIDES_PPTX_FROM_DOM_FINGERPRINT);
+    expect(html).toContain('querySelectorAll("main.deck > section.slide');
+    expect(html).not.toContain('[["1","Context"],["2","Approach"]');
+    expect(html).not.toContain('txt(s, "Presentation Title", 56, 380');
+  });
+});
+
+describe('injected PPTX-from-DOM script', () => {
+  it('overrides window.buildPptx from the live DOM', () => {
+    expect(SLIDES_PPTX_FROM_DOM_SCRIPT).toContain(SLIDES_PPTX_FROM_DOM_SCRIPT_ID);
+    expect(SLIDES_PPTX_FROM_DOM_SCRIPT).toContain(SLIDES_PPTX_FROM_DOM_FINGERPRINT);
+    expect(SLIDES_PPTX_FROM_DOM_SCRIPT).toContain('window.buildPptx = buildPptx');
+    expect(SLIDES_PPTX_FROM_DOM_FN).toContain('querySelectorAll("main.deck > section.slide');
+    expect(SLIDES_PPTX_FROM_DOM_FN).toContain('prop("--panel"');
+    expect(SLIDES_PPTX_FROM_DOM_FN).toContain('classList.contains("cover")');
+  });
+});

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/slides/slides-pptx-from-dom.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/slides/slides-pptx-from-dom.ts
@@ -1,0 +1,441 @@
+/**
+ * HTML is the live Slides source. PPTX is a 1280x720 reconstruction of the
+ * current `.slide` DOM (pptxgenjs). Preview is the HTML stage.
+ *
+ * pptxgenjs cannot match CSS pixel-for-pixel (web fonts, wrapping,
+ * letter-spacing). Export must still carry the same slide count, cover h1,
+ * body copy, layout regions, and theme colors.
+ */
+
+export const SLIDES_PPTX_FROM_DOM_SCRIPT_ID = 'nexus-slides-pptx-from-dom';
+export const SLIDES_PPTX_FROM_DOM_FINGERPRINT = 'NEXUS_SLIDES_PPTX_FROM_DOM_V1';
+
+export const SLIDES_PPTX_STAGE_WIDTH_PX = 1280;
+export const SLIDES_PPTX_STAGE_HEIGHT_PX = 720;
+export const SLIDES_PPTX_DPI = 96;
+export const SLIDES_PPTX_WIDTH_IN = 13.333;
+export const SLIDES_PPTX_HEIGHT_IN = 7.5;
+
+export type SlidesPptxSlideKind =
+  | 'cover'
+  | 'divider'
+  | 'agenda'
+  | 'cards'
+  | 'steps'
+  | 'content';
+
+export type SlidesPptxPlanSlide = {
+  kind: SlidesPptxSlideKind;
+  eyebrow?: string;
+  title?: string;
+  subtitle?: string;
+  hook?: string;
+  footer?: string;
+  texts: string[];
+};
+
+export type SlidesPptxPlan = {
+  stage: {
+    widthPx: number;
+    heightPx: number;
+    widthIn: number;
+    heightIn: number;
+    dpi: number;
+  };
+  colors: {
+    panel: string;
+    ink: string;
+    muted: string;
+    accent: string;
+    card: string;
+  };
+  coverH1: string | null;
+  coverSubtitle: string | null;
+  slideCount: number;
+  slides: SlidesPptxPlanSlide[];
+};
+
+const SECTION_RE =
+  /<section\b[^>]*\bclass=["'][^"']*\bslide\b[^"']*["'][^>]*>[\s\S]*?<\/section>/gi;
+const ROOT_RE = /:root\s*\{([\s\S]*?)\}/;
+const CSS_VAR_RE = /--([a-z0-9-]+)\s*:\s*([^;]+);/gi;
+const TAG_RE = /<[^>]+>/g;
+
+function stripTags(html: string): string {
+  return html.replace(TAG_RE, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function unescapeHtml(value: string): string {
+  return value
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/&mdash;/gi, '-')
+    .replace(/&ndash;/gi, '-')
+    .replace(/&#0*8212;/g, '-')
+    .replace(/&#x0*2014;/gi, '-')
+    .replace(/&#0*8211;/g, '-')
+    .replace(/&#x0*2013;/gi, '-')
+    .replace(/&#(\d+);/g, (_, n: string) => String.fromCodePoint(Number(n)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, n: string) =>
+      String.fromCodePoint(parseInt(n, 16)),
+    );
+}
+
+function inner(html: string, tag: string, className?: string): string | null {
+  const attr = className
+    ? `\\bclass=["'][^"']*\\b${className}\\b[^"']*["']`
+    : '';
+  const re = new RegExp(
+    `<${tag}\\b[^>]*${attr}[^>]*>([\\s\\S]*?)</${tag}>`,
+    'i',
+  );
+  const match = re.exec(html);
+  if (!match) return null;
+  const text = unescapeHtml(stripTags(match[1]));
+  return text || null;
+}
+
+function allInner(html: string, tag: string, className?: string): string[] {
+  const attr = className
+    ? `\\bclass=["'][^"']*\\b${className}\\b[^"']*["']`
+    : '';
+  const re = new RegExp(
+    `<${tag}\\b[^>]*${attr}[^>]*>([\\s\\S]*?)</${tag}>`,
+    'gi',
+  );
+  const out: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(html))) {
+    const text = unescapeHtml(stripTags(match[1]));
+    if (text) out.push(text);
+  }
+  return out;
+}
+
+function hasClass(openTag: string, name: string): boolean {
+  const classMatch = openTag.match(/\bclass=["']([^"']+)["']/i);
+  if (!classMatch) return false;
+  return classMatch[1].split(/\s+/).includes(name);
+}
+
+function normalizeHex(raw: string | undefined, fallback: string): string {
+  const value = (raw || fallback).trim();
+  const hex = value.match(/#([0-9a-fA-F]{6})/);
+  if (hex) return hex[1].toLowerCase();
+  const short = value.match(/#([0-9a-fA-F]{3})\b/);
+  if (short) {
+    const [r, g, b] = short[1];
+    return `${r}${r}${g}${g}${b}${b}`.toLowerCase();
+  }
+  return fallback.replace('#', '').toLowerCase();
+}
+
+function cssVars(html: string): Record<string, string> {
+  const block = ROOT_RE.exec(html);
+  if (!block) return {};
+  const vars: Record<string, string> = {};
+  let match: RegExpExecArray | null;
+  const re = new RegExp(CSS_VAR_RE.source, 'gi');
+  while ((match = re.exec(block[1]))) {
+    vars[match[1]] = match[2].trim();
+  }
+  return vars;
+}
+
+function classify(section: string): SlidesPptxSlideKind {
+  const open = section.match(/^<section\b[^>]*>/i)?.[0] || '';
+  if (hasClass(open, 'cover')) return 'cover';
+  if (hasClass(open, 'section-divider')) return 'divider';
+  if (/\bagenda-row\b/i.test(section)) return 'agenda';
+  if (/\bclass=["'][^"']*\bstep\b/i.test(section)) return 'steps';
+  if (/\bclass=["'][^"']*\bcard\b/i.test(section)) return 'cards';
+  return 'content';
+}
+
+function planSlide(section: string): SlidesPptxPlanSlide {
+  const kind = classify(section);
+  const texts: string[] = [];
+  const eyebrow =
+    kind === 'divider'
+      ? inner(section, 'div', 'divider-eyebrow')
+      : inner(section, 'div', 'eyebrow');
+  const title =
+    kind === 'divider'
+      ? inner(section, 'div', 'divider-title')
+      : inner(section, 'h1');
+  const subtitle =
+    kind === 'divider'
+      ? inner(section, 'div', 'divider-sub')
+      : inner(section, 'p', 'subtitle');
+  const hook = inner(section, 'div', 'hook');
+  const footer = inner(section, 'div', 'footer');
+  if (eyebrow) texts.push(eyebrow);
+  if (title) texts.push(title);
+  if (subtitle) texts.push(subtitle);
+  if (hook) texts.push(hook);
+  for (const h2 of allInner(section, 'h2')) texts.push(h2);
+  for (const li of allInner(section, 'li')) texts.push(li);
+  for (const p of allInner(section, 'p')) {
+    if (p !== subtitle) texts.push(p);
+  }
+  return {
+    kind,
+    ...(eyebrow ? { eyebrow } : {}),
+    ...(title ? { title } : {}),
+    ...(subtitle ? { subtitle } : {}),
+    ...(hook ? { hook } : {}),
+    ...(footer ? { footer } : {}),
+    texts,
+  };
+}
+
+/** Derive the PPTX reconstruction plan from deck HTML (no pptxgenjs). */
+export function planSlidesPptxFromHtml(html: string): SlidesPptxPlan {
+  const vars = cssVars(html);
+  const sections = html.match(SECTION_RE) ?? [];
+  const slides = sections.map(planSlide);
+  const cover = slides.find((s) => s.kind === 'cover') ?? slides[0];
+  return {
+    stage: {
+      widthPx: SLIDES_PPTX_STAGE_WIDTH_PX,
+      heightPx: SLIDES_PPTX_STAGE_HEIGHT_PX,
+      widthIn: SLIDES_PPTX_WIDTH_IN,
+      heightIn: SLIDES_PPTX_HEIGHT_IN,
+      dpi: SLIDES_PPTX_DPI,
+    },
+    colors: {
+      panel: normalizeHex(vars.panel, 'ffffff'),
+      ink: normalizeHex(vars.ink, '1a1a1a'),
+      muted: normalizeHex(vars.muted, '6b6b6b'),
+      accent: normalizeHex(vars.accent, '1a1a1a'),
+      card: normalizeHex(vars.card, 'fafaf8'),
+    },
+    coverH1: cover?.title ?? null,
+    coverSubtitle: cover?.subtitle ?? null,
+    slideCount: slides.length,
+    slides,
+  };
+}
+
+/**
+ * Classic-script walker installed as window.buildPptx. Reads live .slide
+ * nodes so agent HTML edits export without touching script strings.
+ */
+export const SLIDES_PPTX_FROM_DOM_FN = `/* ${SLIDES_PPTX_FROM_DOM_FINGERPRINT} */
+async function buildPptx() {
+  if (typeof PptxGenJS === "undefined") throw new Error("PptxGenJS failed to load");
+  var slides = document.querySelectorAll("main.deck > section.slide, .deck > section.slide");
+  if (!slides.length) throw new Error("No .slide sections to export");
+  var pptx = new PptxGenJS();
+  pptx.defineLayout({ name: "LAYOUT_16x9", width: 13.333, height: 7.5 });
+  pptx.layout = "LAYOUT_16x9";
+  var I = function (px) { return px / 96; };
+  var hex = function (raw, fallback) {
+    var s = String(raw || fallback || "").trim();
+    var m = s.match(/#([0-9a-fA-F]{6})/);
+    if (m) return m[1];
+    m = s.match(/#([0-9a-fA-F]{3})\\b/);
+    if (m) {
+      var a = m[1];
+      return a.charAt(0) + a.charAt(0) + a.charAt(1) + a.charAt(1) + a.charAt(2) + a.charAt(2);
+    }
+    m = s.match(/rgba?\\(\\s*(\\d+)\\s*,\\s*(\\d+)\\s*,\\s*(\\d+)/);
+    if (m) {
+      return [m[1], m[2], m[3]].map(function (n) {
+        return ("0" + Number(n).toString(16)).slice(-2);
+      }).join("");
+    }
+    return String(fallback || "ffffff").replace("#", "");
+  };
+  var cssUrl = function (name) {
+    try {
+      var v = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+      var m = v.match(/url\\(["']?(data:[^"')]+)["']?\\)/);
+      return m ? m[1] : "";
+    } catch (e) {
+      return "";
+    }
+  };
+  var root;
+  try { root = getComputedStyle(document.documentElement); } catch (e) { root = null; }
+  var prop = function (name, fb) {
+    return hex(root ? root.getPropertyValue(name) : "", fb);
+  };
+  var C = {
+    bg: prop("--panel", "ffffff"),
+    ink: prop("--ink", "1a1a1a"),
+    muted: prop("--muted", "6b6b6b"),
+    accent: prop("--accent", "1a1a1a"),
+    card: prop("--card", "fafaf8")
+  };
+  var txt = function (s, t, x, y, w, h, o) {
+    if (!t) return;
+    s.addText(t, Object.assign({
+      x: I(x), y: I(y), w: I(w), h: I(h), fontFace: "Arial", margin: 0
+    }, o || {}));
+  };
+  var textOf = function (el) {
+    return el ? String(el.textContent || "").replace(/\\s+/g, " ").trim() : "";
+  };
+  var first = function (rootEl, sel) {
+    try { return rootEl.querySelector(sel); } catch (e) { return null; }
+  };
+  var heroData = cssUrl("--hero");
+  var divData = cssUrl("--div1");
+  try {
+    if (!heroData && typeof IMG !== "undefined" && IMG && IMG.hero) heroData = IMG.hero;
+    if (!divData && typeof IMG !== "undefined" && IMG && IMG.d1) divData = IMG.d1;
+  } catch (e) {}
+  var coverH1 = "";
+  for (var i = 0; i < slides.length; i++) {
+    var el = slides[i];
+    var s = pptx.addSlide();
+    s.background = { color: C.bg };
+    var footerEl = first(el, ".footer");
+    var footerLeft = "";
+    var footerRight = "";
+    if (footerEl) {
+      var spans = footerEl.querySelectorAll(":scope > span");
+      footerLeft = textOf(spans[0]) || textOf(footerEl);
+      footerRight = spans.length > 1 ? textOf(spans[spans.length - 1]) : "";
+    }
+    var drawFooter = function () {
+      if (footerLeft) txt(s, footerLeft, 56, 686, 900, 20, { fontSize: 9, color: C.muted });
+      if (footerRight) txt(s, footerRight, 1100, 686, 124, 20, { fontSize: 9, color: C.muted, align: "right" });
+    };
+    if (el.classList.contains("cover")) {
+      if (heroData) {
+        try { s.addImage({ data: heroData, x: 0, y: 0, w: I(1280), h: I(300) }); } catch (e) {}
+      } else {
+        s.addShape(pptx.ShapeType.rect, {
+          x: 0, y: 0, w: I(1280), h: I(300),
+          fill: { color: prop("--hero-fallback", "eae8e1") }
+        });
+      }
+      var cEyebrow = textOf(first(el, ".eyebrow"));
+      var cH1 = textOf(first(el, "h1"));
+      var cSub = textOf(first(el, ".subtitle"));
+      var cHook = textOf(first(el, ".hook"));
+      if (!coverH1) coverH1 = cH1;
+      if (cEyebrow) txt(s, cEyebrow.toUpperCase(), 56, 340, 1168, 24, { fontSize: 12, color: C.accent, bold: true });
+      if (cH1) txt(s, cH1, 56, 372, 1168, 64, { fontSize: 32, bold: true, color: C.ink });
+      if (cSub) txt(s, cSub, 56, 444, 1168, 44, { fontSize: 14, color: C.muted });
+      if (cHook) txt(s, cHook, 56, 496, 1168, 28, { fontSize: 13, bold: true, color: C.accent });
+      continue;
+    }
+    if (el.classList.contains("section-divider")) {
+      if (divData) {
+        try { s.addImage({ data: divData, x: 0, y: 0, w: I(1280), h: I(720) }); } catch (e) {}
+      }
+      var dEyebrow = textOf(first(el, ".divider-eyebrow"));
+      var dNum = textOf(first(el, ".divider-number"));
+      var dTitle = textOf(first(el, ".divider-title"));
+      var dSub = textOf(first(el, ".divider-sub"));
+      if (dEyebrow) txt(s, dEyebrow.toUpperCase(), 56, 180, 1168, 24, { fontSize: 12, bold: true, color: C.accent });
+      if (dNum) txt(s, dNum, 56, 210, 1168, 110, { fontSize: 72, bold: true, color: C.ink });
+      if (dTitle) txt(s, dTitle, 56, 330, 1168, 56, { fontSize: 32, bold: true, color: C.ink });
+      if (dSub) txt(s, dSub, 56, 396, 900, 40, { fontSize: 14, color: C.muted });
+      continue;
+    }
+    var eyebrow = textOf(first(el, ":scope > .eyebrow")) || textOf(first(el, ".eyebrow"));
+    var h1 = textOf(first(el, ":scope > h1")) || textOf(first(el, "h1"));
+    if (eyebrow) txt(s, eyebrow.toUpperCase(), 56, 48, 1168, 20, { fontSize: 11, bold: true, color: C.accent });
+    if (h1) txt(s, h1, 56, 76, 1168, 44, { fontSize: 26, bold: true, color: C.ink });
+    var agendaRows = el.querySelectorAll(".agenda-row");
+    if (agendaRows.length) {
+      for (var ar = 0; ar < agendaRows.length; ar++) {
+        var row = agendaRows[ar];
+        var y = 140 + ar * 90;
+        s.addShape(pptx.ShapeType.rect, { x: I(56), y: I(y), w: I(1168), h: I(76), fill: { color: C.card } });
+        txt(s, textOf(first(row, ".agenda-num")), 76, y + 18, 48, 40, { fontSize: 20, bold: true, color: C.accent });
+        txt(s, textOf(first(row, "h2")), 130, y + 14, 820, 28, { fontSize: 16, bold: true, color: C.ink });
+        txt(s, textOf(first(row, "p")), 130, y + 42, 820, 24, { fontSize: 12, color: C.muted });
+        var kids = row.children;
+        if (kids.length) {
+          txt(s, textOf(kids[kids.length - 1]), 980, y + 24, 220, 28, { fontSize: 12, color: C.muted, align: "right" });
+        }
+      }
+      drawFooter();
+      continue;
+    }
+    var stepNodes = el.querySelectorAll(".step");
+    if (stepNodes.length) {
+      for (var st = 0; st < stepNodes.length; st++) {
+        var step = stepNodes[st];
+        var col = st % 2;
+        var srow = Math.floor(st / 2);
+        var sx = 56 + col * 596;
+        var sy = 140 + srow * 220;
+        s.addShape(pptx.ShapeType.rect, { x: I(sx), y: I(sy), w: I(576), h: I(200), fill: { color: C.card } });
+        s.addShape(pptx.ShapeType.rect, { x: I(sx), y: I(sy), w: I(6), h: I(200), fill: { color: C.accent } });
+        txt(s, textOf(first(step, ".step-n")), sx + 24, sy + 28, 60, 40, { fontSize: 24, bold: true, color: C.accent });
+        txt(s, textOf(first(step, "h2")), sx + 90, sy + 36, 450, 32, { fontSize: 16, bold: true, color: C.ink });
+        txt(s, textOf(first(step, "p")), sx + 24, sy + 84, 528, 90, { fontSize: 13, color: C.muted });
+      }
+      drawFooter();
+      continue;
+    }
+    var cards = el.querySelectorAll(".card");
+    if (cards.length) {
+      var n = cards.length;
+      var cols = n >= 4 ? 4 : (n === 3 ? 3 : 2);
+      var gap = 18;
+      var avail = 1168;
+      var cw = (avail - gap * (cols - 1)) / cols;
+      var ch = 360;
+      for (var ci = 0; ci < n; ci++) {
+        var card = cards[ci];
+        var ccol = ci % cols;
+        var crow = Math.floor(ci / cols);
+        var cx = 56 + ccol * (cw + gap);
+        var cy = 140 + crow * (ch + gap);
+        s.addShape(pptx.ShapeType.rect, { x: I(cx), y: I(cy), w: I(cw), h: I(ch), fill: { color: C.card } });
+        var pill = textOf(first(card, ".pill"));
+        var ch2 = textOf(first(card, "h2"));
+        var cp = textOf(first(card, "p"));
+        var lis = [];
+        var liNodes = card.querySelectorAll("li");
+        for (var li = 0; li < liNodes.length; li++) {
+          var lt = textOf(liNodes[li]);
+          if (lt) lis.push(lt);
+        }
+        var ty = cy + 22;
+        if (pill) { txt(s, pill.toUpperCase(), cx + 20, ty, cw - 40, 20, { fontSize: 10, bold: true, color: C.accent }); ty += 26; }
+        if (ch2) { txt(s, ch2, cx + 20, ty, cw - 40, 28, { fontSize: 16, bold: true, color: C.ink }); ty += 36; }
+        if (lis.length) {
+          txt(s, lis.map(function (item) { return "• " + item; }).join("\\n"), cx + 20, ty, cw - 40, Math.max(40, ch - (ty - cy) - 20), { fontSize: 13, color: C.muted, valign: "top" });
+        } else if (cp) {
+          txt(s, cp, cx + 20, ty, cw - 40, Math.max(40, ch - (ty - cy) - 20), { fontSize: 13, color: C.muted, valign: "top" });
+        }
+      }
+      drawFooter();
+      continue;
+    }
+    var gSub = textOf(first(el, ".subtitle"));
+    var gy = 136;
+    if (gSub) { txt(s, gSub, 56, gy, 1168, 36, { fontSize: 14, color: C.muted }); gy += 44; }
+    var paras = el.querySelectorAll(":scope > p");
+    for (var pi = 0; pi < paras.length; pi++) {
+      var pt = textOf(paras[pi]);
+      if (!pt || pt === gSub) continue;
+      txt(s, pt, 56, gy, 1168, 48, { fontSize: 14, color: C.muted });
+      gy += 52;
+    }
+    drawFooter();
+  }
+  var title = coverH1 || textOf(document.querySelector("main.deck h1, .deck h1")) || "Presentation";
+  pptx.title = title;
+  var safe = title.replace(/[^\\w]+/g, "_").replace(/^_|_$/g, "") || "Presentation";
+  return pptx.writeFile({ fileName: safe + ".pptx" });
+}`;
+
+export const SLIDES_PPTX_FROM_DOM_SCRIPT = `<script id="${SLIDES_PPTX_FROM_DOM_SCRIPT_ID}">
+(function () {
+  ${SLIDES_PPTX_FROM_DOM_FN}
+  window.buildPptx = buildPptx;
+})();
+</script>`;

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/slides/slides-preview-fit.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/slides/slides-preview-fit.test.ts
@@ -8,6 +8,7 @@ import {
   SLIDES_STAGE_HEIGHT,
   SLIDES_STAGE_WIDTH,
 } from './slides-preview-fit';
+import { SLIDES_PPTX_FROM_DOM_SCRIPT_ID } from './slides-pptx-from-dom';
 
 describe('computeSlidesPreviewScale', () => {
   it('contains a 16:9 stage in a wide pane (letterbox top/bottom)', () => {
@@ -32,11 +33,25 @@ describe('prepareSlidesPreviewHtml', () => {
     const once = prepareSlidesPreviewHtml(src);
     expect(once).toContain(`id="${SLIDES_PREVIEW_FIT_STYLE_ID}"`);
     expect(once).toContain(`id="${SLIDES_PREVIEW_BRIDGE_SCRIPT_ID}"`);
+    expect(once).toContain(`id="${SLIDES_PPTX_FROM_DOM_SCRIPT_ID}"`);
+    expect(once).toContain('window.buildPptx = buildPptx');
     expect(once).toContain(SLIDES_PREVIEW_MESSAGE_SOURCE);
     expect(once).toContain(`${SLIDES_STAGE_WIDTH}px`);
     expect(once).toContain('deck-menubar');
     const twice = prepareSlidesPreviewHtml(once);
     expect(twice).toBe(once);
+  });
+
+  it('overrides a hardcoded seed buildPptx with the DOM walker', () => {
+    const src =
+      '<!doctype html><html><head></head><body><main class="deck"></main>' +
+      '<script>async function buildPptx(){ /* [["1","Context"],["2","Approach"]] */ }</script>' +
+      '</body></html>';
+    const out = prepareSlidesPreviewHtml(src);
+    const walkerAt = out.lastIndexOf('window.buildPptx = buildPptx');
+    const seedAt = out.indexOf('[["1","Context"],["2","Approach"]]');
+    expect(walkerAt).toBeGreaterThan(seedAt);
+    expect(out).toContain(SLIDES_PPTX_FROM_DOM_SCRIPT_ID);
   });
 
   it('prefixes when head is missing', () => {

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/slides/slides-preview-fit.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/slides/slides-preview-fit.ts
@@ -1,3 +1,8 @@
+import {
+  SLIDES_PPTX_FROM_DOM_SCRIPT,
+  SLIDES_PPTX_FROM_DOM_SCRIPT_ID,
+} from './slides-pptx-from-dom';
+
 /** Canonical slide stage used by Nexus deck seeds. */
 export const SLIDES_STAGE_WIDTH = 1280;
 export const SLIDES_STAGE_HEIGHT = 720;
@@ -155,6 +160,16 @@ export function prepareSlidesPreviewHtml(html: string): string {
       next = next.replace('</head>', `${inject}</head>`);
     } else {
       next = `${inject}${next}`;
+    }
+  }
+
+  // Override window.buildPptx so File → Export reads the live .slide DOM,
+  // even when the seeded deck still has a hardcoded 4-slide exporter.
+  if (!next.includes(`id="${SLIDES_PPTX_FROM_DOM_SCRIPT_ID}"`)) {
+    if (next.includes('</body>')) {
+      next = next.replace('</body>', `${SLIDES_PPTX_FROM_DOM_SCRIPT}</body>`);
+    } else {
+      next = `${next}${SLIDES_PPTX_FROM_DOM_SCRIPT}`;
     }
   }
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/chat-provider-error.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/chat-provider-error.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { humanizeChatProviderError } from './chat-provider-error';
+
+describe('humanizeChatProviderError', () => {
+  it('rewrites a 429 JSON dump', () => {
+    const dumped =
+      "I'm sorry, I encountered an error while processing your request. Error code: 429 - {'error': {'message': 'Provider returned error', 'code': 429, 'metadata': {'raw': 'google/gemma-4-26b-a4b-it:free is temporarily rate-limited upstream.'}}}";
+    expect(humanizeChatProviderError(dumped)).toBe(
+      'This model is rate limited. Pick another model in the agent menu and try again.',
+    );
+  });
+
+  it('leaves a normal assistant reply alone', () => {
+    expect(humanizeChatProviderError('Updated the cover title and agenda.')).toBe(
+      'Updated the cover title and agenda.',
+    );
+  });
+});

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/chat-provider-error.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/chat-provider-error.ts
@@ -1,0 +1,17 @@
+const RATE_LIMIT_RE = /error code:\s*429|rate[- ]limited|temporarily rate-limited/i;
+const RAW_PROVIDER_RE =
+  /encountered an error while processing your request|error code:\s*\d+|provider returned error/i;
+
+/** One-line chat error. Never show raw OpenRouter JSON in the bubble. */
+export function humanizeChatProviderError(content: string): string {
+  const raw = (content || '').trim();
+  if (!raw) return raw;
+  const looksDumped =
+    RAW_PROVIDER_RE.test(raw) &&
+    (raw.includes('{') || raw.includes("'error'") || raw.includes('"error"') || RATE_LIMIT_RE.test(raw));
+  if (!looksDumped && !RATE_LIMIT_RE.test(raw)) return raw;
+  if (RATE_LIMIT_RE.test(raw)) {
+    return 'This model is rate limited. Pick another model in the agent menu and try again.';
+  }
+  return 'The model provider failed. Pick another model and try again.';
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/create-slides-project.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/create-slides-project.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_SLIDES_TEMPLATE_ID,
+  PREFERRED_SLIDES_CHAT_MODEL,
+  parseFastApiDetail,
+  slidesApiErrorMessage,
+  untitledSlidesSlug,
+} from './create-slides-project';
+
+describe('untitledSlidesSlug', () => {
+  it('is kebab-case and unique per timestamp', () => {
+    const a = untitledSlidesSlug(1_700_000_000_000);
+    const b = untitledSlidesSlug(1_700_000_000_001);
+    expect(a).toMatch(/^untitled-[a-z0-9]+$/);
+    expect(b).toMatch(/^untitled-[a-z0-9]+$/);
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('DEFAULT_SLIDES_TEMPLATE_ID', () => {
+  it('seeds Minimal Light', () => {
+    expect(DEFAULT_SLIDES_TEMPLATE_ID).toBe('minimal-light-v1');
+  });
+});
+
+describe('PREFERRED_SLIDES_CHAT_MODEL', () => {
+  it('uses the paid OpenRouter model from config', () => {
+    expect(PREFERRED_SLIDES_CHAT_MODEL).toBe('gpt-4.1-mini');
+  });
+});
+
+describe('parseFastApiDetail', () => {
+  it('reads a string detail', () => {
+    expect(parseFastApiDetail('Forgejo is not configured. Slides needs git storage.')).toBe(
+      'Forgejo is not configured. Slides needs git storage.',
+    );
+  });
+
+  it('reads object and validation-list details', () => {
+    expect(parseFastApiDetail({ msg: 'Git setup temporarily unavailable' })).toBe(
+      'Git setup temporarily unavailable',
+    );
+    expect(parseFastApiDetail([{ loc: ['body', 'title'], msg: 'Field required', type: 'missing' }])).toBe(
+      'Field required',
+    );
+  });
+});
+
+describe('slidesApiErrorMessage', () => {
+  it('rewrites a raw repo id into a human cause', () => {
+    expect(slidesApiErrorMessage('abi/monorepo', 'Failed (502)')).toBe(
+      "Git repo 'abi/monorepo' is missing. Forgejo is not configured, or coding-init did not seed it.",
+    );
+  });
+
+  it('keeps a real 503 message', () => {
+    expect(
+      slidesApiErrorMessage('Forgejo is not configured. Slides needs git storage.', 'Failed'),
+    ).toBe('Forgejo is not configured. Slides needs git storage.');
+  });
+});

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/create-slides-project.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/create-slides-project.ts
@@ -1,0 +1,181 @@
+import { authFetch } from '@/stores/auth';
+import { useAgentsStore } from '@/stores/agents';
+import { dispatchSlidesDeckUpdated, useSlidesStore } from '@/stores/slides';
+import { useWorkspaceStore } from '@/stores/workspace';
+
+export const DEFAULT_SLIDES_TEMPLATE_ID = 'minimal-light-v1';
+export const DEFAULT_SLIDES_TITLE = 'Untitled presentation';
+export const PREFERRED_SLIDES_CHAT_MODEL = 'gpt-4.1-mini';
+export const PREFERRED_SLIDES_CHAT_MODELS = ['gpt-4.1-mini', 'openai/gpt-4.1-mini'];
+
+const REPO_ID_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+
+/** FastAPI `detail` is a string, validation list, or `{msg}` object. */
+export function parseFastApiDetail(detail: unknown): string {
+  if (typeof detail === 'string') return detail.trim();
+  if (Array.isArray(detail)) {
+    return detail
+      .map((item) => {
+        if (typeof item === 'string') return item.trim();
+        if (item && typeof item === 'object' && 'msg' in item) {
+          return String((item as { msg: unknown }).msg).trim();
+        }
+        return '';
+      })
+      .filter(Boolean)
+      .join('; ');
+  }
+  if (detail && typeof detail === 'object') {
+    const obj = detail as Record<string, unknown>;
+    if (typeof obj.msg === 'string') return obj.msg.trim();
+    if (typeof obj.message === 'string') return obj.message.trim();
+    if ('detail' in obj) return parseFastApiDetail(obj.detail);
+  }
+  return '';
+}
+
+/** Human slides API error; never surface a raw owner/name as the cause. */
+export function slidesApiErrorMessage(detail: unknown, fallback: string): string {
+  const raw = parseFastApiDetail(detail);
+  if (!raw) return fallback;
+  if (REPO_ID_RE.test(raw)) {
+    return (
+      `Git repo '${raw}' is missing. Forgejo is not configured, ` +
+      'or coding-init did not seed it.'
+    );
+  }
+  return raw;
+}
+
+export function untitledSlidesSlug(now = Date.now()): string {
+  return `untitled-${now.toString(36)}`;
+}
+
+export type CreatedSlidesProject = {
+  slug: string;
+  title: string;
+};
+
+function pickAbiAgentId(): string | null {
+  const agents = useAgentsStore.getState().agents;
+  const abi =
+    agents.find(
+      (a) =>
+        a.enabled &&
+        (a.name === 'Abi' ||
+          (typeof a.class_name === 'string' && a.class_name.toLowerCase().includes('abiagent'))),
+    ) ??
+    agents.find((a) => a.isDefault && a.enabled) ??
+    agents.find((a) => a.enabled);
+  return abi?.id ?? null;
+}
+
+function pinSlidesChatModel(agentId: string): void {
+  const agent = useAgentsStore.getState().agents.find((a) => a.id === agentId);
+  const available = [
+    ...(agent?.modelIds ?? []),
+    agent?.resolvedModelId,
+    agent?.modelId,
+    ...PREFERRED_SLIDES_CHAT_MODELS,
+  ].filter((id): id is string => Boolean(id));
+  const unique = [...new Set(available)];
+  const preferred =
+    unique.find((id) => PREFERRED_SLIDES_CHAT_MODELS.includes(id)) ||
+    unique.find((id) => !id.includes(':free')) ||
+    null;
+  if (!preferred) return;
+  const current = useWorkspaceStore.getState().selectedChatModels[agentId];
+  if (!current || current.includes(':free')) {
+    useWorkspaceStore.getState().setSelectedChatModel(agentId, preferred);
+  }
+}
+
+/** Open the Abi pane beside the deck so the next message can edit it. */
+export function openSlidesAgentPane(opts?: { freshChat?: boolean }): void {
+  const ws = useWorkspaceStore.getState();
+  ws.setContextPanelOpen(true);
+  if (opts?.freshChat) {
+    ws.setPaneConversationId(null);
+  }
+  const abiId = pickAbiAgentId();
+  if (abiId) {
+    if (!ws.paneAgentExplicitlySelected) ws.setPaneAgent(abiId);
+    pinSlidesChatModel(abiId);
+  }
+}
+
+export async function createUntitledSlidesProject(
+  workspaceId: string,
+  templateId: string = DEFAULT_SLIDES_TEMPLATE_ID,
+): Promise<CreatedSlidesProject> {
+  let lastError = 'Failed to create presentation';
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const slug = untitledSlidesSlug(Date.now() + attempt);
+    const res = await authFetch('/api/slides/projects', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        workspace_id: workspaceId,
+        title: DEFAULT_SLIDES_TITLE,
+        slug,
+        template_id: templateId,
+      }),
+    });
+    if (res.ok) {
+      const created = (await res.json()) as { slug: string; title?: string };
+      return {
+        slug: created.slug,
+        title: created.title || DEFAULT_SLIDES_TITLE,
+      };
+    }
+    const body = (await res.json().catch(() => ({}))) as { detail?: unknown };
+    lastError = slidesApiErrorMessage(body.detail, `Failed (${res.status})`);
+    if (res.status !== 409 && res.status !== 422) {
+      throw new Error(lastError);
+    }
+  }
+  throw new Error(lastError);
+}
+
+/** One click: seed a template (default Minimal Light), open the deck, open Abi. */
+export async function startNewPresentation(
+  workspaceId: string,
+  navigate: (href: string) => void,
+  templateId: string = DEFAULT_SLIDES_TEMPLATE_ID,
+): Promise<CreatedSlidesProject> {
+  const created = await createUntitledSlidesProject(workspaceId, templateId);
+  useSlidesStore.getState().setSelectedSlug(created.slug);
+  useSlidesStore.getState().setSelectedTitle(created.title);
+  openSlidesAgentPane({ freshChat: true });
+  navigate(`/workspace/${workspaceId}/slides/${created.slug}`);
+  return created;
+}
+
+/** Swap the open deck to a seed, or create a new presentation from that template. */
+export async function applySlidesTemplate(
+  workspaceId: string,
+  templateId: string,
+  openSlug: string | null,
+  navigate: (href: string) => void,
+): Promise<CreatedSlidesProject> {
+  if (!openSlug) {
+    return startNewPresentation(workspaceId, navigate, templateId);
+  }
+  const res = await authFetch(
+    `/api/slides/projects/${encodeURIComponent(openSlug)}/apply-template`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ workspace_id: workspaceId, template_id: templateId }),
+    },
+  );
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { detail?: unknown };
+    throw new Error(slidesApiErrorMessage(body.detail, `Failed (${res.status})`));
+  }
+  const title = useSlidesStore.getState().selectedTitle || DEFAULT_SLIDES_TITLE;
+  dispatchSlidesDeckUpdated({ slug: openSlug, source: 'template' });
+  useSlidesStore.getState().requestDeckRefresh(openSlug);
+  openSlidesAgentPane();
+  return { slug: openSlug, title };
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/quick-open.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/quick-open.test.ts
@@ -5,6 +5,8 @@ import {
   conversationUpdatedAtMs,
   filterQuickOpenItems,
   groupQuickOpenItems,
+  QUICK_OPEN_EVENT,
+  requestQuickOpen,
   scoreQuickOpen,
   type QuickOpenItem,
 } from './quick-open';
@@ -134,5 +136,12 @@ describe('buildQuickOpenItems', () => {
       href: '/workspace/ws-1/apps?open=acme-portal',
       panel: 'apps',
     });
+  });
+});
+
+describe('requestQuickOpen', () => {
+  it('uses a stable event name and is safe without window', () => {
+    expect(QUICK_OPEN_EVENT).toBe('nexus:quick-open');
+    expect(() => requestQuickOpen()).not.toThrow();
   });
 });

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/quick-open.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/quick-open.ts
@@ -170,3 +170,11 @@ export function buildQuickOpenItems(input: {
 
   return items;
 }
+
+/** Dispatched on `window` so the dock Search icon can open the header palette. */
+export const QUICK_OPEN_EVENT = 'nexus:quick-open';
+
+export function requestQuickOpen(): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new Event(QUICK_OPEN_EVENT));
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/slides-templates.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/slides-templates.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { templateAssetLabel, templateSlideLabel } from './slides-templates';
+
+describe('templateSlideLabel', () => {
+  it('joins eyebrow and title', () => {
+    expect(templateSlideLabel({ eyebrow: 'Agenda', title: 'What we will cover' })).toBe(
+      'Agenda: What we will cover',
+    );
+  });
+
+  it('uses title when eyebrow matches', () => {
+    expect(templateSlideLabel({ eyebrow: 'Context', title: 'Context' })).toBe('Context');
+  });
+
+  it('falls back to untitled', () => {
+    expect(templateSlideLabel({ eyebrow: '', title: '' })).toBe('Untitled slide');
+  });
+});
+
+describe('templateAssetLabel', () => {
+  it('marks embedded assets', () => {
+    expect(templateAssetLabel({ name: 'hero', kind: 'embedded' })).toBe('hero (embedded)');
+  });
+});

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/slides-templates.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/slides-templates.ts
@@ -1,0 +1,38 @@
+export type SlidesTemplateSlide = {
+  index: number;
+  id?: string | null;
+  eyebrow: string;
+  title: string;
+};
+
+export type SlidesTemplateAsset = {
+  name: string;
+  kind: string;
+};
+
+export type SlidesSeedTemplate = {
+  id: string;
+  name: string;
+  description: string;
+  preview_bg: string;
+  preview_panel: string;
+  preview_accent: string;
+  preview_ink: string;
+  slides: SlidesTemplateSlide[];
+  assets: SlidesTemplateAsset[];
+};
+
+/** Sidebar line: eyebrow plus section title from the seed outline. */
+export function templateSlideLabel(slide: Pick<SlidesTemplateSlide, 'eyebrow' | 'title'>): string {
+  const eyebrow = (slide.eyebrow || '').trim();
+  const title = (slide.title || '').trim();
+  if (eyebrow && title && eyebrow.toLowerCase() !== title.toLowerCase()) {
+    return `${eyebrow}: ${title}`;
+  }
+  return title || eyebrow || 'Untitled slide';
+}
+
+export function templateAssetLabel(asset: Pick<SlidesTemplateAsset, 'name' | 'kind'>): string {
+  const name = (asset.name || '').trim() || 'asset';
+  return asset.kind === 'embedded' ? `${name} (embedded)` : name;
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/slides.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/slides.ts
@@ -49,6 +49,8 @@ interface SlidesState {
   deckSource: SlidesDeckSource;
   /** Monotonic token; editor listens and reloads deck from server. */
   refreshToken: number;
+  /** True while Abi is running a slides write/replace tool. */
+  agentWriting: boolean;
   setSelectedSlug: (slug: string | null) => void;
   setSelectedTitle: (title: string | null) => void;
   setEditorMode: (mode: SlidesEditorMode) => void;
@@ -62,6 +64,7 @@ interface SlidesState {
   setDeckDirty: (dirty: boolean) => void;
   setDeckSource: (source: SlidesDeckSource) => void;
   requestDeckRefresh: (slug?: string | null) => void;
+  setAgentWriting: (writing: boolean) => void;
 }
 
 export const useSlidesStore = create<SlidesState>()(
@@ -79,6 +82,7 @@ export const useSlidesStore = create<SlidesState>()(
       deckDirty: false,
       deckSource: null,
       refreshToken: 0,
+      agentWriting: false,
       setSelectedSlug: (slug) => set({ selectedSlug: slug }),
       setSelectedTitle: (title) => set({ selectedTitle: title }),
       setEditorMode: (mode) => set({ editorMode: mode }),
@@ -104,6 +108,7 @@ export const useSlidesStore = create<SlidesState>()(
         if (slug && open && slug !== open) return;
         set({ refreshToken: get().refreshToken + 1 });
       },
+      setAgentWriting: (writing) => set({ agentWriting: writing }),
     }),
     {
       name: 'nexus:slides:selected',
@@ -114,6 +119,11 @@ export const useSlidesStore = create<SlidesState>()(
     },
   ),
 );
+
+export function isSlidesWriteTool(rawName: string | null | undefined): boolean {
+  const raw = (rawName || '').toLowerCase();
+  return raw.includes('write_slides') || raw.includes('replace_in_slides');
+}
 
 export function dispatchSlidesDeckUpdated(detail: SlidesDeckUpdatedDetail = {}) {
   if (typeof window === 'undefined') return;

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
@@ -247,6 +247,7 @@ interface WorkspaceState {
   // Context panel (right AI / compare surface)
   contextPanelOpen: boolean;
   toggleContextPanel: () => void;
+  setContextPanelOpen: (open: boolean) => void;
   /** Width of the dock (icon nav). Persisted. Same default as the feature column. */
   dockWidth: number;
   setDockWidth: (width: number) => void;
@@ -546,6 +547,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
   // Context panel (right AI / compare surface)
   contextPanelOpen: false,
   toggleContextPanel: () => set((state) => ({ contextPanelOpen: !state.contextPanelOpen })),
+  setContextPanelOpen: (open) => set({ contextPanelOpen: open }),
   dockWidth: DOCK_WIDTH_DEFAULT,
   setDockWidth: (width) => set({ dockWidth: clampDockWidth(width) }),
   sectionPanelWidth: 256,

--- a/libs/naas-abi/naas_abi/apps/nexus/assets/slides/templates/README.md
+++ b/libs/naas-abi/naas_abi/apps/nexus/assets/slides/templates/README.md
@@ -14,9 +14,9 @@ Parent applications may mirror these seeds under their own assets tree if needed
 
 Each deck is a self-contained HTML file with:
 
-- `.deck` / `.slide` structure (1280×720)
+- `.deck` / `.slide` structure (1280x720)
 - Fixed `deck-menubar` + Export menu (PDF / PPTX / Print)
-- In-browser `buildPptx()` (pptxgenjs)
+- In-browser `buildPptx()` that walks the live `.slide` DOM (pptxgenjs). HTML is the source; PPTX is a closest-fit reconstruction (same geometry, type, colors). Not pixel-perfect.
 - Decorative bands as SVG `data:` URLs
 
 New Slides projects copy the chosen seed into Forgejo at `slides/<slug>/deck.html` on branch `slides/<slug>`, and also seed `slides/<slug>/assets/` (`.gitkeep` + README).
@@ -30,7 +30,7 @@ New Slides projects copy the chosen seed into Forgejo at `slides/<slug>/deck.htm
 5. Run API tests: `pytest …/slides__primary_adapter__FastAPI_test.py -k seed`.
 6. Optional: progressive style packs can be imported later by dropping more HTML + catalog rows; do not vendor external skill trees as source.
 
-Gallery UI: **File → New Presentation** (`/slides/new`) loads `GET /api/slides/templates` and posts the selected `template_id` to `POST /api/slides/projects`.
+New Presentation seeds Minimal Light (`minimal-light-v1`) and opens Abi. Catalog rows remain for API seed lookup, not a gallery in front of chat.
 
 ## Assets / images
 

--- a/libs/naas-abi/naas_abi/apps/nexus/assets/slides/templates/executive-v1.html
+++ b/libs/naas-abi/naas_abi/apps/nexus/assets/slides/templates/executive-v1.html
@@ -243,75 +243,212 @@ const IMG = {
   logo: "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22120%22%20height%3D%2228%22%3E%3Crect%20width%3D%22120%22%20height%3D%2228%22%20rx%3D%224%22%20fill%3D%22%23ffffff%22%20fill-opacity%3D%220.15%22%2F%3E%3Ctext%20x%3D%2212%22%20y%3D%2219%22%20font-family%3D%22Arial%2Csans-serif%22%20font-size%3D%2212%22%20fill%3D%22%23ffffff%22%20font-weight%3D%22700%22%3EORG%3C%2Ftext%3E%3C%2Fsvg%3E",
 };
 
-const FOOTER_TXT = "Presentation Title";
-
+/* NEXUS_SLIDES_PPTX_FROM_DOM_V1 */
 async function buildPptx() {
   if (typeof PptxGenJS === "undefined") throw new Error("PptxGenJS failed to load");
-  const pptx = new PptxGenJS();
+  var slides = document.querySelectorAll("main.deck > section.slide, .deck > section.slide");
+  if (!slides.length) throw new Error("No .slide sections to export");
+  var pptx = new PptxGenJS();
   pptx.defineLayout({ name: "LAYOUT_16x9", width: 13.333, height: 7.5 });
   pptx.layout = "LAYOUT_16x9";
-  pptx.title = FOOTER_TXT;
-  const C = {
-    bg: "#13233a".replace("#", ""),
-    ink: "#f4efe4".replace("#", ""),
-    muted: "#b8b0a0".replace("#", ""),
-    accent: "#c9a227".replace("#", ""),
-    card: "#1a2d48".replace("#", ""),
+  var I = function (px) { return px / 96; };
+  var hex = function (raw, fallback) {
+    var s = String(raw || fallback || "").trim();
+    var m = s.match(/#([0-9a-fA-F]{6})/);
+    if (m) return m[1];
+    m = s.match(/#([0-9a-fA-F]{3})\b/);
+    if (m) {
+      var a = m[1];
+      return a.charAt(0) + a.charAt(0) + a.charAt(1) + a.charAt(1) + a.charAt(2) + a.charAt(2);
+    }
+    m = s.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
+    if (m) {
+      return [m[1], m[2], m[3]].map(function (n) {
+        return ("0" + Number(n).toString(16)).slice(-2);
+      }).join("");
+    }
+    return String(fallback || "ffffff").replace("#", "");
   };
-  const I = (px) => px / 96;
-  const txt = (s, t, x, y, w, h, o = {}) =>
-    s.addText(t, { x: I(x), y: I(y), w: I(w), h: I(h), fontFace: "Arial", margin: 0, ...o });
-  const slideBg = { color: C.bg };
-
-  (() => {
-    const s = pptx.addSlide(); s.background = slideBg;
-    s.addImage({ data: IMG.hero, x: 0, y: 0, w: I(1280), h: I(300) });
-    txt(s, "Confidential · Working Session", 56, 340, 1000, 24, { fontSize: 12, color: C.accent, bold: true });
-    txt(s, "Presentation Title", 56, 380, 1100, 56, { fontSize: 32, bold: true, color: C.ink });
-    txt(s, "Subtitle: replace with your session objective and audience.", 56, 450, 1000, 40, { fontSize: 14, color: C.muted });
-  })();
-
-  (() => {
-    const s = pptx.addSlide(); s.background = slideBg;
-    txt(s, "AGENDA", 56, 48, 400, 20, { fontSize: 11, bold: true, color: C.accent });
-    txt(s, "What we will cover", 56, 78, 1100, 40, { fontSize: 26, bold: true, color: C.ink });
-    [["1","Context"],["2","Approach"],["3","Plan"],["4","Next steps"]].forEach((r, i) => {
-      const y = 160 + i * 90;
-      s.addShape(pptx.ShapeType.rect, { x: I(56), y: I(y), w: I(1168), h: I(76), fill: { color: C.card } });
-      txt(s, r[0], 76, y + 22, 40, 36, { fontSize: 20, bold: true, color: C.accent });
-      txt(s, r[1], 130, y + 26, 800, 30, { fontSize: 16, bold: true, color: C.ink });
-    });
-    txt(s, FOOTER_TXT, 56, 686, 760, 20, { fontSize: 9, color: C.muted });
-  })();
-
-  (() => {
-    const s = pptx.addSlide(); s.background = slideBg;
-    txt(s, "CONTEXT", 56, 48, 400, 20, { fontSize: 11, bold: true, color: C.accent });
-    txt(s, "Start from a shared problem statement", 56, 78, 1100, 40, { fontSize: 26, bold: true, color: C.ink });
-    s.addShape(pptx.ShapeType.rect, { x: I(56), y: I(160), w: I(560), h: I(360), fill: { color: C.card } });
-    txt(s, "Current state", 76, 180, 520, 28, { fontSize: 16, bold: true, color: C.ink });
-    txt(s, "Replace with the facts that frame the discussion.", 76, 230, 520, 200, { fontSize: 13, color: C.muted });
-    s.addShape(pptx.ShapeType.rect, { x: I(656), y: I(160), w: I(568), h: I(360), fill: { color: C.card } });
-    txt(s, "Desired state", 676, 180, 520, 28, { fontSize: 16, bold: true, color: C.ink });
-    txt(s, "Clear ownership, repeatable process, measurable quality.", 676, 230, 520, 200, { fontSize: 13, color: C.muted });
-    txt(s, FOOTER_TXT, 56, 686, 760, 20, { fontSize: 9, color: C.muted });
-  })();
-
-  (() => {
-    const s = pptx.addSlide(); s.background = slideBg;
-    txt(s, "NEXT STEPS", 56, 48, 400, 20, { fontSize: 11, bold: true, color: C.accent });
-    txt(s, "Decisions and follow-ups", 56, 78, 1100, 40, { fontSize: 26, bold: true, color: C.ink });
-    [["1","Confirm sponsor"],["2","Assign owners"],["3","Approve Phase 1"],["4","Schedule cadence"]].forEach((st, i) => {
-      const col = i % 2, row = Math.floor(i / 2);
-      const x = 56 + col * 596, y = 150 + row * 220;
-      s.addShape(pptx.ShapeType.rect, { x: I(x), y: I(y), w: I(576), h: I(190), fill: { color: C.card } });
-      txt(s, st[0], x + 20, y + 40, 44, 48, { fontSize: 28, bold: true, color: C.accent });
-      txt(s, st[1], x + 74, y + 48, 460, 32, { fontSize: 16, bold: true, color: C.ink });
-    });
-    txt(s, FOOTER_TXT, 56, 686, 760, 20, { fontSize: 9, color: C.muted });
-  })();
-
-  return pptx.writeFile({ fileName: "Presentation_Title.pptx" });
+  var cssUrl = function (name) {
+    try {
+      var v = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+      var m = v.match(/url\(["']?(data:[^"')]+)["']?\)/);
+      return m ? m[1] : "";
+    } catch (e) {
+      return "";
+    }
+  };
+  var root;
+  try { root = getComputedStyle(document.documentElement); } catch (e) { root = null; }
+  var prop = function (name, fb) {
+    return hex(root ? root.getPropertyValue(name) : "", fb);
+  };
+  var C = {
+    bg: prop("--panel", "ffffff"),
+    ink: prop("--ink", "1a1a1a"),
+    muted: prop("--muted", "6b6b6b"),
+    accent: prop("--accent", "1a1a1a"),
+    card: prop("--card", "fafaf8")
+  };
+  var txt = function (s, t, x, y, w, h, o) {
+    if (!t) return;
+    s.addText(t, Object.assign({
+      x: I(x), y: I(y), w: I(w), h: I(h), fontFace: "Arial", margin: 0
+    }, o || {}));
+  };
+  var textOf = function (el) {
+    return el ? String(el.textContent || "").replace(/\s+/g, " ").trim() : "";
+  };
+  var first = function (rootEl, sel) {
+    try { return rootEl.querySelector(sel); } catch (e) { return null; }
+  };
+  var heroData = cssUrl("--hero");
+  var divData = cssUrl("--div1");
+  try {
+    if (!heroData && typeof IMG !== "undefined" && IMG && IMG.hero) heroData = IMG.hero;
+    if (!divData && typeof IMG !== "undefined" && IMG && IMG.d1) divData = IMG.d1;
+  } catch (e) {}
+  var coverH1 = "";
+  for (var i = 0; i < slides.length; i++) {
+    var el = slides[i];
+    var s = pptx.addSlide();
+    s.background = { color: C.bg };
+    var footerEl = first(el, ".footer");
+    var footerLeft = "";
+    var footerRight = "";
+    if (footerEl) {
+      var spans = footerEl.querySelectorAll(":scope > span");
+      footerLeft = textOf(spans[0]) || textOf(footerEl);
+      footerRight = spans.length > 1 ? textOf(spans[spans.length - 1]) : "";
+    }
+    var drawFooter = function () {
+      if (footerLeft) txt(s, footerLeft, 56, 686, 900, 20, { fontSize: 9, color: C.muted });
+      if (footerRight) txt(s, footerRight, 1100, 686, 124, 20, { fontSize: 9, color: C.muted, align: "right" });
+    };
+    if (el.classList.contains("cover")) {
+      if (heroData) {
+        try { s.addImage({ data: heroData, x: 0, y: 0, w: I(1280), h: I(300) }); } catch (e) {}
+      } else {
+        s.addShape(pptx.ShapeType.rect, {
+          x: 0, y: 0, w: I(1280), h: I(300),
+          fill: { color: prop("--hero-fallback", "eae8e1") }
+        });
+      }
+      var cEyebrow = textOf(first(el, ".eyebrow"));
+      var cH1 = textOf(first(el, "h1"));
+      var cSub = textOf(first(el, ".subtitle"));
+      var cHook = textOf(first(el, ".hook"));
+      if (!coverH1) coverH1 = cH1;
+      if (cEyebrow) txt(s, cEyebrow.toUpperCase(), 56, 340, 1168, 24, { fontSize: 12, color: C.accent, bold: true });
+      if (cH1) txt(s, cH1, 56, 372, 1168, 64, { fontSize: 32, bold: true, color: C.ink });
+      if (cSub) txt(s, cSub, 56, 444, 1168, 44, { fontSize: 14, color: C.muted });
+      if (cHook) txt(s, cHook, 56, 496, 1168, 28, { fontSize: 13, bold: true, color: C.accent });
+      continue;
+    }
+    if (el.classList.contains("section-divider")) {
+      if (divData) {
+        try { s.addImage({ data: divData, x: 0, y: 0, w: I(1280), h: I(720) }); } catch (e) {}
+      }
+      var dEyebrow = textOf(first(el, ".divider-eyebrow"));
+      var dNum = textOf(first(el, ".divider-number"));
+      var dTitle = textOf(first(el, ".divider-title"));
+      var dSub = textOf(first(el, ".divider-sub"));
+      if (dEyebrow) txt(s, dEyebrow.toUpperCase(), 56, 180, 1168, 24, { fontSize: 12, bold: true, color: C.accent });
+      if (dNum) txt(s, dNum, 56, 210, 1168, 110, { fontSize: 72, bold: true, color: C.ink });
+      if (dTitle) txt(s, dTitle, 56, 330, 1168, 56, { fontSize: 32, bold: true, color: C.ink });
+      if (dSub) txt(s, dSub, 56, 396, 900, 40, { fontSize: 14, color: C.muted });
+      continue;
+    }
+    var eyebrow = textOf(first(el, ":scope > .eyebrow")) || textOf(first(el, ".eyebrow"));
+    var h1 = textOf(first(el, ":scope > h1")) || textOf(first(el, "h1"));
+    if (eyebrow) txt(s, eyebrow.toUpperCase(), 56, 48, 1168, 20, { fontSize: 11, bold: true, color: C.accent });
+    if (h1) txt(s, h1, 56, 76, 1168, 44, { fontSize: 26, bold: true, color: C.ink });
+    var agendaRows = el.querySelectorAll(".agenda-row");
+    if (agendaRows.length) {
+      for (var ar = 0; ar < agendaRows.length; ar++) {
+        var row = agendaRows[ar];
+        var y = 140 + ar * 90;
+        s.addShape(pptx.ShapeType.rect, { x: I(56), y: I(y), w: I(1168), h: I(76), fill: { color: C.card } });
+        txt(s, textOf(first(row, ".agenda-num")), 76, y + 18, 48, 40, { fontSize: 20, bold: true, color: C.accent });
+        txt(s, textOf(first(row, "h2")), 130, y + 14, 820, 28, { fontSize: 16, bold: true, color: C.ink });
+        txt(s, textOf(first(row, "p")), 130, y + 42, 820, 24, { fontSize: 12, color: C.muted });
+        var kids = row.children;
+        if (kids.length) {
+          txt(s, textOf(kids[kids.length - 1]), 980, y + 24, 220, 28, { fontSize: 12, color: C.muted, align: "right" });
+        }
+      }
+      drawFooter();
+      continue;
+    }
+    var stepNodes = el.querySelectorAll(".step");
+    if (stepNodes.length) {
+      for (var st = 0; st < stepNodes.length; st++) {
+        var step = stepNodes[st];
+        var col = st % 2;
+        var srow = Math.floor(st / 2);
+        var sx = 56 + col * 596;
+        var sy = 140 + srow * 220;
+        s.addShape(pptx.ShapeType.rect, { x: I(sx), y: I(sy), w: I(576), h: I(200), fill: { color: C.card } });
+        s.addShape(pptx.ShapeType.rect, { x: I(sx), y: I(sy), w: I(6), h: I(200), fill: { color: C.accent } });
+        txt(s, textOf(first(step, ".step-n")), sx + 24, sy + 28, 60, 40, { fontSize: 24, bold: true, color: C.accent });
+        txt(s, textOf(first(step, "h2")), sx + 90, sy + 36, 450, 32, { fontSize: 16, bold: true, color: C.ink });
+        txt(s, textOf(first(step, "p")), sx + 24, sy + 84, 528, 90, { fontSize: 13, color: C.muted });
+      }
+      drawFooter();
+      continue;
+    }
+    var cards = el.querySelectorAll(".card");
+    if (cards.length) {
+      var n = cards.length;
+      var cols = n >= 4 ? 4 : (n === 3 ? 3 : 2);
+      var gap = 18;
+      var avail = 1168;
+      var cw = (avail - gap * (cols - 1)) / cols;
+      var ch = 360;
+      for (var ci = 0; ci < n; ci++) {
+        var card = cards[ci];
+        var ccol = ci % cols;
+        var crow = Math.floor(ci / cols);
+        var cx = 56 + ccol * (cw + gap);
+        var cy = 140 + crow * (ch + gap);
+        s.addShape(pptx.ShapeType.rect, { x: I(cx), y: I(cy), w: I(cw), h: I(ch), fill: { color: C.card } });
+        var pill = textOf(first(card, ".pill"));
+        var ch2 = textOf(first(card, "h2"));
+        var cp = textOf(first(card, "p"));
+        var lis = [];
+        var liNodes = card.querySelectorAll("li");
+        for (var li = 0; li < liNodes.length; li++) {
+          var lt = textOf(liNodes[li]);
+          if (lt) lis.push(lt);
+        }
+        var ty = cy + 22;
+        if (pill) { txt(s, pill.toUpperCase(), cx + 20, ty, cw - 40, 20, { fontSize: 10, bold: true, color: C.accent }); ty += 26; }
+        if (ch2) { txt(s, ch2, cx + 20, ty, cw - 40, 28, { fontSize: 16, bold: true, color: C.ink }); ty += 36; }
+        if (lis.length) {
+          txt(s, lis.map(function (item) { return "• " + item; }).join("\n"), cx + 20, ty, cw - 40, Math.max(40, ch - (ty - cy) - 20), { fontSize: 13, color: C.muted, valign: "top" });
+        } else if (cp) {
+          txt(s, cp, cx + 20, ty, cw - 40, Math.max(40, ch - (ty - cy) - 20), { fontSize: 13, color: C.muted, valign: "top" });
+        }
+      }
+      drawFooter();
+      continue;
+    }
+    var gSub = textOf(first(el, ".subtitle"));
+    var gy = 136;
+    if (gSub) { txt(s, gSub, 56, gy, 1168, 36, { fontSize: 14, color: C.muted }); gy += 44; }
+    var paras = el.querySelectorAll(":scope > p");
+    for (var pi = 0; pi < paras.length; pi++) {
+      var pt = textOf(paras[pi]);
+      if (!pt || pt === gSub) continue;
+      txt(s, pt, 56, gy, 1168, 48, { fontSize: 14, color: C.muted });
+      gy += 52;
+    }
+    drawFooter();
+  }
+  var title = coverH1 || textOf(document.querySelector("main.deck h1, .deck h1")) || "Presentation";
+  pptx.title = title;
+  var safe = title.replace(/[^\w]+/g, "_").replace(/^_|_$/g, "") || "Presentation";
+  return pptx.writeFile({ fileName: safe + ".pptx" });
 }
 
 (function(){

--- a/libs/naas-abi/naas_abi/apps/nexus/assets/slides/templates/minimal-light-v1.html
+++ b/libs/naas-abi/naas_abi/apps/nexus/assets/slides/templates/minimal-light-v1.html
@@ -243,75 +243,212 @@ const IMG = {
   logo: "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22120%22%20height%3D%2228%22%3E%3Crect%20width%3D%22120%22%20height%3D%2228%22%20rx%3D%224%22%20fill%3D%22%231a1a1a%22%20fill-opacity%3D%220.15%22%2F%3E%3Ctext%20x%3D%2212%22%20y%3D%2219%22%20font-family%3D%22Arial%2Csans-serif%22%20font-size%3D%2212%22%20fill%3D%22%231a1a1a%22%20font-weight%3D%22700%22%3EORG%3C%2Ftext%3E%3C%2Fsvg%3E",
 };
 
-const FOOTER_TXT = "Presentation Title";
-
+/* NEXUS_SLIDES_PPTX_FROM_DOM_V1 */
 async function buildPptx() {
   if (typeof PptxGenJS === "undefined") throw new Error("PptxGenJS failed to load");
-  const pptx = new PptxGenJS();
+  var slides = document.querySelectorAll("main.deck > section.slide, .deck > section.slide");
+  if (!slides.length) throw new Error("No .slide sections to export");
+  var pptx = new PptxGenJS();
   pptx.defineLayout({ name: "LAYOUT_16x9", width: 13.333, height: 7.5 });
   pptx.layout = "LAYOUT_16x9";
-  pptx.title = FOOTER_TXT;
-  const C = {
-    bg: "#ffffff".replace("#", ""),
-    ink: "#1a1a1a".replace("#", ""),
-    muted: "#6b6b6b".replace("#", ""),
-    accent: "#1a1a1a".replace("#", ""),
-    card: "#fafaf8".replace("#", ""),
+  var I = function (px) { return px / 96; };
+  var hex = function (raw, fallback) {
+    var s = String(raw || fallback || "").trim();
+    var m = s.match(/#([0-9a-fA-F]{6})/);
+    if (m) return m[1];
+    m = s.match(/#([0-9a-fA-F]{3})\b/);
+    if (m) {
+      var a = m[1];
+      return a.charAt(0) + a.charAt(0) + a.charAt(1) + a.charAt(1) + a.charAt(2) + a.charAt(2);
+    }
+    m = s.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
+    if (m) {
+      return [m[1], m[2], m[3]].map(function (n) {
+        return ("0" + Number(n).toString(16)).slice(-2);
+      }).join("");
+    }
+    return String(fallback || "ffffff").replace("#", "");
   };
-  const I = (px) => px / 96;
-  const txt = (s, t, x, y, w, h, o = {}) =>
-    s.addText(t, { x: I(x), y: I(y), w: I(w), h: I(h), fontFace: "Arial", margin: 0, ...o });
-  const slideBg = { color: C.bg };
-
-  (() => {
-    const s = pptx.addSlide(); s.background = slideBg;
-    s.addImage({ data: IMG.hero, x: 0, y: 0, w: I(1280), h: I(300) });
-    txt(s, "Confidential · Working Session", 56, 340, 1000, 24, { fontSize: 12, color: C.accent, bold: true });
-    txt(s, "Presentation Title", 56, 380, 1100, 56, { fontSize: 32, bold: true, color: C.ink });
-    txt(s, "Subtitle: replace with your session objective and audience.", 56, 450, 1000, 40, { fontSize: 14, color: C.muted });
-  })();
-
-  (() => {
-    const s = pptx.addSlide(); s.background = slideBg;
-    txt(s, "AGENDA", 56, 48, 400, 20, { fontSize: 11, bold: true, color: C.accent });
-    txt(s, "What we will cover", 56, 78, 1100, 40, { fontSize: 26, bold: true, color: C.ink });
-    [["1","Context"],["2","Approach"],["3","Plan"],["4","Next steps"]].forEach((r, i) => {
-      const y = 160 + i * 90;
-      s.addShape(pptx.ShapeType.rect, { x: I(56), y: I(y), w: I(1168), h: I(76), fill: { color: C.card } });
-      txt(s, r[0], 76, y + 22, 40, 36, { fontSize: 20, bold: true, color: C.accent });
-      txt(s, r[1], 130, y + 26, 800, 30, { fontSize: 16, bold: true, color: C.ink });
-    });
-    txt(s, FOOTER_TXT, 56, 686, 760, 20, { fontSize: 9, color: C.muted });
-  })();
-
-  (() => {
-    const s = pptx.addSlide(); s.background = slideBg;
-    txt(s, "CONTEXT", 56, 48, 400, 20, { fontSize: 11, bold: true, color: C.accent });
-    txt(s, "Start from a shared problem statement", 56, 78, 1100, 40, { fontSize: 26, bold: true, color: C.ink });
-    s.addShape(pptx.ShapeType.rect, { x: I(56), y: I(160), w: I(560), h: I(360), fill: { color: C.card } });
-    txt(s, "Current state", 76, 180, 520, 28, { fontSize: 16, bold: true, color: C.ink });
-    txt(s, "Replace with the facts that frame the discussion.", 76, 230, 520, 200, { fontSize: 13, color: C.muted });
-    s.addShape(pptx.ShapeType.rect, { x: I(656), y: I(160), w: I(568), h: I(360), fill: { color: C.card } });
-    txt(s, "Desired state", 676, 180, 520, 28, { fontSize: 16, bold: true, color: C.ink });
-    txt(s, "Clear ownership, repeatable process, measurable quality.", 676, 230, 520, 200, { fontSize: 13, color: C.muted });
-    txt(s, FOOTER_TXT, 56, 686, 760, 20, { fontSize: 9, color: C.muted });
-  })();
-
-  (() => {
-    const s = pptx.addSlide(); s.background = slideBg;
-    txt(s, "NEXT STEPS", 56, 48, 400, 20, { fontSize: 11, bold: true, color: C.accent });
-    txt(s, "Decisions and follow-ups", 56, 78, 1100, 40, { fontSize: 26, bold: true, color: C.ink });
-    [["1","Confirm sponsor"],["2","Assign owners"],["3","Approve Phase 1"],["4","Schedule cadence"]].forEach((st, i) => {
-      const col = i % 2, row = Math.floor(i / 2);
-      const x = 56 + col * 596, y = 150 + row * 220;
-      s.addShape(pptx.ShapeType.rect, { x: I(x), y: I(y), w: I(576), h: I(190), fill: { color: C.card } });
-      txt(s, st[0], x + 20, y + 40, 44, 48, { fontSize: 28, bold: true, color: C.accent });
-      txt(s, st[1], x + 74, y + 48, 460, 32, { fontSize: 16, bold: true, color: C.ink });
-    });
-    txt(s, FOOTER_TXT, 56, 686, 760, 20, { fontSize: 9, color: C.muted });
-  })();
-
-  return pptx.writeFile({ fileName: "Presentation_Title.pptx" });
+  var cssUrl = function (name) {
+    try {
+      var v = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+      var m = v.match(/url\(["']?(data:[^"')]+)["']?\)/);
+      return m ? m[1] : "";
+    } catch (e) {
+      return "";
+    }
+  };
+  var root;
+  try { root = getComputedStyle(document.documentElement); } catch (e) { root = null; }
+  var prop = function (name, fb) {
+    return hex(root ? root.getPropertyValue(name) : "", fb);
+  };
+  var C = {
+    bg: prop("--panel", "ffffff"),
+    ink: prop("--ink", "1a1a1a"),
+    muted: prop("--muted", "6b6b6b"),
+    accent: prop("--accent", "1a1a1a"),
+    card: prop("--card", "fafaf8")
+  };
+  var txt = function (s, t, x, y, w, h, o) {
+    if (!t) return;
+    s.addText(t, Object.assign({
+      x: I(x), y: I(y), w: I(w), h: I(h), fontFace: "Arial", margin: 0
+    }, o || {}));
+  };
+  var textOf = function (el) {
+    return el ? String(el.textContent || "").replace(/\s+/g, " ").trim() : "";
+  };
+  var first = function (rootEl, sel) {
+    try { return rootEl.querySelector(sel); } catch (e) { return null; }
+  };
+  var heroData = cssUrl("--hero");
+  var divData = cssUrl("--div1");
+  try {
+    if (!heroData && typeof IMG !== "undefined" && IMG && IMG.hero) heroData = IMG.hero;
+    if (!divData && typeof IMG !== "undefined" && IMG && IMG.d1) divData = IMG.d1;
+  } catch (e) {}
+  var coverH1 = "";
+  for (var i = 0; i < slides.length; i++) {
+    var el = slides[i];
+    var s = pptx.addSlide();
+    s.background = { color: C.bg };
+    var footerEl = first(el, ".footer");
+    var footerLeft = "";
+    var footerRight = "";
+    if (footerEl) {
+      var spans = footerEl.querySelectorAll(":scope > span");
+      footerLeft = textOf(spans[0]) || textOf(footerEl);
+      footerRight = spans.length > 1 ? textOf(spans[spans.length - 1]) : "";
+    }
+    var drawFooter = function () {
+      if (footerLeft) txt(s, footerLeft, 56, 686, 900, 20, { fontSize: 9, color: C.muted });
+      if (footerRight) txt(s, footerRight, 1100, 686, 124, 20, { fontSize: 9, color: C.muted, align: "right" });
+    };
+    if (el.classList.contains("cover")) {
+      if (heroData) {
+        try { s.addImage({ data: heroData, x: 0, y: 0, w: I(1280), h: I(300) }); } catch (e) {}
+      } else {
+        s.addShape(pptx.ShapeType.rect, {
+          x: 0, y: 0, w: I(1280), h: I(300),
+          fill: { color: prop("--hero-fallback", "eae8e1") }
+        });
+      }
+      var cEyebrow = textOf(first(el, ".eyebrow"));
+      var cH1 = textOf(first(el, "h1"));
+      var cSub = textOf(first(el, ".subtitle"));
+      var cHook = textOf(first(el, ".hook"));
+      if (!coverH1) coverH1 = cH1;
+      if (cEyebrow) txt(s, cEyebrow.toUpperCase(), 56, 340, 1168, 24, { fontSize: 12, color: C.accent, bold: true });
+      if (cH1) txt(s, cH1, 56, 372, 1168, 64, { fontSize: 32, bold: true, color: C.ink });
+      if (cSub) txt(s, cSub, 56, 444, 1168, 44, { fontSize: 14, color: C.muted });
+      if (cHook) txt(s, cHook, 56, 496, 1168, 28, { fontSize: 13, bold: true, color: C.accent });
+      continue;
+    }
+    if (el.classList.contains("section-divider")) {
+      if (divData) {
+        try { s.addImage({ data: divData, x: 0, y: 0, w: I(1280), h: I(720) }); } catch (e) {}
+      }
+      var dEyebrow = textOf(first(el, ".divider-eyebrow"));
+      var dNum = textOf(first(el, ".divider-number"));
+      var dTitle = textOf(first(el, ".divider-title"));
+      var dSub = textOf(first(el, ".divider-sub"));
+      if (dEyebrow) txt(s, dEyebrow.toUpperCase(), 56, 180, 1168, 24, { fontSize: 12, bold: true, color: C.accent });
+      if (dNum) txt(s, dNum, 56, 210, 1168, 110, { fontSize: 72, bold: true, color: C.ink });
+      if (dTitle) txt(s, dTitle, 56, 330, 1168, 56, { fontSize: 32, bold: true, color: C.ink });
+      if (dSub) txt(s, dSub, 56, 396, 900, 40, { fontSize: 14, color: C.muted });
+      continue;
+    }
+    var eyebrow = textOf(first(el, ":scope > .eyebrow")) || textOf(first(el, ".eyebrow"));
+    var h1 = textOf(first(el, ":scope > h1")) || textOf(first(el, "h1"));
+    if (eyebrow) txt(s, eyebrow.toUpperCase(), 56, 48, 1168, 20, { fontSize: 11, bold: true, color: C.accent });
+    if (h1) txt(s, h1, 56, 76, 1168, 44, { fontSize: 26, bold: true, color: C.ink });
+    var agendaRows = el.querySelectorAll(".agenda-row");
+    if (agendaRows.length) {
+      for (var ar = 0; ar < agendaRows.length; ar++) {
+        var row = agendaRows[ar];
+        var y = 140 + ar * 90;
+        s.addShape(pptx.ShapeType.rect, { x: I(56), y: I(y), w: I(1168), h: I(76), fill: { color: C.card } });
+        txt(s, textOf(first(row, ".agenda-num")), 76, y + 18, 48, 40, { fontSize: 20, bold: true, color: C.accent });
+        txt(s, textOf(first(row, "h2")), 130, y + 14, 820, 28, { fontSize: 16, bold: true, color: C.ink });
+        txt(s, textOf(first(row, "p")), 130, y + 42, 820, 24, { fontSize: 12, color: C.muted });
+        var kids = row.children;
+        if (kids.length) {
+          txt(s, textOf(kids[kids.length - 1]), 980, y + 24, 220, 28, { fontSize: 12, color: C.muted, align: "right" });
+        }
+      }
+      drawFooter();
+      continue;
+    }
+    var stepNodes = el.querySelectorAll(".step");
+    if (stepNodes.length) {
+      for (var st = 0; st < stepNodes.length; st++) {
+        var step = stepNodes[st];
+        var col = st % 2;
+        var srow = Math.floor(st / 2);
+        var sx = 56 + col * 596;
+        var sy = 140 + srow * 220;
+        s.addShape(pptx.ShapeType.rect, { x: I(sx), y: I(sy), w: I(576), h: I(200), fill: { color: C.card } });
+        s.addShape(pptx.ShapeType.rect, { x: I(sx), y: I(sy), w: I(6), h: I(200), fill: { color: C.accent } });
+        txt(s, textOf(first(step, ".step-n")), sx + 24, sy + 28, 60, 40, { fontSize: 24, bold: true, color: C.accent });
+        txt(s, textOf(first(step, "h2")), sx + 90, sy + 36, 450, 32, { fontSize: 16, bold: true, color: C.ink });
+        txt(s, textOf(first(step, "p")), sx + 24, sy + 84, 528, 90, { fontSize: 13, color: C.muted });
+      }
+      drawFooter();
+      continue;
+    }
+    var cards = el.querySelectorAll(".card");
+    if (cards.length) {
+      var n = cards.length;
+      var cols = n >= 4 ? 4 : (n === 3 ? 3 : 2);
+      var gap = 18;
+      var avail = 1168;
+      var cw = (avail - gap * (cols - 1)) / cols;
+      var ch = 360;
+      for (var ci = 0; ci < n; ci++) {
+        var card = cards[ci];
+        var ccol = ci % cols;
+        var crow = Math.floor(ci / cols);
+        var cx = 56 + ccol * (cw + gap);
+        var cy = 140 + crow * (ch + gap);
+        s.addShape(pptx.ShapeType.rect, { x: I(cx), y: I(cy), w: I(cw), h: I(ch), fill: { color: C.card } });
+        var pill = textOf(first(card, ".pill"));
+        var ch2 = textOf(first(card, "h2"));
+        var cp = textOf(first(card, "p"));
+        var lis = [];
+        var liNodes = card.querySelectorAll("li");
+        for (var li = 0; li < liNodes.length; li++) {
+          var lt = textOf(liNodes[li]);
+          if (lt) lis.push(lt);
+        }
+        var ty = cy + 22;
+        if (pill) { txt(s, pill.toUpperCase(), cx + 20, ty, cw - 40, 20, { fontSize: 10, bold: true, color: C.accent }); ty += 26; }
+        if (ch2) { txt(s, ch2, cx + 20, ty, cw - 40, 28, { fontSize: 16, bold: true, color: C.ink }); ty += 36; }
+        if (lis.length) {
+          txt(s, lis.map(function (item) { return "• " + item; }).join("\n"), cx + 20, ty, cw - 40, Math.max(40, ch - (ty - cy) - 20), { fontSize: 13, color: C.muted, valign: "top" });
+        } else if (cp) {
+          txt(s, cp, cx + 20, ty, cw - 40, Math.max(40, ch - (ty - cy) - 20), { fontSize: 13, color: C.muted, valign: "top" });
+        }
+      }
+      drawFooter();
+      continue;
+    }
+    var gSub = textOf(first(el, ".subtitle"));
+    var gy = 136;
+    if (gSub) { txt(s, gSub, 56, gy, 1168, 36, { fontSize: 14, color: C.muted }); gy += 44; }
+    var paras = el.querySelectorAll(":scope > p");
+    for (var pi = 0; pi < paras.length; pi++) {
+      var pt = textOf(paras[pi]);
+      if (!pt || pt === gSub) continue;
+      txt(s, pt, 56, gy, 1168, 48, { fontSize: 14, color: C.muted });
+      gy += 52;
+    }
+    drawFooter();
+  }
+  var title = coverH1 || textOf(document.querySelector("main.deck h1, .deck h1")) || "Presentation";
+  pptx.title = title;
+  var safe = title.replace(/[^\w]+/g, "_").replace(/^_|_$/g, "") || "Presentation";
+  return pptx.writeFile({ fileName: safe + ".pptx" });
 }
 
 (function(){

--- a/libs/naas-abi/naas_abi/apps/nexus/assets/slides/templates/pitch-dark-v1.html
+++ b/libs/naas-abi/naas_abi/apps/nexus/assets/slides/templates/pitch-dark-v1.html
@@ -243,75 +243,212 @@ const IMG = {
   logo: "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22120%22%20height%3D%2228%22%3E%3Crect%20width%3D%22120%22%20height%3D%2228%22%20rx%3D%224%22%20fill%3D%22%23ffffff%22%20fill-opacity%3D%220.15%22%2F%3E%3Ctext%20x%3D%2212%22%20y%3D%2219%22%20font-family%3D%22Arial%2Csans-serif%22%20font-size%3D%2212%22%20fill%3D%22%23ffffff%22%20font-weight%3D%22700%22%3EORG%3C%2Ftext%3E%3C%2Fsvg%3E",
 };
 
-const FOOTER_TXT = "Presentation Title";
-
+/* NEXUS_SLIDES_PPTX_FROM_DOM_V1 */
 async function buildPptx() {
   if (typeof PptxGenJS === "undefined") throw new Error("PptxGenJS failed to load");
-  const pptx = new PptxGenJS();
+  var slides = document.querySelectorAll("main.deck > section.slide, .deck > section.slide");
+  if (!slides.length) throw new Error("No .slide sections to export");
+  var pptx = new PptxGenJS();
   pptx.defineLayout({ name: "LAYOUT_16x9", width: 13.333, height: 7.5 });
   pptx.layout = "LAYOUT_16x9";
-  pptx.title = FOOTER_TXT;
-  const C = {
-    bg: "#121212".replace("#", ""),
-    ink: "#f2f2f2".replace("#", ""),
-    muted: "#9a9a9a".replace("#", ""),
-    accent: "#3de0c4".replace("#", ""),
-    card: "#1a1a1a".replace("#", ""),
+  var I = function (px) { return px / 96; };
+  var hex = function (raw, fallback) {
+    var s = String(raw || fallback || "").trim();
+    var m = s.match(/#([0-9a-fA-F]{6})/);
+    if (m) return m[1];
+    m = s.match(/#([0-9a-fA-F]{3})\b/);
+    if (m) {
+      var a = m[1];
+      return a.charAt(0) + a.charAt(0) + a.charAt(1) + a.charAt(1) + a.charAt(2) + a.charAt(2);
+    }
+    m = s.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
+    if (m) {
+      return [m[1], m[2], m[3]].map(function (n) {
+        return ("0" + Number(n).toString(16)).slice(-2);
+      }).join("");
+    }
+    return String(fallback || "ffffff").replace("#", "");
   };
-  const I = (px) => px / 96;
-  const txt = (s, t, x, y, w, h, o = {}) =>
-    s.addText(t, { x: I(x), y: I(y), w: I(w), h: I(h), fontFace: "Arial", margin: 0, ...o });
-  const slideBg = { color: C.bg };
-
-  (() => {
-    const s = pptx.addSlide(); s.background = slideBg;
-    s.addImage({ data: IMG.hero, x: 0, y: 0, w: I(1280), h: I(300) });
-    txt(s, "Confidential · Working Session", 56, 340, 1000, 24, { fontSize: 12, color: C.accent, bold: true });
-    txt(s, "Presentation Title", 56, 380, 1100, 56, { fontSize: 32, bold: true, color: C.ink });
-    txt(s, "Subtitle: replace with your session objective and audience.", 56, 450, 1000, 40, { fontSize: 14, color: C.muted });
-  })();
-
-  (() => {
-    const s = pptx.addSlide(); s.background = slideBg;
-    txt(s, "AGENDA", 56, 48, 400, 20, { fontSize: 11, bold: true, color: C.accent });
-    txt(s, "What we will cover", 56, 78, 1100, 40, { fontSize: 26, bold: true, color: C.ink });
-    [["1","Context"],["2","Approach"],["3","Plan"],["4","Next steps"]].forEach((r, i) => {
-      const y = 160 + i * 90;
-      s.addShape(pptx.ShapeType.rect, { x: I(56), y: I(y), w: I(1168), h: I(76), fill: { color: C.card } });
-      txt(s, r[0], 76, y + 22, 40, 36, { fontSize: 20, bold: true, color: C.accent });
-      txt(s, r[1], 130, y + 26, 800, 30, { fontSize: 16, bold: true, color: C.ink });
-    });
-    txt(s, FOOTER_TXT, 56, 686, 760, 20, { fontSize: 9, color: C.muted });
-  })();
-
-  (() => {
-    const s = pptx.addSlide(); s.background = slideBg;
-    txt(s, "CONTEXT", 56, 48, 400, 20, { fontSize: 11, bold: true, color: C.accent });
-    txt(s, "Start from a shared problem statement", 56, 78, 1100, 40, { fontSize: 26, bold: true, color: C.ink });
-    s.addShape(pptx.ShapeType.rect, { x: I(56), y: I(160), w: I(560), h: I(360), fill: { color: C.card } });
-    txt(s, "Current state", 76, 180, 520, 28, { fontSize: 16, bold: true, color: C.ink });
-    txt(s, "Replace with the facts that frame the discussion.", 76, 230, 520, 200, { fontSize: 13, color: C.muted });
-    s.addShape(pptx.ShapeType.rect, { x: I(656), y: I(160), w: I(568), h: I(360), fill: { color: C.card } });
-    txt(s, "Desired state", 676, 180, 520, 28, { fontSize: 16, bold: true, color: C.ink });
-    txt(s, "Clear ownership, repeatable process, measurable quality.", 676, 230, 520, 200, { fontSize: 13, color: C.muted });
-    txt(s, FOOTER_TXT, 56, 686, 760, 20, { fontSize: 9, color: C.muted });
-  })();
-
-  (() => {
-    const s = pptx.addSlide(); s.background = slideBg;
-    txt(s, "NEXT STEPS", 56, 48, 400, 20, { fontSize: 11, bold: true, color: C.accent });
-    txt(s, "Decisions and follow-ups", 56, 78, 1100, 40, { fontSize: 26, bold: true, color: C.ink });
-    [["1","Confirm sponsor"],["2","Assign owners"],["3","Approve Phase 1"],["4","Schedule cadence"]].forEach((st, i) => {
-      const col = i % 2, row = Math.floor(i / 2);
-      const x = 56 + col * 596, y = 150 + row * 220;
-      s.addShape(pptx.ShapeType.rect, { x: I(x), y: I(y), w: I(576), h: I(190), fill: { color: C.card } });
-      txt(s, st[0], x + 20, y + 40, 44, 48, { fontSize: 28, bold: true, color: C.accent });
-      txt(s, st[1], x + 74, y + 48, 460, 32, { fontSize: 16, bold: true, color: C.ink });
-    });
-    txt(s, FOOTER_TXT, 56, 686, 760, 20, { fontSize: 9, color: C.muted });
-  })();
-
-  return pptx.writeFile({ fileName: "Presentation_Title.pptx" });
+  var cssUrl = function (name) {
+    try {
+      var v = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+      var m = v.match(/url\(["']?(data:[^"')]+)["']?\)/);
+      return m ? m[1] : "";
+    } catch (e) {
+      return "";
+    }
+  };
+  var root;
+  try { root = getComputedStyle(document.documentElement); } catch (e) { root = null; }
+  var prop = function (name, fb) {
+    return hex(root ? root.getPropertyValue(name) : "", fb);
+  };
+  var C = {
+    bg: prop("--panel", "ffffff"),
+    ink: prop("--ink", "1a1a1a"),
+    muted: prop("--muted", "6b6b6b"),
+    accent: prop("--accent", "1a1a1a"),
+    card: prop("--card", "fafaf8")
+  };
+  var txt = function (s, t, x, y, w, h, o) {
+    if (!t) return;
+    s.addText(t, Object.assign({
+      x: I(x), y: I(y), w: I(w), h: I(h), fontFace: "Arial", margin: 0
+    }, o || {}));
+  };
+  var textOf = function (el) {
+    return el ? String(el.textContent || "").replace(/\s+/g, " ").trim() : "";
+  };
+  var first = function (rootEl, sel) {
+    try { return rootEl.querySelector(sel); } catch (e) { return null; }
+  };
+  var heroData = cssUrl("--hero");
+  var divData = cssUrl("--div1");
+  try {
+    if (!heroData && typeof IMG !== "undefined" && IMG && IMG.hero) heroData = IMG.hero;
+    if (!divData && typeof IMG !== "undefined" && IMG && IMG.d1) divData = IMG.d1;
+  } catch (e) {}
+  var coverH1 = "";
+  for (var i = 0; i < slides.length; i++) {
+    var el = slides[i];
+    var s = pptx.addSlide();
+    s.background = { color: C.bg };
+    var footerEl = first(el, ".footer");
+    var footerLeft = "";
+    var footerRight = "";
+    if (footerEl) {
+      var spans = footerEl.querySelectorAll(":scope > span");
+      footerLeft = textOf(spans[0]) || textOf(footerEl);
+      footerRight = spans.length > 1 ? textOf(spans[spans.length - 1]) : "";
+    }
+    var drawFooter = function () {
+      if (footerLeft) txt(s, footerLeft, 56, 686, 900, 20, { fontSize: 9, color: C.muted });
+      if (footerRight) txt(s, footerRight, 1100, 686, 124, 20, { fontSize: 9, color: C.muted, align: "right" });
+    };
+    if (el.classList.contains("cover")) {
+      if (heroData) {
+        try { s.addImage({ data: heroData, x: 0, y: 0, w: I(1280), h: I(300) }); } catch (e) {}
+      } else {
+        s.addShape(pptx.ShapeType.rect, {
+          x: 0, y: 0, w: I(1280), h: I(300),
+          fill: { color: prop("--hero-fallback", "eae8e1") }
+        });
+      }
+      var cEyebrow = textOf(first(el, ".eyebrow"));
+      var cH1 = textOf(first(el, "h1"));
+      var cSub = textOf(first(el, ".subtitle"));
+      var cHook = textOf(first(el, ".hook"));
+      if (!coverH1) coverH1 = cH1;
+      if (cEyebrow) txt(s, cEyebrow.toUpperCase(), 56, 340, 1168, 24, { fontSize: 12, color: C.accent, bold: true });
+      if (cH1) txt(s, cH1, 56, 372, 1168, 64, { fontSize: 32, bold: true, color: C.ink });
+      if (cSub) txt(s, cSub, 56, 444, 1168, 44, { fontSize: 14, color: C.muted });
+      if (cHook) txt(s, cHook, 56, 496, 1168, 28, { fontSize: 13, bold: true, color: C.accent });
+      continue;
+    }
+    if (el.classList.contains("section-divider")) {
+      if (divData) {
+        try { s.addImage({ data: divData, x: 0, y: 0, w: I(1280), h: I(720) }); } catch (e) {}
+      }
+      var dEyebrow = textOf(first(el, ".divider-eyebrow"));
+      var dNum = textOf(first(el, ".divider-number"));
+      var dTitle = textOf(first(el, ".divider-title"));
+      var dSub = textOf(first(el, ".divider-sub"));
+      if (dEyebrow) txt(s, dEyebrow.toUpperCase(), 56, 180, 1168, 24, { fontSize: 12, bold: true, color: C.accent });
+      if (dNum) txt(s, dNum, 56, 210, 1168, 110, { fontSize: 72, bold: true, color: C.ink });
+      if (dTitle) txt(s, dTitle, 56, 330, 1168, 56, { fontSize: 32, bold: true, color: C.ink });
+      if (dSub) txt(s, dSub, 56, 396, 900, 40, { fontSize: 14, color: C.muted });
+      continue;
+    }
+    var eyebrow = textOf(first(el, ":scope > .eyebrow")) || textOf(first(el, ".eyebrow"));
+    var h1 = textOf(first(el, ":scope > h1")) || textOf(first(el, "h1"));
+    if (eyebrow) txt(s, eyebrow.toUpperCase(), 56, 48, 1168, 20, { fontSize: 11, bold: true, color: C.accent });
+    if (h1) txt(s, h1, 56, 76, 1168, 44, { fontSize: 26, bold: true, color: C.ink });
+    var agendaRows = el.querySelectorAll(".agenda-row");
+    if (agendaRows.length) {
+      for (var ar = 0; ar < agendaRows.length; ar++) {
+        var row = agendaRows[ar];
+        var y = 140 + ar * 90;
+        s.addShape(pptx.ShapeType.rect, { x: I(56), y: I(y), w: I(1168), h: I(76), fill: { color: C.card } });
+        txt(s, textOf(first(row, ".agenda-num")), 76, y + 18, 48, 40, { fontSize: 20, bold: true, color: C.accent });
+        txt(s, textOf(first(row, "h2")), 130, y + 14, 820, 28, { fontSize: 16, bold: true, color: C.ink });
+        txt(s, textOf(first(row, "p")), 130, y + 42, 820, 24, { fontSize: 12, color: C.muted });
+        var kids = row.children;
+        if (kids.length) {
+          txt(s, textOf(kids[kids.length - 1]), 980, y + 24, 220, 28, { fontSize: 12, color: C.muted, align: "right" });
+        }
+      }
+      drawFooter();
+      continue;
+    }
+    var stepNodes = el.querySelectorAll(".step");
+    if (stepNodes.length) {
+      for (var st = 0; st < stepNodes.length; st++) {
+        var step = stepNodes[st];
+        var col = st % 2;
+        var srow = Math.floor(st / 2);
+        var sx = 56 + col * 596;
+        var sy = 140 + srow * 220;
+        s.addShape(pptx.ShapeType.rect, { x: I(sx), y: I(sy), w: I(576), h: I(200), fill: { color: C.card } });
+        s.addShape(pptx.ShapeType.rect, { x: I(sx), y: I(sy), w: I(6), h: I(200), fill: { color: C.accent } });
+        txt(s, textOf(first(step, ".step-n")), sx + 24, sy + 28, 60, 40, { fontSize: 24, bold: true, color: C.accent });
+        txt(s, textOf(first(step, "h2")), sx + 90, sy + 36, 450, 32, { fontSize: 16, bold: true, color: C.ink });
+        txt(s, textOf(first(step, "p")), sx + 24, sy + 84, 528, 90, { fontSize: 13, color: C.muted });
+      }
+      drawFooter();
+      continue;
+    }
+    var cards = el.querySelectorAll(".card");
+    if (cards.length) {
+      var n = cards.length;
+      var cols = n >= 4 ? 4 : (n === 3 ? 3 : 2);
+      var gap = 18;
+      var avail = 1168;
+      var cw = (avail - gap * (cols - 1)) / cols;
+      var ch = 360;
+      for (var ci = 0; ci < n; ci++) {
+        var card = cards[ci];
+        var ccol = ci % cols;
+        var crow = Math.floor(ci / cols);
+        var cx = 56 + ccol * (cw + gap);
+        var cy = 140 + crow * (ch + gap);
+        s.addShape(pptx.ShapeType.rect, { x: I(cx), y: I(cy), w: I(cw), h: I(ch), fill: { color: C.card } });
+        var pill = textOf(first(card, ".pill"));
+        var ch2 = textOf(first(card, "h2"));
+        var cp = textOf(first(card, "p"));
+        var lis = [];
+        var liNodes = card.querySelectorAll("li");
+        for (var li = 0; li < liNodes.length; li++) {
+          var lt = textOf(liNodes[li]);
+          if (lt) lis.push(lt);
+        }
+        var ty = cy + 22;
+        if (pill) { txt(s, pill.toUpperCase(), cx + 20, ty, cw - 40, 20, { fontSize: 10, bold: true, color: C.accent }); ty += 26; }
+        if (ch2) { txt(s, ch2, cx + 20, ty, cw - 40, 28, { fontSize: 16, bold: true, color: C.ink }); ty += 36; }
+        if (lis.length) {
+          txt(s, lis.map(function (item) { return "• " + item; }).join("\n"), cx + 20, ty, cw - 40, Math.max(40, ch - (ty - cy) - 20), { fontSize: 13, color: C.muted, valign: "top" });
+        } else if (cp) {
+          txt(s, cp, cx + 20, ty, cw - 40, Math.max(40, ch - (ty - cy) - 20), { fontSize: 13, color: C.muted, valign: "top" });
+        }
+      }
+      drawFooter();
+      continue;
+    }
+    var gSub = textOf(first(el, ".subtitle"));
+    var gy = 136;
+    if (gSub) { txt(s, gSub, 56, gy, 1168, 36, { fontSize: 14, color: C.muted }); gy += 44; }
+    var paras = el.querySelectorAll(":scope > p");
+    for (var pi = 0; pi < paras.length; pi++) {
+      var pt = textOf(paras[pi]);
+      if (!pt || pt === gSub) continue;
+      txt(s, pt, 56, gy, 1168, 48, { fontSize: 14, color: C.muted });
+      gy += 52;
+    }
+    drawFooter();
+  }
+  var title = coverH1 || textOf(document.querySelector("main.deck h1, .deck h1")) || "Presentation";
+  pptx.title = title;
+  var safe = title.replace(/[^\w]+/g, "_").replace(/^_|_$/g, "") || "Presentation";
+  return pptx.writeFile({ fileName: safe + ".pptx" });
 }
 
 (function(){


### PR DESCRIPTION
## Summary
- Left Slides rail is a template browser (Minimal Light, Pitch Dark, Executive). Expand to see slides and assets; click applies seed HTML. Extra New Presentation header and empty-state CTAs are gone. File → New still seeds Minimal Light.
- Quick Open is a real input, not nested in a button, with no blocking backdrop. Dock Search opens the palette.
- Slides chat is research-first (`web_search` then write). Default model is `anthropic/claude-sonnet-5` via OpenRouter (`abi_slides_agent_model`), high reasoning. Persist uses `ensure_repo`, a `slides/<slug>` branch, `project.json`, and `deck.html` without Coder.
- HTML is the live source of truth. Preview refreshes after writes. PPTX is export-from-DOM only (1280x720 closest fit). Coder remains optional locally. In-memory git dies on API restart.

Pairs with jupyter-naas/zen#55.

## Test plan
- [ ] Open Slides: New is in the Templates rail; no second header New Presentation button
- [ ] Expand a template, click it, confirm the open deck HTML changes
- [ ] File → New Presentation seeds Minimal Light with Abi on the right
- [ ] Dock Search or header Quick Open: type to jump; no full-screen blocker
- [ ] Ask for a current-events brief: agent searches, then writes 6-8 slides; preview updates
- [ ] File → Export PPTX matches slide count and cover title (closest fit, not pixel-perfect)
- [ ] Create and write a deck with Coder down; restarting the API drops in-memory git
- [x] `pnpm test` on slides/quick-open frontend tests (39 passed)
- [x] slides_policy, slides_tools, AbiAgent, friendly-error unit tests (34 passed)