### PR TITLE
feat(nexus): filter Knowledge Graph catalog to workspace seed

### DIFF
--- a/libs/naas-abi/naas_abi/__init__.py
+++ b/libs/naas-abi/naas_abi/__init__.py
@@ -307,6 +307,10 @@ class WorkspaceSeedConfig(BaseModel):
     # is set: listed on, others off. ``None`` keeps the full engine listing.
     # An empty list shows none. owl:imports are not implied; name every file.
     ontologies: list[str] | None = None
+    # Named-graph catalog ids (full URI or last path segment). Exclusive when
+    # a list is set: listed on, others off. ``None`` keeps the full store
+    # listing. An empty list shows none. schema and nexus are not implied.
+    graphs: list[str] | None = None
 
 
 class OrganizationSeedConfig(BaseModel):

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/config.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/config.py
@@ -301,6 +301,10 @@ class WorkspaceSeedConfig(BaseModel):
     # is set: listed on, others off. ``None`` keeps the full engine listing.
     # An empty list shows none. owl:imports are not implied; name every file.
     ontologies: list[str] | None = None
+    # Named-graph catalog ids (full URI or last path segment). Exclusive when
+    # a list is set: listed on, others off. ``None`` keeps the full store
+    # listing. An empty list shows none. schema and nexus are not implied.
+    graphs: list[str] | None = None
 
 
 class OrganizationSeedConfig(BaseModel):

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/workspace_catalog_seed.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/workspace_catalog_seed.py
@@ -1,4 +1,4 @@
-"""Resolve per-workspace app, agent, and ontology seed lists from Nexus settings."""
+"""Resolve per-workspace app, agent, ontology, and graph seed lists from Nexus settings."""
 
 from __future__ import annotations
 
@@ -133,6 +133,78 @@ def ontology_matches_seed(path: str, module_name: str, seed_refs: Sequence[str])
         if posix.endswith(_posix(ref)) or path.endswith(ref):
             return True
     return False
