### PR TITLE
feat(nexus): filter Ontology catalog to workspace seed

### DIFF
--- a/libs/naas-abi/naas_abi/__init__.py
+++ b/libs/naas-abi/naas_abi/__init__.py
@@ -303,6 +303,10 @@ class WorkspaceSeedConfig(BaseModel):
     # Catalog ``app_id`` values (``module.path:folder``) to enable at boot.
     # ``None`` means no seed; missing app-config rows default to off.
     apps: list[str] | None = None
+    # Ontology catalog ids (``module:filename.ttl``). Exclusive when a list
+    # is set: listed on, others off. ``None`` keeps the full engine listing.
+    # An empty list shows none. owl:imports are not implied; name every file.
+    ontologies: list[str] | None = None
 
 
 class OrganizationSeedConfig(BaseModel):

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/config.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/config.py
@@ -297,6 +297,10 @@ class WorkspaceSeedConfig(BaseModel):
     default_agent: str | None = None
     agents: list[str] | None = None
     apps: list[str] | None = None
+    # Ontology catalog ids (``module:filename.ttl``). Exclusive when a list
+    # is set: listed on, others off. ``None`` keeps the full engine listing.
+    # An empty list shows none. owl:imports are not implied; name every file.
+    ontologies: list[str] | None = None
 
 
 class OrganizationSeedConfig(BaseModel):

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/workspace_catalog_seed.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/workspace_catalog_seed.py
@@ -1,8 +1,9 @@
-"""Resolve per-workspace app and agent seed lists from Nexus settings."""
+"""Resolve per-workspace app, agent, and ontology seed lists from Nexus settings."""
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
+from pathlib import Path
 from typing import Any
 
 from naas_abi.apps.nexus.apps.api.app.core import config as nexus_config
