### PR TITLE
fix(nexus): renew user sessions automatically

### DIFF
--- a/docs/adr/20260908_nexus_session_renewal.md
+++ b/docs/adr/20260908_nexus_session_renewal.md
@@ -1,0 +1,39 @@
+# Nexus automatic session renewal
+
+Status: Accepted
+
+Date: 2026-09-08
+
+## Context
+
+Nexus persists access and refresh tokens in browser storage. Access tokens expire
+in 30 minutes by default. The API rotates refresh tokens and grants each new
+refresh token another 30 days. Previously, renewal only followed a failed API
+request. Concurrent requests could rotate the same credential, temporary server
+failures caused logout, and the middleware auth flag expired without renewal.
+
+## Decision
+
+Mount a session lifecycle manager at the web application root. Check every 30
+seconds and on focus, visibility, pageshow, and network recovery. Renew within
+60 seconds of access-token expiry; authenticated fetches also check before use.
+Refresh requests time out after 15 seconds and may retry on the next lifecycle
+check. These are frontend reliability defaults, independent of DDS policies.
+
+Share pending refreshes within each store and use the browser Web Locks API to
+serialize rotation across tabs. Read persisted credentials after obtaining the
+lock, adopt other tabs' rotations/logout, and discard responses superseded by a
+login or logout. Renew the middleware routing flag as sessions remain active.
+Only definitive credential rejection clears a session; network, rate-limit,
+and server failures preserve credentials for recovery.
+
+## Consequences
+
+Sessions can renew indefinitely while Nexus is running. Returning within the
+existing 30-day refresh window restores the session without login. A browser
+closed longer than that window, cleared storage, or a revoked credential still
+requires login. Browsers without Web Locks only deduplicate within one tab.
+
+This changes security-sensitive session behavior but does not extend backend
+credential lifetimes or change token storage. The routing cookie is only a UI
+hint; API token validation remains authoritative. No migration is required.

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/layout.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import localFont from 'next/font/local';
 import Script from 'next/script';
 import { AnalyticsPageTracker } from '@/components/analytics-page-tracker';
+import { AuthSessionManager } from '@/components/auth-session-manager';
 import { ThemeProvider } from '@/components/theme-provider';
 import { TenantProvider } from '@/contexts/tenant-context';
 import { WebSocketProvider } from '@/contexts/websocket-context';