+
+
+def _graph_slug(uri: str) -> str:
+    text = (uri or "").strip().rstrip("/")
+    if not text:
+        return ""
+    return text.split("/")[-1].split("#")[-1]
+
+
+def graph_catalog_aliases(uri: str, graph_id: str = "") -> set[str]:
+    """Ids that may appear in ``WorkspaceSeedConfig.graphs`` for this named graph."""
+    slug = _graph_slug(uri)
+    aliases = {uri, uri.lower(), slug, slug.lower()}
+    if graph_id:
+        aliases.add(graph_id)
+        aliases.add(graph_id.lower())
+    return aliases
+
+
+def graph_matches_seed(uri: str, seed_refs: Sequence[str], graph_id: str = "") -> bool:
+    """True when ``uri`` is named in the seed. schema and nexus are not implied."""
+    aliases = graph_catalog_aliases(uri, graph_id)
+    for raw in seed_refs:
+        ref = (raw or "").strip()
+        if not ref:
+            continue
+        if ref in aliases or ref.lower() in aliases:
+            return True
+        if uri.rstrip("/") == ref.rstrip("/"):
+            return True
+    return False
+
+
+def filter_graph_catalog(
+    items: Sequence[Any],
+    seed_refs: Sequence[str] | None,
+) -> list[Any]:
+    """Restrict named-graph rows to the seed list.
+
+    ``None`` keeps the full store listing (existing deployments). An empty
+    list returns nothing. A non-empty list is exclusive: listed on, others
+    off. schema and nexus are not added.
+    """
+    if seed_refs is None:
+        return list(items)
+    if not seed_refs:
+        return []
+    return [
+        item
+        for item in items
+        if graph_matches_seed(item.uri, seed_refs, getattr(item, "id", "") or "")
+    ]
+
+
+def filter_graph_packs(
+    packs: Sequence[Any],
+    seed_refs: Sequence[str] | None,
+) -> list[Any]:
+    """Filter packed graph lists and drop empty role groups."""
+    if seed_refs is None:
+        return list(packs)
+    filtered: list[Any] = []
+    for pack in packs:
+        graphs = filter_graph_catalog(getattr(pack, "graphs", []) or [], seed_refs)
+        if not graphs:
+            continue
+        if hasattr(pack, "__dataclass_fields__"):
+            filtered.append(type(pack)(role_label=pack.role_label, graphs=graphs))
+        else:
+            pack.graphs = graphs
+            filtered.append(pack)
+    return filtered
 
 
 def filter_ontology_catalog(

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/workspace_catalog_seed_test.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/core/workspace_catalog_seed_test.py
@@ -1,7 +1,10 @@
 from types import SimpleNamespace
 
 from naas_abi.apps.nexus.apps.api.app.core.workspace_catalog_seed import (
+    filter_graph_catalog,
+    filter_graph_packs,
     filter_ontology_catalog,
+    graph_matches_seed,
     ontology_matches_seed,
     parse_agent_ref,
     resolve_agent_ref,
@@ -106,3 +109,72 @@ def test_workspace_seed_config_accepts_ontologies() -> None:
     )
     assert seed.ontologies == ["example:ExampleOntology.ttl", "bfo:bfo-core.ttl"]
     assert WorkspaceSeedConfig(name="Example", slug="example").ontologies is None
+
+
+SCHEMA_URI = "http://ontology.naas.ai/graph/schema"
+NEXUS_URI = "http://ontology.naas.ai/graph/nexus"
+EXAMPLE_URI = "http://ontology.example.com/graph/example"
+
+
+def test_graph_matches_seed_uri_and_slug() -> None:
+    assert graph_matches_seed(EXAMPLE_URI, ["example"]) is True
+    assert graph_matches_seed(EXAMPLE_URI, [EXAMPLE_URI]) is True
+    assert graph_matches_seed(EXAMPLE_URI, ["schema"]) is False
+
+
+def test_graph_matches_seed_does_not_imply_schema_or_nexus() -> None:
+    assert graph_matches_seed(SCHEMA_URI, ["example"]) is False
+    assert graph_matches_seed(NEXUS_URI, ["example"]) is False
+
+
+def test_filter_graph_catalog_none_keeps_all() -> None:
+    items = [
+        SimpleNamespace(uri=EXAMPLE_URI, id="example"),
+        SimpleNamespace(uri=SCHEMA_URI, id="schema"),
+    ]
+    assert filter_graph_catalog(items, None) == items
+
+
+def test_filter_graph_catalog_empty_list_is_none() -> None:
+    items = [SimpleNamespace(uri=EXAMPLE_URI, id="example")]
+    assert filter_graph_catalog(items, []) == []
+
+
+def test_filter_graph_catalog_exclusive_list() -> None:
+    example = SimpleNamespace(uri=EXAMPLE_URI, id="example")
+    schema = SimpleNamespace(uri=SCHEMA_URI, id="schema")
+    nexus = SimpleNamespace(uri=NEXUS_URI, id="nexus")
+    other = SimpleNamespace(
+        uri="http://ontology.example.com/graph/other",
+        id="other",
+    )
+    filtered = filter_graph_catalog(
+        [example, schema, nexus, other],
+        ["example"],
+    )
+    assert filtered == [example]
+
+
+def test_filter_graph_packs_drops_empty_roles() -> None:
+    example = SimpleNamespace(uri=EXAMPLE_URI, id="example")
+    schema = SimpleNamespace(uri=SCHEMA_URI, id="schema")
+    packs = [
+        SimpleNamespace(role_label="admin", graphs=[schema]),
+        SimpleNamespace(role_label="unknown", graphs=[example]),
+    ]
+    filtered = filter_graph_packs(packs, ["example"])
+    assert len(filtered) == 1
+    assert filtered[0].role_label == "unknown"
+    assert filtered[0].graphs == [example]
+
+
+def test_workspace_seed_config_accepts_graphs() -> None:
+    from naas_abi.apps.nexus.apps.api.app.core.config import WorkspaceSeedConfig
+
+    seed = WorkspaceSeedConfig(
+        name="Example",
+        slug="example",
+        graphs=["example", EXAMPLE_URI],
+    )
+    assert seed.graphs == ["example", EXAMPLE_URI]
+    assert WorkspaceSeedConfig(name="Example", slug="example").graphs is None

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/graph/adapters/primary/graph__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/graph/adapters/primary/graph__primary_adapter__FastAPI.py
@@ -13,6 +13,10 @@ from naas_abi.apps.nexus.apps.api.app.api.endpoints.auth import (
     require_workspace_access,
 )
 from naas_abi.apps.nexus.apps.api.app.core.config import settings
+from naas_abi.apps.nexus.apps.api.app.core.workspace_catalog_seed import (
+    graph_matches_seed,
+    workspace_seed_for_slug,
+)
 from naas_abi.apps.nexus.apps.api.app.services.graph.adapters.primary.graph__primary_adapter__dependencies import (  # noqa: E501
     get_graph_service,
 )
@@ -192,6 +196,44 @@ def _edge_to_schema(edge) -> GraphEdge:
     )
 
 