@@ -78,3 +79,78 @@ def resolve_app_enabled(
     if app_id in enabled_by_app_id:
         return enabled_by_app_id[app_id]
     return app_id in seed_apps
+
+
+def _posix(path: str) -> str:
+    return path.replace("\\", "/")
+
+
+def _module_key(module_name: str) -> str:
+    return module_name.replace(" ", "_").strip().lower()
+
+
+def normalize_ontology_ref(raw: str) -> str:
+    """Canonical form for a seed id: ``module:filename.ttl``, filename, or path."""
+    text = _posix((raw or "").strip())
+    if not text:
+        return ""
+    if "://" in text:
+        return text
+    if ":" in text and not text.startswith("/"):
+        module, _, filename = text.partition(":")
+        return f"{_module_key(module)}:{filename.strip().lower()}"
+    if "/" not in text:
+        return text.lower()
+    return text
+
+
+def ontology_catalog_aliases(path: str, module_name: str) -> set[str]:
+    """Ids that may appear in ``WorkspaceSeedConfig.ontologies`` for this file."""
+    posix = _posix(path)
+    filename = Path(posix).name
+    module_key = _module_key(module_name)
+    return {
+        path,
+        posix,
+        filename,
+        filename.lower(),
+        f"{module_key}:{filename.lower()}",
+    }
+
+
+def ontology_matches_seed(path: str, module_name: str, seed_refs: Sequence[str]) -> bool:
+    """True when ``path`` is named in the seed. Imports are not implied."""
+    aliases = ontology_catalog_aliases(path, module_name)
+    normalized_aliases = {normalize_ontology_ref(alias) for alias in aliases}
+    posix = _posix(path)
+    for raw in seed_refs:
+        ref = (raw or "").strip()
+        if not ref:
+            continue
+        normalized = normalize_ontology_ref(ref)
+        if normalized in aliases or normalized in normalized_aliases:
+            return True
+        if posix.endswith(_posix(ref)) or path.endswith(ref):
+            return True
+    return False
+
+
+def filter_ontology_catalog(
+    items: Sequence[Any],
+    seed_refs: Sequence[str] | None,
+) -> list[Any]:
+    """Restrict catalog rows to the seed list.
+
+    ``None`` keeps the full engine listing (existing deployments). An empty
+    list returns nothing. A non-empty list is exclusive: listed on, others
+    off. owl:imports are not added.
+    """
+    if seed_refs is None:
+        return list(items)
+    if not seed_refs:
+        return []
+    return [
+        item
+        for item in items
+        if ontology_matches_seed(item.path, item.module_name, seed_refs)
+    ]

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/workspace_catalog_seed_test.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/workspace_catalog_seed_test.py
@@ -1,4 +1,8 @@
+from types import SimpleNamespace
+
 from naas_abi.apps.nexus.apps.api.app.core.workspace_catalog_seed import (
+    filter_ontology_catalog,
+    ontology_matches_seed,
     parse_agent_ref,
     resolve_agent_ref,
     resolve_agent_refs,
@@ -46,3 +50,59 @@ def test_resolve_app_enabled_prefers_db_then_seed() -> None:
     assert resolve_app_enabled("example.module:other", stored, seed) is True
     assert resolve_app_enabled("example.module:dashboard", {}, seed) is True
     assert resolve_app_enabled("example.module:unknown", {}, seed) is False
+
+
+def test_ontology_matches_seed_module_filename() -> None:
+    path = "/repo/src/example/ontologies/modules/ExampleOntology.ttl"
+    assert ontology_matches_seed(path, "example", ["example:ExampleOntology.ttl"]) is True
+    assert ontology_matches_seed(path, "example", ["bfo:bfo-core.ttl"]) is False
+
+
+def test_ontology_matches_seed_does_not_expand_imports() -> None:
+    bfo = "/repo/libs/naas-abi-core/naas_abi_core/modules/bfo/ontologies/modules/bfo-core.ttl"
+    assert ontology_matches_seed(bfo, "bfo", ["example:ExampleOntology.ttl"]) is False
+
+
+def test_filter_ontology_catalog_none_keeps_all() -> None:
+    items = [
+        SimpleNamespace(path="/a/ontologies/modules/A.ttl", module_name="a"),
+        SimpleNamespace(path="/b/ontologies/modules/B.ttl", module_name="b"),
+    ]
+    assert filter_ontology_catalog(items, None) == items
+
+
+def test_filter_ontology_catalog_empty_list_is_none() -> None:
+    items = [SimpleNamespace(path="/a/ontologies/modules/A.ttl", module_name="a")]
+    assert filter_ontology_catalog(items, []) == []
+
+
+def test_filter_ontology_catalog_exclusive_list() -> None:
+    example = SimpleNamespace(
+        path="/repo/src/example/ontologies/modules/ExampleOntology.ttl",
+        module_name="example",
+    )
+    bfo = SimpleNamespace(
+        path="/repo/libs/naas-abi-core/naas_abi_core/modules/bfo/ontologies/modules/bfo-core.ttl",
+        module_name="bfo",
+    )
+    cco = SimpleNamespace(
+        path="/repo/libs/naas-abi-core/naas_abi_core/modules/cco/ontologies/modules/AgentOntology.ttl",
+        module_name="cco",
+    )
+    filtered = filter_ontology_catalog(
+        [example, bfo, cco],
+        ["example:ExampleOntology.ttl", "bfo:bfo-core.ttl"],
+    )
+    assert filtered == [example, bfo]
+
+
+def test_workspace_seed_config_accepts_ontologies() -> None:
+    from naas_abi.apps.nexus.apps.api.app.core.config import WorkspaceSeedConfig
+
+    seed = WorkspaceSeedConfig(
+        name="Example",
+        slug="example",
+        ontologies=["example:ExampleOntology.ttl", "bfo:bfo-core.ttl"],
+    )
+    assert seed.ontologies == ["example:ExampleOntology.ttl", "bfo:bfo-core.ttl"]
+    assert WorkspaceSeedConfig(name="Example", slug="example").ontologies is None

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/ontology/adapters/primary/ontology__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/ontology/adapters/primary/ontology__primary_adapter__FastAPI.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import FileResponse
-from naas_abi.apps.nexus.apps.api.app.api.endpoints.auth import get_current_user_required
+from naas_abi.apps.nexus.apps.api.app.api.endpoints.auth import (
+    User,
+    get_current_user_required,
+    require_workspace_access,
+)
+from naas_abi.apps.nexus.apps.api.app.core.workspace_catalog_seed import (
+    workspace_seed_for_slug,
+)
 from naas_abi.apps.nexus.apps.api.app.services.ontology.adapters.primary.ontology__primary_adapter__dependencies import (  # noqa: E501
     get_ontology_service,
 )
@@ -31,6 +38,7 @@ from naas_abi.apps.nexus.apps.api.app.services.ontology.ontology__schema import 
     OntologyServiceUnavailableError,
 )
 from naas_abi.apps.nexus.apps.api.app.services.ontology.service import OntologyService
+from sqlalchemy import select
 
 router = APIRouter(dependencies=[Depends(get_current_user_required)])
 
@@ -77,16 +85,52 @@ def _edge_to_schema(edge) -> OntologyOverviewGraphEdge:
     )
 
 
