### PR TITLE
feat(dataset): let DuckLake write its data to an object store

### DIFF
--- a/docs/adr/20260903_ducklake-dataset-backend.md
+++ b/docs/adr/20260903_ducklake-dataset-backend.md
@@ -58,5 +58,10 @@ cross-process SQLite writers and all PostgreSQL writers use the retry policy.
   script. Existing PostgreSQL volumes must run that script explicitly.
 - Moving a catalog from SQLite to PostgreSQL requires migrating metadata; it is
   not a configuration-only DSN change.
+- `data_path` may be a local path or an object store URI. A custom S3 endpoint
+  and its credentials are explicit configuration: DuckDB defaults to AWS and
+  virtual-hosted URLs, so a store such as MinIO is unreachable without them.
+  A misconfigured store does not always fail — a batch small enough to be
+  inlined in the catalog commits without the data ever leaving it.
 - Operators must schedule data flushing, adjacent-file compaction, snapshot
   expiry, and cleanup according to their retention policy.

--- a/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_DatasetService.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_DatasetService.py
@@ -19,6 +19,22 @@ class DatasetAdapterDuckLakeConfiguration(BaseModel):
       config:
         catalog: "sqlite:storage/datastore/datasets.sqlite"
         data_path: "storage/datastore/datasets/"
+
+    ``data_path`` may be an object store URI, in which case the table data lives
+    beside everything else the deployment stores rather than on a container disk.
+    S3-compatible stores such as MinIO need the endpoint and credentials given
+    here: DuckDB has no way to guess them, and a write with none of them set
+    fails with HTTP 403 (or, for a batch small enough to be inlined in the
+    catalog, silently never reaches the store):
+
+    dataset_adapter:
+      adapter: "ducklake"
+      config:
+        catalog: "postgres:postgresql://user:password@postgres:5432/ducklake"
+        data_path: "s3://abi/abi/datastore/datasets/"
+        s3_endpoint: "http://minio:9000"
+        s3_access_key_id: "{{ secret.MINIO_ROOT_USER }}"
+        s3_secret_access_key: "{{ secret.MINIO_ROOT_PASSWORD }}"
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -28,6 +44,12 @@ class DatasetAdapterDuckLakeConfiguration(BaseModel):
     max_retries: int = Field(default=10, ge=0)
     retry_base_delay_seconds: float = Field(default=0.05, ge=0)
     retry_max_delay_seconds: float = Field(default=1.0, ge=0)
+    s3_endpoint: str = ""
+    s3_access_key_id: str = ""
+    s3_secret_access_key: str = ""
+    s3_region: str = ""
+    s3_url_style: str = ""
+    s3_use_ssl: bool | None = None
 
 
 class DatasetAdapterConfiguration(GenericLoader):

--- a/libs/naas-abi-core/naas_abi_core/services/dataset/AGENTS.md
+++ b/libs/naas-abi-core/naas_abi_core/services/dataset/AGENTS.md
@@ -46,7 +46,7 @@ JSON values are parsed and deterministically serialized before DuckDB binds them
 
 | Adapter | Notes |
 |---|---|
-| `ducklake` | DuckLake catalog backed by SQLite or PostgreSQL, with Parquet/inlined data under `data_path`. Supports catalog snapshots, time travel, JSON, and upsert. |
+| `ducklake` | DuckLake catalog backed by SQLite or PostgreSQL, with Parquet/inlined data under `data_path`, on a local path or an object store. Supports catalog snapshots, time travel, JSON, and upsert. |
 
 ## Engine config
 