+async def _workspace_slug(workspace_id: str) -> str | None:
+    from naas_abi.apps.nexus.apps.api.app.core.database import AsyncSessionLocal
+    from naas_abi.apps.nexus.apps.api.app.models import WorkspaceModel
+    from sqlalchemy import select
+
+    async with AsyncSessionLocal() as db:
+        result = await db.execute(
+            select(WorkspaceModel.slug).where(WorkspaceModel.id == workspace_id)
+        )
+        return result.scalar_one_or_none()
+
+
+async def graph_catalog_refs(workspace_id: str) -> list[str] | None:
+    """Seed list for this workspace, or None to keep the full store catalog."""
+    seed = workspace_seed_for_slug(await _workspace_slug(workspace_id))
+    if seed is None or getattr(seed, "graphs", None) is None:
+        return None
+    return list(seed.graphs)
+
+
+def _require_catalog_uri(graph_uri: str, catalog_refs: list[str] | None) -> None:
+    if catalog_refs is None:
+        return
+    graph_id = graph_uri.rstrip("/").split("/")[-1]
+    if not graph_matches_seed(graph_uri, catalog_refs, graph_id):
+        raise HTTPException(status_code=404, detail=f"Graph not found: {graph_uri}")
+
+
+async def require_graph_in_catalog(workspace_id: str, graph_uri: str) -> None:
+    _require_catalog_uri(graph_uri, await graph_catalog_refs(workspace_id))
+
+
+async def require_graphs_in_catalog(workspace_id: str, graph_uris: list[str]) -> None:
+    catalog_refs = await graph_catalog_refs(workspace_id)
+    for uri in graph_uris:
+        _require_catalog_uri(uri, catalog_refs)
+
+
 # ── Endpoints ─────────────────────────────────────────────────────────────────
 
 
@@ -201,10 +243,13 @@ async def list_graphs(
     current_user: User = Depends(get_current_user_required),
     graph_service: GraphService = Depends(get_graph_service),
 ) -> list[GraphPack]:
-    """List all graphs available in the triple store and nexus ontology graph."""
+    """List named graphs in the workspace catalog."""
     await require_workspace_access(current_user.id, workspace_id)
     try:
