### PR TITLE
feat(object-storage): add recursive listing to the port and adapters

### DIFF
--- a/libs/naas-abi-core/naas_abi_core/services/object_storage/ObjectStoragePort.py
+++ b/libs/naas-abi-core/naas_abi_core/services/object_storage/ObjectStoragePort.py
@@ -67,6 +67,20 @@ class IObjectStorageAdapter(ABC):
         pass
 
     @abstractmethod
+    def list_objects_recursive(
+        self, prefix: str, queue: Queue | None = None
+    ) -> list[str]:
+        """List every object at or beneath *prefix*, at any nesting depth.
+
+        Unlike :meth:`list_objects`, which returns only the direct children of
+        *prefix*, this walks the whole subtree. Returned entries are object keys
+        only: directory and common-prefix placeholders never appear. Raises
+        :class:`Exceptions.ObjectNotFound` for a prefix that does not exist,
+        matching :meth:`list_objects`.
+        """
+        ...  # pragma: no cover - abstract
+
+    @abstractmethod
     def get_object_metadata(self, prefix: str, key: str) -> ObjectMetaData:
         pass
 
@@ -104,6 +118,13 @@ class IObjectStorageDomain(ABC):
     @abstractmethod
     def list_objects(self, prefix: str, queue: Queue | None = None) -> list[str]:
         pass
+
+    @abstractmethod
+    def list_objects_recursive(
+        self, prefix: str, queue: Queue | None = None
+    ) -> list[str]:
+        """List every object at or beneath *prefix*, at any nesting depth."""
+        ...  # pragma: no cover - abstract
 
     @abstractmethod
     def get_object_metadata(self, prefix: str, key: str) -> ObjectMetaData:

--- a/libs/naas-abi-core/naas_abi_core/services/object_storage/ObjectStorageService.py
+++ b/libs/naas-abi-core/naas_abi_core/services/object_storage/ObjectStorageService.py
@@ -82,5 +82,14 @@ class ObjectStorageService(ServiceBase, IObjectStorageDomain):
 
         return self.adapter.list_objects(prefix, queue)
 
+    def list_objects_recursive(
+        self, prefix: str = "", queue: Queue | None = None
+    ) -> list[str]:
+        prefix = self.__remove_storage_prefix(prefix)
+        if prefix == "/":
+            prefix = ""
+
+        return self.adapter.list_objects_recursive(prefix, queue)
+
     def get_object_metadata(self, prefix: str, key: str) -> ObjectMetaData:
         return self.adapter.get_object_metadata(prefix, key)

--- a/libs/naas-abi-core/naas_abi_core/services/object_storage/ObjectStorageService_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/object_storage/ObjectStorageService_test.py
@@ -129,3 +129,39 @@ def test_event_service_round_trips_via_codec(tmp_path):
     assert reloaded.prefix == "a"
     assert reloaded.key == "b.bin"
     assert reloaded.size_bytes == len(b"payload")
+
+
+def test_list_objects_recursive_walks_the_whole_subtree(tmp_path):
+    storage, _ = _make(tmp_path)
+
+    storage.put_object("papers", "root.pdf", b"root")
+    storage.put_object("papers", "2024/q1/deep.pdf", b"deep")
+
+    found = storage.list_objects_recursive("papers")
+
+    assert {key.rsplit("/", 1)[-1] for key in found} == {"root.pdf", "deep.pdf"}
+
+
+def test_list_objects_still_returns_direct_children_only(tmp_path):
+    storage, _ = _make(tmp_path)
+
+    storage.put_object("papers", "root.pdf", b"root")
+    storage.put_object("papers", "2024/q1/deep.pdf", b"deep")
+
+    shallow = {key.rsplit("/", 1)[-1] for key in storage.list_objects("papers")}
+
+    assert "root.pdf" in shallow
+    assert "deep.pdf" not in shallow
+
+
+def test_list_objects_recursive_strips_the_storage_prefix_like_list_objects(tmp_path):
+    storage, _ = _make(tmp_path)
+
+    storage.put_object("papers", "2024/deep.pdf", b"deep")
+
+    # The service strips a leading "storage/" before reaching the adapter, and
+    # it must do so for both listings or the two disagree on the same input.
+    assert storage.list_objects_recursive(
+        "storage/papers"
+    ) == storage.list_objects_recursive("papers")
+    assert storage.list_objects("storage/papers") == storage.list_objects("papers")