+async def _workspace_slug(workspace_id: str) -> str | None:
+    from naas_abi.apps.nexus.apps.api.app.core.database import AsyncSessionLocal
+    from naas_abi.apps.nexus.apps.api.app.models import WorkspaceModel
+
+    async with AsyncSessionLocal() as db:
+        result = await db.execute(
+            select(WorkspaceModel.slug).where(WorkspaceModel.id == workspace_id)
+        )
+        return result.scalar_one_or_none()
+
+
+async def ontology_catalog_scope(
+    workspace_id: str | None = Query(None),
+    current_user: User = Depends(get_current_user_required),
+) -> list[str] | None:
+    """Seed list for this workspace, or None to keep the full engine catalog."""
+    if not workspace_id:
+        return None
+    await require_workspace_access(current_user.id, workspace_id)
+    seed = workspace_seed_for_slug(await _workspace_slug(workspace_id))
+    if seed is None or getattr(seed, "ontologies", None) is None:
+        return None
+    return list(seed.ontologies)
+
+
+async def _require_catalog_path(
+    ontology_path: str,
+    catalog_refs: list[str] | None,
+    ontology_service: OntologyService,
+) -> None:
+    files = await ontology_service.list_ontology_files(catalog_refs=catalog_refs)
+    if ontology_path not in {item.path for item in files}:
+        raise OntologyPathNotFoundError(f"Ontology path not found: {ontology_path}")
+
+
 # ── Endpoints ─────────────────────────────────────────────────────────────────
 
 
 @router.get("")
 async def list_ontology_items(
     ontology_service: OntologyService = Depends(get_ontology_service),
+    catalog_refs: list[str] | None = Depends(ontology_catalog_scope),
 ) -> dict:
     """List all ontology items (OWL Classes and Object Properties)."""
     try:
-        items = await ontology_service.list_items()
+        items = await ontology_service.list_items(catalog_refs=catalog_refs)
     except OntologyServiceUnavailableError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
     return {"items": [_item_to_schema(i) for i in items]}