-        graphs = await graph_service.list_graphs(workspace_id=workspace_id)
+        graphs = await graph_service.list_graphs(
+            workspace_id=workspace_id,
+            catalog_refs=await graph_catalog_refs(workspace_id),
+        )
     except GraphServiceUnavailableError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
     return [
@@ -228,7 +273,10 @@ async def list_graph_roles(
     """List distinct knowledge graph role labels used in the workspace."""
     await require_workspace_access(current_user.id, workspace_id)
     try:
-        roles = await graph_service.list_graph_roles(workspace_id=workspace_id)
+        roles = await graph_service.list_graph_roles(
+            workspace_id=workspace_id,
+            catalog_refs=await graph_catalog_refs(workspace_id),
+        )
     except GraphServiceUnavailableError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
     return roles
@@ -271,6 +319,7 @@ async def get_graph_detail(
 ) -> GraphDetail:
     """Full metadata for one graph (label, description, role) — used to pre-fill the edit form."""
     await require_workspace_access(current_user.id, workspace_id)
+    await require_graph_in_catalog(workspace_id, uri)
     try:
         graph = await graph_service.get_graph(workspace_id=workspace_id, graph_uri=uri)
     except ValueError as exc:
@@ -294,6 +343,7 @@ async def update_graph(
 ) -> GraphDetail:
     """Update a graph's label, description and role in place (URI/id is preserved)."""
     await require_workspace_access(current_user.id, payload.workspace_id)
+    await require_graph_in_catalog(payload.workspace_id, payload.uri)
     try:
         graph = await graph_service.update_graph(
             workspace_id=payload.workspace_id,
@@ -324,6 +374,7 @@ async def clear_graph(
     graph_service: GraphService = Depends(get_graph_service),
 ) -> dict[str, str]:
     await require_workspace_access(current_user.id, payload.workspace_id)
+    await require_graph_in_catalog(payload.workspace_id, payload.uri)
     try:
         await graph_service.clear_graph(workspace_id=payload.workspace_id, graph_uri=payload.uri)
     except GraphProtectedError as exc:
@@ -354,6 +405,7 @@ async def delete_graph(
     graph_service: GraphService = Depends(get_graph_service),
 ) -> dict[str, str]:
     await require_workspace_access(current_user.id, payload.workspace_id)
+    await require_graph_in_catalog(payload.workspace_id, payload.uri)
     try:
         await graph_service.delete_graph(workspace_id=payload.workspace_id, graph_uri=payload.uri)
     except GraphProtectedError as exc:
@@ -371,6 +423,7 @@ async def create_individual(
 ) -> GraphNode:
     """Insert a new individual into the given named graph."""
     await require_workspace_access(current_user.id, payload.workspace_id)
+    await require_graph_in_catalog(payload.workspace_id, payload.graph_uri)
     try:
         node = await graph_service.create_individual(
             workspace_id=payload.workspace_id,
@@ -397,6 +450,7 @@ async def delete_individual(
 ) -> dict[str, str]:
     """Delete an individual: remove every triple where it is subject or object in the graph."""
     await require_workspace_access(current_user.id, payload.workspace_id)
+    await require_graph_in_catalog(payload.workspace_id, payload.graph_uri)
     try:
         await graph_service.delete_individual(
             workspace_id=payload.workspace_id,
@@ -418,6 +472,7 @@ async def add_data_property(
 ) -> dict[str, str]:
     """Insert a single data property triple on an individual."""
     await require_workspace_access(current_user.id, payload.workspace_id)
+    await require_graph_in_catalog(payload.workspace_id, payload.graph_uri)
     try:
         await graph_service.add_data_property(
             workspace_id=payload.workspace_id,
@@ -443,6 +498,7 @@ async def delete_data_property(
 ) -> dict[str, str]:
     """Delete a single data property triple from an individual."""
     await require_workspace_access(current_user.id, payload.workspace_id)
+    await require_graph_in_catalog(payload.workspace_id, payload.graph_uri)
     try:
         await graph_service.delete_data_property(
             workspace_id=payload.workspace_id,
@@ -466,6 +522,7 @@ async def update_data_property(
 ) -> dict[str, str]:
     """Replace a data property value for an individual (delete old triple, insert new)."""
     await require_workspace_access(current_user.id, payload.workspace_id)
+    await require_graph_in_catalog(payload.workspace_id, payload.graph_uri)
     try:
         await graph_service.update_data_property(
             workspace_id=payload.workspace_id,
@@ -490,6 +547,7 @@ async def add_object_property(
 ) -> dict[str, str]:
     """Insert a single object property triple on an individual."""
     await require_workspace_access(current_user.id, payload.workspace_id)
+    await require_graph_in_catalog(payload.workspace_id, payload.graph_uri)
     try:
         await graph_service.add_object_property(
             workspace_id=payload.workspace_id,
@@ -515,6 +573,7 @@ async def delete_object_property(
 ) -> dict[str, str]:
     """Delete a single object property triple from an individual."""
     await require_workspace_access(current_user.id, payload.workspace_id)
+    await require_graph_in_catalog(payload.workspace_id, payload.graph_uri)
     try:
         await graph_service.delete_object_property(
             workspace_id=payload.workspace_id,
@@ -538,6 +597,7 @@ async def update_object_property(
 ) -> dict[str, str]:
     """Replace an object property triple for an individual (delete old triple, insert new)."""
     await require_workspace_access(current_user.id, payload.workspace_id)
+    await require_graph_in_catalog(payload.workspace_id, payload.graph_uri)
     try:
         await graph_service.update_object_property(
             workspace_id=payload.workspace_id,
@@ -567,6 +627,7 @@ async def get_graph_overview(
 ) -> GraphOverview:
     """Get overview of a given graph."""
     await require_workspace_access(current_user.id, workspace_id)
+    await require_graph_in_catalog(workspace_id, graph_uri)
     try:
         overview = await graph_service.get_graph_overview(
             workspace_id=workspace_id, graph_uri=graph_uri, limit=limit
@@ -593,6 +654,7 @@ async def get_graph_kpis(
     only the first request for a graph ever waits on the count queries.
     """
     await require_workspace_access(current_user.id, workspace_id)
+    await require_graph_in_catalog(workspace_id, graph_uri)
     try:
         kpis = await graph_service.get_graph_kpis(workspace_id=workspace_id, graph_uri=graph_uri)
     except GraphServiceUnavailableError as exc:
@@ -621,6 +683,7 @@ async def get_network_schema(
     multi-million-triple graph takes seconds and must never block a response.
     """
     await require_workspace_access(current_user.id, workspace_id)
+    await require_graph_in_catalog(workspace_id, graph_uri)
     try:
         schema = await graph_service.get_network_schema(
             workspace_id=workspace_id, graph_uri=graph_uri
@@ -661,6 +724,7 @@ async def get_graph_network(
 ) -> GraphData:
     """Get all nodes and edges for a given graph."""
     await require_workspace_access(current_user.id, workspace_id)
+    await require_graph_in_catalog(workspace_id, graph_uri)
     try:
         network = await graph_service.get_graph_network(
             workspace_id=workspace_id, graph_uri=graph_uri, limit=limit
@@ -684,6 +748,7 @@ async def search_graph_network(
 ) -> GraphData:
     """Search nodes by label within a graph. Returns matching individuals and their edges."""
     await require_workspace_access(current_user.id, workspace_id)
+    await require_graph_in_catalog(workspace_id, graph_uri)
     try:
         result = await graph_service.search_network(
             workspace_id=workspace_id,
@@ -721,6 +786,7 @@ async def export_graph(
     Supported formats: ttl (Turtle), owl (RDF/XML), nt (N-Triples).
     """
     await require_workspace_access(current_user.id, workspace_id)
+    await require_graph_in_catalog(workspace_id, graph_uri)
     rdflib_format, media_type, ext = _EXPORT_FORMAT_META.get(format, _EXPORT_FORMAT_META["ttl"])
     try:
         content, triple_count, named_individual_count = await graph_service.export_graph_as_ttl(
@@ -796,6 +862,7 @@ async def import_graph_file(
     Returns ``{"status": "imported", "count": N}`` where N is the number of triples inserted.
     """
     await require_workspace_access(current_user.id, workspace_id)
+    await require_graph_in_catalog(workspace_id, graph_uri)
     content = await file.read()
     fmt = _detect_rdf_format(file.filename or "")
     try:
@@ -824,6 +891,7 @@ async def discovery_classes(
 ) -> list[DiscoveryClass]:
     """List RDF classes that have NamedIndividuals in the given graph."""
     await require_workspace_access(current_user.id, workspace_id)
+    await require_graph_in_catalog(workspace_id, graph_uri)
     try:
         classes = await graph_service.discover_classes(
             workspace_id=workspace_id, graph_uri=graph_uri
@@ -842,7 +910,10 @@ async def discovery_classes_all(
     """List RDF classes aggregated across all workspace graphs."""
     await require_workspace_access(current_user.id, workspace_id)
     try:
-        classes = await graph_service.discover_all_classes(workspace_id=workspace_id)
+        classes = await graph_service.discover_all_classes(
+            workspace_id=workspace_id,
+            catalog_refs=await graph_catalog_refs(workspace_id),
+        )
     except GraphServiceUnavailableError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
     return [DiscoveryClass(uri=c.uri, label=c.label, count=c.count) for c in classes]
@@ -924,6 +995,7 @@ async def discovery_relation_targets(
 ) -> list[DiscoveryRelationTarget]:
     """List individuals that can be used as object-property range values."""
     await require_workspace_access(current_user.id, payload.workspace_id)
+    await require_graph_in_catalog(payload.workspace_id, payload.graph_uri)
     try:
         targets = await graph_service.discover_relation_targets(
             workspace_id=payload.workspace_id,
@@ -954,6 +1026,7 @@ async def discovery_properties(
 ) -> list[DiscoveryProperty]:
     """List datatype/annotation properties used by instances of the given classes."""
     await require_workspace_access(current_user.id, payload.workspace_id)
+    await require_graph_in_catalog(payload.workspace_id, payload.graph_uri)
     try:
         properties = await graph_service.discover_properties(
             workspace_id=payload.workspace_id,
@@ -973,6 +1046,7 @@ async def discovery_instances(
 ) -> list[DiscoveryInstance]:
     """Search instances matching selected classes / properties / global search query."""
     await require_workspace_access(current_user.id, payload.workspace_id)
+    await require_graph_in_catalog(payload.workspace_id, payload.graph_uri)
     try:
         instances = await graph_service.discover_instances(
             workspace_id=payload.workspace_id,
@@ -1012,6 +1086,7 @@ async def discovery_instance_detail(
 ) -> DiscoveryInstanceDetail:
     """Fetch full detail for a single instance: all data properties and relations."""
     await require_workspace_access(current_user.id, payload.workspace_id)
+    await require_graphs_in_catalog(payload.workspace_id, payload.graph_uris)
     try:
         detail = await graph_service.discover_instance_detail(
             workspace_id=payload.workspace_id,
@@ -1054,6 +1129,7 @@ async def discovery_relation_types(
 ) -> list[DiscoveryRelationType]:
     """List object-property relation types found for selected/visible instances."""
     await require_workspace_access(current_user.id, payload.workspace_id)
+    await require_graph_in_catalog(payload.workspace_id, payload.graph_uri)
     try:
         relation_types = await graph_service.discover_relation_types(
             workspace_id=payload.workspace_id,
@@ -1074,6 +1150,7 @@ async def discovery_relations(
 ) -> list[DiscoveryRelationRow]:
     """List concrete relation rows (domain → predicate → range) for selected instances."""
     await require_workspace_access(current_user.id, payload.workspace_id)
+    await require_graph_in_catalog(payload.workspace_id, payload.graph_uri)
     try:
         relations = await graph_service.discover_relations(
             workspace_id=payload.workspace_id,
@@ -1133,6 +1210,7 @@ async def network_node_properties(
 ) -> list[DiscoveryProperty]:
     """Return all data properties available for instances of a given class in the network view."""
     await require_workspace_access(current_user.id, payload.workspace_id)
+    await require_graph_in_catalog(payload.workspace_id, payload.graph_uri)
     try:
         properties = await graph_service.discover_properties(
             workspace_id=payload.workspace_id,
@@ -1152,6 +1230,7 @@ async def network_node_instances(
 ) -> list[DiscoveryInstance]:
     """Return instances of a given class with the selected data properties for the network table view."""
     await require_workspace_access(current_user.id, payload.workspace_id)
+    await require_graph_in_catalog(payload.workspace_id, payload.graph_uri)
     try:
         instances = await graph_service.discover_instances(
             workspace_id=payload.workspace_id,
@@ -1197,6 +1276,7 @@ async def get_network_parents(
     Call once per progressive expansion level.
     """
     await require_workspace_access(current_user.id, workspace_id)
+    await require_graphs_in_catalog(workspace_id, graph_names)
     try:
         result = await graph_service.get_network_parents(
             workspace_id=workspace_id,
@@ -1220,7 +1300,10 @@ def _build_graph_query_service(graph_service: GraphService) -> GraphQueryService
     store = GraphQueryTripleStoreAdapter(triple_store, fts_backend=resolve_fts_backend(triple_store))
 
     async def _owned_graphs(workspace_id: str) -> set[str]:
-        packs = await graph_service.list_graphs(workspace_id)
+        packs = await graph_service.list_graphs(
+            workspace_id,
+            catalog_refs=await graph_catalog_refs(workspace_id),
+        )
         return {g.uri for pack in packs for g in pack.graphs}
 
     # schema/nexus are global system graphs every workspace may read.

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/graph/service.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/graph/service.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from naas_abi import ABIModule
+from naas_abi.apps.nexus.apps.api.app.core.workspace_catalog_seed import filter_graph_packs
 from naas_abi.apps.nexus.apps.api.app.services.graph.graph__schema import (
     DiscoveryClassData,
     DiscoveryClassMetaData,
@@ -1754,12 +1755,17 @@ class GraphService:
         """Clear all filesystem graph caches (KPIs, network schema, BFO buckets, …)."""
         clear_graph_service_caches()
 
-    async def list_graphs(self, workspace_id: str) -> list[GraphPackData]:
+    async def list_graphs(
+        self,
+        workspace_id: str,
+        catalog_refs: list[str] | None = None,
+    ) -> list[GraphPackData]:
         # Every triple-store call below is blocking I/O. Running it directly in
         # this coroutine froze the whole event loop — and because the sidebar and
         # the graph page both request /api/graph/list on load, that stall was
         # serialising every other request the browser had in flight.
-        return await asyncio.to_thread(self._list_graphs_sync)
+        packs = await asyncio.to_thread(self._list_graphs_sync)
+        return filter_graph_packs(packs, catalog_refs)
 
     def _list_graphs_sync(self) -> list[GraphPackData]:
         store = self._get_triple_store()
@@ -1821,8 +1827,12 @@ class GraphService:
             packed_graphs.append(GraphPackData(role_label=role_label, graphs=graphs))
         return packed_graphs
 
-    async def list_graph_roles(self, workspace_id: str) -> list[str]:
-        packs = await self.list_graphs(workspace_id)
+    async def list_graph_roles(
+        self,
+        workspace_id: str,
+        catalog_refs: list[str] | None = None,
+    ) -> list[str]:
+        packs = await self.list_graphs(workspace_id, catalog_refs=catalog_refs)
         roles = sorted({pack.role_label for pack in packs if pack.role_label})
         if "unknown" not in roles:
             roles.append("unknown")
@@ -2672,9 +2682,13 @@ class GraphService:
             for row in rows
         ]
 
-    async def discover_all_classes(self, workspace_id: str) -> list[DiscoveryClassData]:
+    async def discover_all_classes(
+        self,
+        workspace_id: str,
+        catalog_refs: list[str] | None = None,
+    ) -> list[DiscoveryClassData]:
         store = self._get_triple_store()
-        packs = await self.list_graphs(workspace_id)
+        packs = await self.list_graphs(workspace_id, catalog_refs=catalog_refs)
         merged: dict[str, dict[str, Any]] = {}
         for pack in packs:
             for graph in pack.graphs:


### PR DESCRIPTION
## Summary
- Workspace seeds can name an exclusive Knowledge Graph catalog with `graphs: [example]` (full URI or last path segment).
- `None` keeps today's full store listing. An empty list shows none.
- The catalog is exactly the listed ids. `schema` and `nexus` are not implied; name every graph that should appear.
- Graph API list, roles, and URI endpoints take `workspace_id`, filter to that catalog, and 404 graphs outside it.
- The Knowledge Graph sidebar already sends `workspace_id` on `/api/graph/list` and renders the filtered list.

Fixes #1238

## Test plan
- [ ] Seed a workspace with one graph id; Knowledge Graph Network list shows only that named graph
- [ ] Seed with an empty list; Network list is empty
- [ ] Omit `graphs` from the seed; Network list still lists every store graph
- [ ] Open a catalog graph; network and export load. Request a URI that is not in the seed; API returns 404
- [ ] Listing one instance graph does not add `schema` or `nexus` unless those ids are also in the seed