### PR TITLE
feat(code): local git + sandbox runtime (Slides-parity)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -35,6 +35,12 @@ modules:
   - module: naas_abi
     enabled: true
     config:
+      # AbiAgent, PlatformServicesAgent, OntologyEngineerAgent, etc. default to
+      # claude-sonnet-5 upstream; pin to an OpenAI model registered by chatgpt.
+      abi_agent_model: "gpt-4.1-mini"
+      abi_agent_provider: "openai"
+      ontology_engineer_model: "gpt-4.1-mini"
+      ontology_engineer_provider: "openai"
       nexus_config:
         database_url: "sqlite+aiosqlite:///./storage/nexus.db"
         # Dev convenience: enable password login so the seeded admin user
@@ -50,6 +56,28 @@ modules:
           og_title: "ABI"
           og_description: "Your AI Operating System - agents, knowledge, and data in one place."
           og_image_url: "https://repository-images.githubusercontent.com/704324955/444d3ad8-befb-446f-9723-6453aad2c336"
+        feature_flags:
+          enabled_features:
+            - maps
+            - chat
+            - files
+            - agents
+            - skills
+            - apps
+            - marketplace
+            - search
+            - ontology
+            - graph
+            - datasets
+            - settings
+            - slides
+            - code
+          role_baseline:
+            owner: [maps, chat, files, agents, skills, apps, marketplace, search, ontology, graph, datasets, settings, slides, code]
+            admin: [maps, chat, files, agents, skills, apps, marketplace, search, ontology, graph, datasets, settings, slides, code]
+            member: [maps, chat, files, datasets, skills, slides, code]
+            viewer: [maps, chat, files, datasets, skills, slides]
+          workspace_overrides: {}
         marketplace:
           pricing:
             maintenance_standard_usd: 499
@@ -103,13 +131,14 @@ modules:
     config:
       openrouter_api_key: "{{ secret.OPENROUTER_API_KEY }}"
 
-  - module: naas_abi_marketplace.alpha.wsr
-    enabled: true
-    config:
-      opensky_client_id: "{{ secret.OPENSKY_CLIENT_ID }}"
-      opensky_client_secret: "{{ secret.OPENSKY_CLIENT_SECRET }}"
-      tfl_app_key: "{{ secret.TFL_APP_KEY }}"
-      openwebcamdb_api_key: "{{ secret.OPENWEBCAMDB_API_KEY }}"
+  # WSR alpha module — not shipped in this checkout (naas_abi_marketplace.alpha)
+  # - module: naas_abi_marketplace.alpha.wsr
+  #   enabled: true
+  #   config:
+  #     opensky_client_id: "{{ secret.OPENSKY_CLIENT_ID }}"
+  #     opensky_client_secret: "{{ secret.OPENSKY_CLIENT_SECRET }}"
+  #     tfl_app_key: "{{ secret.TFL_APP_KEY }}"
+  #     openwebcamdb_api_key: "{{ secret.OPENWEBCAMDB_API_KEY }}"
 
   - module: naas_abi_marketplace.applications.git
     enabled: true
@@ -125,10 +154,11 @@ modules:
       datastore_path: "sec_gov"
       user_agent: "NAAS-ABI-Marketplace/1.0 (abi@naas.ai)"
 
-  - module: naas_abi_marketplace.applications.x
-    enabled: true
-    config:
-      bearer_token: "{{ secret.X_BEARER_TOKEN }}"
+  # X (Twitter) integration — requires X_BEARER_TOKEN in .env
+  # - module: naas_abi_marketplace.applications.x
+  #   enabled: true
+  #   config:
+  #     bearer_token: "{{ secret.X_BEARER_TOKEN }}"
   
   - module: naas_abi_marketplace.domains.operations.modules.document
     enabled: true
@@ -228,3 +258,9 @@ services:
       adapter: "local_directory"
       config:
         workspaces_root: "storage/workspaces"
+        harness: "opencode"
+        opencode_bin: "opencode"
+        harness_port_start: 18200
+        harness_port_end: 18300
+        opencode_model: "openai/gpt-5.4"
+        opencode_startup_timeout: 30

--- a/config.yaml
+++ b/config.yaml
@@ -218,3 +218,13 @@ services:
       adapter: "sqlite"
       config:
         db_path: "storage/events/events.sqlite"
+  source_control:
+    source_control_adapter:
+      adapter: "local_git"
+      config:
+        repos_root: "storage/git"
+  coding_environment:
+    coding_environment_adapter:
+      adapter: "local_directory"
+      config:
+        workspaces_root: "storage/workspaces"

--- a/docs/adr/20260903_local-code-workspaces-slides-parity.md
+++ b/docs/adr/20260903_local-code-workspaces-slides-parity.md
@@ -1,0 +1,30 @@
+# Local code workspaces (Slides parity)
+
+## Status
+
+Accepted
+
+## Date
+
+2026-09-03
+
+## Context
+
+The Nexus Code feature today depends on **Coder** (per-user Docker workspaces + embedded code-server) and **Forgejo** (git forge, PRs, Actions). That stack is heavy for local development (`abi dev`) and couples the product to infrastructure most solo developers do not need on a laptop.
+
+Slides already demonstrates the desired control loop: the user stays in Nexus, a hidden runtime (sidecar) holds the live working tree, Abi agents edit via domain tools, and git provides history. Code should follow the same pattern locally before adding managed harnesses (OpenCode, Claude Code, Codex, …).
+
+## Decision
+
+1. Add **`local_git`** source-control adapter — repos on disk under `storage/git`, branches/commits/files via the `git` CLI.
+2. Add **`local_directory`** coding-environment adapter — git checkout + **`abi_sidecar`** subprocess on localhost (no Coder).
+3. Follow **Slides-parity UX**: Nexus UI + Abi chat orchestrate edits; no external IDE as the primary loop in v1.
+4. Defer in-app PR/Actions locally (`NotImplementedError` on unsupported port methods).
+5. Managed harness adapters come in a later phase; v1 is Abi + sidecar + git only.
+
+## Consequences
+
+- `abi dev` can enable Code with `local_git` + `local_directory` in config — no Forgejo/Coder containers.
+- Production Docker deploy keeps existing `forgejo` + `coder` adapters unchanged.
+- Nexus provision flow stores `sidecar_base` / `sidecar_secret` on `coding_environments` (same as Slides).
+- Chat binds `context.coding` → sidecar ContextVars → `coding_tools`.

--- a/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_CodingEnvironmentService.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_CodingEnvironmentService.py
@@ -38,8 +38,16 @@ class CodingEnvironmentAdapterInMemoryConfiguration(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class CodingEnvironmentAdapterLocalDirectoryConfiguration(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    workspaces_root: str
+    sidecar_port_start: int = 18000
+    sidecar_port_end: int = 18100
+
+
 class CodingEnvironmentAdapterConfiguration(GenericLoader):
-    adapter: Literal["coder", "code_server", "in_memory", "custom"]
+    adapter: Literal["coder", "code_server", "in_memory", "local_directory", "custom"]
     config: dict | None = None
 
     @model_validator(mode="after")
@@ -70,6 +78,13 @@ class CodingEnvironmentAdapterConfiguration(GenericLoader):
                 "Invalid configuration for services.coding_environment."
                 "coding_environment_adapter 'in_memory' adapter",
             )
+        elif self.adapter == "local_directory":
+            pydantic_model_validator(
+                CodingEnvironmentAdapterLocalDirectoryConfiguration,
+                self.config,
+                "Invalid configuration for services.coding_environment."
+                "coding_environment_adapter 'local_directory' adapter",
+            )
 
         return self
 
@@ -94,6 +109,15 @@ class CodingEnvironmentAdapterConfiguration(GenericLoader):
             )
 
             return InMemoryAdapter(**(self.config or {}))
+        elif self.adapter == "local_directory":
+            assert self.config is not None, (
+                "config is required for local_directory adapter"
+            )
+            from naas_abi_core.services.coding_environment.adapters.secondary.LocalDirectoryAdapter import (
+                LocalDirectoryAdapter,
+            )
+
+            return LocalDirectoryAdapter(**self.config)
         elif self.adapter == "custom":
             return super().load()
         else:

--- a/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_CodingEnvironmentService.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_CodingEnvironmentService.py
@@ -44,6 +44,12 @@ class CodingEnvironmentAdapterLocalDirectoryConfiguration(BaseModel):
     workspaces_root: str
     sidecar_port_start: int = 18000
     sidecar_port_end: int = 18100
+    harness: Literal["none", "opencode"] = "none"
+    harness_port_start: int = 18200
+    harness_port_end: int = 18300
+    opencode_bin: str = "opencode"
+    opencode_model: str | None = None
+    opencode_startup_timeout: int = 15
 
 
 class CodingEnvironmentAdapterConfiguration(GenericLoader):

--- a/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_CodingEnvironmentService_test.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_CodingEnvironmentService_test.py
@@ -12,6 +12,9 @@ from naas_abi_core.services.coding_environment.adapters.secondary.CodeServerComp
 from naas_abi_core.services.coding_environment.adapters.secondary.InMemoryAdapter import (
     InMemoryAdapter,
 )
+from naas_abi_core.services.coding_environment.adapters.secondary.LocalDirectoryAdapter import (
+    LocalDirectoryAdapter,
+)
 from naas_abi_core.services.coding_environment.CodingEnvironmentService import (
     CodingEnvironmentService,
 )
@@ -58,6 +61,19 @@ def test_coding_environment_configuration_code_server_adapter():
 
     adapter = configuration.coding_environment_adapter.load()
     assert isinstance(adapter, CodeServerComposeAdapter)
+    assert isinstance(configuration.load(), CodingEnvironmentService)
+
+
+def test_coding_environment_configuration_local_directory_adapter(tmp_path):
+    configuration = CodingEnvironmentServiceConfiguration(
+        coding_environment_adapter=CodingEnvironmentAdapterConfiguration(
+            adapter="local_directory",
+            config={"workspaces_root": str(tmp_path / "workspaces")},
+        )
+    )
+
+    adapter = configuration.coding_environment_adapter.load()
+    assert isinstance(adapter, LocalDirectoryAdapter)
     assert isinstance(configuration.load(), CodingEnvironmentService)
 
 

--- a/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_SourceControlService.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_SourceControlService.py
@@ -28,8 +28,14 @@ class SourceControlAdapterInMemoryConfiguration(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class SourceControlAdapterLocalGitConfiguration(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    repos_root: str
+
+
 class SourceControlAdapterConfiguration(GenericLoader):
-    adapter: Literal["forgejo", "in_memory", "custom"]
+    adapter: Literal["forgejo", "in_memory", "local_git", "custom"]
     config: dict | None = None
 
     @model_validator(mode="after")
@@ -53,6 +59,13 @@ class SourceControlAdapterConfiguration(GenericLoader):
                 "Invalid configuration for services.source_control."
                 "source_control_adapter 'in_memory' adapter",
             )
+        elif self.adapter == "local_git":
+            pydantic_model_validator(
+                SourceControlAdapterLocalGitConfiguration,
+                self.config,
+                "Invalid configuration for services.source_control."
+                "source_control_adapter 'local_git' adapter",
+            )
 
         return self
 
@@ -70,6 +83,13 @@ class SourceControlAdapterConfiguration(GenericLoader):
             )
 
             return InMemoryAdapter(**(self.config or {}))
+        elif self.adapter == "local_git":
+            assert self.config is not None, "config is required for local_git adapter"
+            from naas_abi_core.services.source_control.adapters.secondary.LocalGitAdapter import (
+                LocalGitAdapter,
+            )
+
+            return LocalGitAdapter(**self.config)
         elif self.adapter == "custom":
             return super().load()
         else:

--- a/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_SourceControlService_test.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_SourceControlService_test.py
@@ -9,6 +9,9 @@ from naas_abi_core.services.source_control.adapters.secondary.ForgejoAdapter imp
 from naas_abi_core.services.source_control.adapters.secondary.InMemoryAdapter import (
     InMemoryAdapter,
 )
+from naas_abi_core.services.source_control.adapters.secondary.LocalGitAdapter import (
+    LocalGitAdapter,
+)
 from naas_abi_core.services.source_control.SourceControlService import (
     SourceControlService,
 )
@@ -40,6 +43,19 @@ def test_source_control_configuration_in_memory_adapter():
 
     adapter = configuration.source_control_adapter.load()
     assert isinstance(adapter, InMemoryAdapter)
+    assert isinstance(configuration.load(), SourceControlService)
+
+
+def test_source_control_configuration_local_git_adapter(tmp_path):
+    configuration = SourceControlServiceConfiguration(
+        source_control_adapter=SourceControlAdapterConfiguration(
+            adapter="local_git",
+            config={"repos_root": str(tmp_path / "git")},
+        )
+    )
+
+    adapter = configuration.source_control_adapter.load()
+    assert isinstance(adapter, LocalGitAdapter)
     assert isinstance(configuration.load(), SourceControlService)
 
 