--- a/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterFS.py
+++ b/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterFS.py
@@ -104,6 +104,25 @@ class ObjectStorageSecondaryAdapterFS(IObjectStorageAdapter):
                     queue.put(obj)
             return objects
 
+    def list_objects_recursive(
+        self, prefix: str, queue: Queue | None = None
+    ) -> list[str]:
+        with self._lock:
+            self.__path_exists(prefix)
+            root = os.path.join(self.base_path, prefix)
+            objects = []
+            for dirpath, _dirnames, filenames in os.walk(root):
+                for filename in filenames:
+                    absolute = os.path.join(dirpath, filename)
+                    objects.append(
+                        os.path.join(prefix, os.path.relpath(absolute, root))
+                    )
+            objects.sort()
+            if queue:
+                for obj in objects:
+                    queue.put(obj)
+            return objects
+
     def get_object_metadata(self, prefix: str, key: str) -> ObjectMetaData:
         self.__path_exists(prefix, key)
 

--- a/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterFS_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterFS_test.py
@@ -1,8 +1,13 @@
 import io
 from concurrent.futures import ThreadPoolExecutor
 
+import pytest
+
 from naas_abi_core.services.object_storage.adapters.secondary.ObjectStorageSecondaryAdapterFS import (
     ObjectStorageSecondaryAdapterFS,
+)
+from naas_abi_core.services.object_storage.tests.object_storage__secondary_adapter__generic_test import (
+    ObjectStorageSecondaryAdapterContract,
 )
 
 
@@ -39,3 +44,9 @@ def test_atomic_concurrent_put(tmp_path):
 
     data = adapter.get_object("objects", "k.bin")
     assert data.startswith(b"value-")
+
+
+class TestObjectStorageSecondaryAdapterFS(ObjectStorageSecondaryAdapterContract):
+    @pytest.fixture
+    def adapter(self, tmp_path) -> ObjectStorageSecondaryAdapterFS:
+        return ObjectStorageSecondaryAdapterFS(base_path=str(tmp_path / "storage"))

--- a/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterFS_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterFS_test.py
@@ -2,7 +2,6 @@ import io
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
-
 from naas_abi_core.services.object_storage.adapters.secondary.ObjectStorageSecondaryAdapterFS import (
     ObjectStorageSecondaryAdapterFS,
 )

--- a/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterNaas.py
+++ b/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterNaas.py
@@ -149,6 +149,15 @@ class ObjectStorageSecondaryAdapterNaas(IObjectStorageAdapter):
 
         return self.__s3_adapter.list_objects(prefix, queue)
 
+    def list_objects_recursive(
+        self, prefix: str, queue: Queue | None = None
+    ) -> list[str]:
+        self.ensure_credentials()
+
+        assert self.__s3_adapter is not None
+
+        return self.__s3_adapter.list_objects_recursive(prefix, queue)
+
     def get_object_metadata(self, prefix: str, key: str) -> ObjectMetaData:
         self.ensure_credentials()
 

--- a/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterS3.py
+++ b/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterS3.py
@@ -229,6 +229,41 @@ class ObjectStorageSecondaryAdapterS3(IObjectStorageAdapter):
                             queue.put(prefix_key)
         return objects
 
