### PR TITLE
Preserve caller-provided LangGraph thread ids in ENV=dev

### DIFF
--- a/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/Agent.py
@@ -119,6 +119,18 @@ def _reset_shared_checkpointer_for_tests() -> None:
 atexit.register(_close_shared_checkpointer)
 
 
+def _maybe_randomize_dev_thread_id(state: "AgentSharedState") -> None:
+    """Isolate default CLI threads in ENV=dev; keep caller-provided ids.
+
+    Historical behavior minted a UUID on every Agent construct when ENV=dev,
+    which broke Nexus chat: each HTTP turn rebuilt the agent tree and lost
+    the conversation id the checkpointer is keyed on. Only the unnamed
+    default ("1") still gets a UUID.
+    """
+    if os.getenv("ENV") == "dev" and state.thread_id == "1":
+        state.set_thread_id(str(uuid.uuid4()))
+
+
 def create_checkpointer() -> BaseCheckpointSaver:
     """Create a checkpointer based on environment configuration.
 
@@ -674,9 +686,10 @@ class Agent(Expose):
         else:
             self._checkpointer = memory
 
-        # Randomize the thread_id to prevent the same thread_id to be used by multiple agents.
-        if os.getenv("ENV") == "dev":
-            self._state.set_thread_id(str(uuid.uuid4()))
+        # Isolate unnamed CLI sessions in ENV=dev (constructor default is "1").
+        # Never overwrite a caller-provided id: Nexus chat keys LangGraph memory
+        # on the conversation id (e.g. conv-7gbvzx7qzj).
+        _maybe_randomize_dev_thread_id(self._state)
 
         # We set the configuration.
         self._configuration = configuration

--- a/libs/naas-abi-core/naas_abi_core/services/agent/Agent_thread_id_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/Agent_thread_id_test.py
@@ -1,0 +1,67 @@
+"""Caller-provided thread ids must survive Agent construction."""
+
+from naas_abi_core.services.agent.Agent import (
+    AgentSharedState,
+    _maybe_randomize_dev_thread_id,
+)
+
+
+def test_dev_env_does_not_overwrite_conversation_id(monkeypatch) -> None:
+    monkeypatch.setenv("ENV", "dev")
+    state = AgentSharedState(thread_id="conv-7gbvzx7qzj")
+
+    _maybe_randomize_dev_thread_id(state)
+
+    assert state.thread_id == "conv-7gbvzx7qzj"
+
+
+def test_dev_env_isolates_default_cli_thread(monkeypatch) -> None:
+    monkeypatch.setenv("ENV", "dev")
+    state = AgentSharedState(thread_id="1")
+
+    _maybe_randomize_dev_thread_id(state)
+
+    assert state.thread_id != "1"
+
+
+def test_non_dev_env_keeps_default_thread(monkeypatch) -> None:
+    monkeypatch.delenv("ENV", raising=False)
+    state = AgentSharedState(thread_id="1")
+
+    _maybe_randomize_dev_thread_id(state)
+
+    assert state.thread_id == "1"
+
+
+def test_agent_construct_keeps_conversation_id_when_env_dev(monkeypatch) -> None:
+    from langchain_core.language_models.fake_chat_models import FakeListChatModel
+    from naas_abi_core.services.agent.Agent import Agent
+
+    monkeypatch.setenv("ENV", "dev")
+    agent = Agent(
+        name="Thread Id Agent",
+        description="Keeps conversation ids",
+        chat_model=FakeListChatModel(responses=["ok"]),
+        state=AgentSharedState(thread_id="conv-7gbvzx7qzj"),
+        enable_default_tools=False,
+    )
+
+    assert agent.state.thread_id == "conv-7gbvzx7qzj"
+
+
+def test_agent_duplicate_keeps_conversation_id_when_env_dev(monkeypatch) -> None:
+    from langchain_core.language_models.fake_chat_models import FakeListChatModel
+    from naas_abi_core.services.agent.Agent import Agent
+
+    monkeypatch.setenv("ENV", "dev")
+    agent = Agent(
+        name="Thread Id Agent",
+        description="Keeps conversation ids",
+        chat_model=FakeListChatModel(responses=["ok"]),
+        enable_default_tools=False,
+    )
+    dup = agent.duplicate(
+        agent_shared_state=AgentSharedState(thread_id="conv-7gbvzx7qzj")
+    )
+
+    assert dup.state.thread_id == "conv-7gbvzx7qzj"

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/provider_runtime.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/provider_runtime.py
@@ -1307,6 +1307,22 @@ def _resolve_inprocess_abi_agent(agent_name: str):
         return instance
 
 
+def _bind_conversation_thread_id(agent: Any, thread_id: str | None) -> Any:
+    """Force the agent's LangGraph thread to the Nexus conversation id.
+
+    Agent.__init__ used to mint a UUID in ENV=dev, and some New() factories
+    still ignore the state Nexus passed. Chat memory is keyed on this id, so
+    the conversation id always wins on the in-process chat path.
+    """
+    if not thread_id:
+        return agent
+    state = getattr(agent, "state", None)
+    setter = getattr(state, "set_thread_id", None)
+    if callable(setter):
+        setter(str(thread_id))
+    return agent
+
+
 def _duplicate_inprocess_agent(template: Any, thread_id: str | None) -> Any:
     """Return a per-request copy of the cached template agent.
 
