### PR TITLE
feat(core): add dataset flushing, compaction, and catalog monitoring

### DIFF
--- a/docs/adr/20260910_dataset-compaction-dagster.md
+++ b/docs/adr/20260910_dataset-compaction-dagster.md
@@ -1,0 +1,63 @@
+# Dataset compaction through Dagster
+
+Status: Accepted
+
+Date: 2026-09-10
+
+## Context
+
+Repeated dataset writes can leave small Parquet files in DuckLake partitions.
+The Dagster application currently discovers module orchestrations, while dataset
+maintenance belongs to the core service and must use its configured catalog and
+object-store credentials.
+
+## Decision
+
+Expose per-dataset `flush` and `compact` through the existing dataset port
+and service, returning the existing `QueryResult` statistics type. Keep maintenance
+SQL and transaction conflict retries in the DuckLake secondary adapter. Register a
+built-in Dagster job at the application composition root when datasets are enabled,
+injecting the engine service as a resource alongside existing module definitions.
+
+Offer manual execution and a daily schedule at 02:00 UTC, running by default.
+Process datasets sequentially, with optional namespace/name selection, flushing
+before compacting each dataset. Reuse the
+adapter's existing retry and SQLite serialization policy, without Dagster retries.
+Default the adapter's per-connection inlining limit to 1,000 rows, configurable
+through `data_inlining_row_limit`. Honor persisted catalog/schema/table overrides.
+Do not rewrite catalog settings during attach, which would add metadata writes
+to every operation and override operator choices. External writers must configure
+their own limit or use a persisted DuckLake option.
+
+Expose `inlined_row_count` for periodic pressure checks, using DuckLake 1.0's
+inline-table registry inside the adapter. Count physical insertion records across
+schema versions, including historical/deleted records, rather than pretending to
+measure total catalog bytes. Separate inline deletion markers are not counted.
+
+Add an hourly Dagster monitor with a configurable 100,000-record warning threshold
+per dataset. The daily job also checks before flushing. Emit `DatasetCatalogPressure`
+using the canonical LogProcess event contract and existing ServiceBase event wiring,
+with fail-open publication. These are core framework services; reuse their existing
+event communication contract. Do not introduce another cross-domain transport or
+new persistence adapter. Keep monitoring off the ingestion path. Warnings repeat
+on each over-limit check; the threshold is advisory, not an enforced storage limit.
+Use service warnings, Dagster logs, and output metadata for observability.
+
+## Consequences
+
+The service stays independent of Dagster. Every dataset adapter must implement the
+new port methods. Each flush and compaction commits independently; failures are visible as failed
+runs, and reruns may revisit completed datasets. The job preserves snapshot history
+and partition boundaries. It does not expire snapshots, delete
+old files, or guarantee one output file per partition. Table-level compaction is
+explicit, so bulk-call `auto_compact` exclusions do not apply. Operators run the
+Dagster daemon to automate execution; saved stopped schedule overrides still need
+to be enabled. Flushing alone does not guarantee that the catalog's on-disk file
+shrinks. PostgreSQL and SQLite database maintenance remains separate.
+
+The current DuckLake extension can retain stale inline-table references on a
+kept-open read connection after flushing old schema versions. Retire the local
+cached connection after flushing. A stale-inline-table failure caused by another
+process also retires the connection, but the failed call is surfaced; the next
+call reattaches. Do not automatically replay arbitrary SQL exposed by `query`,
+which permits mutations and multi-statement requests.

--- a/libs/naas-abi-core/naas_abi_core/apps/__init__.py
+++ b/libs/naas-abi-core/naas_abi_core/apps/__init__.py
@@ -1,0 +1,1 @@
+"""Application composition roots."""

--- a/libs/naas-abi-core/naas_abi_core/apps/dagster/AGENTS.md
+++ b/libs/naas-abi-core/naas_abi_core/apps/dagster/AGENTS.md
@@ -1,0 +1,86 @@
+# Dagster application
+
+## Purpose
+
+Composition root for module orchestrations and built-in service maintenance jobs.
+Keep Dagster imports here; services and outbound ports remain framework-independent.
+
+## Files
+
+- `dagster.py`: loads the engine and merges module and service definitions.
+- `DatasetCompaction.py`: dataset flush/compaction and pressure-monitoring jobs,
+  resource binding, and schedules.
+- `DatasetCompaction_test.py`: job selection, schedule, empty catalog, and failure tests.
+
+## Port and service API
+
+Inject `DatasetService` through the `dataset_compaction_service` Dagster resource.
+The jobs call `list`, `describe`, `check_catalog_pressure`, `flush`, and `compact`;
+DuckLake SQL belongs in the dataset
+secondary adapter. See `../../services/dataset/AGENTS.md` for the service contract.
+
+## Adapters and factory
+
+`dataset_compaction_definitions(service)` builds the job and schedule with the
+engine's configured service. Register only when `dataset_available()` is true.
+Preserve module definitions when adding other built-in jobs.
+
+## Operations
+
+Launch `dataset_compaction_job` manually, or use `dataset_compaction_daily` in
+Dagster. The schedule defaults to running at 02:00 UTC. Each dataset is checked for
+catalog pressure, flushed regardless of its inline count, then compacted.
+Scheduled execution requires a running Dagster daemon. A previously saved stopped
+schedule remains stopped until explicitly enabled in Dagster.
+
+`dataset_catalog_monitor_job` checks all datasets without flushing or compacting.
+Its `dataset_catalog_monitor_hourly` schedule defaults to running hourly, in UTC.
+It emits a `DatasetCatalogPressure` event through the service when unflushed
+insertion records reach the configured limit. No extra scan is added to writes.
+
+Default run config processes all service datasets sequentially. Optional Launchpad
+config targets a namespace or a single dataset:
+
+```yaml
+ops:
+  compact_datasets:
+    config:
+      namespace: analytics
+      name: events
+      inline_warning_threshold: 100000
+```
+
+Omit `name` to process every dataset in the namespace; omit both for all namespaces.
+A name without a namespace targets `default`. Each flush and compaction has its
+own transaction; a failure fails the run and earlier completed work remains
+committed. A failed flush prevents the corresponding compaction. Adapter
+conflict retries apply; no additional Dagster retries are configured.
+
+The monitoring op uses `ops.check_dataset_catalogs.config.inline_warning_threshold`
+with the same 100,000-record default. Set a positive integer. Warnings are emitted
+on every over-limit check, including the daily check; they are not a strict size
+limit or immediate notification on crossing. Counts include historical/deleted
+insertion records, but exclude separate inline delete markers and catalog metadata.
+Event publication failure is logged and does not block flushing/compaction.
+
+Maintenance preserves partition boundaries and snapshot history. It does not
+expire snapshots or clean up files. Explicit table selection also
+means DuckLake's bulk-call `auto_compact` exclusion is not consulted. Compaction
+size follows the catalog's `target_file_size` setting; one file per partition per
+day is not guaranteed. Logging uses Dagster run
+logs for per-dataset results and output metadata for the processed dataset count;
+no new metrics or tracing stack is introduced.
+
+## Tests
+
+From the repository root:
+
+```bash
+uv run pytest -o addopts='' libs/naas-abi-core/naas_abi_core/apps/dagster libs/naas-abi-core/naas_abi_core/services/dataset
+```
+
+## Adding a new adapter
+
+Implement the dataset port including `flush`, `compact`, and `inlined_row_count`;
+unsupported maintenance must raise
+`NotImplementedError`. Do not add adapter-specific SQL to the Dagster job.