@@ -96,10 +140,13 @@ async def list_ontology_items(
 async def list_classes(
     ontology_path: str | None = Query(None, alias="ontology_path"),
     ontology_service: OntologyService = Depends(get_ontology_service),
+    catalog_refs: list[str] | None = Depends(ontology_catalog_scope),
 ) -> dict:
     """List ontology classes by file path (or all when omitted)."""
     try:
-        items = await ontology_service.list_classes(ontology_path=ontology_path)
+        items = await ontology_service.list_classes(
+            ontology_path=ontology_path, catalog_refs=catalog_refs
+        )
     except OntologyPathNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except OntologyServiceUnavailableError as exc:
@@ -111,10 +158,13 @@ async def list_classes(
 async def list_relations(
     ontology_path: str | None = Query(None, alias="ontology_path"),
     ontology_service: OntologyService = Depends(get_ontology_service),
+    catalog_refs: list[str] | None = Depends(ontology_catalog_scope),
 ) -> dict:
     """List ontology object properties by file path (or all when omitted)."""
     try:
-        items = await ontology_service.list_relations(ontology_path=ontology_path)
+        items = await ontology_service.list_relations(
+            ontology_path=ontology_path, catalog_refs=catalog_refs
+        )
     except OntologyPathNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except OntologyServiceUnavailableError as exc:
@@ -125,10 +175,11 @@ async def list_relations(
 @router.get("/ontologies")
 async def list_ontology_files(
     ontology_service: OntologyService = Depends(get_ontology_service),
+    catalog_refs: list[str] | None = Depends(ontology_catalog_scope),
 ) -> dict:
-    """List ontology files from all registered modules."""
+    """List ontology files in the workspace catalog."""
     try:
-        items = await ontology_service.list_ontology_files()
+        items = await ontology_service.list_ontology_files(catalog_refs=catalog_refs)
     except OntologyServiceUnavailableError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
     return {
@@ -153,10 +204,14 @@ async def list_ontology_files(
 async def get_ontology_overview_stats(
     ontology_path: str = Query(..., alias="ontology_path", min_length=1),
     ontology_service: OntologyService = Depends(get_ontology_service),
+    catalog_refs: list[str] | None = Depends(ontology_catalog_scope),
 ) -> OntologyOverviewStats:
     """Return element counts for a specific ontology path."""
     try:
+        await _require_catalog_path(ontology_path, catalog_refs, ontology_service)
         stats = await ontology_service.get_overview_stats(ontology_path=ontology_path)
+    except OntologyPathNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
     except OntologyServiceUnavailableError as exc:
         raise HTTPException(status_code=500, detail="Failed to compute ontology overview stats") from exc
     return OntologyOverviewStats(
@@ -174,10 +229,11 @@ async def get_ontology_overview_stats(
 @router.get("/overview/stats/all")
 async def get_all_ontologies_overview_stats(
     ontology_service: OntologyService = Depends(get_ontology_service),
+    catalog_refs: list[str] | None = Depends(ontology_catalog_scope),
 ) -> OntologyOverviewAggregateStats:
-    """Return consolidated overview stats across all registered ontology files."""
+    """Return consolidated overview stats across the workspace catalog."""
     try:
-        stats = await ontology_service.get_all_overview_stats()
+        stats = await ontology_service.get_all_overview_stats(catalog_refs=catalog_refs)
     except OntologyServiceUnavailableError as exc:
         raise HTTPException(status_code=500, detail="Failed to compute consolidated ontology overview stats") from exc
     return OntologyOverviewAggregateStats(
@@ -197,10 +253,13 @@ async def get_all_ontologies_overview_stats(
 async def get_ontology_type_counts(
     ontology_path: str | None = Query(None, alias="ontology_path"),
     ontology_service: OntologyService = Depends(get_ontology_service),
+    catalog_refs: list[str] | None = Depends(ontology_catalog_scope),
 ) -> OntologyTypeCounts:
     """Return counts for owl:NamedIndividual and owl:DatatypeProperty."""
     try:
-        counts = await ontology_service.get_type_counts(ontology_path=ontology_path)
+        counts = await ontology_service.get_type_counts(
+            ontology_path=ontology_path, catalog_refs=catalog_refs
+        )
     except OntologyPathNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except OntologyServiceUnavailableError as exc:
@@ -217,10 +276,13 @@ async def get_ontology_type_counts(
 async def get_ontology_overview_graph(
     ontology_path: str | None = Query(None, alias="ontology_path"),
     ontology_service: OntologyService = Depends(get_ontology_service),
+    catalog_refs: list[str] | None = Depends(ontology_catalog_scope),
 ) -> OntologyOverviewGraph:
     """Return ontology dependency graph based on owl:imports relations."""
     try:
-        graph = await ontology_service.get_overview_graph(ontology_path=ontology_path)
+        graph = await ontology_service.get_overview_graph(
+            ontology_path=ontology_path, catalog_refs=catalog_refs
+        )
     except OntologyPathNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except OntologyServiceUnavailableError as exc:
@@ -245,9 +307,11 @@ async def get_class_parents(
     ontology_path: str = Query(..., alias="ontology_path"),
     class_iris: list[str] = Query(..., alias="class_iris"),
     ontology_service: OntologyService = Depends(get_ontology_service),
+    catalog_refs: list[str] | None = Depends(ontology_catalog_scope),
 ) -> OntologyOverviewGraph:
     """Return direct rdfs:subClassOf parents for the given class IRIs."""
     try:
+        await _require_catalog_path(ontology_path, catalog_refs, ontology_service)
         result = await ontology_service.get_class_parents(
             class_iris=class_iris,
             ontology_path=ontology_path,
@@ -267,6 +331,7 @@ async def get_subclassof_hierarchy(
     ontology_path: str = Query(..., alias="ontology_path"),
     class_iris: list[str] = Query(..., alias="class_iris"),
     ontology_service: OntologyService = Depends(get_ontology_service),
+    catalog_refs: list[str] | None = Depends(ontology_catalog_scope),
 ) -> OntologyOverviewGraph:
     """Return the full rdfs:subClassOf hierarchy starting from class_iris.
 
@@ -274,6 +339,7 @@ async def get_subclassof_hierarchy(
     dict, so the frontend can group nodes by level without recomputing BFS.
     """
     try:
+        await _require_catalog_path(ontology_path, catalog_refs, ontology_service)
         result = await ontology_service.get_subclassof_hierarchy(
             class_iris=class_iris,
             ontology_path=ontology_path,
@@ -384,10 +450,14 @@ async def import_reference_ontology(
 async def export_ontology_file(
     ontology_path: str = Query(..., alias="ontology_path", min_length=1),
     ontology_service: OntologyService = Depends(get_ontology_service),
+    catalog_refs: list[str] | None = Depends(ontology_catalog_scope),
 ) -> FileResponse:
     """Export a selected ontology file as attachment."""
     try:
+        await _require_catalog_path(ontology_path, catalog_refs, ontology_service)
         path = await ontology_service.export_ontology_file(ontology_path=ontology_path)
+    except OntologyPathNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
     except OntologyFileNotFoundError as exc:
         raise HTTPException(status_code=404, detail="Ontology file does not exist") from exc
     return FileResponse(

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/ontology/service.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/ontology/service.py
@@ -9,6 +9,9 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+from naas_abi.apps.nexus.apps.api.app.core.workspace_catalog_seed import (
+    filter_ontology_catalog,
+)
 from naas_abi.apps.nexus.apps.api.app.services.ontology.ontology__schema import (
     OntologyFileItemData,
     OntologyItemData,
@@ -592,15 +595,25 @@ class OntologyService:
         """Clear all in-memory and filesystem ontology graph caches."""
         clear_graph_caches()
 
-    async def list_items(self) -> list[OntologyItemData]:
+    async def list_items(
+        self, catalog_refs: list[str] | None = None
+    ) -> list[OntologyItemData]:
         """List all ontology items (OWL Classes and Object Properties)."""
-        classes = await self.list_classes(ontology_path=None)
-        relations = await self.list_relations(ontology_path=None)
+        classes = await self.list_classes(
+            ontology_path=None, catalog_refs=catalog_refs
+        )
+        relations = await self.list_relations(
+            ontology_path=None, catalog_refs=catalog_refs
+        )
         return [*classes, *relations]
 
-    async def list_classes(self, ontology_path: str | None) -> list[OntologyItemData]:
+    async def list_classes(
+        self,
+        ontology_path: str | None,
+        catalog_refs: list[str] | None = None,
+    ) -> list[OntologyItemData]:
         """List ontology classes (owl:Class) across registered ontology files."""
-        ontologies = await self.list_ontology_files()
+        ontologies = await self.list_ontology_files(catalog_refs=catalog_refs)
         target_paths = self._resolve_ontology_paths(ontology_path, ontologies)
         by_iri: dict[str, OntologyItemData] = {}
 
@@ -641,9 +654,13 @@ class OntologyService:
                 )
         return sorted(by_iri.values(), key=lambda item: item.name.lower())
 
-    async def list_relations(self, ontology_path: str | None) -> list[OntologyItemData]:
+    async def list_relations(
+        self,
+        ontology_path: str | None,
+        catalog_refs: list[str] | None = None,
+    ) -> list[OntologyItemData]:
         """List ontology object properties (owl:ObjectProperty) across registered ontology files."""
-        ontologies = await self.list_ontology_files()
+        ontologies = await self.list_ontology_files(catalog_refs=catalog_refs)
         target_paths = self._resolve_ontology_paths(ontology_path, ontologies)
         by_iri: dict[str, OntologyItemData] = {}
 
@@ -679,8 +696,10 @@ class OntologyService:
                 )
         return sorted(by_iri.values(), key=lambda item: item.name.lower())
 
-    async def list_ontology_files(self) -> list[OntologyFileItemData]:
-        """List ontology files from all registered modules."""
+    async def list_ontology_files(
+        self, catalog_refs: list[str] | None = None
+    ) -> list[OntologyFileItemData]:
+        """List ontology files from registered modules, optionally seed-filtered."""
         from rdflib import DCTERMS, OWL, RDF, Graph, URIRef
 
         try:
@@ -739,7 +758,7 @@ class OntologyService:
                 )
 
             ontology_files.sort(key=lambda item: (item.module_name.lower(), item.name.lower()))
-            return ontology_files
+            return filter_ontology_catalog(ontology_files, catalog_refs)
         except OntologyServiceUnavailableError:
             raise
         except Exception as exc:
@@ -767,10 +786,12 @@ class OntologyService:
                 "Failed to compute ontology overview stats"
             ) from exc
 
-    async def get_all_overview_stats(self) -> OntologyOverviewAggregateStatsData:
+    async def get_all_overview_stats(
+        self, catalog_refs: list[str] | None = None
+    ) -> OntologyOverviewAggregateStatsData:
         """Return consolidated stats across all registered ontology files."""
         try:
-            ontologies = await self.list_ontology_files()
+            ontologies = await self.list_ontology_files(catalog_refs=catalog_refs)
             totals = [0, 0, 0, 0, 0]  # classes, obj_props, data_props, named_ind, imports
             for item in ontologies:
                 try:
@@ -798,10 +819,14 @@ class OntologyService:
                 "Failed to compute aggregate ontology stats"
             ) from exc
 
-    async def get_type_counts(self, ontology_path: str | None) -> OntologyTypeCountsData:
+    async def get_type_counts(
+        self,
+        ontology_path: str | None,
+        catalog_refs: list[str] | None = None,
+    ) -> OntologyTypeCountsData:
         """Return NamedIndividual and DatatypeProperty counts."""
         try:
-            ontologies = await self.list_ontology_files()
+            ontologies = await self.list_ontology_files(catalog_refs=catalog_refs)
             target_paths = self._resolve_ontology_paths(ontology_path, ontologies)
             named_individuals = 0
             data_properties = 0
@@ -820,11 +845,15 @@ class OntologyService:
         except Exception as exc:
             raise OntologyServiceUnavailableError("Failed to compute ontology type counts") from exc
 
-    async def get_overview_graph(self, ontology_path: str | None) -> OntologyOverviewGraphData:
+    async def get_overview_graph(
+        self,
+        ontology_path: str | None,
+        catalog_refs: list[str] | None = None,
+    ) -> OntologyOverviewGraphData:
         """Return ontology dependency/class graph."""
         store = self._get_triple_store()
         try:
-            ontologies = await self.list_ontology_files()
+            ontologies = await self.list_ontology_files(catalog_refs=catalog_refs)
             _populate_dynamic_uri_map([item.path for item in ontologies])
             target_paths = self._resolve_ontology_paths(ontology_path, ontologies)
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/ontology/export/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/ontology/export/page.tsx
@@ -15,6 +15,7 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { getApiUrl } from '@/lib/config';
+import { ontologyApiQuery } from '@/lib/ontology-query';
 import { authFetch } from '@/stores/auth';
 import { useOntologyStore } from '@/stores/ontology';
 import { KpiCard } from '@/app/analytics/components/kpi-card';
@@ -66,7 +67,7 @@ export default function OntologyExportPage() {
     setFilesLoading(true);
     setFilesError(null);
     try {
-      const res = await authFetch(`${getApiUrl()}/api/ontology/ontologies`);
+      const res = await authFetch(`${getApiUrl()}/api/ontology/ontologies${ontologyApiQuery()}`);
       if (!res.ok) throw new Error(`Failed to load ontologies (${res.status})`);
       const data = (await res.json()) as { items?: OntologyFileApiItem[] };
       const items = Array.isArray(data.items) ? data.items : [];
@@ -129,7 +130,7 @@ export default function OntologyExportPage() {
     void (async () => {
       try {
         const res = await authFetch(
-          `${getApiUrl()}/api/ontology/overview/stats?ontology_path=${encodeURIComponent(activePath)}`,
+          `${getApiUrl()}/api/ontology/overview/stats${ontologyApiQuery({ ontology_path: activePath })}`,
         );
         if (!res.ok) throw new Error(`Failed to load ontology stats (${res.status})`);
         const data = (await res.json()) as OntologyStats;
@@ -151,7 +152,7 @@ export default function OntologyExportPage() {
     setExportError(null);
     try {
       const res = await authFetch(
-        `${getApiUrl()}/api/ontology/export?ontology_path=${encodeURIComponent(activePath)}`,
+        `${getApiUrl()}/api/ontology/export${ontologyApiQuery({ ontology_path: activePath })}`,
       );
       if (!res.ok) throw new Error(`Failed to export ontology (${res.status})`);
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/ontology/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/ontology/page.tsx
@@ -6,6 +6,7 @@ import dynamic from 'next/dynamic';
 import { Header } from '@/components/shell/header';
 import { authFetch } from '@/stores/auth';
 import { getApiUrl } from '@/lib/config';
+import { ontologyApiParams, ontologyApiQuery } from '@/lib/ontology-query';
 import {
   Network,
   Plus,
@@ -151,9 +152,7 @@ export default function OntologyPage() {
       setOverviewGraphError(null);
       try {
         const baseUrl = getApiUrl();
-        const query = selectedOntologyPath
-          ? `?ontology_path=${encodeURIComponent(selectedOntologyPath)}`
-          : '';
+        const query = ontologyApiQuery({ ontology_path: selectedOntologyPath });
         const response = await authFetch(`${baseUrl}/api/ontology/overview/graph${query}`);
         if (!response.ok) throw new Error(`Failed to fetch overview graph: status=${response.status}`);
         const graphData = await response.json();
@@ -219,9 +218,7 @@ export default function OntologyPage() {
     let cancelled = false;
     setLoadingSubclassOptions(true);
     const baseUrl = getApiUrl();
-    const url = selectedOntologyPath
-      ? `${baseUrl}/api/ontology/classes?ontology_path=${encodeURIComponent(selectedOntologyPath)}`
-      : `${baseUrl}/api/ontology/classes`;
+    const url = `${baseUrl}/api/ontology/classes${ontologyApiQuery({ ontology_path: selectedOntologyPath })}`;
     authFetch(url)
       .then((res) => res.json())
       .then((data: { items?: Array<{ id?: string; name?: string }> }) => {
@@ -252,9 +249,7 @@ export default function OntologyPage() {
     let cancelled = false;
     setLoadingSubpropertyOptions(true);
     const baseUrl = getApiUrl();
-    const url = selectedOntologyPath
-      ? `${baseUrl}/api/ontology/relationships?ontology_path=${encodeURIComponent(selectedOntologyPath)}`
-      : `${baseUrl}/api/ontology/relationships`;
+    const url = `${baseUrl}/api/ontology/relationships${ontologyApiQuery({ ontology_path: selectedOntologyPath })}`;
     authFetch(url)
       .then((res) => res.json())
       .then((data: { items?: Array<{ id?: string; name?: string }> }) => {
@@ -1024,8 +1019,8 @@ function OntologyOverviewView({
       try {
         const baseUrl = getApiUrl();
         const endpoint = ontologyPath
-          ? `${baseUrl}/api/ontology/overview/stats?ontology_path=${encodeURIComponent(ontologyPath)}`
-          : `${baseUrl}/api/ontology/overview/stats/all`;
+          ? `${baseUrl}/api/ontology/overview/stats${ontologyApiQuery({ ontology_path: ontologyPath })}`
+          : `${baseUrl}/api/ontology/overview/stats/all${ontologyApiQuery()}`;
         const response = await authFetch(endpoint);
         if (!response.ok) {
           throw new Error(`Failed to fetch overview items: status=${response.status}`);
@@ -1740,7 +1735,7 @@ function OntologyNetworkView({
     setLoadingSubclassOfHierarchy(true);
     try {
       const baseUrl = getApiUrl();
-      const params = new URLSearchParams({ ontology_path: ontologyPath });
+      const params = ontologyApiParams({ ontology_path: ontologyPath });
       subclassOfFrontierForHierarchy.forEach((n) => params.append('class_iris', n.id));
 
       const response = await authFetch(`${baseUrl}/api/ontology/overview/hierarchy?${params.toString()}`);

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/ontology-section.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/ontology-section.tsx
@@ -12,6 +12,7 @@ import { useOntologyStore } from '@/stores/ontology';
 import { useWorkspaceStore } from '@/stores/workspace';
 import { authFetch } from '@/stores/auth';
 import { getApiUrl } from '@/lib/config';
+import { ontologyApiQuery } from '@/lib/ontology-query';
 import { CollapsibleSection } from './collapsible-section';
 import { SidebarToolbar, SidebarToolbarButton } from './sidebar-toolbar';
 import { getWorkspacePath } from './utils';
@@ -115,7 +116,7 @@ export function OntologySection({ collapsed, detailOnly }: { collapsed: boolean;
       setLoadingOntologyFiles(true);
       try {
         const apiUrl = getApiUrl();
-        const response = await authFetch(`${apiUrl}/api/ontology/ontologies`);
+        const response = await authFetch(`${apiUrl}/api/ontology/ontologies${ontologyApiQuery()}`);
         if (!response.ok) {
           throw new Error(`Failed to fetch ontology files: ${response.status}`);
         }
@@ -139,13 +140,17 @@ export function OntologySection({ collapsed, detailOnly }: { collapsed: boolean;
           );
         setOntologyFiles(normalizedFiles);
 
-        // Auto-select and navigate to the first ontology when none is selected.
-        // Read from getState() so we see the post-hydration value.
-        if (!useOntologyStore.getState().selectedOntologyPath && normalizedFiles.length > 0) {
+        const selected = useOntologyStore.getState().selectedOntologyPath;
+        const stillValid = Boolean(
+          selected && normalizedFiles.some((file) => file.path === selected)
+        );
+        if (!stillValid && normalizedFiles.length > 0) {
           const firstPath = normalizedFiles[0].path;
           setSelectedOntologyPath(firstPath);
           const params = new URLSearchParams({ view: 'network', ontology: firstPath });
           router.push(getWorkspacePath(currentWorkspaceId, `/ontology?${params.toString()}`));
+        } else if (!stillValid) {
+          setSelectedOntologyPath(null);
         }
 
         setExpandedOntologyModules(
@@ -171,8 +176,7 @@ export function OntologySection({ collapsed, detailOnly }: { collapsed: boolean;
     };
 
     fetchOntologyFiles();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [currentWorkspaceId, router, setSelectedOntologyPath]);
 
   return (
     <CollapsibleSection

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/ontology-query.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/ontology-query.ts
@@ -1,0 +1,24 @@
+import { useWorkspaceStore } from '@/stores/workspace';
+
+export function ontologyApiParams(
+  extra: Record<string, string | null | undefined> = {},
+): URLSearchParams {
+  const params = new URLSearchParams();
+  const workspaceId = useWorkspaceStore.getState().currentWorkspaceId;
+  if (workspaceId) {
+    params.set('workspace_id', workspaceId);
+  }
+  for (const [key, value] of Object.entries(extra)) {
+    if (value) {
+      params.set(key, value);
+    }
+  }
+  return params;
+}
+
+export function ontologyApiQuery(
+  extra: Record<string, string | null | undefined> = {},
+): string {
+  const encoded = ontologyApiParams(extra).toString();
+  return encoded ? `?${encoded}` : '';
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/ontology.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/ontology.ts
@@ -4,6 +4,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { useWorkspaceStore } from './workspace';
 import { getApiUrl } from '@/lib/config';
+import { ontologyApiQuery } from '@/lib/ontology-query';
 import { authFetch } from './auth';
 
 // Helper to get current workspace ID
@@ -261,8 +262,8 @@ export const useOntologyStore = create<OntologyState>()(
           const baseUrl = getApiUrl();
           const workspaceId = getCurrentWorkspaceId() || 'default';
           const [classesResponse, relationshipsResponse] = await Promise.all([
-            authFetch(`${baseUrl}/api/ontology/classes`),
-            authFetch(`${baseUrl}/api/ontology/relationships`),
+            authFetch(`${baseUrl}/api/ontology/classes${ontologyApiQuery()}`),
+            authFetch(`${baseUrl}/api/ontology/relationships${ontologyApiQuery()}`),
           ]);
 
           if (!classesResponse.ok) {
@@ -343,11 +344,8 @@ export const useOntologyStore = create<OntologyState>()(
           const workspaceId = getCurrentWorkspaceId() || 'default';
           const isClassesView = view === 'classes';
           const pathSuffix = isClassesView ? '/api/ontology/classes' : '/api/ontology/relationships';
-          const query = ontologyPath
-            ? `?ontology_path=${encodeURIComponent(ontologyPath)}`
-            : '';
           const response = await authFetch(
-            `${baseUrl}${pathSuffix}${query}`
+            `${baseUrl}${pathSuffix}${ontologyApiQuery({ ontology_path: ontologyPath })}`
           );
 
           if (!response.ok) {


### PR DESCRIPTION
## Summary
- Workspace seeds can name an exclusive Ontology catalog with `ontologies: [module:filename.ttl]`.
- `None` keeps today's full engine listing. An empty list shows none.
- The catalog is exactly the listed ids. `owl:imports` are not implied; name every file that should appear.
- Ontology API list, stats, and graph endpoints take `workspace_id`, filter to that catalog, and 404 paths outside it.
- The Ontology UI sends `workspace_id` on those requests and drops a selected path that is no longer in the catalog.

Fixes #1235

## Test plan
- [ ] Seed a workspace with two ontology ids; Ontology sidebar lists only those files
- [ ] Seed with an empty list; Ontology sidebar is empty
- [ ] Omit `ontologies` from the seed; Ontology sidebar still lists every engine file
- [ ] Open a catalog file; classes and export load. Request a path that is not in the seed; API returns 404
- [ ] Switch workspace; sidebar refetches and drops a selected path that is not in the new catalog