@@ -1324,19 +1340,55 @@ def _duplicate_inprocess_agent(template: Any, thread_id: str | None) -> Any:
     from naas_abi_core.services.agent.Agent import AgentSharedState
 
     if not hasattr(template, "duplicate"):
-        return template
+        return _bind_conversation_thread_id(template, thread_id)
 
     template_state = getattr(template, "state", None)
     supervisor = getattr(template_state, "supervisor_agent", None)
-    # current_active_agent = getattr(template_state, "current_active_agent", None)
 
     fresh_state = AgentSharedState(
         thread_id=str(thread_id) if thread_id else "1",
         supervisor_agent=supervisor,
-        # current_active_agent=current_active_agent,
     )
     fresh_queue: Queue = Queue()
-    return template.duplicate(queue=fresh_queue, agent_shared_state=fresh_state)
+    duplicated = template.duplicate(queue=fresh_queue, agent_shared_state=fresh_state)
+    return _bind_conversation_thread_id(duplicated, thread_id)
+
+
+def _instantiate_inprocess_agent(
+    template: Any, thread_id: str, llm_model: str | None
+) -> Any:
+    """Build a per-request agent keyed on the Nexus conversation id.
+
+    When the user picked a chat model, call ``New(model_id=...)`` so Bob
+    loads that model. Reuse the template checkpointer: ``New()`` otherwise
+    constructs a fresh in-memory saver and history never survives a turn.
+    """
+    from inspect import signature
+
+    from naas_abi_core.services.agent.Agent import AgentSharedState
+
+    if llm_model:
+        new_fn = getattr(type(template), "New", None)
+        if callable(new_fn):
+            kwargs: dict[str, Any] = {
+                "agent_shared_state": AgentSharedState(thread_id=str(thread_id)),
+            }
+            try:
+                params = signature(new_fn).parameters
+            except (TypeError, ValueError):
+                params = {}
+            if "model_id" in params:
+                kwargs["model_id"] = llm_model
+            if "memory" in params:
+                kwargs["memory"] = getattr(template, "_checkpointer", None)
+            try:
+                agent = new_fn(**kwargs)
+            except TypeError:
+                agent = None
+            if agent is not None:
+                return _bind_conversation_thread_id(agent, thread_id)
+
+    return _duplicate_inprocess_agent(template, thread_id)
 
 
 def _extract_opencode_ui_event(event: dict[str, Any]) -> dict[str, Any] | None:
@@ -1440,21 +1492,7 @@ async def stream_with_abi_inprocess(
     # (the previous behaviour) caused cross-conversation response leakage when
     # two requests overlapped — see jupyter-naas/abi#991.
     assert thread_id is not None, "thread_id is required"
-    agent = None
-    if llm_model:
-        new_fn = getattr(type(template_agent), "New", None)
-        if callable(new_fn):
-            try:
-                from naas_abi_core.services.agent.Agent import AgentSharedState
-
-                agent = new_fn(
-                    agent_shared_state=AgentSharedState(thread_id=str(thread_id)),
-                    model_id=llm_model,
-                )
-            except TypeError:
-                agent = None
-    if agent is None:
-        agent = _duplicate_inprocess_agent(template_agent, thread_id)
+    agent = _instantiate_inprocess_agent(template_agent, thread_id, llm_model)
 
     logger.debug(
         f"Agent.state.thread_id: {getattr(getattr(agent, 'state', None), 'thread_id', None)}"

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/provider_runtime_test.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/provider_runtime_test.py
@@ -160,3 +160,72 @@ def test_redact_url_for_logs_masks_sensitive_query_params() -> None:
     assert "foo=bar" in redacted
     assert "secret123" not in redacted
     assert "xyz" not in redacted
+
+
+class _FakeState:
+    def __init__(self, thread_id: str = "1") -> None:
+        self.thread_id = thread_id
+        self.supervisor_agent = "Bob"
+
+    def set_thread_id(self, thread_id: str) -> None:
+        self.thread_id = thread_id
+
+
+class _FakeAgent:
+    def __init__(self, thread_id: str = "1") -> None:
+        self.state = _FakeState(thread_id)
+        self._checkpointer = object()
+
+    def duplicate(self, queue=None, agent_shared_state=None):
+        dup = _FakeAgent()
+        if agent_shared_state is not None:
+            dup.state.thread_id = agent_shared_state.thread_id
+            dup.state.supervisor_agent = agent_shared_state.supervisor_agent
+        return dup
+
+
+def test_bind_conversation_thread_id_overrides_minted_uuid() -> None:
+    from naas_abi.apps.nexus.apps.api.app.services.provider_runtime import (
+        _bind_conversation_thread_id,
+    )
+
+    agent = _FakeAgent(thread_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+    bound = _bind_conversation_thread_id(agent, "conv-7gbvzx7qzj")
+
+    assert bound.state.thread_id == "conv-7gbvzx7qzj"
+
+
+def test_duplicate_inprocess_agent_uses_conversation_id() -> None:
+    from naas_abi.apps.nexus.apps.api.app.services.provider_runtime import (
+        _duplicate_inprocess_agent,
+    )
+
+    dup = _duplicate_inprocess_agent(_FakeAgent(), "conv-7gbvzx7qzj")
+
+    assert dup.state.thread_id == "conv-7gbvzx7qzj"
+
+
+def test_instantiate_new_path_passes_conversation_state_and_memory() -> None:
+    from naas_abi.apps.nexus.apps.api.app.services.provider_runtime import (
+        _instantiate_inprocess_agent,
+    )
+
+    captured: dict = {}
+
+    class _Factory(_FakeAgent):
+        @classmethod
+        def New(cls, agent_shared_state=None, model_id=None, memory=None):
+            captured["thread_id"] = agent_shared_state.thread_id
+            captured["model_id"] = model_id
+            captured["memory"] = memory
+            agent = cls()
+            agent.state.thread_id = agent_shared_state.thread_id
+            return agent
+
+    template = _Factory()
+    agent = _instantiate_inprocess_agent(template, "conv-7gbvzx7qzj", "qwen-3.6")
+
+    assert captured["thread_id"] == "conv-7gbvzx7qzj"
+    assert captured["model_id"] == "qwen-3.6"
+    assert captured["memory"] is template._checkpointer
+    assert agent.state.thread_id == "conv-7gbvzx7qzj"


### PR DESCRIPTION
## Summary
- Stop overwriting caller-provided thread ids when ENV=dev; only randomize the unnamed default ("1") used by CLI sessions.
- Bind the Nexus conversation id after in-process duplicate / New, and pass the template checkpointer into New(model_id=...) when the factory accepts memory.
- Add unit coverage for thread-id preservation and provider runtime binding.

## Test plan
- [ ] pytest libs/naas-abi-core/naas_abi_core/services/agent/Agent_thread_id_test.py
- [ ] pytest libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/provider_runtime_test.py -k thread
- [ ] Manual: open a Nexus chat in ENV=dev, send two turns, confirm the second turn still has prior context