--- a/libs/naas-abi-core/naas_abi_core/apps/dagster/DatasetCompaction.py
+++ b/libs/naas-abi-core/naas_abi_core/apps/dagster/DatasetCompaction.py
@@ -1,0 +1,97 @@
+"""Dagster entry point for dataset file maintenance."""
+
+import dagster as dg
+
+from naas_abi_core.services.dataset.DatasetService import DatasetService
+
+
+@dg.op(
+    required_resource_keys={"dataset_compaction_service"},
+    config_schema={
+        "namespace": dg.Field(dg.Noneable(str), default_value=None),
+        "name": dg.Field(dg.Noneable(str), default_value=None),
+        "inline_warning_threshold": dg.Field(int, default_value=100_000),
+    },
+)
+def compact_datasets(context: dg.OpExecutionContext) -> None:
+    service: DatasetService = context.resources.dataset_compaction_service
+    namespace = context.op_config["namespace"]
+    name = context.op_config["name"]
+    if name is not None:
+        datasets = [service.describe(name, namespace=namespace or "default")]
+    else:
+        datasets = service.list(namespace=namespace)
+    for dataset in datasets:
+        service.check_catalog_pressure(
+            dataset.name,
+            namespace=dataset.namespace,
+            threshold_records=context.op_config["inline_warning_threshold"],
+        )
+        flushed = service.flush(dataset.name, namespace=dataset.namespace)
+        context.log.info(
+            "Flushed %s.%s: %s", dataset.namespace, dataset.name, flushed.rows
+        )
+        result = service.compact(dataset.name, namespace=dataset.namespace)
+        context.log.info(
+            "Compacted %s.%s: %s", dataset.namespace, dataset.name, result.rows
+        )
+    context.add_output_metadata({"datasets_processed": len(datasets)})
+
+
+@dg.job(
+    description="Flush inline data, then merge small files within partitions; preserve snapshots."
+)
+def dataset_compaction_job() -> None:
+    compact_datasets()
+
+
+@dg.op(
+    required_resource_keys={"dataset_compaction_service"},
+    config_schema={"inline_warning_threshold": dg.Field(int, default_value=100_000)},
+)
+def check_dataset_catalogs(context: dg.OpExecutionContext) -> None:
+    service: DatasetService = context.resources.dataset_compaction_service
+    for dataset in service.list():
+        count = service.check_catalog_pressure(
+            dataset.name,
+            namespace=dataset.namespace,
+            threshold_records=context.op_config["inline_warning_threshold"],
+        )
+        context.log.info(
+            "%s.%s: %s unflushed catalog records",
+            dataset.namespace,
+            dataset.name,
+            count,
+        )
+
+
+@dg.job(description="Report accumulated inline records without interrupting ingestion.")
+def dataset_catalog_monitor_job() -> None:
+    check_dataset_catalogs()
+
+
+def dataset_compaction_definitions(service: DatasetService) -> dg.Definitions:
+    return dg.Definitions(
+        jobs=[dataset_compaction_job, dataset_catalog_monitor_job],
+        resources={
+            "dataset_compaction_service": dg.ResourceDefinition.hardcoded_resource(
+                service
+            )
+        },
+        schedules=[
+            dg.ScheduleDefinition(
+                name="dataset_compaction_daily",
+                job=dataset_compaction_job,
+                cron_schedule="0 2 * * *",
+                execution_timezone="UTC",
+                default_status=dg.DefaultScheduleStatus.RUNNING,
+            ),
+            dg.ScheduleDefinition(
+                name="dataset_catalog_monitor_hourly",
+                job=dataset_catalog_monitor_job,
+                cron_schedule="0 * * * *",
+                execution_timezone="UTC",
+                default_status=dg.DefaultScheduleStatus.RUNNING,
+            ),
+        ],
+    )