+    def list_objects_recursive(
+        self, prefix: str, queue: Queue | None = None
+    ) -> list[str]:
+        """List every object at or beneath *prefix*, at any nesting depth.
+
+        Args:
+            prefix (str): Prefix/folder path to walk
+
+        Returns:
+            list[str]: Object keys at any depth. No ``Delimiter`` is sent, so S3
+                returns the flattened subtree and never a CommonPrefixes entry,
+                which is why no directory placeholders can appear here.
+        """
+        self.__object_exists(prefix)
+
+        objects = []
+        paginator = self.s3_client.get_paginator("list_objects_v2")
+
+        for page in paginator.paginate(
+            Bucket=self.bucket_name,
+            Prefix=self.__get_full_key(prefix),
+        ):
+            for obj in page.get("Contents", []):
+                key = obj["Key"]
+                if self.base_prefix:
+                    key = key.replace(f"{self.base_prefix}/", "", 1)
+                # A zero-byte marker object whose key ends in "/" is how some
+                # tools represent a folder; it is not a retrievable object.
+                if key == "" or key.endswith("/"):
+                    continue
+                objects.append(key)
+                if queue:
+                    queue.put(key)
+        return objects
+
     def get_object_metadata(self, prefix: str, key: str) -> ObjectMetaData:
         """Get object metadata from S3.
 

--- a/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterS3_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterS3_test.py
@@ -1,5 +1,12 @@
+import boto3
+import pytest
+from moto import mock_aws
+
 from naas_abi_core.services.object_storage.adapters.secondary.ObjectStorageSecondaryAdapterS3 import (
     ObjectStorageSecondaryAdapterS3,
+)
+from naas_abi_core.services.object_storage.tests.object_storage__secondary_adapter__generic_test import (
+    ObjectStorageSecondaryAdapterContract,
 )
 
 
@@ -45,3 +52,17 @@ def test_get_full_key_keeps_prefix_trailing_slash_for_list_operations(monkeypatc
     )
 
     assert full_prefix == "datastore/pernod_ricard/inputs/"
+
+
+class TestObjectStorageSecondaryAdapterS3(ObjectStorageSecondaryAdapterContract):
+    @pytest.fixture
+    def adapter(self):
+        with mock_aws():
+            boto3.client("s3", region_name="us-east-1").create_bucket(Bucket="abi")
+            yield ObjectStorageSecondaryAdapterS3(
+                bucket_name="abi",
+                access_key_id="testing",
+                secret_access_key="testing",
+                base_prefix="datastore",
+                region_name="us-east-1",
+            )

--- a/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterS3_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterS3_test.py
@@ -1,7 +1,6 @@
 import boto3
 import pytest
 from moto import mock_aws
-
 from naas_abi_core.services.object_storage.adapters.secondary.ObjectStorageSecondaryAdapterS3 import (
     ObjectStorageSecondaryAdapterS3,
 )

--- a/libs/naas-abi-core/naas_abi_core/services/object_storage/tests/object_storage__secondary_adapter__generic_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/object_storage/tests/object_storage__secondary_adapter__generic_test.py
@@ -1,0 +1,147 @@
+"""Shared conformance suite for object storage secondary adapters.
+
+Subclass ``ObjectStorageSecondaryAdapterContract`` from an adapter's own test
+module and supply the ``adapter`` fixture. Every adapter is then held to the
+same observable behaviour without restating it.
+
+The suite seeds through the port itself (``put_object``), so it makes no
+assumption about how an adapter stores bytes.
+"""
+
+from abc import ABC, abstractmethod
+from queue import Queue
+
+import pytest
+
+from naas_abi_core.services.object_storage.ObjectStoragePort import (
+    Exceptions,
+    IObjectStorageAdapter,
+)
+
+
+class ObjectStorageSecondaryAdapterContract(ABC):
+    @pytest.fixture
+    @abstractmethod
+    def adapter(self) -> IObjectStorageAdapter:
+        raise NotImplementedError()
+
+    # -- helpers ---------------------------------------------------------
+
+    @staticmethod
+    def _seed_tree(adapter: IObjectStorageAdapter, prefix: str = "papers") -> None:
+        """A subtree three levels deep, with siblings at every level."""
+        adapter.put_object(prefix, "root.pdf", b"root")
+        adapter.put_object(prefix, "2024/spring.pdf", b"spring")
+        adapter.put_object(prefix, "2024/q1/january.pdf", b"january")
+        adapter.put_object(prefix, "2024/q1/february.pdf", b"february")
+        adapter.put_object(prefix, "2025/summer.pdf", b"summer")
+
+    @staticmethod
+    def _basenames(keys: list[str]) -> set[str]:
+        return {key.rsplit("/", 1)[-1] for key in keys}
+
+    # -- recursive listing ------------------------------------------------
+
+    def test_recursive_listing_returns_objects_at_every_depth(
+        self, adapter: IObjectStorageAdapter
+    ):
+        self._seed_tree(adapter)
+
+        found = adapter.list_objects_recursive("papers")
+
+        assert self._basenames(found) == {
+            "root.pdf",
+            "spring.pdf",
+            "january.pdf",
+            "february.pdf",
+            "summer.pdf",
+        }
+
+    def test_recursive_listing_returns_no_directory_entries(
+        self, adapter: IObjectStorageAdapter
+    ):
+        self._seed_tree(adapter)
+
+        found = adapter.list_objects_recursive("papers")
+
+        assert len(found) == 5
+        for key in found:
+            assert not key.endswith("/"), f"{key!r} looks like a directory entry"
+        assert self._basenames(found).isdisjoint({"2024", "2025", "q1"})
+
+    def test_recursive_and_non_recursive_agree_on_whether_a_prefix_exists(
+        self, adapter: IObjectStorageAdapter
+    ):
+        # Stores disagree on whether a prefix with nothing under it exists at
+        # all: a filesystem keeps the directory, an object store does not
+        # represent one. The contract is only that the two listings agree.
+        adapter.put_object("emptied", "placeholder", b"x")
+        adapter.delete_object("emptied", "placeholder")
+
+        def outcome(call):
+            try:
+                return ("ok", call("emptied"))
+            except Exceptions.ObjectNotFound:
+                return ("not_found", None)
+
+        assert outcome(adapter.list_objects_recursive)[0] == (
+            outcome(adapter.list_objects)[0]
+        )
+
+    def test_recursive_listing_of_a_missing_prefix_raises_object_not_found(
+        self, adapter: IObjectStorageAdapter
+    ):
+        with pytest.raises(Exceptions.ObjectNotFound):
+            adapter.list_objects_recursive("no/such/prefix")
+
+    def test_recursive_listing_spans_more_than_one_provider_page(
+        self, adapter: IObjectStorageAdapter
+    ):
+        # Comfortably more than a single S3 list_objects_v2 page would be in a
+        # constrained test double, and enough to catch a truncated walk.
+        expected = set()
+        for index in range(120):
+            key = f"batch/{index // 10}/object-{index}.txt"
+            adapter.put_object("bulk", key, str(index).encode())
+            expected.add(f"object-{index}.txt")
+
+        found = adapter.list_objects_recursive("bulk")
+
+        assert self._basenames(found) == expected
+
+    def test_recursive_listing_feeds_the_queue_when_given_one(
+        self, adapter: IObjectStorageAdapter
+    ):
+        self._seed_tree(adapter)
+        queue: Queue = Queue()
+
+        found = adapter.list_objects_recursive("papers", queue)
+
+        drained = []
+        while not queue.empty():
+            drained.append(queue.get())
+        assert sorted(drained) == sorted(found)
+
+    # -- the existing depth-1 listing must not change ---------------------
+
+    def test_non_recursive_listing_still_returns_direct_children_only(
+        self, adapter: IObjectStorageAdapter
+    ):
+        self._seed_tree(adapter)
+
+        shallow = adapter.list_objects("papers")
+
+        assert "root.pdf" in self._basenames(shallow)
+        assert self._basenames(shallow).isdisjoint(
+            {"spring.pdf", "january.pdf", "february.pdf", "summer.pdf"}
+        )
+
+    def test_recursive_and_non_recursive_agree_on_a_flat_prefix(
+        self, adapter: IObjectStorageAdapter
+    ):
+        adapter.put_object("flat", "a.txt", b"a")
+        adapter.put_object("flat", "b.txt", b"b")
+
+        assert sorted(adapter.list_objects_recursive("flat")) == sorted(
+            adapter.list_objects("flat")
+        )

--- a/libs/naas-abi-core/naas_abi_core/services/object_storage/tests/object_storage__secondary_adapter__generic_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/object_storage/tests/object_storage__secondary_adapter__generic_test.py
@@ -12,7 +12,6 @@ from abc import ABC, abstractmethod
 from queue import Queue
 
 import pytest
-
 from naas_abi_core.services.object_storage.ObjectStoragePort import (
     Exceptions,
     IObjectStorageAdapter,

--- a/libs/naas-abi-core/pyproject.toml
+++ b/libs/naas-abi-core/pyproject.toml
@@ -103,6 +103,7 @@ allow-direct-references = true
 
 [dependency-groups]
 dev = [
+    "moto[s3]>=5.0.0",
     "mypy>=1.19.0",
     "pytest>=9.0.1",
     "python-semantic-release>=9.21.0",

--- a/libs/naas-abi-core/uv.lock
+++ b/libs/naas-abi-core/uv.lock
@@ -1128,6 +1128,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/47/16400cb42d18d7a6bb46f0626852c1718612e35dcb0dffa16bbaffdf5dd2/greenlet-3.3.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:c56692189a7d1c7606cb794be0a8381470d95c57ce5be03fb3d0ef57c7853b86", size = 278890, upload-time = "2026-02-20T20:19:39.263Z" },
     { url = "https://files.pythonhosted.org/packages/a3/90/42762b77a5b6aa96cd8c0e80612663d39211e8ae8a6cd47c7f1249a66262/greenlet-3.3.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ebd458fa8285960f382841da585e02201b53a5ec2bac6b156fc623b5ce4499f", size = 581120, upload-time = "2026-02-20T20:47:30.161Z" },
     { url = "https://files.pythonhosted.org/packages/bf/6f/f3d64f4fa0a9c7b5c5b3c810ff1df614540d5aa7d519261b53fba55d4df9/greenlet-3.3.2-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a443358b33c4ec7b05b79a7c8b466f5d275025e750298be7340f8fc63dff2a55", size = 594363, upload-time = "2026-02-20T20:55:56.965Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8b/1430a04657735a3f23116c2e0d5eb10220928846e4537a938a41b350bed6/greenlet-3.3.2-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4375a58e49522698d3e70cc0b801c19433021b5c37686f7ce9c65b0d5c8677d2", size = 605046, upload-time = "2026-02-20T21:02:45.234Z" },
     { url = "https://files.pythonhosted.org/packages/72/83/3e06a52aca8128bdd4dcd67e932b809e76a96ab8c232a8b025b2850264c5/greenlet-3.3.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e2cd90d413acbf5e77ae41e5d3c9b3ac1d011a756d7284d7f3f2b806bbd6358", size = 594156, upload-time = "2026-02-20T20:20:59.955Z" },
     { url = "https://files.pythonhosted.org/packages/70/79/0de5e62b873e08fe3cef7dbe84e5c4bc0e8ed0c7ff131bccb8405cd107c8/greenlet-3.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:442b6057453c8cb29b4fb36a2ac689382fc71112273726e2423f7f17dc73bf99", size = 1554649, upload-time = "2026-02-20T20:49:32.293Z" },
     { url = "https://files.pythonhosted.org/packages/5a/00/32d30dee8389dc36d42170a9c66217757289e2afb0de59a3565260f38373/greenlet-3.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:45abe8eb6339518180d5a7fa47fa01945414d7cca5ecb745346fc6a87d2750be", size = 1619472, upload-time = "2026-02-20T20:21:07.966Z" },
@@ -1136,6 +1137,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
     { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
     { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
     { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
     { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
     { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
@@ -1144,6 +1146,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -1152,6 +1155,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
     { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
     { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
     { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
     { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
     { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
@@ -1160,6 +1164,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
     { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
     { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
     { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
@@ -1991,6 +1996,30 @@ wheels = [
 ]
 
 [[package]]
+name = "moto"
+version = "5.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "cryptography" },
+    { name = "requests" },
+    { name = "responses" },
+    { name = "werkzeug" },
+    { name = "xmltodict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/0f/1682c01ca0608c25526afb150246a3c9c1f609caccbd39758de4850e31bc/moto-5.2.3.tar.gz", hash = "sha256:a9e95c3218b6eda18e74571f1ced11cb1bc3151467d562c1da6037b9d19832cb", size = 8785514, upload-time = "2026-08-22T18:46:00.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/80/ee7ace7a49bd525455497fa2ff198111877d6f93b908b657adeb2cf057a4/moto-5.2.3-py3-none-any.whl", hash = "sha256:5ec31b3cdbb383a19d46030157bd82aaaa7a9cc5f564200f995663d347bd4728", size = 6780972, upload-time = "2026-08-22T18:45:55.719Z" },
+]
+
+[package.optional-dependencies]
+s3 = [
+    { name = "py-partiql-parser" },
+    { name = "pyyaml" },
+]
+
+[[package]]
 name = "msal"
 version = "1.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2326,6 +2355,7 @@ ssh = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "moto", extra = ["s3"] },
     { name = "mypy" },
     { name = "pytest" },
     { name = "python-semantic-release" },
@@ -2394,6 +2424,7 @@ provides-extras = ["ssh", "aws", "qdrant", "sqlite-vec", "all", "openrouter", "d
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "moto", extras = ["s3"], specifier = ">=5.0.0" },
     { name = "mypy", specifier = ">=1.19.0" },
     { name = "pytest", specifier = ">=9.0.1" },
     { name = "python-semantic-release", specifier = ">=9.21.0" },
@@ -3238,6 +3269,15 @@ memory = [
 ]
 
 [[package]]
+name = "py-partiql-parser"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/7a/a0f6bda783eb4df8e3dfd55973a1ac6d368a89178c300e1b5b91cd181e5e/py_partiql_parser-0.6.3.tar.gz", hash = "sha256:09cecf916ce6e3da2c050f0cb6106166de42c33d34a078ec2eb19377ea70389a", size = 17456, upload-time = "2025-10-18T13:56:13.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/33/a7cbfccc39056a5cf8126b7aab4c8bafbedd4f0ca68ae40ecb627a2d2cd3/py_partiql_parser-0.6.3-py2.py3-none-any.whl", hash = "sha256:deb0769c3346179d2f590dcbde556f708cdb929059fb654bad75f4cf6e07f582", size = 23752, upload-time = "2025-10-18T13:56:12.256Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3874,6 +3914,20 @@ wheels = [
 ]
 
 [[package]]
+name = "responses"
+version = "0.26.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/47/f216a33221db8eff328987661cf18371afee89c62a62b434b963d6b509c9/responses-0.26.3.tar.gz", hash = "sha256:b0c11ca8131b8b227b8d5108e6ed39772222bd5aab030ed430e8f99057c4c409", size = 86335, upload-time = "2026-08-26T19:17:24.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/86/ca7958de70cb0752350575e98229368a3a2f746a2942034b3364e17312bb/responses-0.26.3-py3-none-any.whl", hash = "sha256:74474f799334ac4f37d93b6437ecc3bb1bb5c77a8d31780a338643be2dce0af8", size = 36289, upload-time = "2026-08-26T19:17:23.176Z" },
+]
+
+[[package]]
 name = "rich"
 version = "13.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -4024,8 +4078,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -4993,6 +5047,18 @@ wheels = [
 ]
 
 [[package]]
+name = "werkzeug"
+version = "3.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
+]
+
+[[package]]
 name = "win32-setctime"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5074,6 +5140,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
     { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
     { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
+]
+
+[[package]]
+name = "xmltodict"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/70/80f3b7c10d2630aa66414bf23d210386700aa390547278c789afa994fd7e/xmltodict-1.0.4.tar.gz", hash = "sha256:6d94c9f834dd9e44514162799d344d815a3a4faec913717a9ecbfa5be1bb8e61", size = 26124, upload-time = "2026-02-22T02:21:22.074Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/34/98a2f52245f4d47be93b580dae5f9861ef58977d73a79eb47c58f1ad1f3a/xmltodict-1.0.4-py3-none-any.whl", hash = "sha256:a4a00d300b0e1c59fc2bfccb53d7b2e88c32f200df138a0dd2229f842497026a", size = 13580, upload-time = "2026-02-22T02:21:21.039Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3584,7 +3584,7 @@ wheels = [
 
 [[package]]
 name = "naas-abi"
-version = "2.55.2"
+version = "2.61.0"
 source = { editable = "libs/naas-abi" }
 dependencies = [
     { name = "aiosqlite" },
@@ -3666,7 +3666,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-cli"
-version = "2.19.0"
+version = "2.21.0"
 source = { editable = "libs/naas-abi-cli" }
 dependencies = [
     { name = "naas-abi" },
@@ -3692,7 +3692,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-core"
-version = "2.28.1"
+version = "2.30.0"
 source = { editable = "libs/naas-abi-core" }
 dependencies = [
     { name = "click" },
@@ -3817,6 +3817,7 @@ provides-extras = ["ssh", "aws", "qdrant", "sqlite-vec", "all", "openrouter", "d
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "moto", extras = ["s3"], specifier = ">=5.0.0" },
     { name = "mypy", specifier = ">=1.19.0" },
     { name = "pytest", specifier = ">=9.0.1" },
     { name = "python-semantic-release", specifier = ">=9.21.0" },
@@ -3825,7 +3826,7 @@ dev = [
 
 [[package]]
 name = "naas-abi-marketplace"
-version = "3.39.0"
+version = "3.41.0"
 source = { editable = "libs/naas-abi-marketplace" }
 dependencies = [
     { name = "ijson" },


### PR DESCRIPTION
## Summary

`list_objects` returns direct children only — S3 and R2 send `Delimiter="/"`, FS uses `os.listdir` — so a caller that wants a whole subtree has no supported primitive and has to walk it a level at a time, one round trip per directory.

This adds `list_objects_recursive(prefix, queue=None)` to `IObjectStorageAdapter`, `IObjectStorageDomain` and `ObjectStorageService`.

- **FS** walks the tree and returns file keys only.
- **S3** drops the `Delimiter` and paginates, so the store flattens the subtree and no `CommonPrefixes` entry can appear. Zero-byte folder-marker keys ending in `/` are skipped.
- **R2** inherits the S3 implementation unchanged — it defines only `__init__`.
- **Naas** delegates to its inner S3 adapter, as it does for every other operation.

`list_objects` itself is untouched, and the shared suite asserts that.

## A shared conformance suite

Adapters are held to `object_storage__secondary_adapter__generic_test.py`, following the pattern `services/dataset/tests/` already uses. It seeds through the port (`put_object`), so it assumes nothing about how an adapter stores bytes.

FS and S3 both run it. S3 does so against **moto**, added as a `naas-abi-core` dev dependency — the existing S3 test double was `class _DummyS3Client: pass`, which cannot serve a functional listing test. Running against moto also means pagination and `Delimiter` behaviour are checked against real S3 semantics rather than my reading of them.

R2 and Naas are covered transitively: neither contains any recursive-listing logic to validate, and wiring them to the suite would exercise moto rather than their code. An earlier attempt to do so spent 62 seconds making real TLS calls to `r2.cloudflarestorage.com`, since moto only intercepts AWS-shaped URLs — so no test here reaches a live service.

## One deliberate omission from the contract

The suite does **not** assert an outcome for a prefix with nothing under it.

That case is genuinely different per store: a filesystem keeps the directory after its last file is removed, while an object store does not represent an empty prefix at all — the prefix dies with its last object, and `__object_exists` correctly raises. Pinning either answer would make the contract unsatisfiable for one of the two.

What it asserts instead is the invariant that actually matters to callers: the recursive and non-recursive listings must **agree** with each other on whether a prefix exists.

## Validation

- `naas_abi_core/services/object_storage`: 33 passed
- `mypy -p naas_abi_core --follow-untyped-imports`: Success, no issues in 516 source files
- Full `naas-abi-core` suite compared against a pristine worktree of the same base commit, same command and interpreter: **same 35 failures**, errors down 67 → 46, passes up 447 → 656. The pre-existing failures are unrelated (missing optional extras, integration tests needing external services).

## Why

Written while building a paper-ingestion pipeline that takes storage locations as input and needs their whole subtree. Implementing the walk in the consuming module would have cost a round trip per directory level against S3, and every future module would have rewritten it.