@@ -63,13 +63,34 @@ services:
         retry_max_delay_seconds: 1.0
 ```
 
-Default is that block. Modules that use the service declare `DatasetService` in `ModuleDependencies.services`.
+Default is that block.
+
+`data_path` may instead be an object store URI, which keeps table data wherever the
+rest of the deployment persists rather than on a container disk. DuckDB cannot guess
+a custom endpoint or its credentials, so an S3-compatible store such as MinIO needs
+them here:
+
+```yaml
+        data_path: "s3://abi/abi/datastore/datasets/"
+        s3_endpoint: "http://minio:9000"
+        s3_access_key_id: "{{ secret.MINIO_ROOT_USER }}"
+        s3_secret_access_key: "{{ secret.MINIO_ROOT_PASSWORD }}"
+```
+
+The scheme on `s3_endpoint` sets the SSL default and an endpoint implies path-style
+URLs; `s3_use_ssl`, `s3_url_style` and `s3_region` override both. Omit all of them
+for AWS with ambient credentials. Setting them alongside a local `data_path` raises,
+because that pairing can only mean a store was intended and would not be used.
+
+Without them, a write to an object store fails with HTTP 403 — or, for a batch small
+enough for DuckLake to inline in the catalog, appears to succeed while never reaching
+the store. Modules that use the service declare `DatasetService` in `ModuleDependencies.services`.
 
 Each write uses a fresh connection and retries the complete transaction up to 10 times for catalog locks/transaction conflicts. Backoff starts at 50 ms, doubles to a 1-second cap, and has +/-25% jitter. SQLite writers sharing one adapter are serialized before the cross-process retry boundary; PostgreSQL writers remain concurrent. PostgreSQL deployment credentials are rendered from the secret service; do not log the catalog DSN.
 
 ## Operations
 
-- Treat the catalog and `data_path` as one stateful unit. The SQLite catalog can contain inlined rows, so copying only Parquet files is not a backup.
+- Treat the catalog and `data_path` as one stateful unit, including when `data_path` is a bucket: a catalog restored to a different point than the store references Parquet files that are not there. The SQLite catalog can contain inlined rows, so copying only Parquet files is not a backup.
 - `abi stack snapshot create` stops the stack, then captures `postgres_data` and `storage/`; this produces a coherent local-deployment backup for both PostgreSQL and SQLite catalogs.
 - Flush inlined rows before storage-only maintenance with `CALL ducklake_flush_inlined_data('abi_datasets')`.
 - Compact adjacent small files with `CALL ducklake_merge_adjacent_files('abi_datasets')`.

--- a/libs/naas-abi-core/naas_abi_core/services/dataset/DatasetFactory.py
+++ b/libs/naas-abi-core/naas_abi_core/services/dataset/DatasetFactory.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from naas_abi_core.services.dataset.adapters.secondary.DatasetSecondaryAdapterDuckLake import (
     DatasetSecondaryAdapterDuckLake,
 )
@@ -7,10 +9,11 @@ from naas_abi_core.services.dataset.DatasetService import DatasetService
 class DatasetFactory:
     @staticmethod
     def DatasetServiceDuckLake(
-        catalog: str, data_path: str, **options: object
+        catalog: str, data_path: str, **options: Any
     ) -> DatasetService:
+        """``options`` are forwarded to the adapter: retry budget and object-store settings."""
         return DatasetService(
             DatasetSecondaryAdapterDuckLake(
-                catalog=catalog, data_path=data_path, **options  # type: ignore[arg-type]
+                catalog=catalog, data_path=data_path, **options
             )
         )

--- a/libs/naas-abi-core/naas_abi_core/services/dataset/DatasetFactory.py
+++ b/libs/naas-abi-core/naas_abi_core/services/dataset/DatasetFactory.py
@@ -6,7 +6,11 @@ from naas_abi_core.services.dataset.DatasetService import DatasetService
 
 class DatasetFactory:
     @staticmethod
-    def DatasetServiceDuckLake(catalog: str, data_path: str) -> DatasetService:
+    def DatasetServiceDuckLake(
+        catalog: str, data_path: str, **options: object
+    ) -> DatasetService:
         return DatasetService(
-            DatasetSecondaryAdapterDuckLake(catalog=catalog, data_path=data_path)
+            DatasetSecondaryAdapterDuckLake(
+                catalog=catalog, data_path=data_path, **options  # type: ignore[arg-type]
+            )
         )

--- a/libs/naas-abi-core/naas_abi_core/services/dataset/DatasetService_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/dataset/DatasetService_test.py
@@ -25,3 +25,19 @@ def test_dataset_service_create_write_query(tmp_path):
     result = service.query("SELECT SUM(hours) AS total FROM hours")
     assert result.rows[0]["total"] == 3.5
     assert service.list_snapshots()
+
+
+def test_factory_forwards_adapter_options(tmp_path):
+    """Object-store and retry settings have to reach the adapter, not be dropped here."""
+    service = DatasetFactory.DatasetServiceDuckLake(
+        f"sqlite:{tmp_path / 'datasets.sqlite'}",
+        "s3://bucket/warehouse/",
+        s3_endpoint="http://minio:9000",
+        s3_access_key_id="key",
+        s3_secret_access_key="secret",
+        max_retries=3,
+    )
+    adapter = service._DatasetService__adapter
+    assert adapter._s3.configured is True
+    assert adapter._s3.endpoint == "http://minio:9000"
+    assert adapter._max_retries == 3

--- a/libs/naas-abi-core/naas_abi_core/services/dataset/adapters/secondary/DatasetSecondaryAdapterDuckLake.py
+++ b/libs/naas-abi-core/naas_abi_core/services/dataset/adapters/secondary/DatasetSecondaryAdapterDuckLake.py
@@ -9,6 +9,7 @@ import random
 import threading
 import time
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, TypeVar
 
@@ -26,7 +27,9 @@ from naas_abi_core.services.dataset.DatasetPort import (
 )
 
 CATALOG_ALIAS = "abi_datasets"
+S3_SECRET_NAME = "abi_datasets_store"
 SPEC_COMMENT_PREFIX = "abi.dataset-spec:"
+OBJECT_STORE_SCHEMES = ("s3://", "s3a://", "gcs://", "gs://", "r2://", "azure://", "abfss://")
 
 DUCKDB_TYPES = {
     "string": "VARCHAR",
@@ -41,6 +44,57 @@ DUCKDB_TYPES = {
 
 _T = TypeVar("_T")
 logger = logging.getLogger(__name__)
+
+
+def _is_object_store(path: str) -> bool:
+    return path.startswith(OBJECT_STORE_SCHEMES)
+
+
+def _sql_literal(value: str) -> str:
+    return "'" + str(value).replace("'", "''") + "'"
+
+
+@dataclass(frozen=True)
+class _S3Settings:
+    """Credentials and endpoint for the object store behind ``data_path``.
+
+    MinIO and other S3-compatible stores need the endpoint, path-style URLs and
+    plain HTTP; none of those are DuckDB defaults, so each is explicit here.
+    """
+
+    endpoint: str = ""
+    access_key_id: str = ""
+    secret_access_key: str = ""
+    region: str = ""
+    url_style: str = ""
+    use_ssl: bool | None = None
+
+    @property
+    def configured(self) -> bool:
+        return bool(self.endpoint or self.access_key_id or self.secret_access_key)
+
+    def sql(self) -> str:
+        parts = ["TYPE s3"]
+        if self.access_key_id:
+            parts.append(f"KEY_ID {_sql_literal(self.access_key_id)}")
+        if self.secret_access_key:
+            parts.append(f"SECRET {_sql_literal(self.secret_access_key)}")
+        if self.endpoint:
+            endpoint = self.endpoint
+            use_ssl = self.use_ssl
+            for scheme, ssl in (("https://", True), ("http://", False)):
+                if endpoint.startswith(scheme):
+                    endpoint = endpoint[len(scheme) :]
+                    use_ssl = ssl if use_ssl is None else use_ssl
+                    break
+            parts.append(f"ENDPOINT {_sql_literal(endpoint.rstrip('/'))}")
+            # A custom endpoint is almost never virtual-hosted; MinIO is not.
+            parts.append(f"URL_STYLE {_sql_literal(self.url_style or 'path')}")
+            parts.append(f"USE_SSL {'true' if (use_ssl is not False) else 'false'}")
+        elif self.url_style:
+            parts.append(f"URL_STYLE {_sql_literal(self.url_style)}")
+        parts.append(f"REGION {_sql_literal(self.region or 'us-east-1')}")
+        return ", ".join(parts)
 
 
 class DatasetSecondaryAdapterDuckLake(IDatasetPort):
@@ -59,6 +113,12 @@ class DatasetSecondaryAdapterDuckLake(IDatasetPort):
         max_retries: int = 10,
         retry_base_delay_seconds: float = 0.05,
         retry_max_delay_seconds: float = 1.0,
+        s3_endpoint: str = "",
+        s3_access_key_id: str = "",
+        s3_secret_access_key: str = "",
+        s3_region: str = "",
+        s3_url_style: str = "",
+        s3_use_ssl: bool | None = None,
     ) -> None:
         if max_retries < 0:
             raise ValueError("max_retries must be greater than or equal to zero")
@@ -72,6 +132,19 @@ class DatasetSecondaryAdapterDuckLake(IDatasetPort):
 
         self._catalog = catalog
         self._data_path = data_path.rstrip("/") + "/"
+        self._s3 = _S3Settings(
+            endpoint=s3_endpoint,
+            access_key_id=s3_access_key_id,
+            secret_access_key=s3_secret_access_key,
+            region=s3_region,
+            url_style=s3_url_style,
+            use_ssl=s3_use_ssl,
+        )
+        if self._s3.configured and not _is_object_store(self._data_path):
+            raise ValueError(
+                "S3 settings were given for a data_path that is not an object store URI: "
+                f"{self._data_path!r}"
+            )
         self._max_retries = max_retries
         self._retry_base_delay_seconds = retry_base_delay_seconds
         self._retry_max_delay_seconds = retry_max_delay_seconds
@@ -272,6 +345,7 @@ class DatasetSecondaryAdapterDuckLake(IDatasetPort):
                 con.execute("INSTALL ducklake")
                 con.execute("LOAD ducklake")
             con.execute("SET ducklake_max_retry_count = 0")
+            self._configure_object_store(con)
             options = [f"DATA_PATH {self._sql_string(self._data_path)}"]
             if snapshot_id is not None:
                 options.append(f"SNAPSHOT_VERSION {int(snapshot_id)}")
@@ -497,6 +571,24 @@ class DatasetSecondaryAdapterDuckLake(IDatasetPort):
 
     def _qualified_table(self, namespace: str, name: str) -> str:
         return f"{self._qualified_schema(namespace)}.{self._ident(name)}"
+
+    def _configure_object_store(self, con: Any) -> None:
+        """Teach the connection to reach the object store holding ``data_path``.
+
+        DuckLake writes Parquet straight to ``data_path``. Without this the write
+        either fails with HTTP 403 or, for a batch small enough to be inlined in
+        the catalog, appears to succeed while never reaching the store at all.
+        """
+        import duckdb
+
+        if not self._s3.configured:
+            return
+        try:
+            con.execute("LOAD httpfs")
+        except duckdb.Error:
+            con.execute("INSTALL httpfs")
+            con.execute("LOAD httpfs")
+        con.execute(f"CREATE OR REPLACE SECRET {self._ident(S3_SECRET_NAME)} ({self._s3.sql()})")
 
     def _prepare_local_paths(self) -> None:
         if self._catalog.startswith("sqlite:"):

--- a/libs/naas-abi-core/naas_abi_core/services/dataset/adapters/secondary/DatasetSecondaryAdapterDuckLake_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/dataset/adapters/secondary/DatasetSecondaryAdapterDuckLake_test.py
@@ -4,6 +4,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 from naas_abi_core.services.dataset.adapters.secondary.DatasetSecondaryAdapterDuckLake import (
     DatasetSecondaryAdapterDuckLake,
+    _S3Settings,
 )
 from naas_abi_core.services.dataset.DatasetPort import (
     ColumnSpec,
@@ -203,3 +204,61 @@ def test_postgres_catalog_concurrent_writers_preserve_acknowledged_appends(tmp_p
 
         result = setup_adapter.query("SELECT id FROM events ORDER BY id")
         assert [row["id"] for row in result.rows] == list(range(8))
+
+
+class TestObjectStoreDataPath:
+    """``data_path`` may be an object store, which DuckDB cannot reach unconfigured."""
+
+    def test_endpoint_implies_path_style_and_derives_ssl_from_the_scheme(self):
+        assert _S3Settings(
+            endpoint="http://minio:9000", access_key_id="k", secret_access_key="s"
+        ).sql() == (
+            "TYPE s3, KEY_ID 'k', SECRET 's', ENDPOINT 'minio:9000', "
+            "URL_STYLE 'path', USE_SSL false, REGION 'us-east-1'"
+        )
+        assert "USE_SSL true" in _S3Settings(
+            endpoint="https://s3.example.com", access_key_id="k"
+        ).sql()
+
+    def test_explicit_settings_win_over_what_the_scheme_implies(self):
+        sql = _S3Settings(
+            endpoint="http://minio:9000",
+            url_style="vhost",
+            use_ssl=True,
+            region="eu-west-3",
+        ).sql()
+        assert "URL_STYLE 'vhost'" in sql
+        assert "USE_SSL true" in sql
+        assert "REGION 'eu-west-3'" in sql
+
+    def test_no_endpoint_leaves_duckdb_defaults_alone(self):
+        assert _S3Settings(access_key_id="k", secret_access_key="s").sql() == (
+            "TYPE s3, KEY_ID 'k', SECRET 's', REGION 'us-east-1'"
+        )
+
+    def test_credentials_are_escaped_not_interpolated(self):
+        assert "SECRET 'pa''ss'" in _S3Settings(secret_access_key="pa'ss").sql()
+
+    def test_settings_are_inert_until_something_is_configured(self):
+        assert _S3Settings().configured is False
+        assert _S3Settings(access_key_id="k").configured is True
+
+    def test_s3_settings_on_a_local_data_path_are_rejected(self, tmp_path):
+        """Silently ignoring them would leave the store unreachable at write time."""
+        with pytest.raises(ValueError, match="not an object store URI"):
+            DatasetSecondaryAdapterDuckLake(
+                catalog=f"sqlite:{tmp_path / 'catalog.sqlite'}",
+                data_path=str(tmp_path / "data"),
+                s3_endpoint="http://minio:9000",
+            )
+
+    def test_a_local_data_path_still_needs_no_object_store_setup(self, tmp_path):
+        adapter = DatasetSecondaryAdapterDuckLake(
+            catalog=f"sqlite:{tmp_path / 'catalog.sqlite'}",
+            data_path=str(tmp_path / "data"),
+        )
+        adapter.create(
+            DatasetSpec(name="plain", columns=(ColumnSpec(name="id", type="integer"),))
+        )
+        adapter.write("plain", [{"id": 1}])
+        assert adapter.query("SELECT id FROM plain").rows == [{"id": 1}]


### PR DESCRIPTION
Stacked on #1241 — base is `feat/1240-ducklake-dataset-backend`, so this shows only the two commits on top of it. Part of #1240.

## Why

`data_path` already accepted a URI: `_prepare_local_paths` deliberately skips `mkdir` when it sees a scheme. But nothing configured the store, so DuckDB could not reach it. Pointing it at MinIO failed **two different ways**, and the second is the reason this is worth fixing before the backend lands:

```
HTTPException: Unable to connect to URL s3://abi/.../ducklake-….parquet:
Forbidden (HTTP code 403) — AccessDenied
```

and, for a batch small enough for DuckLake to inline in the catalog, **it did not fail at all**. The write returned, the query returned the rows, and nothing ever reached the store. A small dataset looks correct in staging and loses everything in production.

I found this while adapting Zen: its GCP deployment stores everything else in MinIO (`object_storage` is the `s3` adapter against the same bucket) while the dataset service was writing Parquet to the VM disk. Colocating them is what surfaced the gap.

## What

`_S3Settings` plus `_configure_object_store` on the DuckLake adapter: `LOAD httpfs`, then `CREATE OR REPLACE SECRET (TYPE s3, …)` before `ATTACH`.

A custom endpoint needs three things DuckDB does not default to — the endpoint itself, path-style URLs, and plain HTTP — so each is explicit rather than inferred silently:

- the scheme on `s3_endpoint` picks the SSL default, and an endpoint implies path style
- `s3_use_ssl`, `s3_url_style`, `s3_region` override both, for stores that want otherwise
- omit all of them for AWS with ambient credentials
- credentials are escaped into the secret, never interpolated

Configuring S3 alongside a **local** `data_path` now raises. That pairing can only mean a store was intended and would not be used, and silently ignoring it reproduces exactly the failure above.

```yaml
dataset_adapter:
  adapter: "ducklake"
  config:
    catalog: "postgres:postgresql://user:pass@postgres:5432/ducklake"
    data_path: "s3://abi/abi/datastore/datasets/"
    s3_endpoint: "http://minio:9000"
    s3_access_key_id: "{{ secret.MINIO_ROOT_USER }}"
    s3_secret_access_key: "{{ secret.MINIO_ROOT_PASSWORD }}"