--- a/libs/naas-abi-core/naas_abi_core/apps/dagster/DatasetCompaction_test.py
+++ b/libs/naas-abi-core/naas_abi_core/apps/dagster/DatasetCompaction_test.py
@@ -1,0 +1,131 @@
+import runpy
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import Mock, call
+
+import pytest
+from dagster import DefaultScheduleStatus, Definitions, job
+
+from naas_abi_core.apps.dagster.DatasetCompaction import dataset_compaction_definitions
+from naas_abi_core.orchestrations.DagsterOrchestration import DagsterOrchestration
+from naas_abi_core.services.dataset.DatasetPort import QueryResult
+from naas_abi_core.services.dataset.DatasetService import DatasetService
+
+
+@pytest.mark.parametrize(
+    "config, expected",
+    [
+        ({}, [("a", "first"), ("b", "second")]),
+        ({"namespace": "first"}, [("a", "first")]),
+        ({"name": "a", "namespace": "first"}, [("a", "first")]),
+        ({"name": "a"}, [("a", "default")]),
+    ],
+)
+def test_job_targets_datasets(config, expected):
+    service = Mock(spec=DatasetService)
+    service.list.side_effect = lambda namespace: [
+        SimpleNamespace(name=name, namespace=scope)
+        for name, scope in [("a", "first"), ("b", "second")]
+        if namespace is None or scope == namespace
+    ]
+    service.describe.side_effect = lambda name, namespace: SimpleNamespace(
+        name=name, namespace=namespace
+    )
+    service.compact.return_value = QueryResult(columns=[], rows=[])
+    definitions = dataset_compaction_definitions(service)
+    Definitions.validate_loadable(definitions)
+    result = definitions.get_job_def("dataset_compaction_job").execute_in_process(
+        run_config={"ops": {"compact_datasets": {"config": config}}}
+    )
+    assert result.success
+    assert [
+        (call.args[0], call.kwargs["namespace"])
+        for call in service.compact.call_args_list
+    ] == expected
+    schedule = definitions.get_schedule_def("dataset_compaction_daily")
+    assert schedule.default_status == DefaultScheduleStatus.RUNNING
+    assert schedule.cron_schedule == "0 2 * * *"
+    assert schedule.execution_timezone == "UTC"
+    operations = [c for c in service.mock_calls if c[0] in ("flush", "compact")]
+    assert operations == [
+        operation
+        for name, namespace in expected
+        for operation in (
+            call.flush(name, namespace=namespace),
+            call.compact(name, namespace=namespace),
+        )
+    ]
+
+
+def test_empty_catalog_and_failed_compaction():
+    service = Mock(spec=DatasetService)
+    service.list.return_value = []
+    job = dataset_compaction_definitions(service).get_job_def("dataset_compaction_job")
+    assert job.execute_in_process().success
+    service.compact.assert_not_called()
+    service.list.return_value = [SimpleNamespace(name="a", namespace="first")]
+    service.compact.side_effect = RuntimeError("compaction failed")
+    assert not job.execute_in_process(raise_on_error=False).success
+
+
+def test_failed_flush_prevents_compaction():
+    service = Mock(spec=DatasetService)
+    service.list.return_value = [SimpleNamespace(name="events", namespace="analytics")]
+    service.flush.side_effect = RuntimeError("flush failed")
+    job = dataset_compaction_definitions(service).get_job_def("dataset_compaction_job")
+    assert not job.execute_in_process(raise_on_error=False).success
+    service.compact.assert_not_called()
+
+
+def test_catalog_monitor_only_checks_pressure():
+    service = Mock(spec=DatasetService)
+    service.list.return_value = [SimpleNamespace(name="events", namespace="analytics")]
+    definitions = dataset_compaction_definitions(service)
+    result = definitions.get_job_def("dataset_catalog_monitor_job").execute_in_process(
+        run_config={
+            "ops": {
+                "check_dataset_catalogs": {"config": {"inline_warning_threshold": 2000}}
+            }
+        }
+    )
+    assert result.success
+    service.check_catalog_pressure.assert_called_once_with(
+        "events", namespace="analytics", threshold_records=2000
+    )
+    service.flush.assert_not_called()
+    service.compact.assert_not_called()
+    schedule = definitions.get_schedule_def("dataset_catalog_monitor_hourly")
+    assert schedule.default_status == DefaultScheduleStatus.RUNNING
+    assert schedule.cron_schedule == "0 * * * *"
+
+
+@pytest.mark.parametrize("available", [True, False])
+def test_app_registers_maintenance_alongside_module_jobs(monkeypatch, available):
+    @job
+    def module_job():
+        pass
+
+    class ModuleOrchestration(DagsterOrchestration):
+        @classmethod
+        def New(cls):
+            return cls(Definitions(jobs=[module_job]))
+
+    engine = SimpleNamespace(
+        load=Mock(),
+        services=SimpleNamespace(
+            dataset_available=lambda: available, dataset=Mock(spec=DatasetService)
+        ),
+        modules={"example": SimpleNamespace(orchestrations=[ModuleOrchestration])},
+    )
+    engine_module = ModuleType("naas_abi_core.engine.Engine")
+    engine_module.Engine = lambda: engine
+    monkeypatch.setitem(sys.modules, "naas_abi_core.engine.Engine", engine_module)
+    definitions = runpy.run_path(str(Path(__file__).with_name("dagster.py")))[
+        "definitions"
+    ]
+    Definitions.validate_loadable(definitions)
+    assert definitions.get_job_def("module_job").name == "module_job"
+    names = {definition.name for definition in definitions.jobs}
+    assert ("dataset_compaction_job" in names) is available
+    engine.load.assert_called_once()

--- a/libs/naas-abi-core/naas_abi_core/apps/dagster/__init__.py
+++ b/libs/naas-abi-core/naas_abi_core/apps/dagster/__init__.py
@@ -1,0 +1,1 @@
+"""Dagster application and built-in maintenance jobs."""

--- a/libs/naas-abi-core/naas_abi_core/apps/dagster/dagster.py
+++ b/libs/naas-abi-core/naas_abi_core/apps/dagster/dagster.py
@@ -1,7 +1,8 @@
-
 from typing import cast
 
 from dagster import Definitions
+
+from naas_abi_core.apps.dagster.DatasetCompaction import dataset_compaction_definitions
 from naas_abi_core.engine.Engine import Engine
 from naas_abi_core.orchestrations.DagsterOrchestration import DagsterOrchestration
 
@@ -10,19 +11,26 @@ engine.load()
 
 all_definitions: list[Definitions] = []
 
+if engine.services.dataset_available():
+    all_definitions.append(dataset_compaction_definitions(engine.services.dataset))
+
 for module in engine.modules.values():
     for orchestration in module.orchestrations:
         if issubclass(orchestration, DagsterOrchestration):
-            assert issubclass(orchestration, DagsterOrchestration), "Orchestration must be a subclass of DagsterOrchestration"
+            assert issubclass(orchestration, DagsterOrchestration), (
+                "Orchestration must be a subclass of DagsterOrchestration"
+            )
             dagster_orchestration_cls = cast(
                 type[DagsterOrchestration],
                 orchestration,
             )
-            dagster_orchestration: DagsterOrchestration = dagster_orchestration_cls.New()
+            dagster_orchestration: DagsterOrchestration = (
+                dagster_orchestration_cls.New()
+            )
             definitions = dagster_orchestration.definitions
 
             all_definitions.append(definitions)
-            
+
 if all_definitions:
     definitions = Definitions.merge(*all_definitions)
 else:

--- a/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_DatasetService.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_DatasetService.py
@@ -44,6 +44,7 @@ class DatasetAdapterDuckLakeConfiguration(BaseModel):
 
     catalog: str = "sqlite:storage/datasets.sqlite"
     data_path: str = "storage/datasets/"
+    data_inlining_row_limit: int = Field(default=1000, ge=0)
     max_retries: int = Field(default=10, ge=0)
     retry_base_delay_seconds: float = Field(default=0.05, ge=0)
     retry_max_delay_seconds: float = Field(default=1.0, ge=0)

--- a/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_DatasetService_test.py
+++ b/libs/naas-abi-core/naas_abi_core/engine/engine_configuration/EngineConfiguration_DatasetService_test.py
@@ -24,6 +24,7 @@ def test_dataset_service_configuration(tmp_path):
     adapter = configuration.dataset_adapter.load()
     assert isinstance(adapter, IDatasetPort)
     assert isinstance(adapter, DatasetSecondaryAdapterDuckLake)
+    assert adapter._data_inlining_row_limit == 1000
 
     service = configuration.load()
     assert isinstance(service, DatasetService)
@@ -66,3 +67,18 @@ def test_dataset_defaults_do_not_overlap_object_storage_namespace():
 
     assert configuration.catalog == "sqlite:storage/datasets.sqlite"
     assert configuration.data_path == "storage/datasets/"
+    assert configuration.data_inlining_row_limit == 1000
+
+
+def test_dataset_inlining_configuration(tmp_path):
+    with pytest.raises(ValueError):
+        DatasetAdapterDuckLakeConfiguration(data_inlining_row_limit=-1)
+    configuration = DatasetAdapterConfiguration(
+        adapter="ducklake",
+        config={
+            "catalog": f"sqlite:{tmp_path / 'catalog.sqlite'}",
+            "data_path": str(tmp_path / "data"),
+            "data_inlining_row_limit": 2000,
+        },
+    )
+    assert configuration.load()._data_inlining_row_limit == 2000

--- a/libs/naas-abi-core/naas_abi_core/services/dataset/AGENTS.md
+++ b/libs/naas-abi-core/naas_abi_core/services/dataset/AGENTS.md
@@ -32,6 +32,9 @@ class IDatasetPort:
     def list(*, namespace=None) -> list[DatasetInfo]
     def write(name, rows, *, namespace="default", mode="append"|"replace"|"upsert", snapshot_id=None) -> DatasetInfo
     def query(sql, *, namespace="default", snapshot_id=None) -> QueryResult
+    def compact(name, *, namespace="default") -> QueryResult
+    def flush(name, *, namespace="default") -> QueryResult
+    def inlined_row_count(name, *, namespace="default") -> int
     def list_snapshots() -> list[DatasetSnapshotInfo]
     def drop(name, *, namespace="default") -> None
 ```
@@ -60,12 +63,19 @@ services:
       config:
         catalog: "sqlite:storage/datasets.sqlite"
         data_path: "storage/datasets/"
+        data_inlining_row_limit: 1000
         max_retries: 10
         retry_base_delay_seconds: 0.05
         retry_max_delay_seconds: 1.0
 ```
 
 Default is that block.
+
+The adapter passes `DATA_INLINING_ROW_LIMIT` on every connection, including fresh
+connections used by retries. It is a per-insert row limit, not an accumulated
+catalog limit. Set it to 0 to disable inlining. Persisted DuckLake table, schema,
+or catalog overrides take precedence; this default does not rewrite those options
+or change connections opened outside the service. Larger inserts still use Parquet.
 
 `data_path` may instead use an `s3://` or `s3a://` URI, which keeps table data
 wherever the deployment persists datasets rather than on a container disk. Other
@@ -127,6 +137,40 @@ Every connection attaches with `AUTOMATIC_MIGRATION`, so the adapter initializes
 - `abi stack snapshot create` stops the stack, then captures `postgres_data` and `storage/`; this produces a coherent local-deployment backup for both PostgreSQL and SQLite catalogs.
 - Flush inlined rows before storage-only maintenance with `CALL ducklake_flush_inlined_data('abi_datasets')`.
 - Compact adjacent small files with `CALL ducklake_merge_adjacent_files('abi_datasets')`.
+- Application callers can use `service.compact(name, namespace="default")`, which
+  returns maintenance statistics and uses the adapter's write conflict retries.
+  It preserves partitions and snapshots and does not flush inlined data or delete
+  old files. Missing datasets raise `DatasetNotFoundError`.
+- Dagster registers `dataset_compaction_job` when the service is enabled. Launch it
+  manually or use `dataset_compaction_daily` (02:00 UTC, running by default).
+  The job calls `flush` before `compact` for each dataset, even for small totals.
+  Flushing and compaction are separate transactions, both with adapter retries.
+  A failed flush prevents compaction of that dataset. A failed compaction leaves
+  successfully flushed data intact for the next run.
+  Flush retires this adapter's cached read connection because DuckLake can drop
+  old inline tables. If another process flushes, an affected cached reader can
+  report a stale inline-table error once; the adapter retires that connection so
+  the next call reattaches. Arbitrary `query()` SQL is not replayed automatically
+  because it can contain writes or multiple statements.
+  Optional op config selects `namespace` and `name`; otherwise it processes all
+  service datasets. See `../../apps/dagster/AGENTS.md` for run config and semantics.
+- `inlined_row_count` reads DuckLake's inline-table registry and counts insertion
+  records across schema versions, including deleted/historical records still in
+  the inline tables. It does not scan Parquet. It excludes separate inline delete
+  markers and does not measure catalog bytes or total metadata/history overhead.
+  The adapter owns access to these DuckLake 1.0 metadata tables.
+- `service.check_catalog_pressure(name, namespace=..., threshold_records=100_000)`
+  logs a warning and publishes `DatasetCatalogPressure` through the engine-wired
+  event service on each check at or above the threshold. This follows the existing
+  core service `ServiceBase` event wiring convention. Publication is fail-open;
+  failures are logged. Without an event service, the warning is still logged.
+  The event is defined under `ontologies/classes/ontology_naas_ai/abi/dataset/` and
+  described by `ontologies/modules/DatasetEventOntology.ttl`; it inherits the
+  canonical `LogProcess` contract. It signals accumulation, not data loss.
+- `dataset_catalog_monitor_hourly` checks all datasets hourly without flushing.
+  The daily maintenance job also checks before flushing. Both schedules default
+  to running but require the Dagster daemon; persisted stopped overrides remain
+  stopped. Checks are outside the write path and warnings repeat while over limit.
 - Configure a retention window with DuckLake's `expire_older_than` option, then run `CALL ducklake_expire_snapshots('abi_datasets')` followed by `CALL ducklake_cleanup_old_files('abi_datasets')`. Never expire snapshots still required by restore/audit policy.
 - Moving from a SQLite catalog to PostgreSQL is a metadata migration. A DSN change alone loses snapshot history and any inlined rows.
 