@@ -136,6 +137,7 @@ export default function RootLayout({
           disableTransitionOnChange
         >
           <TenantProvider>
+            <AuthSessionManager />
             <WebSocketProvider>
               <AnalyticsPageTracker />
               {children}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/auth-session-manager.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/auth-session-manager.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import { useEffect } from 'react';
+import { startAuthSessionLifecycle } from '@/lib/auth-session-lifecycle';
+
+export function AuthSessionManager() {
+  useEffect(startAuthSessionLifecycle, []);
+  return null;
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/auth-session-lifecycle.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/auth-session-lifecycle.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { startAuthSessionLifecycle } from './auth-session-lifecycle';
+import { shouldRefreshAccessToken } from './auth-session';
+
+const { state, sync } = vi.hoisted(() => ({
+  state: { token: '', refreshToken: 'refresh', refreshAccessToken: vi.fn() },
+  sync: vi.fn(),
+}));
+vi.mock('@/stores/auth', () => ({
+  syncPersistedAuthSession: sync,
+  useAuthStore: {
+    getState: () => state,
+    persist: { hasHydrated: () => true, onFinishHydration: () => vi.fn() },
+  },
+}));
+const jwt = (expires: number) => `header.${btoa(JSON.stringify({ exp: expires }))}.signature`;
+let stop: () => void;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.stubGlobal('window', Object.assign(new EventTarget(), { setInterval, clearInterval }));
+  vi.stubGlobal('document', Object.assign(new EventTarget(), { cookie: '' }));
+  state.token = jwt(Date.now() / 1000 + 120);
+  state.refreshAccessToken.mockClear();
+  state.refreshToken = 'refresh';
+});
+afterEach(() => { stop?.(); vi.useRealTimers(); vi.unstubAllGlobals(); });
+
+it('renews before expiry and removes its timer on unmount', () => {
+  stop = startAuthSessionLifecycle();
+  expect(state.refreshAccessToken).not.toHaveBeenCalled();
+  vi.advanceTimersByTime(60000);
+  expect(state.refreshAccessToken).toHaveBeenCalledTimes(1);
+  stop();
+  vi.advanceTimersByTime(60000);
+  expect(state.refreshAccessToken).toHaveBeenCalledTimes(1);
+});
+
+it.each(['focus', 'online', 'pageshow'])('renews on %s after browser sleep', (event) => {
+  stop = startAuthSessionLifecycle();
+  state.token = jwt(Date.now() / 1000 - 1);
+  window.dispatchEvent(new Event(event));
+  expect(state.refreshAccessToken).toHaveBeenCalledTimes(1);
+});
+
+it('renews when visibility changes', () => {
+  stop = startAuthSessionLifecycle();
+  state.token = jwt(Date.now() / 1000 - 1);
+  document.dispatchEvent(new Event('visibilitychange'));
+  expect(state.refreshAccessToken).toHaveBeenCalledTimes(1);
+});
+
+it('does not renew a logged-out session', () => {
+  state.refreshToken = '';
+  state.token = '';
+  stop = startAuthSessionLifecycle();
+  vi.advanceTimersByTime(60000);
+  expect(state.refreshAccessToken).not.toHaveBeenCalled();
+});
+
+it('handles absent and malformed tokens without throwing', () => {
+  expect(shouldRefreshAccessToken(null)).toBe(true);
+  expect(shouldRefreshAccessToken('bad')).toBe(true);
+  expect(shouldRefreshAccessToken(jwt(Date.now() / 1000 + 1800))).toBe(false);
+});

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/auth-session-lifecycle.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/auth-session-lifecycle.ts
@@ -1,0 +1,34 @@
+import { shouldRefreshAccessToken, setAuthFlagCookie } from './auth-session';
+import { syncPersistedAuthSession, useAuthStore } from '@/stores/auth';
+
+/** Keep sessions renewed, including after browser sleep and network recovery. */
+export function startAuthSessionLifecycle(): () => void {
+  const renew = () => {
+    if (!useAuthStore.persist.hasHydrated()) return;
+    syncPersistedAuthSession();
+    const state = useAuthStore.getState();
+    if (!state.refreshToken) return;
+    setAuthFlagCookie();
+    if (shouldRefreshAccessToken(state.token)) void state.refreshAccessToken();
+  };
+  const onStorage = (event: StorageEvent) => {
+    if (event.key === 'nexus-auth') renew();
+  };
+  const unsubscribe = useAuthStore.persist.onFinishHydration(renew);
+  const timer = window.setInterval(renew, 30000);
+  window.addEventListener('focus', renew);
+  window.addEventListener('online', renew);
+  window.addEventListener('pageshow', renew);
+  window.addEventListener('storage', onStorage);
+  document.addEventListener('visibilitychange', renew);
+  renew();
+  return () => {
+    unsubscribe();
+    window.clearInterval(timer);
+    window.removeEventListener('focus', renew);
+    window.removeEventListener('online', renew);
+    window.removeEventListener('pageshow', renew);
+    window.removeEventListener('storage', onStorage);
+    document.removeEventListener('visibilitychange', renew);
+  };
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/auth-session.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/auth-session.ts
@@ -57,3 +57,14 @@ export function mergeAuthPersistedState<T extends PersistedAuthSnapshot>(
 
   return { ...current, ...stored } as T;
 }
+
+/** Refresh one minute before JWT expiry; the API remains the validation authority. */
+export function shouldRefreshAccessToken(token: string | null, now = Date.now()): boolean {
+  if (!token) return true;
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')));
+    return typeof payload.exp !== 'number' || payload.exp * 1000 <= now + 60000;
+  } catch {
+    return true;
+  }
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/auth.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/auth.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { authFetch, syncPersistedAuthSession, useAuthStore } from './auth';
+import { getSafeStorage } from '@/lib/safe-storage';
+
+vi.mock('@/lib/config', () => ({ getApiUrl: () => 'https://api.example.test' }));
+const jwt = () => `header.${btoa(JSON.stringify({ exp: Date.now() / 1000 + 1800 }))}.signature`;
+const response = (status: number, body = {}) => new Response(JSON.stringify(body), { status });
+const session = () => useAuthStore.setState({
+  token: jwt(), refreshToken: 'refresh-old', isAuthenticated: true,
+  user: { id: '1', email: 'test@example.test', name: 'Test', createdAt: new Date() },
+});
+
+beforeEach(() => {
+  session();
+  vi.stubGlobal('fetch', vi.fn());
+});
+afterEach(() => vi.unstubAllGlobals());
+
+describe('session renewal', () => {
+  it('shares one rotation across concurrent callers', async () => {
+    vi.mocked(fetch).mockResolvedValue(response(200, { access_token: jwt(), refresh_token: 'refresh-new' }));
+    expect(await Promise.all(Array.from({ length: 5 }, () => useAuthStore.getState().refreshAccessToken())))
+      .toEqual([true, true, true, true, true]);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(useAuthStore.getState().refreshToken).toBe('refresh-new');
+  });
+
+  it.each([429, 500, 502, 503])('keeps credentials after refresh HTTP %s', async (status) => {
+    vi.mocked(fetch).mockResolvedValue(response(status));
+    expect(await useAuthStore.getState().refreshAccessToken()).toBe(false);
+    expect(useAuthStore.getState().refreshToken).toBe('refresh-old');
+    expect(useAuthStore.getState().isAuthenticated).toBe(true);
+  });
+
+  it('keeps the session when /me expires and refresh is offline', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(response(401)).mockRejectedValueOnce(new TypeError('offline'));
+    expect(await useAuthStore.getState().checkAuth()).toBe(true);
+    expect(useAuthStore.getState().refreshToken).toBe('refresh-old');
+  });
+
+  it('keeps the session when the /me retry has a server error', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(response(401))
+      .mockResolvedValueOnce(response(200, { access_token: jwt(), refresh_token: 'refresh-new' }))
+      .mockResolvedValueOnce(response(503));
+    expect(await useAuthStore.getState().checkAuth()).toBe(true);
+    expect(useAuthStore.getState().refreshToken).toBe('refresh-new');
+  });
+
+  it('authFetch keeps credentials when refresh is unavailable', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(response(401)).mockResolvedValueOnce(response(503));
+    expect((await authFetch('/api/workspaces')).status).toBe(401);
+    expect(useAuthStore.getState().isAuthenticated).toBe(true);
+  });
+
+  it('renews an expired token before sending an API request', async () => {
+    useAuthStore.setState({ token: 'expired' });
+    vi.mocked(fetch).mockResolvedValueOnce(response(200, { access_token: 'fresh-token', refresh_token: 'refresh-new' }))
+      .mockResolvedValueOnce(response(200));
+    expect((await authFetch('/api/workspaces')).status).toBe(200);
+    expect(vi.mocked(fetch).mock.calls[0][0]).toContain('/api/auth/refresh');
+    expect(new Headers(vi.mocked(fetch).mock.calls[1][1]?.headers).get('Authorization')).toBe('Bearer fresh-token');
+  });
+
+  it('retries a late 401 using a token already renewed by another request', async () => {
+    let finish!: (value: Response) => void;
+    vi.mocked(fetch).mockImplementationOnce(() => new Promise((resolve) => { finish = resolve; }))
+      .mockResolvedValueOnce(response(200));
+    const pending = authFetch('/api/workspaces');
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+    useAuthStore.setState({ token: 'already-renewed', refreshToken: 'refresh-new' });
+    finish(response(401));
+    expect((await pending).status).toBe(200);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(new Headers(vi.mocked(fetch).mock.calls[1][1]?.headers).get('Authorization')).toBe('Bearer already-renewed');
+  });
+
+  it('does not restore a user after logout during /me validation', async () => {
+    let finish!: (value: Response) => void;
+    vi.mocked(fetch).mockImplementationOnce(() => new Promise((resolve) => { finish = resolve; }));
+    const pending = useAuthStore.getState().checkAuth();
+    useAuthStore.getState().logout();
+    finish(response(200, { id: '1' }));
+    expect(await pending).toBe(false);
+    expect(useAuthStore.getState().user).toBeNull();
+  });
+
+  it('logs out when the refresh credential is rejected', async () => {
+    vi.mocked(fetch).mockResolvedValue(response(401));
+    expect(await useAuthStore.getState().refreshAccessToken()).toBe(false);
+    expect(useAuthStore.getState().refreshToken).toBeNull();
+    expect(useAuthStore.getState().isAuthenticated).toBe(false);
+  });
+
+  it('does not restore a session after logout during refresh', async () => {
+    let finish!: (value: Response) => void;
+    vi.mocked(fetch).mockImplementation(() => new Promise((resolve) => { finish = resolve; }));
+    const pending = useAuthStore.getState().refreshAccessToken();
+    useAuthStore.getState().logout();
+    finish(response(200, { access_token: jwt(), refresh_token: 'refresh-new' }));
+    expect(await pending).toBe(false);
+    expect(useAuthStore.getState().token).toBeNull();
+  });
+
+  it('adopts another tab rotation after obtaining the browser lock', async () => {
+    vi.stubGlobal('navigator', { locks: { request: vi.fn(async (_name, callback) => {
+      getSafeStorage().setItem('nexus-auth', JSON.stringify({ state: {
+        token: 'other-token', refreshToken: 'other-refresh', isAuthenticated: true,
+      } }));
+      return callback();
+    }) } });
+    expect(await useAuthStore.getState().refreshAccessToken()).toBe(true);
+    expect(fetch).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().token).toBe('other-token');
+  });
+
+  it('adopts explicit logout from another tab', () => {
+    getSafeStorage().setItem('nexus-auth', JSON.stringify({ state: {
+      token: null, refreshToken: null, user: null, isAuthenticated: false,
+    } }));
+    syncPersistedAuthSession();
+    expect(useAuthStore.getState().isAuthenticated).toBe(false);
+    expect(useAuthStore.getState().token).toBeNull();
+  });
+});

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/auth.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/auth.ts
@@ -5,7 +5,7 @@
 
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
-import { clearAuthFlagCookie, mergeAuthPersistedState, setAuthFlagCookie } from '@/lib/auth-session';
+import { clearAuthFlagCookie, mergeAuthPersistedState, setAuthFlagCookie, shouldRefreshAccessToken } from '@/lib/auth-session';
 import { getSafeStorage } from '@/lib/safe-storage';
 
 export interface User {
@@ -47,7 +47,9 @@ import { getApiUrl } from '@/lib/config';
 
 export const useAuthStore = create<AuthState>()(
   persist(
-    (set, get) => ({
+    (set, get) => {
+      let refreshPromise: Promise<boolean> | null = null;
+      return {
       // Initial state
       user: null,
       token: null,
@@ -297,36 +299,49 @@ export const useAuthStore = create<AuthState>()(
         set({ error: null });
       },
 
-      // Silently exchange the refresh token for a new access token.
-      // Returns true on success, false if the refresh token is missing or rejected.
-      refreshAccessToken: async (): Promise<boolean> => {
-        const { refreshToken } = get();
-        if (!refreshToken) return false;
+      // Share rotation within a tab, and serialize it across tabs where supported.
+      refreshAccessToken: (): Promise<boolean> => {
+        if (refreshPromise) return refreshPromise;
+        const originalRefreshToken = get().refreshToken;
+        const refresh = async (): Promise<boolean> => {
+          // Another tab may have rotated or logged out while we waited for the lock.
+          syncPersistedAuthSession();
+          const { refreshToken } = get();
+          if (!refreshToken) return false;
+          if (refreshToken !== originalRefreshToken) return Boolean(get().token);
 
-        try {
-          const apiBase = getApiUrl();
-          const response = await fetch(`${apiBase}/api/auth/refresh`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ refresh_token: refreshToken }),
-          });
-
-          if (!response.ok) {
-            // Refresh token is expired or invalid — force full logout
-            set({ user: null, token: null, refreshToken: null, isAuthenticated: false });
+          try {
+            const response = await fetch(`${getApiUrl()}/api/auth/refresh`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ refresh_token: refreshToken }),
+              signal: AbortSignal.timeout(15000),
+            });
+            // A login/logout during this request owns the newer state.
+            syncPersistedAuthSession();
+            if (get().refreshToken !== refreshToken) return false;
+            if (!response.ok) {
+              if (response.status === 401 || response.status === 403) get().logout();
+              return false;
+            }
+            const data = await response.json();
+            if (get().refreshToken !== refreshToken) return false;
+            if (!data.access_token || !data.refresh_token) return false;
+            set({ token: data.access_token, refreshToken: data.refresh_token, isAuthenticated: true });
+            setAuthFlagCookie();
+            return true;
+          } catch {
+            // Offline, timeout, or server failure: keep credentials for the next attempt.
             return false;
           }
-
-          const data = await response.json();
-          set({
-            token: data.access_token,
-            refreshToken: data.refresh_token ?? null,
-          });
-          return true;
-        } catch {
-          // Network error — don't clear state, let the caller decide
-          return false;
-        }
+        };
+        refreshPromise = (async () => {
+          if (typeof navigator !== 'undefined' && navigator.locks) {
+            return await navigator.locks.request('nexus-auth-refresh', refresh);
+          }
+          return await refresh();
+        })().finally(() => { refreshPromise = null; });
+        return refreshPromise;
       },
 
       // Check if current token is valid; silently refreshes if expired.
@@ -337,8 +352,7 @@ export const useAuthStore = create<AuthState>()(
         if (!token) {
           const refreshed = await get().refreshAccessToken();
           if (!refreshed) {
-            set({ isAuthenticated: false, user: null });
-            return false;
+            return get().isAuthenticated;
           }
         }
 
@@ -351,24 +365,28 @@ export const useAuthStore = create<AuthState>()(
             },
           });
 
+          if (get().token !== currentToken) return get().isAuthenticated;
           if (response.status === 401) {
             // Access token rejected — try refresh once
             const refreshed = await get().refreshAccessToken();
             if (!refreshed) {
-              set({ isAuthenticated: false, user: null, token: null });
-              return false;
+              if (!get().refreshToken) get().logout();
+              return get().isAuthenticated;
             }
             // Retry /me with the new token
             const newToken = get().token;
             const retryResponse = await fetch(`${apiBase}/api/auth/me`, {
               headers: { 'Authorization': `Bearer ${newToken}` },
             });
+            if (get().token !== newToken) return get().isAuthenticated;
             if (!retryResponse.ok) {
-              set({ isAuthenticated: false, user: null, token: null, refreshToken: null });
-              return false;
+              if (retryResponse.status === 401 || retryResponse.status === 403) get().logout();
+              return get().isAuthenticated;
             }
             const retryUser = await retryResponse.json();
+            if (get().token !== newToken) return get().isAuthenticated;
             const normalizeAvatar = (a?: string) => (a && a.startsWith('/') ? `${apiBase}${a}` : a);
+            setAuthFlagCookie();
             set({ user: { ...retryUser, avatar: normalizeAvatar(retryUser?.avatar) }, isAuthenticated: true });
             return true;
           }
@@ -379,7 +397,9 @@ export const useAuthStore = create<AuthState>()(
           }
 
           const user = await response.json();
+          if (get().token !== currentToken) return get().isAuthenticated;
           const normalizeAvatar = (a?: string) => (a && a.startsWith('/') ? `${apiBase}${a}` : a);
+          setAuthFlagCookie();
           set({ user: { ...user, avatar: normalizeAvatar(user?.avatar) }, isAuthenticated: true });
           return true;
         } catch {
@@ -387,7 +407,8 @@ export const useAuthStore = create<AuthState>()(
           return get().isAuthenticated;
         }
       },
-    }),
+    };
+    },
     {
       name: 'nexus-auth',
       storage: createJSONStorage(() => getSafeStorage()),
@@ -433,18 +454,25 @@ export async function authFetch(url: string, options: RequestInit = {}): Promise
   begin();
 
   try {
-    const response = await makeRequest(useAuthStore.getState().token);
+    if (shouldRefreshAccessToken(useAuthStore.getState().token)) {
+      await useAuthStore.getState().refreshAccessToken();
+    }
+    const requestToken = useAuthStore.getState().token;
+    const response = await makeRequest(requestToken);
 
     if (response.status === 401) {
       // Try a silent token refresh
-      const refreshed = await useAuthStore.getState().refreshAccessToken();
+      const refreshed = useAuthStore.getState().token !== requestToken
+        ? Boolean(useAuthStore.getState().token)
+        : await useAuthStore.getState().refreshAccessToken();
       if (refreshed) {
         // Retry the original request with the new token
         return await makeRequest(useAuthStore.getState().token);
       }
 
-      // Refresh failed — full logout
-      console.warn('Auth token expired and refresh failed, logging out...');
+      // Temporary refresh failures must not destroy a recoverable session.
+      if (useAuthStore.getState().refreshToken) return response;
+
       useAuthStore.getState().logout();
       // Skip redirect if already on an auth route — otherwise we trigger a
       // reload loop with stores that auto-fetch on hydration.
@@ -456,5 +484,27 @@ export async function authFetch(url: string, options: RequestInit = {}): Promise
     return response;
   } finally {
     end();
+  }
+}
+
+/** Adopt rotations and explicit logout from other tabs before using shared credentials. */
+export function syncPersistedAuthSession(): void {
+  try {
+    const raw = getSafeStorage().getItem('nexus-auth');
+    if (!raw) return;
+    const { state } = JSON.parse(raw);
+    if (!state || !('refreshToken' in state)) return;
+    const current = useAuthStore.getState();
+    if (current.token === state.token && current.refreshToken === state.refreshToken) return;
+    useAuthStore.setState({
+      user: state.user ?? null,
+      token: state.token ?? null,
+      refreshToken: state.refreshToken ?? null,
+      isAuthenticated: Boolean(state.isAuthenticated),
+    });
+    if (state.isAuthenticated) setAuthFlagCookie();
+    else clearAuthFlagCookie();
+  } catch {
+    // An unreadable storage snapshot must not replace a live session.
   }
 }


### PR DESCRIPTION
Nexus could log users out when concurrent requests raced to rotate refresh tokens or when a temporary outage interrupted renewal. Sessions now renew before access-token expiry and recover automatically after browser sleep or network reconnection.

- Share refresh requests within a tab and coordinate rotation across tabs using Web Locks.
- Preserve credentials on network, rate-limit, and server failures; clear sessions on definitive credential rejection.
- Synchronize rotated credentials and logout across tabs, discard stale authentication responses, and renew the middleware routing cookie.
- Document the behavior and reliability defaults in an ADR.

The existing backend lifetime remains unchanged: active sessions can renew indefinitely, but more than 30 days without renewal still requires login. Browsers without Web Locks deduplicate refreshes within each tab only. No database migration is required.

Validation: 28 targeted Vitest tests passed, `pnpm typecheck` passed, and ESLint passed for all changed frontend files. `git diff --check` passed. Browser end-to-end testing was not performed.

The repository commit hook also passed core and marketplace quality/security checks and the Nexus production build. The build reported existing warnings in unrelated files.