```

Exposed through `DatasetAdapterDuckLakeConfiguration`, so it is YAML-configurable. `DatasetFactory` forwards adapter options — that forwarding had no test, which is how an `s3_endpoint` gets silently dropped, so it has one now.

The second commit is documentation the first one owed: the `AGENTS.md` adapter row and engine-config section, and an ADR consequence recording that a misconfigured store does not reliably fail. It also replaces a `# type: ignore` I had added on the factory with a real annotation.

## Verified

Against a real MinIO container, not asserted:

- 5,000 partitioned rows land as Parquet under the data path and query back, where the identical write previously returned 403.
- Driven end to end from Zen's actual `config.gcp.yaml` block against `postgres:17-alpine` + MinIO: 600 messages and 400 commits written and read back, partitioned as `google_gmail/messages/mailbox=…/month=8/` and `github/commits/org=…/repo=…/month=8/`.

Test suite: `naas_abi_core/services/dataset` 24 passed, 1 skipped; mypy clean on the service. The eight failures in `naas_abi_core/engine` are pre-existing on the base branch — confirmed by stashing this diff and re-running.

The new tests are unit-level on purpose, so CI needs no MinIO.

## Note for operators

With data in an object store, the catalog and the bucket become one backup/restore unit across two systems. A catalog restored to a different point than the store references Parquet files that are not there. The ADR and the operations section both say so now.

https://claude.ai/code/session_01XERrpQ9szqS891bcRdKYfF