--- a/libs/naas-abi-core/naas_abi_core/services/dataset/DatasetPort.py
+++ b/libs/naas-abi-core/naas_abi_core/services/dataset/DatasetPort.py
@@ -216,6 +216,25 @@ class IDatasetPort(ABC):
         """Run SQL against datasets in ``namespace``. Tables are registered by dataset name."""
 
     @abstractmethod
+    def flush(self, name: str, *, namespace: str = "default") -> QueryResult:
+        """Materialize inlined data as Parquet while preserving snapshot history."""
+
+    @abstractmethod
+    def inlined_row_count(self, name: str, *, namespace: str = "default") -> int:
+        """Count unflushed insertion records, including historical/deleted rows.
+
+        This is a pressure indicator, not total catalog bytes or live row count.
+        """
+
+    @abstractmethod
+    def compact(self, name: str, *, namespace: str = "default") -> QueryResult:
+        """Merge eligible small files within partitions, preserving snapshots.
+
+        Returns adapter maintenance statistics. Does not flush inlined rows,
+        expire snapshots, or delete old files. Raises DatasetNotFoundError.
+        """
+
+    @abstractmethod
     def list_snapshots(self) -> builtins.list[DatasetSnapshotInfo]:
         """List the coherent, catalog-level snapshots available for time travel."""
 

--- a/libs/naas-abi-core/naas_abi_core/services/dataset/DatasetService.py
+++ b/libs/naas-abi-core/naas_abi_core/services/dataset/DatasetService.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import builtins
 from typing import Any
 
+from naas_abi_core import logger
 from naas_abi_core.services.dataset.DatasetPort import (
     DatasetInfo,
     DatasetSnapshotInfo,
@@ -12,6 +13,9 @@ from naas_abi_core.services.dataset.DatasetPort import (
     IDatasetPort,
     QueryResult,
     WriteMode,
+)
+from naas_abi_core.services.dataset.ontologies.classes.ontology_naas_ai.abi.dataset.DatasetCatalogPressure import (
+    DatasetCatalogPressure,
 )
 from naas_abi_core.services.ServiceBase import ServiceBase
 
@@ -62,9 +66,49 @@ class DatasetService(ServiceBase, IDatasetPort):
         namespace: str = "default",
         snapshot_id: int | None = None,
     ) -> QueryResult:
-        return self.__adapter.query(
-            sql, namespace=namespace, snapshot_id=snapshot_id
-        )
+        return self.__adapter.query(sql, namespace=namespace, snapshot_id=snapshot_id)
+
+    def compact(self, name: str, *, namespace: str = "default") -> QueryResult:
+        return self.__adapter.compact(name, namespace=namespace)
+
+    def flush(self, name: str, *, namespace: str = "default") -> QueryResult:
+        return self.__adapter.flush(name, namespace=namespace)
+
+    def inlined_row_count(self, name: str, *, namespace: str = "default") -> int:
+        return self.__adapter.inlined_row_count(name, namespace=namespace)
+
+    def check_catalog_pressure(
+        self, name: str, *, namespace: str = "default", threshold_records: int = 100_000
+    ) -> int:
+        """Measure accumulation and emit a warning event on each over-limit check."""
+        if threshold_records <= 0:
+            raise ValueError("threshold_records must be positive")
+        count = self.inlined_row_count(name, namespace=namespace)
+        if count >= threshold_records:
+            logger.warning(
+                "Dataset {}.{} has {} unflushed catalog records (threshold {}); "
+                "run dataset flushing and compaction.",
+                namespace,
+                name,
+                count,
+                threshold_records,
+            )
+            if self.services_wired and self.services.events_available():
+                try:
+                    self.services.events.publish(
+                        DatasetCatalogPressure(
+                            dataset_name=name,
+                            namespace=namespace,
+                            inlined_records=count,
+                            threshold_records=threshold_records,
+                        )
+                    )
+                except Exception as exc:  # noqa: BLE001 - event publication is fail-open
+                    logger.warning(
+                        "Dataset catalog pressure event publication failed: {}",
+                        type(exc).__name__,
+                    )
+        return count
 
     def list_snapshots(self) -> builtins.list[DatasetSnapshotInfo]:
         return self.__adapter.list_snapshots()

--- a/libs/naas-abi-core/naas_abi_core/services/dataset/DatasetService_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/dataset/DatasetService_test.py
@@ -1,5 +1,11 @@
+import pytest
 from naas_abi_core.services.dataset.DatasetFactory import DatasetFactory
-from naas_abi_core.services.dataset.DatasetPort import ColumnSpec, DatasetSpec
+from naas_abi_core.services.dataset.DatasetPort import (
+    ColumnSpec,
+    DatasetNotFoundError,
+    DatasetSpec,
+    PartitionSpec,
+)
 from naas_abi_core.services.dataset.DatasetService import DatasetService
 
 
@@ -41,3 +47,52 @@ def test_factory_forwards_adapter_options(tmp_path):
     assert adapter._s3.configured is True
     assert adapter._s3.endpoint == "http://minio:9000"
     assert adapter._max_retries == 3