--- a/libs/naas-abi-core/naas_abi_core/services/agent/context.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/context.py
@@ -65,3 +65,7 @@ coding_active_repo: ContextVar[str | None] = ContextVar(
 coding_active_branch: ContextVar[str | None] = ContextVar(
     "coding_active_branch", default=None
 )
+# Managed coding harness (OpenCode serve) bound to the open sandbox checkout.
+coding_harness_base: ContextVar[str | None] = ContextVar(
+    "coding_harness_base", default=None
+)

--- a/libs/naas-abi-core/naas_abi_core/services/agent/context.py
+++ b/libs/naas-abi-core/naas_abi_core/services/agent/context.py
@@ -56,3 +56,12 @@ slides_active_title: ContextVar[str | None] = ContextVar(
 slides_active_mode: ContextVar[str | None] = ContextVar(
     "slides_active_mode", default=None
 )
+
+# Open Code repo context in the Nexus UI. Set at the chat stream boundary so Abi
+# tools default to this repo/branch sandbox (Slides-parity for Code).
+coding_active_repo: ContextVar[str | None] = ContextVar(
+    "coding_active_repo", default=None
+)
+coding_active_branch: ContextVar[str | None] = ContextVar(
+    "coding_active_branch", default=None
+)

--- a/libs/naas-abi-core/naas_abi_core/services/coding_environment/CodingEnvironmentFactory.py
+++ b/libs/naas-abi-core/naas_abi_core/services/coding_environment/CodingEnvironmentFactory.py
@@ -51,3 +51,22 @@ class CodingEnvironmentFactory:
         return CodingEnvironmentService(
             InMemoryAdapter(polls_until_ready=polls_until_ready)
         )
+
+    @staticmethod
+    def CodingEnvironmentServiceLocalDirectory(
+        *,
+        workspaces_root: str,
+        sidecar_port_start: int = 18000,
+        sidecar_port_end: int = 18100,
+    ) -> CodingEnvironmentService:
+        from naas_abi_core.services.coding_environment.adapters.secondary.LocalDirectoryAdapter import (
+            LocalDirectoryAdapter,
+        )
+
+        return CodingEnvironmentService(
+            LocalDirectoryAdapter(
+                workspaces_root=workspaces_root,
+                sidecar_port_start=sidecar_port_start,
+                sidecar_port_end=sidecar_port_end,
+            )
+        )

--- a/libs/naas-abi-core/naas_abi_core/services/coding_environment/CodingEnvironmentService.py
+++ b/libs/naas-abi-core/naas_abi_core/services/coding_environment/CodingEnvironmentService.py
@@ -175,6 +175,16 @@ class CodingEnvironmentService(ServiceBase):
         except Exception:  # noqa: BLE001
             return None
 
+    def get_harness_binding(self, *, workspace_id: str) -> str | None:
+        """Return OpenCode (or other harness) base URL when configured."""
+        fn = getattr(self._adapter, "get_harness_binding", None)
+        if not callable(fn):
+            return None
+        try:
+            return fn(workspace_id=workspace_id)
+        except Exception:  # noqa: BLE001
+            return None
+
     def wait_until_ready(
         self,
         *,

--- a/libs/naas-abi-core/naas_abi_core/services/coding_environment/CodingEnvironmentService.py
+++ b/libs/naas-abi-core/naas_abi_core/services/coding_environment/CodingEnvironmentService.py
@@ -165,6 +165,16 @@ class CodingEnvironmentService(ServiceBase):
         except Exception:  # noqa: BLE001 - optional enrichment; never fail callers
             return None
 
+    def get_runtime_binding(self, *, workspace_id: str) -> tuple[str, str] | None:
+        """Return (sidecar_base, sidecar_secret) when the adapter exposes a runtime."""
+        fn = getattr(self._adapter, "get_runtime_binding", None)
+        if not callable(fn):
+            return None
+        try:
+            return fn(workspace_id=workspace_id)
+        except Exception:  # noqa: BLE001
+            return None
+
     def wait_until_ready(
         self,
         *,

--- a/libs/naas-abi-core/naas_abi_core/services/coding_environment/adapters/secondary/LocalDirectoryAdapter.py
+++ b/libs/naas-abi-core/naas_abi_core/services/coding_environment/adapters/secondary/LocalDirectoryAdapter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import shutil
 import socket
 import subprocess
@@ -11,7 +12,11 @@ import urllib.error
 import urllib.request
 import uuid
 from pathlib import Path
+from typing import Literal
 
+from naas_abi_core.services.coding_environment.adapters.secondary.OpencodeHarnessClient import (
+    wait_for_healthy as wait_for_opencode_healthy,
+)
 from naas_abi_core.services.coding_environment.CodingEnvironmentPorts import (
     PHASE_ERROR,
     PHASE_RUNNING,
@@ -28,7 +33,10 @@ from naas_abi_core.services.coding_environment.CodingEnvironmentPorts import (
 _SIDECAR_SCRIPT = Path(__file__).with_name("abi_sidecar.py")
 _DEFAULT_PORT_START = 18000
 _DEFAULT_PORT_END = 18100
+_DEFAULT_HARNESS_PORT_START = 18200
+_DEFAULT_HARNESS_PORT_END = 18300
 _HEALTH_TIMEOUT_S = 15.0
+HarnessKind = Literal["none", "opencode"]
 
 
 class LocalDirectoryAdapter(ICodingEnvironmentAdapter):
@@ -48,11 +56,23 @@ class LocalDirectoryAdapter(ICodingEnvironmentAdapter):
         workspaces_root: str,
         sidecar_port_start: int = _DEFAULT_PORT_START,
         sidecar_port_end: int = _DEFAULT_PORT_END,
+        harness: HarnessKind = "none",
+        harness_port_start: int = _DEFAULT_HARNESS_PORT_START,
+        harness_port_end: int = _DEFAULT_HARNESS_PORT_END,
+        opencode_bin: str = "opencode",
+        opencode_model: str | None = None,
+        opencode_startup_timeout: int = 15,
     ) -> None:
         self._root = Path(workspaces_root).expanduser().resolve()
         self._root.mkdir(parents=True, exist_ok=True)
         self._port_start = sidecar_port_start
         self._port_end = sidecar_port_end
+        self._harness = harness
+        self._harness_port_start = harness_port_start
+        self._harness_port_end = harness_port_end
+        self._opencode_bin = opencode_bin
+        self._opencode_model = opencode_model
+        self._opencode_startup_timeout = opencode_startup_timeout
         self._users: dict[str, str] = {}
         self._workspaces: dict[str, dict] = {}
         self._load_existing()
@@ -75,9 +95,20 @@ class LocalDirectoryAdapter(ICodingEnvironmentAdapter):
         serializable = {key: value for key, value in record.items() if not key.startswith("_")}
         meta.write_text(json.dumps(serializable, indent=2, sort_keys=True), encoding="utf-8")
 
-    def _allocate_port(self) -> int:
-        used = {int(record["port"]) for record in self._workspaces.values() if record.get("port")}
-        for port in range(self._port_start, self._port_end):
+    def _allocate_port(
+        self,
+        *,
+        start: int,
+        end: int,
+        used_keys: tuple[str, ...] = ("port", "harness_port"),
+    ) -> int:
+        used: set[int] = set()
+        for record in self._workspaces.values():
+            for key in used_keys:
+                value = record.get(key)
+                if value is not None:
+                    used.add(int(value))
+        for port in range(start, end):
             if port in used:
                 continue
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
@@ -87,7 +118,21 @@ class LocalDirectoryAdapter(ICodingEnvironmentAdapter):
                     return port
                 except OSError:
                     continue
-        raise ProvisionFailedError("no free sidecar port in configured range")
+        raise ProvisionFailedError("no free port in configured range")
+
+    def _allocate_sidecar_port(self) -> int:
+        return self._allocate_port(
+            start=self._port_start,
+            end=self._port_end,
+            used_keys=("port",),
+        )
+
+    def _allocate_harness_port(self) -> int:
+        return self._allocate_port(
+            start=self._harness_port_start,
+            end=self._harness_port_end,
+            used_keys=("harness_port",),
+        )
 
     @staticmethod
     def _wait_for_sidecar(base: str, secret: str) -> bool:
@@ -123,15 +168,78 @@ class LocalDirectoryAdapter(ICodingEnvironmentAdapter):
             text=True,
         )
 
-    def _stop_sidecar(self, record: dict) -> None:
-        proc = record.get("_proc")
+    def _stop_process(self, record: dict, proc_key: str) -> None:
+        proc = record.get(proc_key)
         if isinstance(proc, subprocess.Popen) and proc.poll() is None:
             proc.terminate()
             try:
                 proc.wait(timeout=5)
             except subprocess.TimeoutExpired:
                 proc.kill()
-        record["_proc"] = None
+        record[proc_key] = None
+
+    def _stop_sidecar(self, record: dict) -> None:
+        self._stop_process(record, "_proc")
+
+    def _stop_harness(self, record: dict) -> None:
+        self._stop_process(record, "_harness_proc")
+
+    @staticmethod
+    def _ensure_opencode_auth() -> None:
+        from naas_abi_core.services.agent.OpencodeAgent import OpencodeAgent
+
+        OpencodeAgent._ensure_opencode_auth_file_once()
+
+    def _resolve_opencode_bin(self) -> str:
+        if shutil.which(self._opencode_bin):
+            return self._opencode_bin
+        home_bin = Path.home() / ".opencode" / "bin" / "opencode"
+        if home_bin.is_file():
+            return str(home_bin)
+        return self._opencode_bin
+
+    def _start_opencode(self, checkout: Path, port: int) -> subprocess.Popen[str]:
+        self._ensure_opencode_auth()
+        opencode_bin = self._resolve_opencode_bin()
+        launch_command = (
+            f"source ~/.bashrc >/dev/null 2>&1; "
+            f"{shlex.quote(opencode_bin)} serve --port {port}"
+        )
+        return subprocess.Popen(
+            ["bash", "-lc", launch_command],
+            cwd=str(checkout),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+
+    def _ensure_harness(self, record: dict) -> bool:
+        if self._harness != "opencode":
+            return False
+        harness_base = record.get("harness_base")
+        proc = record.get("_harness_proc")
+        if isinstance(proc, subprocess.Popen) and proc.poll() is None:
+            if harness_base and wait_for_opencode_healthy(
+                str(harness_base), timeout_s=2.0
+            ):
+                record["harness_ready"] = True
+                return True
+        checkout = Path(record["checkout"])
+        port = int(record.get("harness_port") or self._allocate_harness_port())
+        record["harness_port"] = port
+        proc = self._start_opencode(checkout, port)
+        record["_harness_proc"] = proc
+        harness_base = f"http://127.0.0.1:{port}"
+        record["harness_base"] = harness_base
+        ready = wait_for_opencode_healthy(
+            harness_base, timeout_s=float(self._opencode_startup_timeout)
+        )
+        record["harness_ready"] = ready
+        if not ready and isinstance(proc, subprocess.Popen) and proc.poll() is None:
+            proc.kill()
+            record["_harness_proc"] = None
+        self._persist(record)
+        return ready
 
     def get_runtime_binding(self, *, workspace_id: str) -> tuple[str, str] | None:
         record = self._workspaces.get(workspace_id)
@@ -142,6 +250,18 @@ class LocalDirectoryAdapter(ICodingEnvironmentAdapter):
         if base and secret:
             return str(base), str(secret)
         return None
+
+    def get_harness_binding(self, *, workspace_id: str) -> str | None:
+        record = self._workspaces.get(workspace_id)
+        if record is None:
+            return None
+        if self._harness == "none":
+            return None
+        if not record.get("harness_ready"):
+            if not self._ensure_harness(record):
+                return None
+        base = record.get("harness_base")
+        return str(base) if base else None
 
     def ensure_user(self, *, external_id: str, email: str, username: str) -> str:
         del email, username
@@ -198,7 +318,7 @@ class LocalDirectoryAdapter(ICodingEnvironmentAdapter):
             checkout.mkdir(parents=True)
             subprocess.run(["git", "init", "-b", branch], cwd=checkout, check=True)
 
-        port = self._allocate_port()
+        port = self._allocate_sidecar_port()
         proc = self._start_sidecar(checkout, port, sidecar_secret)
         sidecar_base = f"http://127.0.0.1:{port}"
         ready = self._wait_for_sidecar(sidecar_base, sidecar_secret)
@@ -218,11 +338,25 @@ class LocalDirectoryAdapter(ICodingEnvironmentAdapter):
             "sidecar_secret": sidecar_secret,
             "branch": branch,
             "repo_url": repo_url,
+            "harness": self._harness,
             "phase": PHASE_RUNNING,
             "agent_ready": True,
+            "harness_ready": False,
         }
         self._workspaces[workspace_id] = record
         record["_proc"] = proc
+        if self._harness == "opencode":
+            harness_ready = self._ensure_harness(record)
+            if not harness_ready:
+                self._stop_sidecar(record)
+                self._stop_harness(record)
+                shutil.rmtree(checkout, ignore_errors=True)
+                self._workspaces.pop(workspace_id, None)
+                raise ProvisionFailedError(
+                    "OpenCode harness did not become healthy "
+                    f"(is `{self._resolve_opencode_bin()}` installed?)"
+                )
+            record["agent_ready"] = True
         self._persist(record)
         return self._status(workspace_id)
 
@@ -249,11 +383,14 @@ class LocalDirectoryAdapter(ICodingEnvironmentAdapter):
 
     def get_logs(self, *, workspace_id: str) -> list[str]:
         record = self._record(workspace_id)
-        return [
+        lines = [
             f"checkout: {record.get('checkout')}",
             f"sidecar: {record.get('sidecar_base')}",
             f"branch: {record.get('branch')}",
         ]
+        if record.get("harness_base"):
+            lines.append(f"harness: {record.get('harness_base')}")
+        return lines
 
     def get_status(self, *, workspace_id: str) -> WorkspaceStatus:
         return self._status(workspace_id)
@@ -264,16 +401,21 @@ class LocalDirectoryAdapter(ICodingEnvironmentAdapter):
         del params
         record = self._record(workspace_id)
         proc = record.get("_proc")
+        sidecar_ok = True
         if not isinstance(proc, subprocess.Popen) or proc.poll() is not None:
             checkout = Path(record["checkout"])
             port = int(record["port"])
             secret = str(record["sidecar_secret"])
             proc = self._start_sidecar(checkout, port, secret)
             record["_proc"] = proc
-            if not self._wait_for_sidecar(str(record["sidecar_base"]), secret):
-                record["phase"] = PHASE_ERROR
-                record["agent_ready"] = False
-                return self._status(workspace_id)
+            sidecar_ok = self._wait_for_sidecar(str(record["sidecar_base"]), secret)
+        harness_ok = True
+        if self._harness == "opencode":
+            harness_ok = self._ensure_harness(record)
+        if not sidecar_ok or not harness_ok:
+            record["phase"] = PHASE_ERROR
+            record["agent_ready"] = False
+            return self._status(workspace_id)
         record["phase"] = PHASE_RUNNING
         record["agent_ready"] = True
         return self._status(workspace_id)
@@ -281,13 +423,16 @@ class LocalDirectoryAdapter(ICodingEnvironmentAdapter):
     def stop(self, *, workspace_id: str) -> WorkspaceStatus:
         record = self._record(workspace_id)
         self._stop_sidecar(record)
+        self._stop_harness(record)
         record["phase"] = PHASE_STOPPED
         record["agent_ready"] = False
+        record["harness_ready"] = False
         return self._status(workspace_id)
 
     def delete(self, *, workspace_id: str) -> None:
         record = self._record(workspace_id)
         self._stop_sidecar(record)
+        self._stop_harness(record)
         checkout = Path(record["checkout"])
         shutil.rmtree(checkout, ignore_errors=True)
         self._workspaces.pop(workspace_id, None)
@@ -295,6 +440,6 @@ class LocalDirectoryAdapter(ICodingEnvironmentAdapter):
     def get_access(
         self, *, workspace_id: str, user_id: str, app_slug: str
     ) -> WorkspaceAccess:
-        del user_id, app_slug
-        record = self._record(workspace_id)
-        return WorkspaceAccess(url=str(record.get("sidecar_base", "")), token=None)
+        del workspace_id, user_id, app_slug
+        # Local sandboxes have no embedded IDE — the sidecar is agent-only HTTP.
+        return WorkspaceAccess(url="", token=None)

--- a/libs/naas-abi-core/naas_abi_core/services/coding_environment/adapters/secondary/LocalDirectoryAdapter.py
+++ b/libs/naas-abi-core/naas_abi_core/services/coding_environment/adapters/secondary/LocalDirectoryAdapter.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+import uuid
+from pathlib import Path
+
+from naas_abi_core.services.coding_environment.CodingEnvironmentPorts import (
+    PHASE_ERROR,
+    PHASE_RUNNING,
+    PHASE_STOPPED,
+    ICodingEnvironmentAdapter,
+    ProvisionFailedError,
+    WorkspaceAccess,
+    WorkspaceNameConflictError,
+    WorkspaceNotFoundError,
+    WorkspaceStatus,
+    WorkspaceTemplate,
+)
+
+_SIDECAR_SCRIPT = Path(__file__).with_name("abi_sidecar.py")
+_DEFAULT_PORT_START = 18000
+_DEFAULT_PORT_END = 18100
+_HEALTH_TIMEOUT_S = 15.0
+
+
+class LocalDirectoryAdapter(ICodingEnvironmentAdapter):
+    """Local git checkout + abi_sidecar process (Slides-parity, no Coder).
+
+    Each workspace is a directory under ``workspaces_root/{user_id}/{name}`` with
+    a sidecar listening on localhost. ``get_runtime_binding`` returns the base
+    URL and bearer secret for agent tools.
+    """
+
+    TEMPLATE_ID = "local-directory"
+    TEMPLATE_NAME = "local-directory"
+
+    def __init__(
+        self,
+        *,
+        workspaces_root: str,
+        sidecar_port_start: int = _DEFAULT_PORT_START,
+        sidecar_port_end: int = _DEFAULT_PORT_END,
+    ) -> None:
+        self._root = Path(workspaces_root).expanduser().resolve()
+        self._root.mkdir(parents=True, exist_ok=True)
+        self._port_start = sidecar_port_start
+        self._port_end = sidecar_port_end
+        self._users: dict[str, str] = {}
+        self._workspaces: dict[str, dict] = {}
+        self._load_existing()
+
+    def _load_existing(self) -> None:
+        for meta_path in self._root.glob("*/*/.abi/workspace.json"):
+            try:
+                payload = json.loads(meta_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            workspace_id = str(payload.get("id") or "")
+            if not workspace_id:
+                continue
+            self._workspaces[workspace_id] = payload
+
+    def _persist(self, record: dict) -> None:
+        checkout = Path(record["checkout"])
+        meta = checkout / ".abi" / "workspace.json"
+        meta.parent.mkdir(parents=True, exist_ok=True)
+        serializable = {key: value for key, value in record.items() if not key.startswith("_")}
+        meta.write_text(json.dumps(serializable, indent=2, sort_keys=True), encoding="utf-8")
+
+    def _allocate_port(self) -> int:
+        used = {int(record["port"]) for record in self._workspaces.values() if record.get("port")}
+        for port in range(self._port_start, self._port_end):
+            if port in used:
+                continue
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                try:
+                    sock.bind(("127.0.0.1", port))
+                    return port
+                except OSError:
+                    continue
+        raise ProvisionFailedError("no free sidecar port in configured range")
+
+    @staticmethod
+    def _wait_for_sidecar(base: str, secret: str) -> bool:
+        req = urllib.request.Request(
+            f"{base.rstrip('/')}/health",
+            headers={"Authorization": f"Bearer {secret}"},
+            method="GET",
+        )
+        deadline = time.monotonic() + _HEALTH_TIMEOUT_S
+        while time.monotonic() < deadline:
+            try:
+                with urllib.request.urlopen(req, timeout=1.0) as resp:  # nosec B310
+                    payload = json.loads(resp.read().decode("utf-8"))
+                    if payload.get("ok"):
+                        return True
+            except (urllib.error.URLError, TimeoutError, json.JSONDecodeError):
+                time.sleep(0.25)
+        return False
+
+    def _start_sidecar(self, checkout: Path, port: int, secret: str) -> subprocess.Popen[str]:
+        env = {
+            **os.environ,
+            "ABI_SIDECAR_ROOT": str(checkout),
+            "ABI_SIDECAR_SECRET": secret,
+            "ABI_SIDECAR_PORT": str(port),
+        }
+        return subprocess.Popen(
+            [sys.executable, str(_SIDECAR_SCRIPT)],
+            cwd=str(checkout),
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+
+    def _stop_sidecar(self, record: dict) -> None:
+        proc = record.get("_proc")
+        if isinstance(proc, subprocess.Popen) and proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+        record["_proc"] = None
+
+    def get_runtime_binding(self, *, workspace_id: str) -> tuple[str, str] | None:
+        record = self._workspaces.get(workspace_id)
+        if record is None:
+            return None
+        base = record.get("sidecar_base")
+        secret = record.get("sidecar_secret")
+        if base and secret:
+            return str(base), str(secret)
+        return None
+
+    def ensure_user(self, *, external_id: str, email: str, username: str) -> str:
+        del email, username
+        if external_id not in self._users:
+            self._users[external_id] = external_id
+        return self._users[external_id]
+
+    def list_templates(self) -> list[WorkspaceTemplate]:
+        return [
+            WorkspaceTemplate(
+                id=self.TEMPLATE_ID,
+                name=self.TEMPLATE_NAME,
+                active_version_id="local",
+            )
+        ]
+
+    def provision(
+        self,
+        *,
+        user_id: str,
+        template_id: str,
+        name: str,
+        params: dict[str, str] | None = None,
+    ) -> WorkspaceStatus:
+        del template_id
+        for existing in self._workspaces.values():
+            if existing["user_id"] == user_id and existing["name"] == name:
+                raise WorkspaceNameConflictError(
+                    f"workspace '{name}' already exists for user {user_id}"
+                )
+
+        params = dict(params or {})
+        branch = params.get("branch", "main")
+        repo_url = params.get("repo_url", "").strip()
+        sidecar_secret = params.get("sidecar_secret") or uuid.uuid4().hex
+
+        checkout = self._root / user_id / name
+        if checkout.exists():
+            shutil.rmtree(checkout)
+        checkout.parent.mkdir(parents=True, exist_ok=True)
+
+        if repo_url:
+            clone = subprocess.run(
+                ["git", "clone", "--branch", branch, repo_url, str(checkout)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if clone.returncode != 0:
+                raise ProvisionFailedError(
+                    (clone.stderr or clone.stdout or "git clone failed").strip()
+                )
+        else:
+            checkout.mkdir(parents=True)
+            subprocess.run(["git", "init", "-b", branch], cwd=checkout, check=True)
+
+        port = self._allocate_port()
+        proc = self._start_sidecar(checkout, port, sidecar_secret)
+        sidecar_base = f"http://127.0.0.1:{port}"
+        ready = self._wait_for_sidecar(sidecar_base, sidecar_secret)
+        if not ready:
+            proc.kill()
+            shutil.rmtree(checkout, ignore_errors=True)
+            raise ProvisionFailedError("sidecar did not become healthy")
+
+        workspace_id = uuid.uuid4().hex
+        record = {
+            "id": workspace_id,
+            "name": name,
+            "user_id": user_id,
+            "checkout": str(checkout),
+            "port": port,
+            "sidecar_base": sidecar_base,
+            "sidecar_secret": sidecar_secret,
+            "branch": branch,
+            "repo_url": repo_url,
+            "phase": PHASE_RUNNING,
+            "agent_ready": True,
+        }
+        self._workspaces[workspace_id] = record
+        record["_proc"] = proc
+        self._persist(record)
+        return self._status(workspace_id)
+
+    def _record(self, workspace_id: str) -> dict:
+        if workspace_id not in self._workspaces:
+            raise WorkspaceNotFoundError(workspace_id)
+        return self._workspaces[workspace_id]
+
+    def _status(self, workspace_id: str) -> WorkspaceStatus:
+        record = self._record(workspace_id)
+        return WorkspaceStatus(
+            id=workspace_id,
+            name=record["name"],
+            phase=record.get("phase", PHASE_RUNNING),
+            agent_ready=bool(record.get("agent_ready")),
+        )
+
+    def list_environments(self, *, user_id: str) -> list[WorkspaceStatus]:
+        return [
+            self._status(workspace_id)
+            for workspace_id, record in self._workspaces.items()
+            if record.get("user_id") == user_id
+        ]
+
+    def get_logs(self, *, workspace_id: str) -> list[str]:
+        record = self._record(workspace_id)
+        return [
+            f"checkout: {record.get('checkout')}",
+            f"sidecar: {record.get('sidecar_base')}",
+            f"branch: {record.get('branch')}",
+        ]
+
+    def get_status(self, *, workspace_id: str) -> WorkspaceStatus:
+        return self._status(workspace_id)
+
+    def start(
+        self, *, workspace_id: str, params: dict[str, str] | None = None
+    ) -> WorkspaceStatus:
+        del params
+        record = self._record(workspace_id)
+        proc = record.get("_proc")
+        if not isinstance(proc, subprocess.Popen) or proc.poll() is not None:
+            checkout = Path(record["checkout"])
+            port = int(record["port"])
+            secret = str(record["sidecar_secret"])
+            proc = self._start_sidecar(checkout, port, secret)
+            record["_proc"] = proc
+            if not self._wait_for_sidecar(str(record["sidecar_base"]), secret):
+                record["phase"] = PHASE_ERROR
+                record["agent_ready"] = False
+                return self._status(workspace_id)
+        record["phase"] = PHASE_RUNNING
+        record["agent_ready"] = True
+        return self._status(workspace_id)
+
+    def stop(self, *, workspace_id: str) -> WorkspaceStatus:
+        record = self._record(workspace_id)
+        self._stop_sidecar(record)
+        record["phase"] = PHASE_STOPPED
+        record["agent_ready"] = False
+        return self._status(workspace_id)
+
+    def delete(self, *, workspace_id: str) -> None:
+        record = self._record(workspace_id)
+        self._stop_sidecar(record)
+        checkout = Path(record["checkout"])
+        shutil.rmtree(checkout, ignore_errors=True)
+        self._workspaces.pop(workspace_id, None)
+
+    def get_access(
+        self, *, workspace_id: str, user_id: str, app_slug: str
+    ) -> WorkspaceAccess:
+        del user_id, app_slug
+        record = self._record(workspace_id)
+        return WorkspaceAccess(url=str(record.get("sidecar_base", "")), token=None)

--- a/libs/naas-abi-core/naas_abi_core/services/coding_environment/adapters/secondary/LocalDirectoryAdapter_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/coding_environment/adapters/secondary/LocalDirectoryAdapter_test.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pytest
+from naas_abi_core.services.coding_environment.adapters.secondary.LocalDirectoryAdapter import (
+    LocalDirectoryAdapter,
+)
+from naas_abi_core.services.coding_environment.tests.coding_environment__secondary_adapter__generic_test import (
+    GenericCodingEnvironmentSecondaryAdapterTest,
+)
+from naas_abi_core.services.source_control.adapters.secondary.LocalGitAdapter import (
+    LocalGitAdapter,
+)
+
+
+class TestLocalDirectoryAdapter(GenericCodingEnvironmentSecondaryAdapterTest):
+    @pytest.fixture
+    def adapter_class(self):
+        return LocalDirectoryAdapter
+
+
+@pytest.fixture
+def git_repo(tmp_path):
+    adapter = LocalGitAdapter(repos_root=str(tmp_path / "git"))
+    repo = adapter.ensure_repo(owner="abi", name="demo")
+    return adapter, repo
+
+
+@pytest.fixture
+def workspace_adapter(tmp_path):
+    return LocalDirectoryAdapter(workspaces_root=str(tmp_path / "workspaces"))
+
+
+def test_provision_clone_and_sidecar(
+    workspace_adapter: LocalDirectoryAdapter, git_repo
+) -> None:
+    git_adapter, repo = git_repo
+    user_id = "user-1"
+    workspace_adapter.ensure_user(
+        external_id=user_id, email="u@example.com", username="user"
+    )
+    status = workspace_adapter.provision(
+        user_id=user_id,
+        template_id=LocalDirectoryAdapter.TEMPLATE_ID,
+        name="swift-otter",
+        params={
+            "repo_url": repo.clone_url,
+            "branch": "main",
+            "sidecar_secret": "test-secret",
+        },
+    )
+    assert status.phase == "running"
+    assert status.agent_ready
+    binding = workspace_adapter.get_runtime_binding(workspace_id=status.id)
+    assert binding is not None
+    base, secret = binding
+    assert base.startswith("http://127.0.0.1:")
+    assert secret == "test-secret"
+    logs = workspace_adapter.get_logs(workspace_id=status.id)
+    assert any("sidecar:" in line for line in logs)
+    del git_adapter

--- a/libs/naas-abi-core/naas_abi_core/services/coding_environment/adapters/secondary/OpencodeHarnessClient.py
+++ b/libs/naas-abi-core/naas_abi_core/services/coding_environment/adapters/secondary/OpencodeHarnessClient.py
@@ -1,0 +1,161 @@
+"""Minimal sync HTTP client for an OpenCode ``serve`` instance in a sandbox."""
+
+from __future__ import annotations
+
+import json
+import time
+import urllib.error
+import urllib.request
+from typing import Any
+
+
+class OpencodeHarnessError(Exception):
+    """Base error for harness HTTP failures."""
+
+
+class OpencodeHarnessUnavailableError(OpencodeHarnessError):
+    """Harness server is not reachable or not healthy."""
+
+
+class OpencodeHarnessRequestError(OpencodeHarnessError):
+    def __init__(self, status_code: int, body: str):
+        super().__init__(f"opencode request failed ({status_code}): {body}")
+        self.status_code = status_code
+        self.body = body
+
+
+def is_healthy(base_url: str, *, timeout_s: float = 1.0) -> bool:
+    url = f"{base_url.rstrip('/')}/global/health"
+    try:
+        with urllib.request.urlopen(url, timeout=timeout_s) as resp:  # nosec B310
+            payload = json.loads(resp.read().decode("utf-8"))
+            return isinstance(payload, dict) and payload.get("healthy") is True
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError):
+        return False
+
+
+def wait_for_healthy(
+    base_url: str, *, timeout_s: float = 15.0, poll_s: float = 0.25
+) -> bool:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if is_healthy(base_url):
+            return True
+        time.sleep(poll_s)
+    return False
+
+
+def _model_payload(model: str | None) -> dict[str, str] | None:
+    if not model:
+        return None
+    model_value = model.strip()
+    if not model_value or "/" not in model_value:
+        return None
+    provider_id, model_id = model_value.split("/", 1)
+    provider_id = provider_id.strip()
+    model_id = model_id.strip()
+    if not provider_id or not model_id:
+        return None
+    return {"providerID": provider_id, "modelID": model_id}
+
+
+def _request_json(
+    method: str,
+    url: str,
+    payload: dict[str, Any] | None = None,
+    *,
+    timeout_s: float = 120.0,
+) -> dict[str, Any]:
+    data = None
+    headers = {"Accept": "application/json"}
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_s) as resp:  # nosec B310
+            body = resp.read().decode("utf-8").strip()
+            if not body:
+                return {}
+            parsed = json.loads(body)
+            return parsed if isinstance(parsed, dict) else {}
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise OpencodeHarnessRequestError(exc.code, body) from exc
+    except urllib.error.URLError as exc:
+        raise OpencodeHarnessUnavailableError(str(exc)) from exc
+
+
+def _extract_text(parts: list[dict[str, Any]]) -> str:
+    chunks: list[str] = []
+    for part in parts:
+        text = part.get("text") or part.get("content")
+        if isinstance(text, str) and text.strip():
+            chunks.append(text.strip())
+    return "\n".join(chunks).strip()
+
+
+def _extract_parts(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    parts = payload.get("parts")
+    if isinstance(parts, list):
+        return [part for part in parts if isinstance(part, dict)]
+    message = payload.get("message")
+    if isinstance(message, dict) and isinstance(message.get("parts"), list):
+        return [part for part in message["parts"] if isinstance(part, dict)]
+    return []
+
+
+def create_session(base_url: str, *, title: str = "abi-coding-harness") -> str:
+    payload = _request_json(
+        "POST",
+        f"{base_url.rstrip('/')}/session",
+        {"title": title},
+        timeout_s=30.0,
+    )
+    session_id = (
+        payload.get("id")
+        or payload.get("session", {}).get("id")
+        or payload.get("session_id")
+    )
+    if not session_id:
+        raise OpencodeHarnessRequestError(200, json.dumps(payload))
+    return str(session_id)
+
+
+def run_task(
+    base_url: str,
+    message: str,
+    *,
+    model: str | None = None,
+    session_id: str | None = None,
+    timeout_s: float = 600.0,
+) -> dict[str, Any]:
+    """Send a task to OpenCode and return assistant text plus session id."""
+    if not wait_for_healthy(base_url, timeout_s=min(15.0, timeout_s)):
+        return {"error": "OpenCode harness is not healthy", "session_id": session_id}
+
+    active_session = session_id
+    try:
+        if not active_session:
+            active_session = create_session(base_url)
+        body: dict[str, Any] = {
+            "parts": [{"type": "text", "text": message}],
+            "noReply": False,
+        }
+        model_payload = _model_payload(model)
+        if model_payload is not None:
+            body["model"] = model_payload
+        payload = _request_json(
+            "POST",
+            f"{base_url.rstrip('/')}/session/{active_session}/message",
+            body,
+            timeout_s=timeout_s,
+        )
+        text = _extract_text(_extract_parts(payload))
+        return {
+            "session_id": active_session,
+            "completion": text,
+            "raw_parts": _extract_parts(payload),
+        }
+    except OpencodeHarnessError as exc:
+        return {"error": str(exc), "session_id": active_session}

--- a/libs/naas-abi-core/naas_abi_core/services/coding_environment/adapters/secondary/OpencodeHarnessClient_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/coding_environment/adapters/secondary/OpencodeHarnessClient_test.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from naas_abi_core.services.coding_environment.adapters.secondary.OpencodeHarnessClient import (
+    _extract_text,
+    create_session,
+    is_healthy,
+    run_task,
+)
+
+
+def test_extract_text_joins_parts() -> None:
+    assert _extract_text([{"type": "text", "text": "hello"}, {"text": "world"}]) == (
+        "hello\nworld"
+    )
+
+
+def test_is_healthy_true() -> None:
+    payload = json.dumps({"healthy": True}).encode()
+
+    class FakeResp:
+        def read(self) -> bytes:
+            return payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    with patch("urllib.request.urlopen", return_value=FakeResp()):
+        assert is_healthy("http://127.0.0.1:18200") is True
+
+
+def test_create_session_parses_id() -> None:
+    payload = json.dumps({"id": "sess-1"}).encode()
+
+    class FakeResp:
+        def read(self) -> bytes:
+            return payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    with patch("urllib.request.urlopen", return_value=FakeResp()):
+        assert create_session("http://127.0.0.1:18200") == "sess-1"
+
+
+def test_run_task_unhealthy() -> None:
+    with patch(
+        "naas_abi_core.services.coding_environment.adapters.secondary.OpencodeHarnessClient.wait_for_healthy",
+        return_value=False,
+    ):
+        result = run_task("http://127.0.0.1:18200", "fix tests")
+    assert result["error"]
+    assert "not healthy" in result["error"]

--- a/libs/naas-abi-core/naas_abi_core/services/coding_environment/adapters/secondary/abi_sidecar.py
+++ b/libs/naas-abi-core/naas_abi_core/services/coding_environment/adapters/secondary/abi_sidecar.py
@@ -1,0 +1,171 @@
+"""abi workspace tool-exec sidecar.
+
+Runs beside a local git checkout and exposes path-jailed filesystem tools over
+HTTP. Used by ``local_directory`` coding workspaces and Slides/Coder runtimes.
+"""
+
+from __future__ import annotations
+
+import hmac
+import json
+import os
+import subprocess
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+ROOT = os.path.realpath(os.environ.get("ABI_SIDECAR_ROOT") or os.path.expanduser("~/project"))
+SECRET = os.environ.get("ABI_SIDECAR_SECRET", "")
+INSECURE = os.environ.get("ABI_SIDECAR_INSECURE", "").strip() in {"1", "true", "TRUE", "yes", "YES"}
+PORT = int(os.environ.get("ABI_SIDECAR_PORT", "8378"))
+MAX_BODY = 8 * 1024 * 1024
+MAX_OUT = 20000
+DEFAULT_TIMEOUT = 120
+MAX_TIMEOUT = 600
+
+
+def _resolve(rel_path: str) -> str:
+    candidate = os.path.realpath(os.path.join(ROOT, rel_path.lstrip("/")))
+    if candidate != ROOT and not candidate.startswith(ROOT + os.sep):
+        raise ValueError(f"path escapes project root: {rel_path}")
+    return candidate
+
+
+def _write_file(body: dict) -> dict:
+    path = body["path"]
+    content = body.get("content", "")
+    target = _resolve(path)
+    os.makedirs(os.path.dirname(target) or ROOT, exist_ok=True)
+    data = content.encode("utf-8")
+    with open(target, "wb") as fh:
+        fh.write(data)
+    return {"ok": True, "path": os.path.relpath(target, ROOT), "bytes": len(data)}
+
+
+def _read_file(body: dict) -> dict:
+    target = _resolve(body["path"])
+    with open(target, "rb") as fh:
+        raw = fh.read(MAX_BODY)
+    try:
+        text = raw.decode("utf-8")
+        return {"ok": True, "path": os.path.relpath(target, ROOT), "content": text}
+    except UnicodeDecodeError:
+        return {"ok": True, "path": os.path.relpath(target, ROOT), "binary": True, "bytes": len(raw)}
+
+
+def _list_dir(body: dict) -> dict:
+    target = _resolve(body.get("path", "."))
+    entries = []
+    for name in sorted(os.listdir(target)):
+        full = os.path.join(target, name)
+        entries.append({"name": name, "type": "dir" if os.path.isdir(full) else "file"})
+    return {"ok": True, "path": os.path.relpath(target, ROOT), "entries": entries}
+
+
+def _run_terminal(body: dict) -> dict:
+    command = body.get("command")
+    if not command or not isinstance(command, str):
+        raise ValueError("command (string) is required")
+    timeout = min(max(int(body.get("timeout_s", DEFAULT_TIMEOUT)), 1), MAX_TIMEOUT)
+    cwd = _resolve(body.get("cwd") or ".")
+    if not os.path.isdir(cwd):
+        cwd = ROOT
+    try:
+        proc = subprocess.run(
+            command,
+            shell=True,  # nosec B602 - intentional workspace shell; jailed cwd + timeout
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        out = exc.stdout if isinstance(exc.stdout, str) else ""
+        err = exc.stderr if isinstance(exc.stderr, str) else ""
+        return {
+            "ok": False,
+            "timed_out": True,
+            "timeout_s": timeout,
+            "stdout": out[-MAX_OUT:],
+            "stderr": err[-MAX_OUT:],
+        }
+    return {
+        "ok": True,
+        "exit_code": proc.returncode,
+        "cwd": os.path.relpath(cwd, ROOT),
+        "stdout": proc.stdout[-MAX_OUT:],
+        "stderr": proc.stderr[-MAX_OUT:],
+    }
+
+
+TOOLS = {
+    "write_file": _write_file,
+    "read_file": _read_file,
+    "list_dir": _list_dir,
+    "run_terminal": _run_terminal,
+}
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *args):  # silence default stderr logging
+        pass
+
+    def _send(self, code: int, payload: dict) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _authed(self) -> bool:
+        if INSECURE and not SECRET:
+            return True
+        header = self.headers.get("Authorization", "")
+        token = header[7:] if header.startswith("Bearer ") else ""
+        if not SECRET or not token:
+            return False
+        return hmac.compare_digest(token, SECRET)
+
+    def do_GET(self) -> None:
+        if self.path != "/health":
+            self._send(404, {"ok": False, "error": "not found"})
+            return
+        if not self._authed():
+            self._send(401, {"ok": False, "error": "unauthorized"})
+            return
+        self._send(200, {"ok": True})
+
+    def do_POST(self) -> None:
+        if not self.path.startswith("/tools/"):
+            self._send(404, {"ok": False, "error": "not found"})
+            return
+        if not self._authed():
+            self._send(401, {"ok": False, "error": "unauthorized"})
+            return
+        tool = self.path[len("/tools/") :]
+        fn = TOOLS.get(tool)
+        if fn is None:
+            self._send(404, {"ok": False, "error": f"unknown tool: {tool}"})
+            return
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+            body = json.loads(self.rfile.read(length) or b"{}") if length else {}
+            self._send(200, fn(body))
+        except (ValueError, KeyError) as exc:
+            self._send(400, {"ok": False, "error": str(exc)})
+        except Exception as exc:  # noqa: BLE001
+            self._send(500, {"ok": False, "error": str(exc)})
+
+
+def main() -> None:
+    if not SECRET and not INSECURE:
+        raise SystemExit(
+            "ABI_SIDECAR_SECRET is required "
+            "(set ABI_SIDECAR_INSECURE=1 only for explicit local keyless mode)"
+        )
+    os.makedirs(ROOT, exist_ok=True)
+    ThreadingHTTPServer(("127.0.0.1", PORT), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/libs/naas-abi-core/naas_abi_core/services/source_control/SourceControlFactory.py
+++ b/libs/naas-abi-core/naas_abi_core/services/source_control/SourceControlFactory.py
@@ -32,3 +32,11 @@ class SourceControlFactory:
     @staticmethod
     def SourceControlServiceInMemory() -> SourceControlService:
         return SourceControlService(InMemoryAdapter())
+
+    @staticmethod
+    def SourceControlServiceLocalGit(*, repos_root: str) -> SourceControlService:
+        from naas_abi_core.services.source_control.adapters.secondary.LocalGitAdapter import (
+            LocalGitAdapter,
+        )
+
+        return SourceControlService(LocalGitAdapter(repos_root=repos_root))

--- a/libs/naas-abi-core/naas_abi_core/services/source_control/adapters/secondary/LocalGitAdapter.py
+++ b/libs/naas-abi-core/naas_abi_core/services/source_control/adapters/secondary/LocalGitAdapter.py
@@ -1,0 +1,387 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from typing import NoReturn
+
+from naas_abi_core.services.source_control.SourceControlPorts import (
+    Branch,
+    BranchNameConflictError,
+    BranchNotFoundError,
+    Check,
+    Comment,
+    Commit,
+    ContentEntry,
+    Diff,
+    FileContent,
+    ISourceControlAdapter,
+    MergeResult,
+    Proposal,
+    Repo,
+    RepoNotFoundError,
+    Review,
+    SourceControlError,
+    WorkflowRun,
+)
+
+
+def _git_env(author_name: str | None = None, author_email: str | None = None) -> dict[str, str]:
+    env = os.environ.copy()
+    if author_name:
+        env["GIT_AUTHOR_NAME"] = author_name
+        env["GIT_COMMITTER_NAME"] = author_name
+    if author_email:
+        env["GIT_AUTHOR_EMAIL"] = author_email
+        env["GIT_COMMITTER_EMAIL"] = author_email
+    return env
+
+
+class LocalGitAdapter(ISourceControlAdapter):
+    """Disk-backed git repos for local development (no Forgejo).
+
+    Repositories live at ``{repos_root}/{owner}/{name}/`` as normal (non-bare)
+    git checkouts. ``clone_url`` uses the ``file://`` scheme.
+    """
+
+    def __init__(self, *, repos_root: str) -> None:
+        self._root = Path(repos_root).expanduser().resolve()
+        self._root.mkdir(parents=True, exist_ok=True)
+        self._users: dict[str, str] = {}
+
+    def _repo_path(self, repo_id: str) -> Path:
+        owner, _, name = repo_id.partition("/")
+        if not owner or not name:
+            raise RepoNotFoundError(repo_id)
+        return self._root / owner / name
+
+    def _run(
+        self,
+        *args: str,
+        cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+    ) -> str:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            env=env or os.environ.copy(),
+            check=False,
+        )
+        if result.returncode != 0:
+            message = (result.stderr or result.stdout or "git command failed").strip()
+            raise SourceControlError(message)
+        return result.stdout.strip()
+
+    def _repo_exists(self, repo_id: str) -> bool:
+        path = self._repo_path(repo_id)
+        return (path / ".git").is_dir()
+
+    def _resolve_ref(self, repo_id: str, ref: str | None) -> str:
+        path = self._repo_path(repo_id)
+        if not self._repo_exists(repo_id):
+            raise RepoNotFoundError(repo_id)
+        if ref:
+            return ref
+        return self._run("rev-parse", "--abbrev-ref", "HEAD", cwd=path)
+
+    def _to_repo(self, repo_id: str) -> Repo:
+        path = self._repo_path(repo_id)
+        if not self._repo_exists(repo_id):
+            raise RepoNotFoundError(repo_id)
+        owner, _, name = repo_id.partition("/")
+        default_branch = "main"
+        try:
+            default_branch = self._run("rev-parse", "--abbrev-ref", "HEAD", cwd=path)
+        except SourceControlError:
+            default_branch = "main"
+        return Repo(
+            id=repo_id,
+            name=name,
+            owner=owner,
+            default_branch=default_branch,
+            clone_url=path.as_uri(),
+            html_url=path.as_uri(),
+            private=True,
+            empty=not any(path.iterdir()),
+        )
+
+    def _unsupported(self, feature: str) -> NoReturn:
+        raise NotImplementedError(f"{feature} is not supported by the local_git adapter")
+
+    def ensure_user(self, *, external_id: str, email: str, username: str) -> str:
+        del email
+        if username not in self._users:
+            self._users[username] = external_id or username
+        return self._users[username]
+
+    def ensure_repo(
+        self, *, owner: str, name: str, private: bool = True, auto_init: bool = True
+    ) -> Repo:
+        del private
+        repo_id = f"{owner}/{name}"
+        path = self._repo_path(repo_id)
+        if not self._repo_exists(repo_id):
+            path.mkdir(parents=True, exist_ok=True)
+            self._run("init", "-b", "main", cwd=path)
+            if auto_init:
+                readme = path / "README.md"
+                readme.write_text(f"# {name}\n", encoding="utf-8")
+                env = _git_env("abi", "abi@local")
+                self._run("add", "README.md", cwd=path, env=env)
+                self._run("commit", "-m", "Initial commit", cwd=path, env=env)
+        return self._to_repo(repo_id)
+
+    def list_repos(self) -> list[Repo]:
+        repos: list[Repo] = []
+        if not self._root.is_dir():
+            return repos
+        for owner_dir in sorted(self._root.iterdir()):
+            if not owner_dir.is_dir():
+                continue
+            for repo_dir in sorted(owner_dir.iterdir()):
+                if not repo_dir.is_dir():
+                    continue
+                repo_id = f"{owner_dir.name}/{repo_dir.name}"
+                if self._repo_exists(repo_id):
+                    repos.append(self._to_repo(repo_id))
+        return repos
+
+    def add_collaborator(
+        self, *, repo_id: str, username: str, permission: str = "write"
+    ) -> None:
+        del repo_id, username, permission
+
+    def list_contents(
+        self, *, repo_id: str, path: str = "", ref: str | None = None
+    ) -> list[ContentEntry]:
+        repo_path = self._repo_path(repo_id)
+        if not self._repo_exists(repo_id):
+            raise RepoNotFoundError(repo_id)
+        ref_name = self._resolve_ref(repo_id, ref)
+        tree_path = path.strip("/")
+        args = ["ls-tree", "-l", ref_name, tree_path or "."]
+        output = self._run(*args, cwd=repo_path)
+        entries: list[ContentEntry] = []
+        for line in output.splitlines():
+            if not line.strip():
+                continue
+            meta, entry_path = line.split("\t", 1)
+            parts = meta.split()
+            if len(parts) < 4:
+                continue
+            mode = parts[0]
+            size = int(parts[3]) if parts[3].isdigit() else 0
+            entry_type = "dir" if mode.startswith("04") else "file"
+            name = entry_path.rsplit("/", 1)[-1]
+            entries.append(
+                ContentEntry(name=name, path=entry_path, type=entry_type, size=size)
+            )
+        return sorted(entries, key=lambda entry: entry.name.lower())
+
+    def get_file(
+        self, *, repo_id: str, path: str, ref: str | None = None
+    ) -> FileContent:
+        repo_path = self._repo_path(repo_id)
+        if not self._repo_exists(repo_id):
+            raise RepoNotFoundError(repo_id)
+        ref_name = self._resolve_ref(repo_id, ref)
+        spec = f"{ref_name}:{path.lstrip('/')}"
+        try:
+            raw = subprocess.check_output(
+                ["git", "show", spec],
+                cwd=repo_path,
+                stderr=subprocess.STDOUT,
+            )
+        except subprocess.CalledProcessError as exc:
+            raise RepoNotFoundError(f"{repo_id}:{path}") from exc
+        try:
+            text = raw.decode("utf-8")
+            is_binary = False
+        except UnicodeDecodeError:
+            text = None
+            is_binary = True
+        name = path.rsplit("/", 1)[-1]
+        return FileContent(
+            path=path,
+            name=name,
+            size=len(raw),
+            text=text,
+            is_binary=is_binary,
+        )
+
+    def upsert_file(
+        self,
+        *,
+        repo_id: str,
+        path: str,
+        content: str,
+        message: str,
+        branch: str,
+        author_name: str | None = None,
+        author_email: str | None = None,
+    ) -> Commit:
+        repo_path = self._repo_path(repo_id)
+        if not self._repo_exists(repo_id):
+            raise RepoNotFoundError(repo_id)
+        env = _git_env(author_name or "abi", author_email or "abi@local")
+        self._run("checkout", branch, cwd=repo_path, env=env)
+        target = repo_path / path.lstrip("/")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+        self._run("add", path.lstrip("/"), cwd=repo_path, env=env)
+        self._run("commit", "-m", message, cwd=repo_path, env=env)
+        sha = self._run("rev-parse", "HEAD", cwd=repo_path, env=env)
+        return Commit(sha=sha, message=message, author=author_name or "abi")
+
+    def list_commits(
+        self, *, repo_id: str, ref: str | None = None, limit: int = 20
+    ) -> list[Commit]:
+        repo_path = self._repo_path(repo_id)
+        if not self._repo_exists(repo_id):
+            raise RepoNotFoundError(repo_id)
+        ref_name = self._resolve_ref(repo_id, ref)
+        output = self._run(
+            "log",
+            ref_name,
+            f"-n{limit}",
+            "--pretty=format:%H%x09%s%x09%an%x09%ai",
+            cwd=repo_path,
+        )
+        commits: list[Commit] = []
+        for line in output.splitlines():
+            parts = line.split("\t")
+            if len(parts) < 2:
+                continue
+            sha, message = parts[0], parts[1]
+            author = parts[2] if len(parts) > 2 else ""
+            date = parts[3] if len(parts) > 3 else None
+            commits.append(
+                Commit(sha=sha, message=message, author=author, date=date or None)
+            )
+        return commits
+
+    def list_branches(self, *, repo_id: str) -> list[Branch]:
+        repo_path = self._repo_path(repo_id)
+        if not self._repo_exists(repo_id):
+            raise RepoNotFoundError(repo_id)
+        output = self._run(
+            "for-each-ref",
+            "--format=%(refname:short)\t%(objectname)",
+            "refs/heads/",
+            cwd=repo_path,
+        )
+        branches: list[Branch] = []
+        for line in output.splitlines():
+            if not line.strip():
+                continue
+            name, sha = line.split("\t", 1)
+            branches.append(Branch(name=name, commit_sha=sha))
+        return branches
+
+    def create_branch(self, *, repo_id: str, name: str, from_ref: str) -> Branch:
+        repo_path = self._repo_path(repo_id)
+        if not self._repo_exists(repo_id):
+            raise RepoNotFoundError(repo_id)
+        existing = {branch.name for branch in self.list_branches(repo_id=repo_id)}
+        if name in existing:
+            raise BranchNameConflictError(name)
+        self._run("branch", name, from_ref, cwd=repo_path)
+        sha = self._run("rev-parse", name, cwd=repo_path)
+        return Branch(name=name, commit_sha=sha)
+
+    def delete_branch(self, *, repo_id: str, name: str) -> None:
+        repo_path = self._repo_path(repo_id)
+        if not self._repo_exists(repo_id):
+            raise RepoNotFoundError(repo_id)
+        existing = {branch.name for branch in self.list_branches(repo_id=repo_id)}
+        if name not in existing:
+            raise BranchNotFoundError(name)
+        self._run("branch", "-D", name, cwd=repo_path)
+
+    def get_diff(self, *, repo_id: str, base: str, head: str) -> Diff:
+        del repo_id, base, head
+        self._unsupported("get_diff")
+
+    def create_proposal(
+        self,
+        *,
+        repo_id: str,
+        title: str,
+        body: str,
+        source_branch: str,
+        target_branch: str,
+        reviewers: list[str] | None = None,
+    ) -> Proposal:
+        del repo_id, title, body, source_branch, target_branch, reviewers
+        self._unsupported("create_proposal")
+
+    def list_proposals(self, *, repo_id: str, state: str = "open") -> list[Proposal]:
+        del repo_id, state
+        self._unsupported("list_proposals")
+
+    def get_proposal(self, *, repo_id: str, number: int) -> Proposal:
+        del repo_id, number
+        self._unsupported("get_proposal")
+
+    def get_proposal_diff(self, *, repo_id: str, number: int) -> Diff:
+        del repo_id, number
+        self._unsupported("get_proposal_diff")
+
+    def list_proposal_commits(self, *, repo_id: str, number: int) -> list[Commit]:
+        del repo_id, number
+        self._unsupported("list_proposal_commits")
+
+    def list_comments(self, *, repo_id: str, number: int) -> list[Comment]:
+        del repo_id, number
+        self._unsupported("list_comments")
+
+    def list_reviews(self, *, repo_id: str, number: int) -> list[Review]:
+        del repo_id, number
+        self._unsupported("list_reviews")
+
+    def add_comment(
+        self,
+        *,
+        repo_id: str,
+        number: int,
+        body: str,
+        path: str | None = None,
+        line: int | None = None,
+    ) -> Comment:
+        del repo_id, number, body, path, line
+        self._unsupported("add_comment")
+
+    def submit_review(
+        self, *, repo_id: str, number: int, event: str, body: str = ""
+    ) -> Review:
+        del repo_id, number, event, body
+        self._unsupported("submit_review")
+
+    def list_checks(self, *, repo_id: str, number: int) -> list[Check]:
+        del repo_id, number
+        self._unsupported("list_checks")
+
+    def set_branch_protection(
+        self,
+        *,
+        repo_id: str,
+        branch: str,
+        required_approvals: int,
+        required_checks: list[str],
+    ) -> None:
+        del repo_id, branch, required_approvals, required_checks
+        self._unsupported("set_branch_protection")
+
+    def merge(self, *, repo_id: str, number: int, method: str = "merge") -> MergeResult:
+        del repo_id, number, method
+        self._unsupported("merge")
+
+    def list_workflow_runs(self, *, repo_id: str, limit: int = 20) -> list[WorkflowRun]:
+        del repo_id, limit
+        self._unsupported("list_workflow_runs")
+
+    def mint_git_token(self, *, user_id: str) -> str:
+        del user_id
+        return "local"

--- a/libs/naas-abi-core/naas_abi_core/services/source_control/adapters/secondary/LocalGitAdapter_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/source_control/adapters/secondary/LocalGitAdapter_test.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pytest
+from naas_abi_core.services.source_control.adapters.secondary.LocalGitAdapter import (
+    LocalGitAdapter,
+)
+from naas_abi_core.services.source_control.SourceControlPorts import (
+    BranchNameConflictError,
+    RepoNotFoundError,
+)
+from naas_abi_core.services.source_control.tests.source_control__secondary_adapter__generic_test import (
+    GenericSourceControlSecondaryAdapterTest,
+)
+
+
+class TestLocalGitAdapter(GenericSourceControlSecondaryAdapterTest):
+    @pytest.fixture
+    def adapter_class(self):
+        return LocalGitAdapter
+
+
+@pytest.fixture
+def adapter(tmp_path):
+    return LocalGitAdapter(repos_root=str(tmp_path / "git"))
+
+
+def test_ensure_repo_and_list_contents(adapter: LocalGitAdapter) -> None:
+    repo = adapter.ensure_repo(owner="abi", name="demo")
+    repo_id = f"{repo.owner}/{repo.name}"
+    entries = adapter.list_contents(repo_id=repo_id)
+    assert any(entry.name == "README.md" for entry in entries)
+    file = adapter.get_file(repo_id=repo_id, path="README.md")
+    assert file.text is not None
+    assert "demo" in file.text
+
+
+def test_branch_and_commit_flow(adapter: LocalGitAdapter) -> None:
+    repo = adapter.ensure_repo(owner="abi", name="demo")
+    repo_id = f"{repo.owner}/{repo.name}"
+    adapter.create_branch(repo_id=repo_id, name="feat/x", from_ref="main")
+    adapter.upsert_file(
+        repo_id=repo_id,
+        path="notes.txt",
+        content="hello\n",
+        message="add notes",
+        branch="feat/x",
+    )
+    commits = adapter.list_commits(repo_id=repo_id, ref="feat/x", limit=5)
+    assert commits
+    assert commits[0].message == "add notes"
+
+
+def test_create_branch_conflict(adapter: LocalGitAdapter) -> None:
+    repo = adapter.ensure_repo(owner="abi", name="demo")
+    repo_id = f"{repo.owner}/{repo.name}"
+    adapter.create_branch(repo_id=repo_id, name="feat/x", from_ref="main")
+    with pytest.raises(BranchNameConflictError):
+        adapter.create_branch(repo_id=repo_id, name="feat/x", from_ref="main")
+
+
+def test_missing_repo(adapter: LocalGitAdapter) -> None:
+    with pytest.raises(RepoNotFoundError):
+        adapter.list_branches(repo_id="abi/missing")

--- a/libs/naas-abi-marketplace/naas_abi_marketplace/domains/operations/modules/ontology_engineer/agents/SevenBucketsAgent.py
+++ b/libs/naas-abi-marketplace/naas_abi_marketplace/domains/operations/modules/ontology_engineer/agents/SevenBucketsAgent.py
@@ -11,8 +11,8 @@ from naas_abi_core.services.agent.Agent import (
 from rdflib import Graph
 
 NAME = "7_Buckets"
-ONTOLOGIES_DIR = "libs/naas-abi-marketplace/naas_abi_marketplace/domains/signals/pipelines/ontology_engineer/ontologies"
-TEMPLATE_ONTOLOGY = Path(ONTOLOGIES_DIR) / "BFO7BucketsProcessOntology.ttl"
+_ONTOLOGIES_DIR = Path(__file__).resolve().parent.parent / "ontologies"
+TEMPLATE_ONTOLOGY = _ONTOLOGIES_DIR / "BFO7BucketsProcessOntology.ttl"
 AVATAR_URL = (
     "https://naasai-public.s3.eu-west-3.amazonaws.com/abi-demo/ontology_ABI.png"
 )
@@ -404,8 +404,8 @@ def create_agent(
     ) -> str:
         """Validate a Turtle ontology with rdflib and save it into the ontologies folder."""
         safe_name = _safe_ontology_filename(filename)
-        Path(ONTOLOGIES_DIR).mkdir(parents=True, exist_ok=True)
-        filepath = Path(ONTOLOGIES_DIR) / safe_name
+        _ONTOLOGIES_DIR.mkdir(parents=True, exist_ok=True)
+        filepath = _ONTOLOGIES_DIR / safe_name
         if filepath.exists() and not overwrite:
             return (
                 f"File already exists: {safe_name}. Set overwrite=true to replace it."

--- a/libs/naas-abi/naas_abi/agents/AbiAgent.py
+++ b/libs/naas-abi/naas_abi/agents/AbiAgent.py
@@ -171,6 +171,14 @@ Respond only based on what your available agents and tools can actually deliver.
             logger = __import__("logging").getLogger(__name__)
             logger.debug("slides tools unavailable: %s", exc)
 
+        try:
+            from naas_abi.agents.tools.coding_tools import coding_tools
+
+            tools += coding_tools()
+        except Exception as exc:  # noqa: BLE001
+            logger = __import__("logging").getLogger(__name__)
+            logger.debug("coding tools unavailable: %s", exc)
+
         # NOTE: coding-workspace filesystem tools (write_file/read_file/list_dir)
         # are injected generically for every agent via default_tools, so the
         # supervisor and all sub-agents can act on the caller's workspace.

--- a/libs/naas-abi/naas_abi/agents/tools/coding_tools.py
+++ b/libs/naas-abi/naas_abi/agents/tools/coding_tools.py
@@ -13,13 +13,39 @@ from naas_abi_core.services.agent.context import (
     coder_workspace_base,
     coding_active_branch,
     coding_active_repo,
+    coding_harness_base,
 )
 from naas_abi_core.services.agent.tools.workspace_tools import _call as _sidecar_call
+from naas_abi_core.services.coding_environment.adapters.secondary.OpencodeHarnessClient import (
+    run_task as run_harness_task,
+)
 
 _NO_SANDBOX = (
     "No coding sandbox is connected to this session. Open a repository in Code "
     "and wait for the sandbox runtime to become ready."
 )
+_NO_HARNESS = (
+    "No coding harness is connected. Open a repository in Code and wait for the "
+    "sandbox runtime (OpenCode) to become ready."
+)
+
+
+def _harness_model() -> str | None:
+    try:
+        from naas_abi_core.engine.engine_configuration.EngineConfiguration import (
+            EngineConfiguration,
+        )
+
+        configuration = EngineConfiguration.load_configuration()
+        adapter_cfg = (
+            configuration.services.coding_environment.coding_environment_adapter
+        )
+        if adapter_cfg.adapter != "local_directory" or not adapter_cfg.config:
+            return None
+        model = adapter_cfg.config.get("opencode_model")
+        return str(model) if model else None
+    except (ImportError, AttributeError, ValueError, OSError):
+        return None
 
 
 def _coding_context() -> dict[str, str | None]:
@@ -27,6 +53,7 @@ def _coding_context() -> dict[str, str | None]:
         "repo_id": coding_active_repo.get(),
         "branch": coding_active_branch.get(),
         "sidecar_bound": bool(coder_workspace_base.get()),
+        "harness_bound": bool(coding_harness_base.get()),
     }
 
 
@@ -61,4 +88,25 @@ def coding_tools() -> list[BaseTool]:
         result["coding_context"] = _coding_context()
         return result
 
-    return [read_coding_file, write_coding_file, list_coding_dir, run_in_coding_sandbox]
+    @tool(return_direct=False)
+    def run_coding_harness_task(message: str, session_id: str = "") -> dict[str, Any]:
+        """Delegate a multi-step coding task to the managed OpenCode harness."""
+        base = coding_harness_base.get()
+        if not base:
+            return {"error": _NO_HARNESS, "coding_context": _coding_context()}
+        result = run_harness_task(
+            base,
+            message,
+            model=_harness_model(),
+            session_id=session_id or None,
+        )
+        result["coding_context"] = _coding_context()
+        return result
+
+    return [
+        read_coding_file,
+        write_coding_file,
+        list_coding_dir,
+        run_in_coding_sandbox,
+        run_coding_harness_task,
+    ]

--- a/libs/naas-abi/naas_abi/agents/tools/coding_tools.py
+++ b/libs/naas-abi/naas_abi/agents/tools/coding_tools.py
@@ -1,0 +1,64 @@
+"""Abi tools for Nexus Code sandboxes (Slides-parity).
+
+When a repo is open and a local sandbox sidecar is bound, tools read/write the
+live checkout. Otherwise they return a clear unavailable message.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.tools import BaseTool, tool
+from naas_abi_core.services.agent.context import (
+    coder_workspace_base,
+    coding_active_branch,
+    coding_active_repo,
+)
+from naas_abi_core.services.agent.tools.workspace_tools import _call as _sidecar_call
+
+_NO_SANDBOX = (
+    "No coding sandbox is connected to this session. Open a repository in Code "
+    "and wait for the sandbox runtime to become ready."
+)
+
+
+def _coding_context() -> dict[str, str | None]:
+    return {
+        "repo_id": coding_active_repo.get(),
+        "branch": coding_active_branch.get(),
+        "sidecar_bound": bool(coder_workspace_base.get()),
+    }
+
+
+def coding_tools() -> list[BaseTool]:
+    @tool(return_direct=False)
+    def read_coding_file(path: str) -> dict[str, Any]:
+        """Read a UTF-8 text file from the open coding sandbox checkout."""
+        result = _sidecar_call("read_file", {"path": path})
+        result["coding_context"] = _coding_context()
+        return result
+
+    @tool(return_direct=False)
+    def write_coding_file(path: str, content: str) -> dict[str, Any]:
+        """Create or overwrite a file in the open coding sandbox checkout."""
+        result = _sidecar_call("write_file", {"path": path, "content": content})
+        result["coding_context"] = _coding_context()
+        return result
+
+    @tool(return_direct=False)
+    def list_coding_dir(path: str = ".") -> dict[str, Any]:
+        """List files and directories under ``path`` in the coding sandbox."""
+        result = _sidecar_call("list_dir", {"path": path})
+        result["coding_context"] = _coding_context()
+        return result
+
+    @tool(return_direct=False)
+    def run_in_coding_sandbox(command: str, cwd: str = ".") -> dict[str, Any]:
+        """Run a shell command in the coding sandbox checkout."""
+        result = _sidecar_call(
+            "run_terminal", {"command": command, "cwd": cwd, "timeout_s": 120}
+        )
+        result["coding_context"] = _coding_context()
+        return result
+
+    return [read_coding_file, write_coding_file, list_coding_dir, run_in_coding_sandbox]

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__streaming.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__streaming.py
@@ -296,6 +296,44 @@ async def stream_chat_response(
                                     exc_info=True,
                                 )
 
+                coding_ctx = (
+                    client_ctx.get("coding") if isinstance(client_ctx, dict) else None
+                )
+                if isinstance(coding_ctx, dict):
+                    repo_id = str(coding_ctx.get("repo_id") or "").strip()
+                    branch = str(coding_ctx.get("branch") or "").strip()
+                    if repo_id:
+                        from naas_abi_core.services.agent.context import (  # noqa: PLC0415
+                            coding_active_branch,
+                            coding_active_repo,
+                        )
+
+                        coding_active_repo.set(repo_id)
+                        if branch:
+                            coding_active_branch.set(branch)
+                        if request.workspace_id:
+                            try:
+                                from naas_abi.apps.nexus.apps.api.app.services.coding_environment.adapters.primary.coding_environment__primary_adapter__FastAPI import (  # noqa: PLC0415
+                                    lookup_code_sidecar,
+                                )
+
+                                ws_base, ws_secret = await lookup_code_sidecar(
+                                    db,
+                                    workspace_id=str(request.workspace_id),
+                                    user_id=str(current_user.id),
+                                    repo_id=repo_id,
+                                    branch=branch or "main",
+                                )
+                                if ws_base and ws_secret:
+                                    coder_workspace_base.set(ws_base)
+                                    coder_workspace_secret.set(ws_secret)
+                            except Exception:
+                                logger.warning(
+                                    "Failed to bind coding sidecar for %s",
+                                    repo_id,
+                                    exc_info=True,
+                                )
+
                 provider_messages = await build_provider_messages_with_agents(
                     request=request,
                     context=request_context(current_user),

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__streaming.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__streaming.py
@@ -313,23 +313,35 @@ async def stream_chat_response(
                             coding_active_branch.set(branch)
                         if request.workspace_id:
                             try:
+                                from naas_abi import ABIModule  # noqa: PLC0415
                                 from naas_abi.apps.nexus.apps.api.app.services.coding_environment.adapters.primary.coding_environment__primary_adapter__FastAPI import (  # noqa: PLC0415
-                                    lookup_code_sidecar,
+                                    lookup_code_bindings,
+                                )
+                                from naas_abi_core.services.agent.context import (  # noqa: PLC0415
+                                    coding_harness_base,
                                 )
 
-                                ws_base, ws_secret = await lookup_code_sidecar(
-                                    db,
-                                    workspace_id=str(request.workspace_id),
-                                    user_id=str(current_user.id),
-                                    repo_id=repo_id,
-                                    branch=branch or "main",
+                                coding_service = (
+                                    ABIModule.get_instance().engine.services.coding_environment
+                                )
+                                ws_base, ws_secret, harness_base, _env_id = (
+                                    await lookup_code_bindings(
+                                        db,
+                                        workspace_id=str(request.workspace_id),
+                                        user_id=str(current_user.id),
+                                        repo_id=repo_id,
+                                        branch=branch or "main",
+                                        service=coding_service,
+                                    )
                                 )
                                 if ws_base and ws_secret:
                                     coder_workspace_base.set(ws_base)
                                     coder_workspace_secret.set(ws_secret)
+                                if harness_base:
+                                    coding_harness_base.set(harness_base)
                             except Exception:
                                 logger.warning(
-                                    "Failed to bind coding sidecar for %s",
+                                    "Failed to bind coding runtime for %s",
                                     repo_id,
                                     exc_info=True,
                                 )

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/service.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/service.py
@@ -228,7 +228,9 @@ def _render_coding_context_block(client_context: dict | None) -> str:
         "The user is browsing this repository in the Code overlay. You are operating "
         "on the live sandbox checkout via coding tools when the sidecar runtime is "
         "ready. Do not ask which repository or branch. Prefer read_coding_file, "
-        "write_coding_file, list_coding_dir, and run_in_coding_sandbox for edits.\n"
+        "write_coding_file, list_coding_dir, and run_in_coding_sandbox for direct "
+        "edits. For larger multi-file refactors, use run_coding_harness_task to "
+        "delegate to the managed OpenCode harness in the same checkout.\n"
         + "\n".join(lines)
         + "\n"
     )

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/service.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/chat/service.py
@@ -206,6 +206,34 @@ def _render_slides_context_block(client_context: dict | None) -> str:
     )
 
 
+def _render_coding_context_block(client_context: dict | None) -> str:
+    """Inject open Code repo/branch so Abi edits the sandbox checkout."""
+    if not isinstance(client_context, dict):
+        return ""
+    coding = client_context.get("coding")
+    if not isinstance(coding, dict):
+        return ""
+    repo_id = str(coding.get("repo_id") or "").strip()
+    if not repo_id:
+        return ""
+    branch = str(coding.get("branch") or "main").strip()
+    path = str(coding.get("path") or ".").strip()
+    lines = [
+        f"- repo_id: {repo_id}",
+        f"- branch: {branch}",
+        f"- cwd: {path}",
+    ]
+    return (
+        "\n\n## Open Code repository\n"
+        "The user is browsing this repository in the Code overlay. You are operating "
+        "on the live sandbox checkout via coding tools when the sidecar runtime is "
+        "ready. Do not ask which repository or branch. Prefer read_coding_file, "
+        "write_coding_file, list_coding_dir, and run_in_coding_sandbox for edits.\n"
+        + "\n".join(lines)
+        + "\n"
+    )
+
+
 def _render_user_context_block(
     user: AuthUserRecord,
     workspace_id: str | None = None,
@@ -270,6 +298,9 @@ class ChatService:
         slides_block = _render_slides_context_block(client_context)
         if slides_block:
             system_prompt += slides_block
+        coding_block = _render_coding_context_block(client_context)
+        if coding_block:
+            system_prompt += coding_block
 
         has_prior_assistant = any(getattr(m, "role", None) == "assistant" for m in prior_messages)
         if has_prior_assistant:
@@ -302,6 +333,10 @@ class ChatService:
         slides_block = _render_slides_context_block(client_context)
         if slides_block.strip():
             parts.append(slides_block.strip())
+
+        coding_block = _render_coding_context_block(client_context)
+        if coding_block.strip():
+            parts.append(coding_block.strip())
 
         has_prior_assistant = any(getattr(m, "role", None) == "assistant" for m in prior_messages)
         if has_prior_assistant:

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/coding_environment/adapters/primary/coding_environment__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/coding_environment/adapters/primary/coding_environment__primary_adapter__FastAPI.py
@@ -16,8 +16,13 @@ to a worker thread via ``run_in_threadpool`` to avoid blocking the event loop.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import re
 import secrets
+import time
+import urllib.error
+import urllib.request
 from datetime import timedelta
 from urllib.parse import quote
 
@@ -155,11 +160,16 @@ def _public_clone_url(repo_id: str) -> str:
 
 def _to_repo_item(repo: Repo) -> RepoListItem:
     repo_id = f"{repo.owner}/{repo.name}"
+    clone_url = (
+        repo.clone_url
+        if repo.clone_url.startswith("file:")
+        else _public_clone_url(repo_id)
+    )
     return RepoListItem(
         repo_id=repo_id,
         name=repo.name,
         default_branch=repo.default_branch,
-        clone_url=_public_clone_url(repo_id),
+        clone_url=clone_url,
         description=repo.description,
         private=repo.private,
         empty=repo.empty,
@@ -253,6 +263,11 @@ def _prepare_clone(
         checkout = new_branch
     else:
         checkout = source_branch
+
+    repos = sc.list_repos()
+    repo = next((item for item in repos if f"{item.owner}/{item.name}" == repo_id), None)
+    if repo and repo.clone_url.startswith("file:"):
+        return repo.clone_url, checkout
 
     token = sc.mint_git_token(user_id=username)
     creds = f"{quote(username, safe='')}:{quote(token, safe='')}"
@@ -825,6 +840,16 @@ async def provision_environment(
         )
     except CodingEnvironmentError as exc:
         raise _http_error(exc) from exc
+
+    sidecar_base = ws_base
+    sidecar_secret = ws_secret
+    binding = await run_in_threadpool(service.get_runtime_binding, workspace_id=status.id)
+    if binding:
+        sidecar_base, sidecar_secret = binding
+        params["abi_token"] = _mint_agent_token(
+            current_user.id, ws_base=sidecar_base, ws_secret=sidecar_secret
+        )
+
     # Record which repo this workspace was cloned from so the workspaces list can
     # be scoped per-repo. Best-effort: the workspace already exists in Coder, so a
     # bookkeeping failure must not fail the request.
@@ -835,12 +860,213 @@ async def provision_environment(
                 workspace_id=body.workspace_id,
                 user_id=current_user.id,
                 repo_id=repo_id or None,
+                sidecar_base=sidecar_base,
+                sidecar_secret=sidecar_secret,
             )
         )
         await db.commit()
     except Exception:
         await db.rollback()
     return _to_env(status, repo_id or None)
+
+
+class SandboxRuntimeResponse(BaseModel):
+    ensured: bool
+    sidecar_ready: bool = False
+    environment_id: str | None = None
+    label: str
+    branch: str
+    detail: str | None = None
+
+
+def _code_runtime_label(*, workspace_id: str, repo_id: str, branch: str) -> str:
+    ws = re.sub(r"[^a-zA-Z0-9._-]+", "-", workspace_id.strip()).strip("-._")
+    branch_slug = re.sub(r"[^a-zA-Z0-9._-]+", "-", branch.strip()).strip("-._")
+    return f"code/{ws}/{repo_id}/{branch_slug}"
+
+
+def _sandbox_workspace_name(*, workspace_id: str, repo_id: str, branch: str) -> str:
+    digest = hashlib.sha1(f"{workspace_id}:{repo_id}:{branch}".encode()).hexdigest()[:10]
+    return f"sbox-{digest}"
+
+
+def _wait_for_sidecar(base: str, secret: str, *, timeout_s: float = 15.0) -> bool:
+    req = urllib.request.Request(
+        f"{base.rstrip('/')}/health",
+        headers={"Authorization": f"Bearer {secret}"},
+        method="GET",
+    )
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(req, timeout=1.0) as resp:  # nosec B310
+                payload = json.loads(resp.read().decode("utf-8"))
+                if payload.get("ok"):
+                    return True
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError):
+            time.sleep(0.25)
+    return False
+
+
+async def lookup_code_sidecar(
+    db: AsyncSession,
+    *,
+    workspace_id: str,
+    user_id: str,
+    repo_id: str,
+    branch: str,
+) -> tuple[str | None, str | None]:
+    label = _code_runtime_label(
+        workspace_id=workspace_id, repo_id=repo_id, branch=branch
+    )
+    result = await db.execute(
+        select(CodingEnvironmentModel).where(
+            CodingEnvironmentModel.workspace_id == workspace_id,
+            CodingEnvironmentModel.user_id == user_id,
+            CodingEnvironmentModel.label == label,
+        )
+    )
+    row = result.scalars().first()
+    if row and row.sidecar_base and row.sidecar_secret:
+        return str(row.sidecar_base), str(row.sidecar_secret)
+    return None, None
+
+
+@router.post("/sandbox/runtime", response_model=SandboxRuntimeResponse)
+async def ensure_sandbox_runtime(
+    workspace_id: str,
+    repo_id: str,
+    branch: str = "main",
+    current_user: User = Depends(get_current_user_required),
+    service: CodingEnvironmentService = Depends(_get_coding_environment_service),
+    source_control: SourceControlService | None = Depends(_get_source_control_service),
+    db: AsyncSession = Depends(get_db),
+) -> SandboxRuntimeResponse:
+    """Ensure a local sandbox + sidecar for the open repo (Slides-parity)."""
+    await require_workspace_access(current_user.id, workspace_id)
+    label = _code_runtime_label(workspace_id=workspace_id, repo_id=repo_id, branch=branch)
+    name = _sandbox_workspace_name(
+        workspace_id=workspace_id, repo_id=repo_id, branch=branch
+    )
+
+    existing = await db.execute(
+        select(CodingEnvironmentModel).where(
+            CodingEnvironmentModel.workspace_id == workspace_id,
+            CodingEnvironmentModel.user_id == current_user.id,
+            CodingEnvironmentModel.label == label,
+        )
+    )
+    row = existing.scalars().first()
+    if row and row.sidecar_base and row.sidecar_secret:
+        ready = await run_in_threadpool(
+            _wait_for_sidecar, str(row.sidecar_base), str(row.sidecar_secret)
+        )
+        if not ready:
+            await run_in_threadpool(service.start, workspace_id=row.id)
+            ready = await run_in_threadpool(
+                _wait_for_sidecar, str(row.sidecar_base), str(row.sidecar_secret)
+            )
+        return SandboxRuntimeResponse(
+            ensured=True,
+            sidecar_ready=ready,
+            environment_id=row.id,
+            label=label,
+            branch=branch,
+            detail=None if ready else "Sidecar not reachable",
+        )
+
+    templates = await run_in_threadpool(service.list_templates)
+    template = next((item for item in templates if item.name == "local-directory"), None)
+    if template is None:
+        template = templates[0] if templates else None
+    if template is None:
+        return SandboxRuntimeResponse(
+            ensured=False,
+            label=label,
+            branch=branch,
+            detail="No coding environment template available",
+        )
+
+    ws_secret = secrets.token_hex(16)
+    params: dict[str, str] = {"branch": branch, "sidecar_secret": ws_secret}
+    if source_control is not None:
+        try:
+            repo_url, checkout_branch = await run_in_threadpool(
+                _prepare_clone,
+                source_control,
+                repo_id=repo_id,
+                external_id=current_user.id,
+                email=str(current_user.email),
+                display_name=current_user.name or "",
+                source_branch=branch,
+                new_branch=None,
+            )
+            params["repo_url"] = repo_url
+            params["branch"] = checkout_branch
+        except SourceControlError as exc:
+            return SandboxRuntimeResponse(
+                ensured=False,
+                label=label,
+                branch=branch,
+                detail=str(exc),
+            )
+
+    user_id = await run_in_threadpool(
+        service.ensure_user,
+        external_id=current_user.id,
+        email=str(current_user.email),
+        username=current_user.name,
+    )
+    try:
+        status = await run_in_threadpool(
+            service.provision,
+            user_id=user_id,
+            template_id=template.id,
+            name=name,
+            params=params,
+        )
+    except CodingEnvironmentError as exc:
+        return SandboxRuntimeResponse(
+            ensured=False,
+            label=label,
+            branch=branch,
+            detail=str(exc),
+        )
+
+    sidecar_base = None
+    sidecar_secret = ws_secret
+    binding = await run_in_threadpool(service.get_runtime_binding, workspace_id=status.id)
+    if binding:
+        sidecar_base, sidecar_secret = binding
+
+    ready = bool(
+        sidecar_base
+        and await run_in_threadpool(_wait_for_sidecar, sidecar_base, sidecar_secret)
+    )
+    try:
+        db.add(
+            CodingEnvironmentModel(
+                id=status.id,
+                workspace_id=workspace_id,
+                user_id=current_user.id,
+                repo_id=repo_id,
+                label=label,
+                sidecar_base=sidecar_base,
+                sidecar_secret=sidecar_secret,
+            )
+        )
+        await db.commit()
+    except Exception:
+        await db.rollback()
+
+    return SandboxRuntimeResponse(
+        ensured=True,
+        sidecar_ready=ready,
+        environment_id=status.id,
+        label=label,
+        branch=params.get("branch", branch),
+        detail=None if ready else "Sidecar not reachable",
+    )
 
 
 @router.get("/{environment_id}")

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/coding_environment/adapters/primary/coding_environment__primary_adapter__FastAPI.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/api/app/services/coding_environment/adapters/primary/coding_environment__primary_adapter__FastAPI.py
@@ -873,6 +873,7 @@ async def provision_environment(
 class SandboxRuntimeResponse(BaseModel):
     ensured: bool
     sidecar_ready: bool = False
+    harness_ready: bool = False
     environment_id: str | None = None
     label: str
     branch: str
@@ -908,14 +909,24 @@ def _wait_for_sidecar(base: str, secret: str, *, timeout_s: float = 15.0) -> boo
     return False
 
 
-async def lookup_code_sidecar(
+def _wait_for_harness(base: str, *, timeout_s: float = 15.0) -> bool:
+    from naas_abi_core.services.coding_environment.adapters.secondary.OpencodeHarnessClient import (  # noqa: PLC0415
+        wait_for_healthy,
+    )
+
+    return wait_for_healthy(base, timeout_s=timeout_s)
+
+
+async def lookup_code_bindings(
     db: AsyncSession,
     *,
     workspace_id: str,
     user_id: str,
     repo_id: str,
     branch: str,
-) -> tuple[str | None, str | None]:
+    service: CodingEnvironmentService | None = None,
+) -> tuple[str | None, str | None, str | None, str | None]:
+    """Return sidecar_base, sidecar_secret, harness_base, environment_id."""
     label = _code_runtime_label(
         workspace_id=workspace_id, repo_id=repo_id, branch=branch
     )
@@ -927,9 +938,37 @@ async def lookup_code_sidecar(
         )
     )
     row = result.scalars().first()
-    if row and row.sidecar_base and row.sidecar_secret:
-        return str(row.sidecar_base), str(row.sidecar_secret)
-    return None, None
+    if not row or not row.sidecar_base or not row.sidecar_secret:
+        return None, None, None, None
+    harness_base = None
+    if service is not None and row.id:
+        harness_base = await run_in_threadpool(
+            service.get_harness_binding, workspace_id=row.id
+        )
+    return (
+        str(row.sidecar_base),
+        str(row.sidecar_secret),
+        harness_base,
+        str(row.id),
+    )
+
+
+async def lookup_code_sidecar(
+    db: AsyncSession,
+    *,
+    workspace_id: str,
+    user_id: str,
+    repo_id: str,
+    branch: str,
+) -> tuple[str | None, str | None]:
+    sidecar_base, sidecar_secret, _, _ = await lookup_code_bindings(
+        db,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        repo_id=repo_id,
+        branch=branch,
+    )
+    return sidecar_base, sidecar_secret
 
 
 @router.post("/sandbox/runtime", response_model=SandboxRuntimeResponse)
@@ -961,18 +1000,41 @@ async def ensure_sandbox_runtime(
         ready = await run_in_threadpool(
             _wait_for_sidecar, str(row.sidecar_base), str(row.sidecar_secret)
         )
+        harness_ready = False
         if not ready:
             await run_in_threadpool(service.start, workspace_id=row.id)
             ready = await run_in_threadpool(
                 _wait_for_sidecar, str(row.sidecar_base), str(row.sidecar_secret)
             )
+        harness_base = await run_in_threadpool(
+            service.get_harness_binding, workspace_id=row.id
+        )
+        if harness_base:
+            harness_ready = await run_in_threadpool(_wait_for_harness, harness_base)
+            if not harness_ready:
+                await run_in_threadpool(service.start, workspace_id=row.id)
+                harness_base = await run_in_threadpool(
+                    service.get_harness_binding, workspace_id=row.id
+                )
+                if harness_base:
+                    harness_ready = await run_in_threadpool(
+                        _wait_for_harness, harness_base
+                    )
+        detail = None
+        if not ready and not harness_ready:
+            detail = "Sidecar and harness not reachable"
+        elif not ready:
+            detail = "Sidecar not reachable"
+        elif harness_base and not harness_ready:
+            detail = "OpenCode harness not reachable"
         return SandboxRuntimeResponse(
             ensured=True,
             sidecar_ready=ready,
+            harness_ready=harness_ready,
             environment_id=row.id,
             label=label,
             branch=branch,
-            detail=None if ready else "Sidecar not reachable",
+            detail=detail,
         )
 
     templates = await run_in_threadpool(service.list_templates)
@@ -1043,6 +1105,12 @@ async def ensure_sandbox_runtime(
         sidecar_base
         and await run_in_threadpool(_wait_for_sidecar, sidecar_base, sidecar_secret)
     )
+    harness_base = await run_in_threadpool(
+        service.get_harness_binding, workspace_id=status.id
+    )
+    harness_ready = bool(
+        harness_base and await run_in_threadpool(_wait_for_harness, harness_base)
+    )
     try:
         db.add(
             CodingEnvironmentModel(
@@ -1059,13 +1127,22 @@ async def ensure_sandbox_runtime(
     except Exception:
         await db.rollback()
 
+    detail = None
+    if not ready and not harness_ready:
+        detail = "Sidecar and harness not reachable"
+    elif not ready:
+        detail = "Sidecar not reachable"
+    elif harness_base and not harness_ready:
+        detail = "OpenCode harness not reachable"
+
     return SandboxRuntimeResponse(
         ensured=True,
         sidecar_ready=ready,
+        harness_ready=harness_ready,
         environment_id=status.id,
         label=label,
         branch=params.get("branch", branch),
-        detail=None if ready else "Sidecar not reachable",
+        detail=detail,
     )
 
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/code/r/[owner]/[repo]/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/code/r/[owner]/[repo]/page.tsx
@@ -21,7 +21,7 @@ import {
   X,
 } from 'lucide-react';
 import { authFetch } from '@/stores/auth';
-import { useCodeStore } from '@/stores/code';
+import { CODE_FILE_UPDATED_EVENT, useCodeStore } from '@/stores/code';
 
 function timeAgo(iso: string | null | undefined): string {
   if (!iso) return '';
@@ -125,8 +125,40 @@ export default function RepoCodePage() {
   // Publish the browsed ref to the shell status footer (real Forgejo branch).
   useEffect(() => {
     if (!ref) return;
+    useCodeStore.getState().setSelectedRepoId(repoId);
     useCodeStore.getState().setRuntimeMeta({ activeBranch: ref });
-  }, [ref]);
+  }, [ref, repoId]);
+
+  // Ensure local sandbox + sidecar for Abi coding tools (Slides-parity).
+  useEffect(() => {
+    if (!workspaceId || !repoId || !ref) return;
+    useCodeStore.getState().setRuntimeMeta({ sandboxRuntimeStatus: 'ensuring' });
+    void (async () => {
+      try {
+        const res = await authFetch(
+          `/api/coding-environments/sandbox/runtime?workspace_id=${encodeURIComponent(workspaceId)}&repo_id=${encodeURIComponent(repoId)}&branch=${encodeURIComponent(ref)}`,
+          { method: 'POST' },
+        );
+        const data = res.ok
+          ? ((await res.json()) as { sidecar_ready?: boolean; ensured?: boolean })
+          : null;
+        const ready = Boolean(data?.sidecar_ready);
+        useCodeStore.getState().setRuntimeMeta({
+          sandboxRuntimeStatus: ready ? 'ready' : data?.ensured ? 'degraded' : 'error',
+        });
+      } catch {
+        useCodeStore.getState().setRuntimeMeta({ sandboxRuntimeStatus: 'error' });
+      }
+    })();
+  }, [workspaceId, repoId, ref]);
+
+  useEffect(() => {
+    const onUpdated = () => {
+      useCodeStore.getState().bumpRefreshToken();
+    };
+    window.addEventListener(CODE_FILE_UPDATED_EVENT, onUpdated);
+    return () => window.removeEventListener(CODE_FILE_UPDATED_EVENT, onUpdated);
+  }, []);
 
   const loadDir = useCallback(
     async (dirPath: string, atRef: string) => {
@@ -160,6 +192,12 @@ export default function RepoCodePage() {
     if (ref) void loadDir(path, ref);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ref, path]);
+
+  const refreshToken = useCodeStore((s) => s.refreshToken);
+  useEffect(() => {
+    if (!ref || refreshToken === 0) return;
+    void loadDir(path, ref);
+  }, [refreshToken, ref, path, loadDir]);
 
   // Dismiss the clone dropdown with Escape.
   useEffect(() => {

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/code/workspaces/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/code/workspaces/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams, useSearchParams } from 'next/navigation';
 import {
@@ -526,6 +527,30 @@ export default function IdePage() {
               className="h-full w-full border-0"
               allow="clipboard-read; clipboard-write"
             />
+          ) : env.phase === 'running' && env.agent_ready ? (
+            <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
+              <p className="text-sm font-medium">Local sandbox is ready</p>
+              <p className="max-w-md text-xs text-muted-foreground">
+                There is no embedded VS Code in local dev. Browse and edit files under{' '}
+                <strong>Code → Repos</strong>, or ask Abi in chat to change the checkout via
+                the OpenCode harness.
+              </p>
+              {selectedRepoId ? (
+                <Link
+                  href={`/workspace/${workspaceId}/code/r/${selectedRepoId}`}
+                  className="rounded-md border border-border px-3 py-1.5 text-xs font-medium hover:bg-workspace-accent-10"
+                >
+                  Open repository
+                </Link>
+              ) : (
+                <Link
+                  href={`/workspace/${workspaceId}/code/repos`}
+                  className="rounded-md border border-border px-3 py-1.5 text-xs font-medium hover:bg-workspace-accent-10"
+                >
+                  Go to repositories
+                </Link>
+              )}
+            </div>
           ) : env.phase === 'error' ? (
             <div className="flex h-full items-center justify-center px-6 text-center text-sm text-muted-foreground">
               The workspace failed to start. Try deleting and recreating it.

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/chat/chat-interface.tsx
@@ -17,6 +17,7 @@ import { useModelsStore, modelDisplayName } from '@/stores/models';
 import { useSkillsStore, type Skill, type SkillScope } from '@/stores/skills';
 import { useSecretsStore } from '@/stores/secrets';
 import { dispatchSlidesDeckUpdated, useSlidesStore } from '@/stores/slides';
+import { dispatchCodeFileUpdated, useCodeStore } from '@/stores/code';
 import { useAuthStore, authFetch } from '@/stores/auth';
 import { useWebSocket } from '@/contexts/websocket-context';
 import { useTenant } from '@/contexts/tenant-context';
@@ -920,6 +921,31 @@ export function ChatInterface({
       },
     };
   }, [pathname, slidesSlug, slidesTitle, slidesMode]);
+
+  const codeActiveBranch = useCodeStore((s) => s.activeBranch);
+  const codeSelectedRepo = useCodeStore((s) => s.selectedRepoId);
+  const codingChatContext = useMemo(() => {
+    const onCode =
+      typeof pathname === 'string' && pathname.includes('/code/r/');
+    const repoMatch = pathname?.match(/\/code\/r\/([^/]+)\/([^/]+)/);
+    const repoId = repoMatch ? `${repoMatch[1]}/${repoMatch[2]}` : codeSelectedRepo;
+    if (!onCode || !repoId) return null;
+    return {
+      coding: {
+        repo_id: repoId,
+        branch: codeActiveBranch || 'main',
+        path: '.',
+      },
+    };
+  }, [pathname, codeActiveBranch, codeSelectedRepo]);
+
+  const chatRequestContext = useMemo(() => {
+    const merged = {
+      ...(slidesChatContext ?? {}),
+      ...(codingChatContext ?? {}),
+    };
+    return Object.keys(merged).length > 0 ? merged : null;
+  }, [slidesChatContext, codingChatContext]);
 
   useEffect(() => {
     if (!mounted || isPane) return;
@@ -2086,6 +2112,12 @@ export function ChatInterface({
             }
             dispatchSlidesDeckUpdated({ slug, source: target.rawName || target.toolName });
           }
+          if (
+            raw.includes('write_coding') ||
+            raw.includes('run_in_coding')
+          ) {
+            dispatchCodeFileUpdated({ source: target.rawName || target.toolName });
+          }
 
           const toolUrls = extractUrlsFromContent(output);
           if (toolUrls.length > 0) {
@@ -2234,7 +2266,7 @@ export function ChatInterface({
             system_prompt: systemPrompt,
             search_enabled: false,
             regenerate_of: regenerateOf ?? null,
-            ...(slidesChatContext ? { context: slidesChatContext } : {}),
+            ...(chatRequestContext ? { context: chatRequestContext } : {}),
             // search_enabled: searchEnabled,
           }),
         });
@@ -2451,7 +2483,7 @@ export function ChatInterface({
             llm_model: llmModel,
             system_prompt: systemPrompt,
             regenerate_of: regenerateOf ?? null,
-            ...(slidesChatContext ? { context: slidesChatContext } : {}),
+            ...(chatRequestContext ? { context: chatRequestContext } : {}),
           }),
         });
 

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/code.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/code.ts
@@ -15,14 +15,34 @@ interface CodeState {
   coderPhase: string | null;
   /** Coder dashboard URL for the focused workspace (new tab). */
   coderUiUrl: string | null;
+  /** Local sandbox runtime (Slides-parity). */
+  sandboxRuntimeStatus: 'idle' | 'ensuring' | 'ready' | 'degraded' | 'error';
+  refreshToken: number;
   setSelectedRepoId: (repoId: string) => void;
   setRuntimeMeta: (meta: {
     activeBranch?: string | null;
     coderWorkspace?: string | null;
     coderPhase?: string | null;
     coderUiUrl?: string | null;
+    sandboxRuntimeStatus?: CodeState['sandboxRuntimeStatus'];
   }) => void;
+  bumpRefreshToken: () => void;
   clearRuntimeMeta: () => void;
+}
+
+export const CODE_FILE_UPDATED_EVENT = 'code-file-updated';
+
+export type CodeFileUpdatedDetail = {
+  repoId?: string;
+  path?: string;
+  source?: string;
+};
+
+export function dispatchCodeFileUpdated(detail: CodeFileUpdatedDetail = {}) {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(
+    new CustomEvent<CodeFileUpdatedDetail>(CODE_FILE_UPDATED_EVENT, { detail }),
+  );
 }
 
 export const useCodeStore = create<CodeState>()(
@@ -33,6 +53,8 @@ export const useCodeStore = create<CodeState>()(
       coderWorkspace: null,
       coderPhase: null,
       coderUiUrl: null,
+      sandboxRuntimeStatus: 'idle',
+      refreshToken: 0,
       setSelectedRepoId: (repoId) => set({ selectedRepoId: repoId }),
       setRuntimeMeta: (meta) =>
         set({
@@ -46,13 +68,20 @@ export const useCodeStore = create<CodeState>()(
             meta.coderPhase !== undefined ? meta.coderPhase : get().coderPhase,
           coderUiUrl:
             meta.coderUiUrl !== undefined ? meta.coderUiUrl : get().coderUiUrl,
+          sandboxRuntimeStatus:
+            meta.sandboxRuntimeStatus !== undefined
+              ? meta.sandboxRuntimeStatus
+              : get().sandboxRuntimeStatus,
         }),
+      bumpRefreshToken: () =>
+        set((state) => ({ refreshToken: state.refreshToken + 1 })),
       clearRuntimeMeta: () =>
         set({
           activeBranch: null,
           coderWorkspace: null,
           coderPhase: null,
           coderUiUrl: null,
+          sandboxRuntimeStatus: 'idle',
         }),
     }),
     {


### PR DESCRIPTION
## Summary

- Add `local_git` and `local_directory` adapters so `abi dev` can run Code without Coder or Forgejo
- Mirror the Slides control loop: repo page ensures a sandbox sidecar, chat binds `context.coding`, and Abi uses `coding_tools` against the live checkout
- Wire default config for local dev (`storage/git`, `storage/workspaces`) and document the decision in a new ADR

## Test plan

- [ ] `uv run pytest libs/naas-abi-core/naas_abi_core/services/source_control/adapters/secondary/LocalGitAdapter_test.py libs/naas-abi-core/naas_abi_core/services/coding_environment/adapters/secondary/LocalDirectoryAdapter_test.py -v`
- [ ] Enable the `code` feature flag and start `abi dev up -d`
- [ ] Create repo `abi/monorepo` via Code UI or `POST /api/coding-environments/repos`
- [ ] Open `/workspace/{id}/code/r/abi/monorepo` and confirm sandbox runtime becomes ready
- [ ] Ask Abi in chat to create/edit a file; confirm file tree refreshes after tool writes
- [ ] Confirm Docker/Coder deploy path is unchanged (Forgejo + Coder adapters still available)


Made with [Cursor](https://cursor.com)