+
+
+def test_compaction_merges_partition_files_and_preserves_history(tmp_path):
+    service = DatasetFactory.DatasetServiceDuckLake(
+        f"sqlite:{tmp_path / 'datasets.sqlite'}", str(tmp_path / "warehouse")
+    )
+    service.create(
+        DatasetSpec(
+            name="events",
+            namespace="analytics",
+            columns=(
+                ColumnSpec(name="id", type="integer"),
+                ColumnSpec(name="region", type="string"),
+            ),
+            partitions=(PartitionSpec(column="region"),),
+        )
+    )
+    service.query(
+        "CALL abi_datasets.set_option('data_inlining_row_limit', 0)",
+        namespace="analytics",
+    )
+    snapshots = []
+    for i in range(3):
+        snapshots.append(
+            service.write(
+                "events",
+                [{"id": i, "region": region} for region in ("eu", "us")],
+                namespace="analytics",
+            )
+        )
+    files_sql = "SELECT count(*) AS n FROM ducklake_list_files('abi_datasets', 'events', schema => 'analytics')"
+    before = service.query(files_sql, namespace="analytics").rows[0]["n"]
+    result = service.compact("events", namespace="analytics")
+    after = service.query(files_sql, namespace="analytics").rows[0]["n"]
+    assert before == 6
+    assert after == 2
+    assert result.rows
+    assert service.query(
+        "SELECT count(*) AS n FROM events", namespace="analytics"
+    ).rows == [{"n": 6}]
+    assert service.query(
+        "SELECT count(*) AS n FROM events",
+        namespace="analytics",
+        snapshot_id=snapshots[0].snapshot_id,
+    ).rows == [{"n": 2}]
+    service.compact("events", namespace="analytics")
+    assert service.query(files_sql, namespace="analytics").rows[0]["n"] == after
+    with pytest.raises(DatasetNotFoundError):
+        service.compact("missing", namespace="analytics")

--- a/libs/naas-abi-core/naas_abi_core/services/dataset/adapters/secondary/DatasetSecondaryAdapterDuckLake.py
+++ b/libs/naas-abi-core/naas_abi_core/services/dataset/adapters/secondary/DatasetSecondaryAdapterDuckLake.py
@@ -135,6 +135,7 @@ class DatasetSecondaryAdapterDuckLake(IDatasetPort):
         data_path: str,
         *,
         max_retries: int = 10,
+        data_inlining_row_limit: int = 1000,
         retry_base_delay_seconds: float = 0.05,
         retry_max_delay_seconds: float = 1.0,
         s3_endpoint: str = "",
@@ -144,6 +145,9 @@ class DatasetSecondaryAdapterDuckLake(IDatasetPort):
         s3_url_style: str = "",
         s3_use_ssl: bool | None = None,
     ) -> None:
+        if data_inlining_row_limit < 0:
+            raise ValueError("data_inlining_row_limit must be non-negative")
+        self._data_inlining_row_limit = data_inlining_row_limit
         if max_retries < 0:
             raise ValueError("max_retries must be greater than or equal to zero")
         if retry_base_delay_seconds < 0:
@@ -371,6 +375,68 @@ class DatasetSecondaryAdapterDuckLake(IDatasetPort):
 
         self._write_transaction(operation)
 
+    def inlined_row_count(self, name: str, *, namespace: str = "default") -> int:
+        con = self._connect()
+        try:
+            con.execute("BEGIN")
+            self._load_spec(con, namespace, name)
+            metadata = self._ident(f"__ducklake_metadata_{CATALOG_ALIAS}")
+            tables = con.execute(
+                f"SELECT i.table_name FROM {metadata}.ducklake_inlined_data_tables i "
+                f"JOIN {metadata}.ducklake_table t ON i.table_id = t.table_id "
+                f"JOIN {metadata}.ducklake_schema s ON t.schema_id = s.schema_id "
+                "WHERE t.table_name = ? AND s.schema_name = ? "
+                "AND t.end_snapshot IS NULL AND s.end_snapshot IS NULL",
+                [name, namespace],
+            ).fetchall()
+            count = sum(
+                int(
+                    con.execute(
+                        f"SELECT count(*) FROM {metadata}.{self._ident(table)}"
+                    ).fetchone()[0]
+                )
+                for (table,) in tables
+            )
+            con.execute("COMMIT")
+            return count
+        finally:
+            con.close()
+
+    def flush(self, name: str, *, namespace: str = "default") -> QueryResult:
+        result = self._maintain(name, namespace=namespace, flush=True)
+        # Flush can drop inline tables from older schema versions. New reads
+        # must attach again; existing cursors retain their connection reference.
+        with self._read_connection_lock:
+            self._read_connection = None
+        return result
+
+    def compact(self, name: str, *, namespace: str = "default") -> QueryResult:
+        return self._maintain(name, namespace=namespace, flush=False)
+
+    def _maintain(self, name: str, *, namespace: str, flush: bool) -> QueryResult:
+        def operation(con: Any) -> QueryResult:
+            self._load_spec(con, namespace, name)
+            if flush:
+                sql = (
+                    f"CALL ducklake_flush_inlined_data({self._sql_string(CATALOG_ALIAS)}, "
+                    f"table_name => {self._sql_string(name)}, "
+                    f"schema_name => {self._sql_string(namespace)})"
+                )
+            else:
+                sql = (
+                    f"CALL ducklake_merge_adjacent_files({self._sql_string(CATALOG_ALIAS)}, "
+                    f"{self._sql_string(name)}, schema => {self._sql_string(namespace)})"
+                )
+            result = con.execute(sql)
+            columns = [str(column[0]) for column in result.description or []]
+            return QueryResult(
+                columns=columns,
+                rows=[dict(zip(columns, row)) for row in result.fetchall()],
+            )
+
+        result, _ = self._write_transaction(operation)
+        return result
+
     def _connect(self, *, snapshot_id: int | None = None) -> Any:
         import duckdb
 
@@ -385,6 +451,7 @@ class DatasetSecondaryAdapterDuckLake(IDatasetPort):
             self._configure_object_store(con)
             options = [
                 "AUTOMATIC_MIGRATION",
+                f"DATA_INLINING_ROW_LIMIT {int(self._data_inlining_row_limit)}",
                 f"DATA_PATH {self._sql_string(self._data_path)}",
             ]
             if snapshot_id is not None:
@@ -425,9 +492,23 @@ class DatasetSecondaryAdapterDuckLake(IDatasetPort):
         cursor's error (bad SQL, a missing table) does not affect the shared
         connection or any other cursor.
         """
-        cursor = self._get_read_connection().cursor()
+        import duckdb
+
+        connection = self._get_read_connection()
+        cursor = connection.cursor()
         try:
             return operation(cursor)
+        except duckdb.CatalogException as exc:
+            # Another process may flush and drop a cached inline table. Retire
+            # this connection for subsequent calls without interrupting cursors
+            # already using it. Do not replay arbitrary SQL: query() allows writes.
+            if "Failed to read inlined data from DuckLake" in str(
+                exc
+            ) and "does not exist" in str(exc):
+                with self._read_connection_lock:
+                    if self._read_connection is connection:
+                        self._read_connection = None
+            raise
         finally:
             cursor.close()
 

--- a/libs/naas-abi-core/naas_abi_core/services/dataset/ontologies/classes/ontology_naas_ai/abi/dataset/DatasetCatalogPressure.py
+++ b/libs/naas-abi-core/naas_abi_core/services/dataset/ontologies/classes/ontology_naas_ai/abi/dataset/DatasetCatalogPressure.py
@@ -1,0 +1,24 @@
+"""Catalog accumulation event using the canonical event-service contract."""
+
+from typing import ClassVar
+
+from naas_abi_core.services.event.ontologies.modules.EventOntology import LogProcess
+from pydantic import Field
+
+
+class DatasetCatalogPressure(LogProcess):
+    _class_uri: ClassVar[str] = (
+        "http://ontology.naas.ai/abi/dataset/DatasetCatalogPressure"
+    )
+    _property_uris: ClassVar[dict] = {
+        **LogProcess._property_uris,
+        "dataset_name": "http://ontology.naas.ai/abi/dataset/datasetName",
+        "namespace": "http://ontology.naas.ai/abi/dataset/namespace",
+        "inlined_records": "http://ontology.naas.ai/abi/dataset/inlinedRecords",
+        "threshold_records": "http://ontology.naas.ai/abi/dataset/thresholdRecords",
+    }
+
+    dataset_name: str
+    namespace: str
+    inlined_records: int = Field(ge=0)
+    threshold_records: int = Field(gt=0)

--- a/libs/naas-abi-core/naas_abi_core/services/dataset/ontologies/modules/DatasetEventOntology.ttl
+++ b/libs/naas-abi-core/naas_abi_core/services/dataset/ontologies/modules/DatasetEventOntology.ttl
@@ -1,0 +1,22 @@
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix abi: <http://ontology.naas.ai/abi/> .
+@prefix ds: <http://ontology.naas.ai/abi/dataset/> .
+
+ds:DatasetEventOntology a owl:Ontology ;
+    owl:imports <http://ontology.naas.ai/abi/EventService> .
+
+ds:DatasetCatalogPressure a owl:Class ;
+    rdfs:subClassOf abi:LogProcess ;
+    rdfs:label "Dataset catalog pressure" ;
+    rdfs:comment "Unflushed insertion records reached a warning threshold; this does not indicate data loss." .
+
+ds:datasetName a owl:DatatypeProperty ;
+    rdfs:domain ds:DatasetCatalogPressure ; rdfs:range xsd:string .
+ds:namespace a owl:DatatypeProperty ;
+    rdfs:domain ds:DatasetCatalogPressure ; rdfs:range xsd:string .
+ds:inlinedRecords a owl:DatatypeProperty ;
+    rdfs:domain ds:DatasetCatalogPressure ; rdfs:range xsd:nonNegativeInteger .
+ds:thresholdRecords a owl:DatatypeProperty ;
+    rdfs:domain ds:DatasetCatalogPressure ; rdfs:range xsd:positiveInteger .

--- a/libs/naas-abi-core/naas_abi_core/services/dataset/tests/DatasetMaintenance_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/dataset/tests/DatasetMaintenance_test.py
@@ -1,0 +1,178 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from naas_abi_core.services.dataset.DatasetFactory import DatasetFactory
+from naas_abi_core.services.dataset.DatasetPort import (
+    ColumnSpec,
+    DatasetNotFoundError,
+    DatasetSpec,
+    IDatasetPort,
+    PartitionSpec,
+)
+from naas_abi_core.services.dataset.DatasetService import DatasetService
+from naas_abi_core.services.dataset.ontologies.classes.ontology_naas_ai.abi.dataset.DatasetCatalogPressure import (
+    DatasetCatalogPressure,
+)
+from naas_abi_core.services.event.adapters.secondary.EventSQLiteAdapter import (
+    EventSQLiteAdapter,
+)
+from naas_abi_core.services.event.EventService import EventService
+
+
+@pytest.fixture
+def service(tmp_path):
+    service = DatasetFactory.DatasetServiceDuckLake(
+        f"sqlite:{tmp_path / 'catalog.sqlite'}", str(tmp_path / "data")
+    )
+    for namespace in ("analytics", "other"):
+        service.create(
+            DatasetSpec(
+                name="events",
+                namespace=namespace,
+                columns=(
+                    ColumnSpec(name="id", type="integer"),
+                    ColumnSpec(name="region", type="string"),
+                ),
+                partitions=(PartitionSpec(column="region"),),
+                primary_key=("id",),
+            )
+        )
+    return service
+
+
+def files(service):
+    return service.query(
+        "SELECT count(*) AS n FROM ducklake_list_files('abi_datasets', 'events', schema => 'analytics')",
+        namespace="analytics",
+    ).rows[0]["n"]
+
+
+def test_inline_accumulation_flush_and_history(service):
+    snapshots = []
+    for batch in range(3):
+        snapshots.append(
+            service.write(
+                "events",
+                [
+                    {"id": batch * 999 + i, "region": "eu" if i % 2 else "us"}
+                    for i in range(999)
+                ],
+                namespace="analytics",
+            )
+        )
+    assert files(service) == 0
+    assert service.inlined_row_count("events", namespace="analytics") == 2997
+    service.write("events", [{"id": 1, "region": "eu"}], namespace="other")
+    flushed = service.flush("events", namespace="analytics")
+    assert sum(row["rows_flushed"] for row in flushed.rows) == 2997
+    assert service.inlined_row_count("events", namespace="analytics") == 0
+    assert service.inlined_row_count("events", namespace="other") == 1
+    assert files(service) == 2
+    service.compact("events", namespace="analytics")
+    for i, snapshot in enumerate(snapshots):
+        assert service.query(
+            "SELECT count(*) AS n FROM events",
+            namespace="analytics",
+            snapshot_id=snapshot.snapshot_id,
+        ).rows == [{"n": (i + 1) * 999}]
+    assert service.flush("events", namespace="analytics").rows == []
+
+
+def test_large_batch_bypasses_inlining(service):
+    service.write(
+        "events",
+        [{"id": i, "region": "eu"} for i in range(1001)],
+        namespace="analytics",
+    )
+    assert service.inlined_row_count("events", namespace="analytics") == 0
+    assert files(service) == 1
+
+
+def test_persisted_override_takes_precedence(service):
+    service.query(
+        "CALL abi_datasets.set_option('data_inlining_row_limit', 0)",
+        namespace="analytics",
+    )
+    service.write("events", [{"id": 1, "region": "eu"}], namespace="analytics")
+    assert service.inlined_row_count("events", namespace="analytics") == 0
+    assert files(service) == 1
+
+
+def test_count_across_schema_versions_and_deleted_records(service):
+    first = service.write("events", [{"id": 1, "region": "eu"}], namespace="analytics")
+    service.query("ALTER TABLE events ADD COLUMN extra VARCHAR", namespace="analytics")
+    service.write("events", [{"id": 2, "region": "us"}], namespace="analytics")
+    service.query("DELETE FROM events WHERE id = 1", namespace="analytics")
+    assert service.inlined_row_count("events", namespace="analytics") == 2
+    service.flush("events", namespace="analytics")
+    assert service.inlined_row_count("events", namespace="analytics") == 0
+    assert service.query("SELECT id FROM events", namespace="analytics").rows == [
+        {"id": 2}
+    ]
+    assert service.query(
+        "SELECT id FROM events", namespace="analytics", snapshot_id=first.snapshot_id
+    ).rows == [{"id": 1}]
+
+
+def test_missing_dataset_maintenance(service):
+    for operation in (service.flush, service.inlined_row_count):
+        with pytest.raises(DatasetNotFoundError):
+            operation("missing", namespace="analytics")
+
+
+def test_stale_inline_catalog_error_retires_reader_without_replaying_sql(service):
+    import duckdb
+
+    adapter = service._DatasetService__adapter
+    old_connection = adapter._get_read_connection()
+    operation = Mock(
+        side_effect=duckdb.CatalogException(
+            "Failed to read inlined data from DuckLake: Table does not exist"
+        )
+    )
+    with pytest.raises(duckdb.CatalogException):
+        adapter._read(operation)
+    operation.assert_called_once()
+    assert adapter._get_read_connection() is not old_connection
+    assert service.query(
+        "SELECT count(*) AS n FROM events", namespace="analytics"
+    ).rows == [{"n": 0}]
+
+
+def test_pressure_event_persists_and_roundtrips(tmp_path):
+    adapter = Mock(spec=IDatasetPort)
+    service = DatasetService(adapter)
+    events = EventService(EventSQLiteAdapter(str(tmp_path / "events.sqlite")))
+    service.set_services(SimpleNamespace(events_available=lambda: True, events=events))
+    adapter.inlined_row_count.return_value = 9
+    service.check_catalog_pressure(
+        "events", namespace="analytics", threshold_records=10
+    )
+    assert events.query(DatasetCatalogPressure) == []
+    adapter.inlined_row_count.return_value = 10
+    assert (
+        service.check_catalog_pressure(
+            "events", namespace="analytics", threshold_records=10
+        )
+        == 10
+    )
+    (event,) = events.query(DatasetCatalogPressure)
+    assert event.dataset_name == "events"
+    assert event.namespace == "analytics"
+    assert event.inlined_records == event.threshold_records == 10
+    with pytest.raises(ValueError):
+        service.check_catalog_pressure("events", threshold_records=0)
+
+
+def test_pressure_event_failure_does_not_block_maintenance():
+    adapter = Mock(spec=IDatasetPort)
+    adapter.inlined_row_count.return_value = 100_000
+    service = DatasetService(adapter)
+    assert service.check_catalog_pressure("events") == 100_000
+    events = Mock()
+    events.publish.side_effect = RuntimeError("event store unavailable")
+    service.set_services(SimpleNamespace(events_available=lambda: True, events=events))
+    assert service.check_catalog_pressure("events") == 100_000
+    service.flush("events")
+    adapter.flush.assert_called_once_with("events", namespace="default")


### PR DESCRIPTION
Small dataset writes can produce many tiny Parquet files, while inlined records can accumulate indefinitely without maintenance. Default service connections to a configurable 1,000-row inlining limit and add Dagster jobs that flush and compact daily and report catalog pressure hourly.

- Add `flush`, `compact`, and `inlined_row_count` to the dataset port and DuckLake adapter, preserving snapshot history and using existing transaction retries.
- Register `dataset_compaction_job` alongside module orchestrations: flush each selected dataset before compacting it. The daily schedule defaults to running at 02:00 UTC.
- Add `dataset_catalog_monitor_job` and an hourly schedule. Emit the canonical `DatasetCatalogPressure` event at a configurable 100,000 unflushed insertion records per dataset. Monitoring stays off the write path; event publication is fail-open.
- Honor existing persisted DuckLake inlining overrides. No snapshot expiration or old-file cleanup is introduced, and one output file per partition is not guaranteed.
- Document defaults, operating instructions, and the architecture decision. Persisted stopped schedules still require enabling in Dagster.

Validation: targeted dataset, configuration, and Dagster tests pass (68 passed, 1 PostgreSQL integration test skipped), plus the added stale-reader regression test passes. Ruff checks and `git diff --check` pass for changed code. Tests cover actual SQLite-backed DuckLake flushing/compaction, partition separation, schema evolution, historical reads, event-store round trips, job ordering/failures, and registration alongside module jobs.

The repository-wide commit hook is blocked by an existing import-order error in `libs/naas-abi/naas_abi/apply_nexus_platform_pipeline_test.py`; the hook was bypassed after fixing changed-file findings and running targeted checks. PostgreSQL/S3 maintenance has not been exercised here.

Runtime limitation: the current DuckLake extension can cache inline-table references removed by flushing. Local flushes retire the cached read connection. A stale reader in another process can surface one error before reattaching on its next call; arbitrary SQL is not automatically replayed because `query()` permits mutations and multiple statements. Pressure counts use DuckLake 1.0 metadata and count unflushed insertion records, including historical records, rather than catalog bytes.
