### PR TITLE
feat(nexus): add Infrastructure map of the shared ABI codebase

### DIFF
--- a/libs/naas-abi-core/naas_abi_core/services/dataset/adapters/secondary/DatasetSecondaryAdapterDuckLake.py
+++ b/libs/naas-abi-core/naas_abi_core/services/dataset/adapters/secondary/DatasetSecondaryAdapterDuckLake.py
@@ -382,7 +382,7 @@ class DatasetSecondaryAdapterDuckLake(IDatasetPort):
             self._load_spec(con, namespace, name)
             metadata = self._ident(f"__ducklake_metadata_{CATALOG_ALIAS}")
             tables = con.execute(
-                f"SELECT i.table_name FROM {metadata}.ducklake_inlined_data_tables i "
+                f"SELECT i.table_name FROM {metadata}.ducklake_inlined_data_tables i "  # nosec B608
                 f"JOIN {metadata}.ducklake_table t ON i.table_id = t.table_id "
                 f"JOIN {metadata}.ducklake_schema s ON t.schema_id = s.schema_id "
                 "WHERE t.table_name = ? AND s.schema_name = ? "
@@ -392,7 +392,7 @@ class DatasetSecondaryAdapterDuckLake(IDatasetPort):
             count = sum(
                 int(
                     con.execute(
-                        f"SELECT count(*) FROM {metadata}.{self._ident(table)}"
+                        f"SELECT count(*) FROM {metadata}.{self._ident(table)}"  # nosec B608
                     ).fetchone()[0]
                 )
                 for (table,) in tables

--- a/libs/naas-abi/naas_abi/apply_nexus_platform_pipeline_test.py
+++ b/libs/naas-abi/naas_abi/apply_nexus_platform_pipeline_test.py
@@ -1,10 +1,11 @@
 from unittest.mock import MagicMock, patch
 
+from naas_abi_core.services.triple_store.TripleStorePorts import Exceptions
+
 from naas_abi.apply_nexus_platform_pipeline import (
     NEXUS_PLATFORM_GRAPH_URI,
     apply_nexus_platform_pipeline,
 )
-from naas_abi_core.services.triple_store.TripleStorePorts import Exceptions
 
 
 def test_disabled_pipeline_drops_nexus_graph_without_running():

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/next.config.js
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/next.config.js
@@ -3,7 +3,7 @@ const path = require('path');
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  transpilePackages: ['@nexus/ui', '@embedpdf/snippet'],
+  transpilePackages: ['@nexus/ui', '@embedpdf/snippet', 'three'],
   experimental: {
     optimizePackageImports: ['lucide-react'],
   },

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/package.json
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/package.json
@@ -36,6 +36,7 @@
     "remark-gfm": "^4.0.1",
     "socket.io-client": "^4.8.3",
     "tailwind-merge": "^2.2.1",
+    "three": "^0.186.0",
     "zustand": "^4.5.7"
   },
   "devDependencies": {
@@ -44,6 +45,7 @@
     "@types/node": "^20.11.0",
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
+    "@types/three": "^0.185.4",
     "autoprefixer": "^10.4.17",
     "eslint": "^8.56.0",
     "eslint-config-next": "14.1.0",

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/README.md
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/README.md
@@ -1,0 +1,76 @@
+# ABI infrastructure
+
+Workspace Settings → Infrastructure provides a 3D map of the shared ABI Python
+codebase. It inherits the existing workspace authentication and
+`settings.workspace` feature guard. It does not query workspace secrets, send
+source to a model, or represent a workspace's actual deployment.
+
+- Architecture and Inspector live in the shared Nexus feature column.
+- File exports the snapshot; View contains fit, zoom, decomposition and dependency controls.
+- Click a layer (in the map or sidebar) to isolate it and animate to a fitted,
+  face-on view. Clicking it again restores framing after orbiting.
+- Drag to orbit, scroll or use +/− to zoom; Fit view restores the current framing.
+- Decompose separates the component tiles from their plate.
+- Dependencies draws links between visible components. Selecting a component
+  filters these lines and lists directed **Depends on** and **Used by** links in
+  the inspector, including relationships to other layers.
+- Every selection is also available through ordinary keyboard-accessible buttons.
+  The inspector remains usable when WebGL is unavailable.
+
+## Refresh the source snapshot
+
+From the Nexus directory, with Python and `uv` installed:
+
+```sh
+python3 scripts/build_abi_architecture.py
+```
+
+The script resolves the parent ABI `libs` directory automatically; use `--libs`
+for another checkout. It stages only Python source in a temporary directory and
+runs pinned `graphifyy==0.9.57` with `--code-only --no-cluster`. Graphify's AST pass
+runs locally. The first invocation may download the extractor from PyPI.
+`--graph path/to/graph.json` can reuse a graph extracted from the **same corpus**.
+The output contains relative file paths and aggregate metadata, never source
+contents or environment configuration. Commit the generated JSON with changes
+that should appear in the map. It is a build-time snapshot, not live indexing.
+
+Layers follow deterministic package/service boundaries. Component dependencies
+aggregate Graphify `EXTRACTED` imports, calls, references, uses, inheritance and
+re-exports with both endpoints resolved to different components. Inferred and
+unresolved links are excluded. The raw graph totals include internal symbols and
+relationships, so they are larger than the component-level graph.
+
+Files, physical lines (including blanks/comments), classes and functions come
+from Python's AST/source scan. Test files are counted separately, not executed;
+this count is not coverage. Migrations are excluded. Dynamic imports, runtime
+registration and deployment wiring can be absent from the graph. Ontology TTL,
+frontend TypeScript, running service health, latency, usage and costs are outside
+this snapshot's scope.
+
+## Checks
+
+From Nexus:
+
+```sh
+python3 -m unittest discover -s scripts -p '*_test.py'
+cd apps/web
+pnpm typecheck
+pnpm dlx vitest@3.2.4 run 'src/app/workspace/[workspaceId]/settings/infrastructure'
+```
+
+Camera tests check that both plane dimensions fit across portrait/landscape
+viewports, including decomposition. Generator tests cover adapter separation,
+metrics, and exclusion of inferred, unresolved and self dependencies.
+
+## Layers and diagram views
+
+Use the visible Layers / Diagram switch or the View menu. The diagram always shows
+all components and directed dependencies; selecting a component highlights its
+neighborhood without hiding cross-layer connections. Drag to pan and scroll to
+zoom. The same sidebar inspector works in both views.
+
+Hover close to a visible dependency in Layers view, or hover/focus a link in Diagram
+view, for source → destination, relationship types and extracted counts. Enable
+View → Dependencies to show links in Layers view. Diagram layout uses five labeled architectural columns with fixed card spacing.
+Orthogonal links use row gaps and column gutters; layer/component selection hides
+unrelated links. Layout is deterministic and derived from the existing snapshot; it does not add inferred relationships.

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/abi-architecture.json
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/abi-architecture.json
@@ -1,0 +1,3422 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-09-10T20:05:31.439729+00:00",
+  "revision": "3f031a8d9",
+  "extractor": "Graphify \u00b7 local AST",
+  "extractorVersion": "0.9.57",
+  "scope": "Python source in naas_abi and naas_abi_core. Tests counted separately; migrations excluded. Shared code architecture, not workspace deployment or live telemetry.",
+  "layers": [
+    {
+      "id": "applications",
+      "label": "Agents & applications",
+      "description": "ABI agents, workflows, pipelines and the Nexus application.",
+      "color": "#B8A3F5"
+    },
+    {
+      "id": "runtime",
+      "label": "Execution & models",
+      "description": "Engine, module lifecycle, agent execution and model abstractions.",
+      "color": "#8EACF5"
+    },
+    {
+      "id": "knowledge",
+      "label": "Knowledge & data",
+      "description": "Ontologies, structured datasets, vector search and the triple store.",
+      "color": "#62C5C2"
+    },
+    {
+      "id": "platform",
+      "label": "Platform services",
+      "description": "Service contracts for events, storage, secrets and integrations.",
+      "color": "#D5B679"
+    },
+    {
+      "id": "adapters",
+      "label": "Infrastructure adapters",
+      "description": "Concrete implementations of service ports; availability is not runtime health.",
+      "color": "#92A4BC"
+    }
+  ],
+  "components": [
+    {
+      "id": "adapters/activity_log",
+      "label": "Activity Log Adapters",
+      "layer": "adapters",
+      "files": 1,
+      "lines": 215,
+      "classes": 1,
+      "functions": 13,
+      "tests": 1,
+      "symbols": 16,
+      "sourcePaths": [
+        "naas_abi_core/services/activity_log/adapters/secondary/ActivityLogSqliteAdapter.py"
+      ]
+    },
+    {
+      "id": "adapters/bus",
+      "label": "Bus Adapters",
+      "layer": "adapters",
+      "files": 2,
+      "lines": 569,
+      "classes": 2,
+      "functions": 30,
+      "tests": 2,
+      "symbols": 31,
+      "sourcePaths": [
+        "naas_abi_core/services/bus/adapters/secondary/PythonQueueAdapter.py",
+        "naas_abi_core/services/bus/adapters/secondary/RabbitMQAdapter.py"
+      ]
+    },
+    {
+      "id": "adapters/cache",
+      "label": "Cache Adapters",
+      "layer": "adapters",
+      "files": 3,
+      "lines": 240,
+      "classes": 3,
+      "functions": 25,
+      "tests": 2,
+      "symbols": 35,
+      "sourcePaths": [
+        "naas_abi_core/services/cache/adapters/secondary/CacheFSAdapter.py",
+        "naas_abi_core/services/cache/adapters/secondary/CacheObjectStorageAdapter.py",
+        "naas_abi_core/services/cache/adapters/secondary/CacheRedisAdapter.py"
+      ]
+    },
+    {
+      "id": "adapters/coding_environment",
+      "label": "Coding Environment Adapters",
+      "layer": "adapters",
+      "files": 7,
+      "lines": 1545,
+      "classes": 8,
+      "functions": 109,
+      "tests": 5,
+      "symbols": 140,
+      "sourcePaths": [
+        "naas_abi_core/services/coding_environment/adapters/secondary/CodeServerComposeAdapter.py",
+        "naas_abi_core/services/coding_environment/adapters/secondary/CoderAdapter.py",
+        "naas_abi_core/services/coding_environment/adapters/secondary/InMemoryAdapter.py",
+        "naas_abi_core/services/coding_environment/adapters/secondary/LocalDirectoryAdapter.py",
+        "naas_abi_core/services/coding_environment/adapters/secondary/OpencodeHarnessClient.py",
+        "naas_abi_core/services/coding_environment/adapters/secondary/__init__.py",
+        "naas_abi_core/services/coding_environment/adapters/secondary/abi_sidecar.py"
+      ]
+    },
+    {
+      "id": "adapters/dataset",
+      "label": "Dataset Adapters",
+      "layer": "adapters",
+      "files": 1,
+      "lines": 675,
+      "classes": 2,
+      "functions": 41,
+      "tests": 1,
+      "symbols": 45,
+      "sourcePaths": [
+        "naas_abi_core/services/dataset/adapters/secondary/DatasetSecondaryAdapterDuckLake.py"
+      ]
+    },
+    {
+      "id": "adapters/email",
+      "label": "Email Adapters",
+      "layer": "adapters",
+      "files": 6,
+      "lines": 481,
+      "classes": 5,
+      "functions": 16,
+      "tests": 5,
+      "symbols": 29,
+      "sourcePaths": [
+        "naas_abi_core/services/email/adapters/secondary/FilesystemAdapter.py",
+        "naas_abi_core/services/email/adapters/secondary/MicrosoftOutlookAdapter.py",
+        "naas_abi_core/services/email/adapters/secondary/SESAdapter.py",
+        "naas_abi_core/services/email/adapters/secondary/SMTPAdapter.py",
+        "naas_abi_core/services/email/adapters/secondary/SendGridAdapter.py",
+        "naas_abi_core/services/email/adapters/secondary/__init__.py"
+      ]
+    },
+    {
+      "id": "adapters/event",
+      "label": "Event Adapters",
+      "layer": "adapters",
+      "files": 3,
+      "lines": 277,
+      "classes": 1,
+      "functions": 9,
+      "tests": 1,
+      "symbols": 15,
+      "sourcePaths": [
+        "naas_abi_core/services/event/adapters/__init__.py",
+        "naas_abi_core/services/event/adapters/secondary/EventSQLiteAdapter.py",
+        "naas_abi_core/services/event/adapters/secondary/__init__.py"
+      ]
+    },
+    {
+      "id": "adapters/keyvalue",
+      "label": "Keyvalue Adapters",
+      "layer": "adapters",
+      "files": 2,
+      "lines": 265,
+      "classes": 3,
+      "functions": 19,
+      "tests": 2,
+      "symbols": 24,
+      "sourcePaths": [
+        "naas_abi_core/services/keyvalue/adapters/secondary/PythonAdapter.py",
+        "naas_abi_core/services/keyvalue/adapters/secondary/RedisAdapter.py"
+      ]
+    },
+    {
+      "id": "adapters/object_storage",
+      "label": "Object Storage Adapters",
+      "layer": "adapters",
+      "files": 4,
+      "lines": 664,
+      "classes": 5,
+      "functions": 35,
+      "tests": 3,
+      "symbols": 59,
+      "sourcePaths": [
+        "naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterFS.py",
+        "naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterNaas.py",
+        "naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterR2.py",
+        "naas_abi_core/services/object_storage/adapters/secondary/ObjectStorageSecondaryAdapterS3.py"
+      ]
+    },
+    {
+      "id": "adapters/source_control",
+      "label": "Source Control Adapters",
+      "layer": "adapters",
+      "files": 4,
+      "lines": 1813,
+      "classes": 3,
+      "functions": 117,
+      "tests": 3,
+      "symbols": 128,
+      "sourcePaths": [
+        "naas_abi_core/services/source_control/adapters/secondary/ForgejoAdapter.py",
+        "naas_abi_core/services/source_control/adapters/secondary/InMemoryAdapter.py",
+        "naas_abi_core/services/source_control/adapters/secondary/LocalGitAdapter.py",
+        "naas_abi_core/services/source_control/adapters/secondary/__init__.py"
+      ]
+    },
+    {
+      "id": "adapters/vector_store",
+      "label": "Vector Store Adapters",
+      "layer": "adapters",
+      "files": 3,
+      "lines": 949,
+      "classes": 3,
+      "functions": 46,
+      "tests": 2,
+      "symbols": 58,
+      "sourcePaths": [
+        "naas_abi_core/services/vector_store/adapters/QdrantAdapter.py",
+        "naas_abi_core/services/vector_store/adapters/QdrantInMemoryAdapter.py",
+        "naas_abi_core/services/vector_store/adapters/SqliteVecAdapter.py"
+      ]
+    },
+    {
+      "id": "abi/agents/AbiAgent",
+      "label": "AbiAgent",
+      "layer": "applications",
+      "files": 1,
+      "lines": 330,
+      "classes": 1,
+      "functions": 6,
+      "tests": 0,
+      "symbols": 11,
+      "sourcePaths": [
+        "naas_abi/agents/AbiAgent.py"
+      ]
+    },
+    {
+      "id": "abi/apps/analytics",
+      "label": "Analytics",
+      "layer": "applications",
+      "files": 1,
+      "lines": 0,
+      "classes": 0,
+      "functions": 0,
+      "tests": 0,
+      "symbols": 1,
+      "sourcePaths": [
+        "naas_abi/apps/analytics/__init__.py"
+      ]
+    },
+    {
+      "id": "abi/agents/CodingAgent",
+      "label": "CodingAgent",
+      "layer": "applications",
+      "files": 1,
+      "lines": 48,
+      "classes": 1,
+      "functions": 1,
+      "tests": 0,
+      "symbols": 3,
+      "sourcePaths": [
+        "naas_abi/agents/CodingAgent.py"
+      ]
+    },
+    {
+      "id": "abi/module/module",
+      "label": "Module",
+      "layer": "applications",
+      "files": 3,
+      "lines": 1588,
+      "classes": 16,
+      "functions": 19,
+      "tests": 2,
+      "symbols": 65,
+      "sourcePaths": [
+        "naas_abi/__init__.py",
+        "naas_abi/apply_nexus_platform_pipeline.py",
+        "naas_abi/cli.py"
+      ]
+    },
+    {
+      "id": "abi/apps/nexus",
+      "label": "Nexus",
+      "layer": "applications",
+      "files": 299,
+      "lines": 50662,
+      "classes": 634,
+      "functions": 1826,
+      "tests": 68,
+      "symbols": 3405,
+      "sourcePaths": [
+        "naas_abi/apps/nexus/apps/api/app/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/api/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/api/endpoints/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/api/endpoints/abi.py",
+        "naas_abi/apps/nexus/apps/api/app/api/endpoints/admin.py",
+        "naas_abi/apps/nexus/apps/api/app/api/endpoints/agents.py",
+        "naas_abi/apps/nexus/apps/api/app/api/endpoints/analytics.py",
+        "naas_abi/apps/nexus/apps/api/app/api/endpoints/auth.py",
+        "naas_abi/apps/nexus/apps/api/app/api/endpoints/chat.py",
+        "naas_abi/apps/nexus/apps/api/app/api/endpoints/files.py",
+        "naas_abi/apps/nexus/apps/api/app/api/endpoints/graph.py",
+        "naas_abi/apps/nexus/apps/api/app/api/endpoints/ontology.py",
+        "naas_abi/apps/nexus/apps/api/app/api/endpoints/organizations.py",
+        "naas_abi/apps/nexus/apps/api/app/api/endpoints/providers.py",
+        "naas_abi/apps/nexus/apps/api/app/api/endpoints/search.py",
+        "naas_abi/apps/nexus/apps/api/app/api/endpoints/secrets.py",
+        "naas_abi/apps/nexus/apps/api/app/api/endpoints/speech.py",
+        "naas_abi/apps/nexus/apps/api/app/api/endpoints/tenant.py",
+        "naas_abi/apps/nexus/apps/api/app/api/endpoints/transcribe.py",
+        "naas_abi/apps/nexus/apps/api/app/api/endpoints/view.py",
+        "naas_abi/apps/nexus/apps/api/app/api/endpoints/websocket.py",
+        "naas_abi/apps/nexus/apps/api/app/api/endpoints/workspaces.py",
+        "naas_abi/apps/nexus/apps/api/app/api/router.py",
+        "naas_abi/apps/nexus/apps/api/app/core/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/core/config.py",
+        "naas_abi/apps/nexus/apps/api/app/core/database.py",
+        "naas_abi/apps/nexus/apps/api/app/core/datetime_compat.py",
+        "naas_abi/apps/nexus/apps/api/app/core/feature_flags.py",
+        "naas_abi/apps/nexus/apps/api/app/core/logging.py",
+        "naas_abi/apps/nexus/apps/api/app/core/org_seed.py",
+        "naas_abi/apps/nexus/apps/api/app/core/postgres_session_registry.py",
+        "naas_abi/apps/nexus/apps/api/app/core/workspace_catalog_seed.py",
+        "naas_abi/apps/nexus/apps/api/app/main.py",
+        "naas_abi/apps/nexus/apps/api/app/models.py",
+        "naas_abi/apps/nexus/apps/api/app/services/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/activity_log/HttpActivityLogMiddleware.py",
+        "naas_abi/apps/nexus/apps/api/app/services/activity_log/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/agents/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/agents/adapters/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/agents/adapters/primary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/agents/adapters/primary/agents__primary_adapter__FastAPI.py",
+        "naas_abi/apps/nexus/apps/api/app/services/agents/adapters/secondary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/agents/adapters/secondary/postgres.py",
+        "naas_abi/apps/nexus/apps/api/app/services/agents/handlers/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/agents/handlers/agents__http_handler.py",
+        "naas_abi/apps/nexus/apps/api/app/services/agents/port.py",
+        "naas_abi/apps/nexus/apps/api/app/services/agents/service.py",
+        "naas_abi/apps/nexus/apps/api/app/services/analytics/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/analytics/adapters/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/analytics/adapters/primary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/analytics/adapters/primary/analytics__primary_adapter__FastAPI.py",
+        "naas_abi/apps/nexus/apps/api/app/services/analytics/adapters/secondary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/analytics/adapters/secondary/analytics__secondary_adapter__event_log.py",
+        "naas_abi/apps/nexus/apps/api/app/services/analytics/adapters/secondary/analytics__secondary_adapter__object_storage.py",
+        "naas_abi/apps/nexus/apps/api/app/services/analytics/handlers/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/analytics/handlers/analytics__http_handler.py",
+        "naas_abi/apps/nexus/apps/api/app/services/analytics/ontologies/AnalyticsEventOntology.py",
+        "naas_abi/apps/nexus/apps/api/app/services/analytics/ontologies/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/analytics/port.py",
+        "naas_abi/apps/nexus/apps/api/app/services/analytics/service.py",
+        "naas_abi/apps/nexus/apps/api/app/services/apps/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/apps/adapters/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/apps/adapters/primary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/apps/adapters/primary/apps__primary_adapter__FastAPI.py",
+        "naas_abi/apps/nexus/apps/api/app/services/apps/adapters/secondary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/apps/adapters/secondary/postgres.py",
+        "naas_abi/apps/nexus/apps/api/app/services/apps/app_html_access.py",
+        "naas_abi/apps/nexus/apps/api/app/services/apps/handlers/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/apps/handlers/apps__http_handler.py",
+        "naas_abi/apps/nexus/apps/api/app/services/apps/pages_sso.py",
+        "naas_abi/apps/nexus/apps/api/app/services/apps/port.py",
+        "naas_abi/apps/nexus/apps/api/app/services/apps/service.py",
+        "naas_abi/apps/nexus/apps/api/app/services/audit.py",
+        "naas_abi/apps/nexus/apps/api/app/services/auth/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/auth/adapters/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/auth/adapters/primary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/auth/adapters/primary/auth__primary_adapter__FastAPI.py",
+        "naas_abi/apps/nexus/apps/api/app/services/auth/adapters/primary/auth__primary_adapter__dependencies.py",
+        "naas_abi/apps/nexus/apps/api/app/services/auth/adapters/primary/auth__primary_adapter__schemas.py",
+        "naas_abi/apps/nexus/apps/api/app/services/auth/adapters/secondary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/auth/adapters/secondary/postgres.py",
+        "naas_abi/apps/nexus/apps/api/app/services/auth/handlers/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/auth/handlers/auth__http_handler.py",
+        "naas_abi/apps/nexus/apps/api/app/services/auth/port.py",
+        "naas_abi/apps/nexus/apps/api/app/services/auth/service.py",
+        "naas_abi/apps/nexus/apps/api/app/services/chat/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/chat/adapters/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__FastAPI.py",
+        "naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__dependencies.py",
+        "naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__export.py",
+        "naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__schemas.py",
+        "naas_abi/apps/nexus/apps/api/app/services/chat/adapters/primary/chat__primary_adapter__streaming.py",
+        "naas_abi/apps/nexus/apps/api/app/services/chat/adapters/secondary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/chat/adapters/secondary/postgres.py",
+        "naas_abi/apps/nexus/apps/api/app/services/chat/chat__schema.py",
+        "naas_abi/apps/nexus/apps/api/app/services/chat/chat_file_embeddings.py",
+        "naas_abi/apps/nexus/apps/api/app/services/chat/chat_file_ingestion.py",
+        "naas_abi/apps/nexus/apps/api/app/services/chat/chat_ingestion_jobs.py",
+        "naas_abi/apps/nexus/apps/api/app/services/chat/chat_ingestion_worker.py",
+        "naas_abi/apps/nexus/apps/api/app/services/chat/handlers/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/chat/handlers/chat__http_handler.py",
+        "naas_abi/apps/nexus/apps/api/app/services/chat/port.py",
+        "naas_abi/apps/nexus/apps/api/app/services/chat/service.py",
+        "naas_abi/apps/nexus/apps/api/app/services/code_review/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/code_review/adapters/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/code_review/adapters/primary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/code_review/adapters/primary/code_review__primary_adapter__FastAPI.py",
+        "naas_abi/apps/nexus/apps/api/app/services/code_review/handlers/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/coding_environment/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/coding_environment/adapters/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/coding_environment/adapters/primary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/coding_environment/adapters/primary/coding_environment__primary_adapter__FastAPI.py",
+        "naas_abi/apps/nexus/apps/api/app/services/coding_environment/handlers/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/datasets/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/datasets/adapters/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/datasets/adapters/primary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/datasets/adapters/primary/datasets__primary_adapter__FastAPI.py",
+        "naas_abi/apps/nexus/apps/api/app/services/datasets/adapters/primary/datasets__primary_adapter__dependencies.py",
+        "naas_abi/apps/nexus/apps/api/app/services/datasets/adapters/primary/datasets__primary_adapter__schemas.py",
+        "naas_abi/apps/nexus/apps/api/app/services/datasets/datasets__schema.py",
+        "naas_abi/apps/nexus/apps/api/app/services/datasets/handlers/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/datasets/handlers/datasets__http_handler.py",
+        "naas_abi/apps/nexus/apps/api/app/services/datasets/service.py",
+        "naas_abi/apps/nexus/apps/api/app/services/datasets/sql_safe.py",
+        "naas_abi/apps/nexus/apps/api/app/services/exceptions.py",
+        "naas_abi/apps/nexus/apps/api/app/services/files/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/files/adapters/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/files/adapters/primary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/files/adapters/primary/files__primary_adapter__FastAPI.py",
+        "naas_abi/apps/nexus/apps/api/app/services/files/adapters/primary/files__primary_adapter__dependencies.py",
+        "naas_abi/apps/nexus/apps/api/app/services/files/adapters/primary/files__primary_adapter__schemas.py",
+        "naas_abi/apps/nexus/apps/api/app/services/files/drive_roots.py",
+        "naas_abi/apps/nexus/apps/api/app/services/files/files__schema.py",
+        "naas_abi/apps/nexus/apps/api/app/services/files/handlers/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/files/handlers/files__http_handler.py",
+        "naas_abi/apps/nexus/apps/api/app/services/files/legacy_storage_migration.py",
+        "naas_abi/apps/nexus/apps/api/app/services/files/service.py",
+        "naas_abi/apps/nexus/apps/api/app/services/graph/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/graph/adapters/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/graph/adapters/primary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/graph/adapters/primary/graph__primary_adapter__FastAPI.py",
+        "naas_abi/apps/nexus/apps/api/app/services/graph/adapters/primary/graph__primary_adapter__dependencies.py",
+        "naas_abi/apps/nexus/apps/api/app/services/graph/adapters/primary/graph__primary_adapter__schemas.py",
+        "naas_abi/apps/nexus/apps/api/app/services/graph/discovery_triples_export.py",
+        "naas_abi/apps/nexus/apps/api/app/services/graph/graph__schema.py",
+        "naas_abi/apps/nexus/apps/api/app/services/graph/handlers/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/graph/handlers/graph__http_handler.py",
+        "naas_abi/apps/nexus/apps/api/app/services/graph/query/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/graph/query/adapters/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/graph/query/adapters/primary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/graph/query/adapters/primary/graph_query__primary_adapter__schemas.py",
+        "naas_abi/apps/nexus/apps/api/app/services/graph/query/adapters/secondary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/graph/query/adapters/secondary/graph_query__secondary_adapter__triplestore.py",
+        "naas_abi/apps/nexus/apps/api/app/services/graph/query/column_discovery.py",
+        "naas_abi/apps/nexus/apps/api/app/services/graph/query/compiler.py",
+        "naas_abi/apps/nexus/apps/api/app/services/graph/query/count_key.py",
+        "naas_abi/apps/nexus/apps/api/app/services/graph/query/guards.py",
+        "naas_abi/apps/nexus/apps/api/app/services/graph/query/port.py",
+        "naas_abi/apps/nexus/apps/api/app/services/graph/query/query__schema.py",
+        "naas_abi/apps/nexus/apps/api/app/services/graph/query/search.py",
+        "naas_abi/apps/nexus/apps/api/app/services/graph/query/service.py",
+        "naas_abi/apps/nexus/apps/api/app/services/graph/query/sparql_safe.py",
+        "naas_abi/apps/nexus/apps/api/app/services/graph/service.py",
+        "naas_abi/apps/nexus/apps/api/app/services/iam/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/iam/adapters/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/iam/adapters/secondary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/iam/adapters/secondary/postgres.py",
+        "naas_abi/apps/nexus/apps/api/app/services/iam/authorization.py",
+        "naas_abi/apps/nexus/apps/api/app/services/iam/port.py",
+        "naas_abi/apps/nexus/apps/api/app/services/iam/service.py",
+        "naas_abi/apps/nexus/apps/api/app/services/invites/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/invites/sign_in_email.py",
+        "naas_abi/apps/nexus/apps/api/app/services/modules/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/modules/handlers.py",
+        "naas_abi/apps/nexus/apps/api/app/services/modules/schema.py",
+        "naas_abi/apps/nexus/apps/api/app/services/modules/service.py",
+        "naas_abi/apps/nexus/apps/api/app/services/ollama.py",
+        "naas_abi/apps/nexus/apps/api/app/services/ontology/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/ontology/adapters/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/ontology/adapters/primary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/ontology/adapters/primary/ontology__primary_adapter__FastAPI.py",
+        "naas_abi/apps/nexus/apps/api/app/services/ontology/adapters/primary/ontology__primary_adapter__dependencies.py",
+        "naas_abi/apps/nexus/apps/api/app/services/ontology/adapters/primary/ontology__primary_adapter__schemas.py",
+        "naas_abi/apps/nexus/apps/api/app/services/ontology/handlers/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/ontology/handlers/ontology__http_handler.py",
+        "naas_abi/apps/nexus/apps/api/app/services/ontology/ontology__schema.py",
+        "naas_abi/apps/nexus/apps/api/app/services/ontology/service.py",
+        "naas_abi/apps/nexus/apps/api/app/services/openai_gateway/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/openai_gateway/adapters/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/openai_gateway/adapters/primary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/openai_gateway/adapters/primary/openai_gateway__primary_adapter__FastAPI.py",
+        "naas_abi/apps/nexus/apps/api/app/services/openai_gateway/handlers/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/openrouter_attribution.py",
+        "naas_abi/apps/nexus/apps/api/app/services/organizations/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/organizations/adapters/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/organizations/adapters/primary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/organizations/adapters/primary/organizations__primary_adapter__FastAPI.py",
+        "naas_abi/apps/nexus/apps/api/app/services/organizations/adapters/secondary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/organizations/adapters/secondary/postgres.py",
+        "naas_abi/apps/nexus/apps/api/app/services/organizations/handlers/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/organizations/handlers/organizations__http_handler.py",
+        "naas_abi/apps/nexus/apps/api/app/services/organizations/port.py",
+        "naas_abi/apps/nexus/apps/api/app/services/organizations/service.py",
+        "naas_abi/apps/nexus/apps/api/app/services/platform/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/platform/adapters/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/platform/adapters/primary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/platform/adapters/primary/platform__primary_adapter__FastAPI.py",
+        "naas_abi/apps/nexus/apps/api/app/services/platform/handlers/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/provider_runtime.py",
+        "naas_abi/apps/nexus/apps/api/app/services/providers/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/providers/adapters/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/providers/adapters/primary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/providers/adapters/primary/providers__primary_adapter__FastAPI.py",
+        "naas_abi/apps/nexus/apps/api/app/services/providers/adapters/primary/providers__primary_adapter__schemas.py",
+        "naas_abi/apps/nexus/apps/api/app/services/providers/adapters/secondary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/providers/adapters/secondary/providers__secondary_adapter__postgres.py",
+        "naas_abi/apps/nexus/apps/api/app/services/providers/handlers/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/providers/handlers/providers__http_handler.py",
+        "naas_abi/apps/nexus/apps/api/app/services/providers/model_catalog.py",
+        "naas_abi/apps/nexus/apps/api/app/services/providers/port.py",
+        "naas_abi/apps/nexus/apps/api/app/services/providers/providers__schema.py",
+        "naas_abi/apps/nexus/apps/api/app/services/providers/service.py",
+        "naas_abi/apps/nexus/apps/api/app/services/rate_limit.py",
+        "naas_abi/apps/nexus/apps/api/app/services/refresh_token.py",
+        "naas_abi/apps/nexus/apps/api/app/services/registry.py",
+        "naas_abi/apps/nexus/apps/api/app/services/registry_bootstrap.py",
+        "naas_abi/apps/nexus/apps/api/app/services/search/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/search/adapters/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/search/adapters/primary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/search/adapters/primary/search__primary_adapter__FastAPI.py",
+        "naas_abi/apps/nexus/apps/api/app/services/search/adapters/primary/search__primary_adapter__dependencies.py",
+        "naas_abi/apps/nexus/apps/api/app/services/search/adapters/primary/search__primary_adapter__schemas.py",
+        "naas_abi/apps/nexus/apps/api/app/services/search/handlers/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/search/handlers/search__http_handler.py",
+        "naas_abi/apps/nexus/apps/api/app/services/search/search__schema.py",
+        "naas_abi/apps/nexus/apps/api/app/services/search/service.py",
+        "naas_abi/apps/nexus/apps/api/app/services/secrets/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/secrets/adapters/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/secrets/adapters/primary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/secrets/adapters/primary/secrets__primary_adapter__FastAPI.py",
+        "naas_abi/apps/nexus/apps/api/app/services/secrets/adapters/secondary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/secrets/adapters/secondary/postgres.py",
+        "naas_abi/apps/nexus/apps/api/app/services/secrets/handlers/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/secrets/handlers/secrets__http_handler.py",
+        "naas_abi/apps/nexus/apps/api/app/services/secrets/port.py",
+        "naas_abi/apps/nexus/apps/api/app/services/secrets/secrets__schema.py",
+        "naas_abi/apps/nexus/apps/api/app/services/secrets/service.py",
+        "naas_abi/apps/nexus/apps/api/app/services/secrets_crypto.py",
+        "naas_abi/apps/nexus/apps/api/app/services/service_base.py",
+        "naas_abi/apps/nexus/apps/api/app/services/skills/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/skills/adapters/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/skills/adapters/primary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/skills/adapters/primary/skills__primary_adapter__FastAPI.py",
+        "naas_abi/apps/nexus/apps/api/app/services/skills/adapters/secondary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/skills/adapters/secondary/postgres.py",
+        "naas_abi/apps/nexus/apps/api/app/services/skills/handlers/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/skills/handlers/skills__http_handler.py",
+        "naas_abi/apps/nexus/apps/api/app/services/skills/port.py",
+        "naas_abi/apps/nexus/apps/api/app/services/skills/service.py",
+        "naas_abi/apps/nexus/apps/api/app/services/slides/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/slides/adapters/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/slides/adapters/primary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/slides/adapters/primary/slides__primary_adapter__FastAPI.py",
+        "naas_abi/apps/nexus/apps/api/app/services/slides/handlers/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/tenant/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/tenant/service.py",
+        "naas_abi/apps/nexus/apps/api/app/services/tenant/tenant__schema.py",
+        "naas_abi/apps/nexus/apps/api/app/services/view/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/view/service.py",
+        "naas_abi/apps/nexus/apps/api/app/services/websocket/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/websocket/adapters/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/websocket/adapters/primary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/websocket/adapters/primary/websocket__primary_adapter__FastAPI.py",
+        "naas_abi/apps/nexus/apps/api/app/services/websocket/admin_events.py",
+        "naas_abi/apps/nexus/apps/api/app/services/websocket/handlers/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/websocket/handlers/websocket__http_handler.py",
+        "naas_abi/apps/nexus/apps/api/app/services/websocket/runtime.py",
+        "naas_abi/apps/nexus/apps/api/app/services/websocket/service.py",
+        "naas_abi/apps/nexus/apps/api/app/services/workspaces/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/workspaces/adapters/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/workspaces/adapters/primary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/workspaces/adapters/primary/workspaces__primary_adapter__FastAPI.py",
+        "naas_abi/apps/nexus/apps/api/app/services/workspaces/adapters/secondary/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/workspaces/adapters/secondary/postgres.py",
+        "naas_abi/apps/nexus/apps/api/app/services/workspaces/handlers/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/services/workspaces/handlers/workspaces__http_handler.py",
+        "naas_abi/apps/nexus/apps/api/app/services/workspaces/port.py",
+        "naas_abi/apps/nexus/apps/api/app/services/workspaces/service.py",
+        "naas_abi/apps/nexus/apps/api/app/utils/__init__.py",
+        "naas_abi/apps/nexus/apps/api/app/utils/public_urls.py",
+        "naas_abi/apps/nexus/apps/api/run_migrations.py",
+        "naas_abi/apps/nexus/apps/api/src/worker.py",
+        "naas_abi/apps/nexus/assets/__init__.py",
+        "naas_abi/apps/nexus/assets/slides/__init__.py",
+        "naas_abi/apps/nexus/assets/slides/templates/__init__.py",
+        "naas_abi/apps/nexus/ontology/scripts/generate_all_processes.py",
+        "naas_abi/apps/nexus/ontology/scripts/generate_process_ontologies.py",
+        "naas_abi/apps/nexus/scripts/build_abi_architecture.py"
+      ]
+    },
+    {
+      "id": "abi/agents/OntologyEngineerAgent",
+      "label": "OntologyEngineerAgent",
+      "layer": "applications",
+      "files": 1,
+      "lines": 150,
+      "classes": 2,
+      "functions": 6,
+      "tests": 0,
+      "symbols": 10,
+      "sourcePaths": [
+        "naas_abi/agents/OntologyEngineerAgent.py"
+      ]
+    },
+    {
+      "id": "abi/orchestrations/orchestrations",
+      "label": "Orchestrations",
+      "layer": "applications",
+      "files": 1,
+      "lines": 16,
+      "classes": 1,
+      "functions": 1,
+      "tests": 0,
+      "symbols": 3,
+      "sourcePaths": [
+        "naas_abi/orchestrations/DemoOrchestration.py"
+      ]
+    },
+    {
+      "id": "abi/apps/oxigraph_admin",
+      "label": "Oxigraph Admin",
+      "layer": "applications",
+      "files": 2,
+      "lines": 549,
+      "classes": 1,
+      "functions": 27,
+      "tests": 0,
+      "symbols": 54,
+      "sourcePaths": [
+        "naas_abi/apps/oxigraph_admin/main.py",
+        "naas_abi/apps/oxigraph_admin/terminal_style.py"
+      ]
+    },
+    {
+      "id": "abi/pipelines/pipelines",
+      "label": "Pipelines",
+      "layer": "applications",
+      "files": 6,
+      "lines": 1785,
+      "classes": 18,
+      "functions": 48,
+      "tests": 4,
+      "symbols": 98,
+      "sourcePaths": [
+        "naas_abi/pipelines/AddIndividualPipeline.py",
+        "naas_abi/pipelines/InsertDataSPARQLPipeline.py",
+        "naas_abi/pipelines/MergeIndividualsPipeline.py",
+        "naas_abi/pipelines/NexusPlatformPipeline.py",
+        "naas_abi/pipelines/RemoveIndividualPipeline.py",
+        "naas_abi/pipelines/UpdateDataPropertyPipeline.py"
+      ]
+    },
+    {
+      "id": "abi/agents/PlatformServicesAgent",
+      "label": "PlatformServicesAgent",
+      "layer": "applications",
+      "files": 1,
+      "lines": 115,
+      "classes": 2,
+      "functions": 5,
+      "tests": 0,
+      "symbols": 9,
+      "sourcePaths": [
+        "naas_abi/agents/PlatformServicesAgent.py"
+      ]
+    },
+    {
+      "id": "abi/agents/slides",
+      "label": "Slides",
+      "layer": "applications",
+      "files": 3,
+      "lines": 863,
+      "classes": 0,
+      "functions": 34,
+      "tests": 2,
+      "symbols": 61,
+      "sourcePaths": [
+        "naas_abi/agents/slides/__init__.py",
+        "naas_abi/agents/slides/policy.py",
+        "naas_abi/agents/slides/title.py"
+      ]
+    },
+    {
+      "id": "abi/agents/SlidesAgent",
+      "label": "SlidesAgent",
+      "layer": "applications",
+      "files": 1,
+      "lines": 236,
+      "classes": 2,
+      "functions": 7,
+      "tests": 0,
+      "symbols": 13,
+      "sourcePaths": [
+        "naas_abi/agents/SlidesAgent.py"
+      ]
+    },
+    {
+      "id": "abi/apps/sparql_terminal",
+      "label": "Sparql Terminal",
+      "layer": "applications",
+      "files": 2,
+      "lines": 307,
+      "classes": 1,
+      "functions": 16,
+      "tests": 0,
+      "symbols": 29,
+      "sourcePaths": [
+        "naas_abi/apps/sparql_terminal/main.py",
+        "naas_abi/apps/sparql_terminal/terminal_style.py"
+      ]
+    },
+    {
+      "id": "abi/agents/tools",
+      "label": "Tools",
+      "layer": "applications",
+      "files": 6,
+      "lines": 3451,
+      "classes": 0,
+      "functions": 159,
+      "tests": 3,
+      "symbols": 151,
+      "sourcePaths": [
+        "naas_abi/agents/tools/__init__.py",
+        "naas_abi/agents/tools/coding_tools.py",
+        "naas_abi/agents/tools/nexus_admin_tools.py",
+        "naas_abi/agents/tools/platform_tools.py",
+        "naas_abi/agents/tools/slides_tools.py",
+        "naas_abi/agents/tools/web_tools.py"
+      ]
+    },
+    {
+      "id": "abi/workflows/workflows",
+      "label": "Workflows",
+      "layer": "applications",
+      "files": 5,
+      "lines": 1295,
+      "classes": 15,
+      "functions": 45,
+      "tests": 5,
+      "symbols": 102,
+      "sourcePaths": [
+        "naas_abi/workflows/AgentRecommendationWorkflow.py",
+        "naas_abi/workflows/ArtificialAnalysisWorkflow.py",
+        "naas_abi/workflows/GetObjectPropertiesFromClassWorkflow.py",
+        "naas_abi/workflows/GetSubjectGraphWorkflow.py",
+        "naas_abi/workflows/SearchIndividualWorkflow.py"
+      ]
+    },
+    {
+      "id": "services/dataset",
+      "label": "Dataset",
+      "layer": "knowledge",
+      "files": 3,
+      "lines": 328,
+      "classes": 14,
+      "functions": 27,
+      "tests": 3,
+      "symbols": 54,
+      "sourcePaths": [
+        "naas_abi_core/services/dataset/DatasetFactory.py",
+        "naas_abi_core/services/dataset/DatasetPort.py",
+        "naas_abi_core/services/dataset/DatasetService.py"
+      ]
+    },
+    {
+      "id": "abi/ontologies/ontologies",
+      "label": "Ontologies",
+      "layer": "knowledge",
+      "files": 84,
+      "lines": 4885,
+      "classes": 165,
+      "functions": 108,
+      "tests": 0,
+      "symbols": 554,
+      "sourcePaths": [
+        "naas_abi/ontologies/classes/ontology_naas_ai/abi/Agent.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/abi/Book.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/abi/Disposition.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/abi/DocumentContentEntity.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/abi/FormDocument.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/abi/GenericallyDependentContinuant.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/abi/JournalArticle.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/abi/MaterialEntity.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/abi/Organization.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/abi/Person.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/abi/Process.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/abi/Quality.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/abi/Report.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/abi/Role.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/abi/Site.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/abi/Spreadsheet.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/abi/TemporalInstant.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/abi/TemporalRegion.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/abi/Transcript.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/AIModel.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/AddUserToWorkspace.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/Agent.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/AgentIntent.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/AgentRole.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/AgentTool.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/AuthenticationStatus.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/Capabilities.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/Conversation.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/ConversationRole.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/CreateUser.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/CreateWorkspace.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/DeploymentSite.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/FileRole.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/FileSystem.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/FileSystemRole.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/Files.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/FrontEndEvent.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/GraphFilter.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/GraphFilterRole.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/GraphView.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/GraphViewRole.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/KnowledgeGraph.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/KnowledgeGraphRole.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/Login.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/LoginInterval.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/Logout.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/LogoutInterval.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/MarketplaceAppRole.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/MarketplaceApps.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/Message.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/MessageRole.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/NexusOrganization.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/Ontology.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/OntologyClass.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/OntologyClassRole.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/OntologyModule.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/OntologyModuleRole.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/OntologyObjectProperty.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/OntologyObjectPropertyRole.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/OntologyRole.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/Page.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/PageView.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/Search.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/SearchRole.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/Server.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/Session.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/Tenant.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/User.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/UserSite.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/VisitSession.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/VisitSessionInterval.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/Workspace.py",
+        "naas_abi/ontologies/classes/ontology_naas_ai/nexus/WorkspaceRole.py",
+        "naas_abi/ontologies/classes/purl_obolibrary_org/obo/Disposition.py",
+        "naas_abi/ontologies/classes/purl_obolibrary_org/obo/GenericallyDependentContinuant.py",
+        "naas_abi/ontologies/classes/purl_obolibrary_org/obo/MaterialEntity.py",
+        "naas_abi/ontologies/classes/purl_obolibrary_org/obo/Process.py",
+        "naas_abi/ontologies/classes/purl_obolibrary_org/obo/Quality.py",
+        "naas_abi/ontologies/classes/purl_obolibrary_org/obo/Role.py",
+        "naas_abi/ontologies/classes/purl_obolibrary_org/obo/Site.py",
+        "naas_abi/ontologies/classes/purl_obolibrary_org/obo/TemporalRegion.py",
+        "naas_abi/ontologies/modules/ABIOntology.py",
+        "naas_abi/ontologies/modules/BFO7BucketsProcessOntology.py",
+        "naas_abi/ontologies/modules/NexusPlatformOntology.py"
+      ]
+    },
+    {
+      "id": "services/ontology",
+      "label": "Ontology",
+      "layer": "knowledge",
+      "files": 3,
+      "lines": 89,
+      "classes": 4,
+      "functions": 6,
+      "tests": 0,
+      "symbols": 15,
+      "sourcePaths": [
+        "naas_abi_core/services/ontology/OntologyPorts.py",
+        "naas_abi_core/services/ontology/OntologyService.py",
+        "naas_abi_core/services/ontology/adaptors/secondary/OntologyService_SecondaryAdaptor_NERPort.py"
+      ]
+    },
+    {
+      "id": "services/triple_store",
+      "label": "Triple Store",
+      "layer": "knowledge",
+      "files": 23,
+      "lines": 5698,
+      "classes": 40,
+      "functions": 205,
+      "tests": 11,
+      "symbols": 366,
+      "sourcePaths": [
+        "naas_abi_core/services/triple_store/TripleStoreFactory.py",
+        "naas_abi_core/services/triple_store/TripleStorePorts.py",
+        "naas_abi_core/services/triple_store/TripleStoreService.py",
+        "naas_abi_core/services/triple_store/adaptors/secondary/AWSNeptune.py",
+        "naas_abi_core/services/triple_store/adaptors/secondary/ApacheJenaTDB2.py",
+        "naas_abi_core/services/triple_store/adaptors/secondary/Oxigraph.py",
+        "naas_abi_core/services/triple_store/adaptors/secondary/TripleStoreService__SecondaryAdaptor__Filesystem.py",
+        "naas_abi_core/services/triple_store/adaptors/secondary/TripleStoreService__SecondaryAdaptor__ObjectStorage.py",
+        "naas_abi_core/services/triple_store/adaptors/secondary/TripleStoreService__SecondaryAdaptor__OxigraphEmbedded.py",
+        "naas_abi_core/services/triple_store/adaptors/secondary/base/TripleStoreService__SecondaryAdaptor__FileBase.py",
+        "naas_abi_core/services/triple_store/ontologies/__init__.py",
+        "naas_abi_core/services/triple_store/ontologies/classes/ontology_naas_ai/abi/triple_store/GraphCleared.py",
+        "naas_abi_core/services/triple_store/ontologies/classes/ontology_naas_ai/abi/triple_store/GraphCreated.py",
+        "naas_abi_core/services/triple_store/ontologies/classes/ontology_naas_ai/abi/triple_store/GraphDropped.py",
+        "naas_abi_core/services/triple_store/ontologies/classes/ontology_naas_ai/abi/triple_store/SchemaLoaded.py",
+        "naas_abi_core/services/triple_store/ontologies/classes/ontology_naas_ai/abi/triple_store/SchemaRemoved.py",
+        "naas_abi_core/services/triple_store/ontologies/classes/ontology_naas_ai/abi/triple_store/TripleStoreError.py",
+        "naas_abi_core/services/triple_store/ontologies/classes/ontology_naas_ai/abi/triple_store/TriplesInserted.py",
+        "naas_abi_core/services/triple_store/ontologies/classes/ontology_naas_ai/abi/triple_store/TriplesRemoved.py",
+        "naas_abi_core/services/triple_store/ontologies/modules/TripleStoreEventOntology.py",
+        "naas_abi_core/services/triple_store/ontologies/modules/__init__.py",
+        "naas_abi_core/services/triple_store/oxigraph_server.py",
+        "naas_abi_core/services/triple_store/resolve.py"
+      ]
+    },
+    {
+      "id": "services/vector_store",
+      "label": "Vector Store",
+      "layer": "knowledge",
+      "files": 13,
+      "lines": 976,
+      "classes": 18,
+      "functions": 42,
+      "tests": 3,
+      "symbols": 94,
+      "sourcePaths": [
+        "naas_abi_core/services/vector_store/IVectorStorePort.py",
+        "naas_abi_core/services/vector_store/VectorStoreFactory.py",
+        "naas_abi_core/services/vector_store/VectorStoreService.py",
+        "naas_abi_core/services/vector_store/__init__.py",
+        "naas_abi_core/services/vector_store/ontologies/__init__.py",
+        "naas_abi_core/services/vector_store/ontologies/classes/ontology_naas_ai/abi/vector_store/CollectionDeleted.py",
+        "naas_abi_core/services/vector_store/ontologies/classes/ontology_naas_ai/abi/vector_store/CollectionEnsured.py",
+        "naas_abi_core/services/vector_store/ontologies/classes/ontology_naas_ai/abi/vector_store/DocumentUpdated.py",
+        "naas_abi_core/services/vector_store/ontologies/classes/ontology_naas_ai/abi/vector_store/DocumentsAdded.py",
+        "naas_abi_core/services/vector_store/ontologies/classes/ontology_naas_ai/abi/vector_store/DocumentsDeleted.py",
+        "naas_abi_core/services/vector_store/ontologies/classes/ontology_naas_ai/abi/vector_store/VectorStoreError.py",
+        "naas_abi_core/services/vector_store/ontologies/modules/VectorStoreEventOntology.py",
+        "naas_abi_core/services/vector_store/ontologies/modules/__init__.py"
+      ]
+    },
+    {
+      "id": "services/activity_log",
+      "label": "Activity Log",
+      "layer": "platform",
+      "files": 3,
+      "lines": 142,
+      "classes": 6,
+      "functions": 14,
+      "tests": 4,
+      "symbols": 26,
+      "sourcePaths": [
+        "naas_abi_core/services/activity_log/ActivityLogFactory.py",
+        "naas_abi_core/services/activity_log/ActivityLogPort.py",
+        "naas_abi_core/services/activity_log/ActivityLogService.py"
+      ]
+    },
+    {
+      "id": "services/bus",
+      "label": "Bus",
+      "layer": "platform",
+      "files": 8,
+      "lines": 676,
+      "classes": 9,
+      "functions": 24,
+      "tests": 3,
+      "symbols": 64,
+      "sourcePaths": [
+        "naas_abi_core/services/bus/BusPorts.py",
+        "naas_abi_core/services/bus/BusService.py",
+        "naas_abi_core/services/bus/ontologies/__init__.py",
+        "naas_abi_core/services/bus/ontologies/classes/ontology_naas_ai/abi/bus/BusError.py",
+        "naas_abi_core/services/bus/ontologies/classes/ontology_naas_ai/abi/bus/BusMessageEnqueued.py",
+        "naas_abi_core/services/bus/ontologies/classes/ontology_naas_ai/abi/bus/BusMessagePublished.py",
+        "naas_abi_core/services/bus/ontologies/modules/BusEventOntology.py",
+        "naas_abi_core/services/bus/ontologies/modules/__init__.py"
+      ]
+    },
+    {
+      "id": "services/cache",
+      "label": "Cache",
+      "layer": "platform",
+      "files": 9,
+      "lines": 1082,
+      "classes": 17,
+      "functions": 68,
+      "tests": 1,
+      "symbols": 118,
+      "sourcePaths": [
+        "naas_abi_core/services/cache/CacheFactory.py",
+        "naas_abi_core/services/cache/CachePort.py",
+        "naas_abi_core/services/cache/CacheService.py",
+        "naas_abi_core/services/cache/ontologies/__init__.py",
+        "naas_abi_core/services/cache/ontologies/classes/ontology_naas_ai/abi/cache/CacheDeleted.py",
+        "naas_abi_core/services/cache/ontologies/classes/ontology_naas_ai/abi/cache/CacheError.py",
+        "naas_abi_core/services/cache/ontologies/classes/ontology_naas_ai/abi/cache/CacheSet.py",
+        "naas_abi_core/services/cache/ontologies/modules/CacheEventOntology.py",
+        "naas_abi_core/services/cache/ontologies/modules/__init__.py"
+      ]
+    },
+    {
+      "id": "services/email",
+      "label": "Email",
+      "layer": "platform",
+      "files": 10,
+      "lines": 675,
+      "classes": 9,
+      "functions": 22,
+      "tests": 2,
+      "symbols": 55,
+      "sourcePaths": [
+        "naas_abi_core/services/email/EmailFactory.py",
+        "naas_abi_core/services/email/EmailMessageBuilder.py",
+        "naas_abi_core/services/email/EmailPorts.py",
+        "naas_abi_core/services/email/EmailService.py",
+        "naas_abi_core/services/email/__init__.py",
+        "naas_abi_core/services/email/ontologies/__init__.py",
+        "naas_abi_core/services/email/ontologies/classes/ontology_naas_ai/abi/email/EmailError.py",
+        "naas_abi_core/services/email/ontologies/classes/ontology_naas_ai/abi/email/EmailSent.py",
+        "naas_abi_core/services/email/ontologies/modules/EmailEventOntology.py",
+        "naas_abi_core/services/email/ontologies/modules/__init__.py"
+      ]
+    },
+    {
+      "id": "services/event",
+      "label": "Event",
+      "layer": "platform",
+      "files": 17,
+      "lines": 1631,
+      "classes": 15,
+      "functions": 75,
+      "tests": 1,
+      "symbols": 163,
+      "sourcePaths": [
+        "naas_abi_core/services/event/EventCodec.py",
+        "naas_abi_core/services/event/EventFactory.py",
+        "naas_abi_core/services/event/EventFilter.py",
+        "naas_abi_core/services/event/EventPort.py",
+        "naas_abi_core/services/event/EventService.py",
+        "naas_abi_core/services/event/__init__.py",
+        "naas_abi_core/services/event/benchmark.py",
+        "naas_abi_core/services/event/ontologies/__init__.py",
+        "naas_abi_core/services/event/ontologies/classes/__init__.py",
+        "naas_abi_core/services/event/ontologies/classes/ontology_naas_ai/__init__.py",
+        "naas_abi_core/services/event/ontologies/classes/ontology_naas_ai/abi/LogProcess.py",
+        "naas_abi_core/services/event/ontologies/classes/ontology_naas_ai/abi/__init__.py",
+        "naas_abi_core/services/event/ontologies/classes/purl_obolibrary_org/__init__.py",
+        "naas_abi_core/services/event/ontologies/classes/purl_obolibrary_org/obo/Process.py",
+        "naas_abi_core/services/event/ontologies/classes/purl_obolibrary_org/obo/__init__.py",
+        "naas_abi_core/services/event/ontologies/modules/EventOntology.py",
+        "naas_abi_core/services/event/ontologies/modules/__init__.py"
+      ]
+    },
+    {
+      "id": "services/keyvalue",
+      "label": "Keyvalue",
+      "layer": "platform",
+      "files": 8,
+      "lines": 629,
+      "classes": 11,
+      "functions": 28,
+      "tests": 4,
+      "symbols": 64,
+      "sourcePaths": [
+        "naas_abi_core/services/keyvalue/KeyValuePorts.py",
+        "naas_abi_core/services/keyvalue/KeyValueService.py",
+        "naas_abi_core/services/keyvalue/ontologies/__init__.py",
+        "naas_abi_core/services/keyvalue/ontologies/classes/ontology_naas_ai/abi/keyvalue/KeyValueDeleted.py",
+        "naas_abi_core/services/keyvalue/ontologies/classes/ontology_naas_ai/abi/keyvalue/KeyValueError.py",
+        "naas_abi_core/services/keyvalue/ontologies/classes/ontology_naas_ai/abi/keyvalue/KeyValueSet.py",
+        "naas_abi_core/services/keyvalue/ontologies/modules/KeyValueEventOntology.py",
+        "naas_abi_core/services/keyvalue/ontologies/modules/__init__.py"
+      ]
+    },
+    {
+      "id": "services/object_storage",
+      "label": "Object Storage",
+      "layer": "platform",
+      "files": 12,
+      "lines": 692,
+      "classes": 13,
+      "functions": 43,
+      "tests": 3,
+      "symbols": 87,
+      "sourcePaths": [
+        "naas_abi_core/services/object_storage/ObjectStorageFactory.py",
+        "naas_abi_core/services/object_storage/ObjectStoragePort.py",
+        "naas_abi_core/services/object_storage/ObjectStorageService.py",
+        "naas_abi_core/services/object_storage/ontologies/__init__.py",
+        "naas_abi_core/services/object_storage/ontologies/classes/__init__.py",
+        "naas_abi_core/services/object_storage/ontologies/classes/ontology_naas_ai/__init__.py",
+        "naas_abi_core/services/object_storage/ontologies/classes/ontology_naas_ai/abi/__init__.py",
+        "naas_abi_core/services/object_storage/ontologies/classes/ontology_naas_ai/abi/object_storage/ObjectDeleted.py",
+        "naas_abi_core/services/object_storage/ontologies/classes/ontology_naas_ai/abi/object_storage/ObjectPut.py",
+        "naas_abi_core/services/object_storage/ontologies/classes/ontology_naas_ai/abi/object_storage/__init__.py",
+        "naas_abi_core/services/object_storage/ontologies/modules/ObjectStorageEventOntology.py",
+        "naas_abi_core/services/object_storage/ontologies/modules/__init__.py"
+      ]
+    },
+    {
+      "id": "services/secret",
+      "label": "Secret",
+      "layer": "platform",
+      "files": 11,
+      "lines": 833,
+      "classes": 14,
+      "functions": 44,
+      "tests": 3,
+      "symbols": 90,
+      "sourcePaths": [
+        "naas_abi_core/services/secret/Secret.py",
+        "naas_abi_core/services/secret/SecretPorts.py",
+        "naas_abi_core/services/secret/adaptors/secondary/Base64Secret.py",
+        "naas_abi_core/services/secret/adaptors/secondary/NaasSecret.py",
+        "naas_abi_core/services/secret/adaptors/secondary/dotenv_secret_secondaryadaptor.py",
+        "naas_abi_core/services/secret/ontologies/__init__.py",
+        "naas_abi_core/services/secret/ontologies/classes/ontology_naas_ai/abi/secret/SecretError.py",
+        "naas_abi_core/services/secret/ontologies/classes/ontology_naas_ai/abi/secret/SecretRemoved.py",
+        "naas_abi_core/services/secret/ontologies/classes/ontology_naas_ai/abi/secret/SecretSet.py",
+        "naas_abi_core/services/secret/ontologies/modules/SecretEventOntology.py",
+        "naas_abi_core/services/secret/ontologies/modules/__init__.py"
+      ]
+    },
+    {
+      "id": "services/source_control",
+      "label": "Source Control",
+      "layer": "platform",
+      "files": 11,
+      "lines": 929,
+      "classes": 35,
+      "functions": 65,
+      "tests": 2,
+      "symbols": 155,
+      "sourcePaths": [
+        "naas_abi_core/services/source_control/SourceControlFactory.py",
+        "naas_abi_core/services/source_control/SourceControlPorts.py",
+        "naas_abi_core/services/source_control/SourceControlService.py",
+        "naas_abi_core/services/source_control/__init__.py",
+        "naas_abi_core/services/source_control/ontologies/__init__.py",
+        "naas_abi_core/services/source_control/ontologies/classes/ontology_naas_ai/abi/source_control/ProposalMergeBlocked.py",
+        "naas_abi_core/services/source_control/ontologies/classes/ontology_naas_ai/abi/source_control/ProposalMerged.py",
+        "naas_abi_core/services/source_control/ontologies/classes/ontology_naas_ai/abi/source_control/ProposalOpened.py",
+        "naas_abi_core/services/source_control/ontologies/classes/ontology_naas_ai/abi/source_control/ReviewSubmitted.py",
+        "naas_abi_core/services/source_control/ontologies/modules/SourceControlEventOntology.py",
+        "naas_abi_core/services/source_control/ontologies/modules/__init__.py"
+      ]
+    },
+    {
+      "id": "services/agent",
+      "label": "Agent",
+      "layer": "runtime",
+      "files": 24,
+      "lines": 7149,
+      "classes": 47,
+      "functions": 240,
+      "tests": 16,
+      "symbols": 395,
+      "sourcePaths": [
+        "naas_abi_core/services/agent/Agent.py",
+        "naas_abi_core/services/agent/CoordinatorAgent.py",
+        "naas_abi_core/services/agent/IntentAgent.py",
+        "naas_abi_core/services/agent/OpencodeAgent.py",
+        "naas_abi_core/services/agent/OpencodeSessionService.py",
+        "naas_abi_core/services/agent/SqliteCheckpointSaver.py",
+        "naas_abi_core/services/agent/beta/IntentMapper.py",
+        "naas_abi_core/services/agent/beta/LocalModel.py",
+        "naas_abi_core/services/agent/beta/VectorStore.py",
+        "naas_abi_core/services/agent/context.py",
+        "naas_abi_core/services/agent/intents/default_intents.py",
+        "naas_abi_core/services/agent/ontologies/__init__.py",
+        "naas_abi_core/services/agent/ontologies/classes/ontology_naas_ai/abi/agent/AgentAIMessageEmitted.py",
+        "naas_abi_core/services/agent/ontologies/classes/ontology_naas_ai/abi/agent/AgentInvocationCompleted.py",
+        "naas_abi_core/services/agent/ontologies/classes/ontology_naas_ai/abi/agent/AgentModelCalled.py",
+        "naas_abi_core/services/agent/ontologies/classes/ontology_naas_ai/abi/agent/AgentRouted.py",
+        "naas_abi_core/services/agent/ontologies/classes/ontology_naas_ai/abi/agent/AgentToolCalled.py",
+        "naas_abi_core/services/agent/ontologies/classes/ontology_naas_ai/abi/agent/AgentToolResponded.py",
+        "naas_abi_core/services/agent/ontologies/classes/ontology_naas_ai/abi/agent/AgentUserMessageReceived.py",
+        "naas_abi_core/services/agent/ontologies/modules/AgentEventOntology.py",
+        "naas_abi_core/services/agent/ontologies/modules/__init__.py",
+        "naas_abi_core/services/agent/tools/default_tools.py",
+        "naas_abi_core/services/agent/tools/utils.py",
+        "naas_abi_core/services/agent/tools/workspace_tools.py"
+      ]
+    },
+    {
+      "id": "core/apps",
+      "label": "Apps",
+      "layer": "runtime",
+      "files": 7,
+      "lines": 1716,
+      "classes": 3,
+      "functions": 57,
+      "tests": 3,
+      "symbols": 89,
+      "sourcePaths": [
+        "naas_abi_core/apps/api/abi_api_key_auth.py",
+        "naas_abi_core/apps/api/api.py",
+        "naas_abi_core/apps/api/openapi_doc.py",
+        "naas_abi_core/apps/dagster/dagster.py",
+        "naas_abi_core/apps/mcp/mcp_server.py",
+        "naas_abi_core/apps/terminal_agent/main.py",
+        "naas_abi_core/apps/terminal_agent/terminal_style.py"
+      ]
+    },
+    {
+      "id": "services/coding_environment",
+      "label": "Coding Environment",
+      "layer": "runtime",
+      "files": 13,
+      "lines": 670,
+      "classes": 28,
+      "functions": 39,
+      "tests": 2,
+      "symbols": 119,
+      "sourcePaths": [
+        "naas_abi_core/services/coding_environment/CodingEnvironmentFactory.py",
+        "naas_abi_core/services/coding_environment/CodingEnvironmentPorts.py",
+        "naas_abi_core/services/coding_environment/CodingEnvironmentService.py",
+        "naas_abi_core/services/coding_environment/__init__.py",
+        "naas_abi_core/services/coding_environment/ontologies/__init__.py",
+        "naas_abi_core/services/coding_environment/ontologies/classes/ontology_naas_ai/abi/coding_environment/WorkspaceAccessGranted.py",
+        "naas_abi_core/services/coding_environment/ontologies/classes/ontology_naas_ai/abi/coding_environment/WorkspaceDeleted.py",
+        "naas_abi_core/services/coding_environment/ontologies/classes/ontology_naas_ai/abi/coding_environment/WorkspaceProvisionFailed.py",
+        "naas_abi_core/services/coding_environment/ontologies/classes/ontology_naas_ai/abi/coding_environment/WorkspaceProvisioned.py",
+        "naas_abi_core/services/coding_environment/ontologies/classes/ontology_naas_ai/abi/coding_environment/WorkspaceStarted.py",
+        "naas_abi_core/services/coding_environment/ontologies/classes/ontology_naas_ai/abi/coding_environment/WorkspaceStopped.py",
+        "naas_abi_core/services/coding_environment/ontologies/modules/CodingEnvironmentEventOntology.py",
+        "naas_abi_core/services/coding_environment/ontologies/modules/__init__.py"
+      ]
+    },
+    {
+      "id": "core/engine",
+      "label": "Engine",
+      "layer": "runtime",
+      "files": 26,
+      "lines": 3980,
+      "classes": 90,
+      "functions": 154,
+      "tests": 16,
+      "symbols": 310,
+      "sourcePaths": [
+        "naas_abi_core/engine/Engine.py",
+        "naas_abi_core/engine/EngineProxy.py",
+        "naas_abi_core/engine/IEngine.py",
+        "naas_abi_core/engine/conftest.py",
+        "naas_abi_core/engine/context.py",
+        "naas_abi_core/engine/engine_configuration/EngineConfiguration.py",
+        "naas_abi_core/engine/engine_configuration/EngineConfiguration_ActivityLogService.py",
+        "naas_abi_core/engine/engine_configuration/EngineConfiguration_BusService.py",
+        "naas_abi_core/engine/engine_configuration/EngineConfiguration_CacheService.py",
+        "naas_abi_core/engine/engine_configuration/EngineConfiguration_CodingEnvironmentService.py",
+        "naas_abi_core/engine/engine_configuration/EngineConfiguration_DatasetService.py",
+        "naas_abi_core/engine/engine_configuration/EngineConfiguration_Deploy.py",
+        "naas_abi_core/engine/engine_configuration/EngineConfiguration_EmailService.py",
+        "naas_abi_core/engine/engine_configuration/EngineConfiguration_EventService.py",
+        "naas_abi_core/engine/engine_configuration/EngineConfiguration_GenericLoader.py",
+        "naas_abi_core/engine/engine_configuration/EngineConfiguration_KeyValueService.py",
+        "naas_abi_core/engine/engine_configuration/EngineConfiguration_ModelRegistryService.py",
+        "naas_abi_core/engine/engine_configuration/EngineConfiguration_ObjectStorageService.py",
+        "naas_abi_core/engine/engine_configuration/EngineConfiguration_SecretService.py",
+        "naas_abi_core/engine/engine_configuration/EngineConfiguration_SourceControlService.py",
+        "naas_abi_core/engine/engine_configuration/EngineConfiguration_TripleStoreService.py",
+        "naas_abi_core/engine/engine_configuration/EngineConfiguration_VectorStoreService.py",
+        "naas_abi_core/engine/engine_configuration/utils/PydanticModelValidator.py",
+        "naas_abi_core/engine/engine_loaders/EngineModuleLoader.py",
+        "naas_abi_core/engine/engine_loaders/EngineOntologyLoader.py",
+        "naas_abi_core/engine/engine_loaders/EngineServiceLoader.py"
+      ]
+    },
+    {
+      "id": "core/foundation",
+      "label": "Foundation",
+      "layer": "runtime",
+      "files": 1,
+      "lines": 1,
+      "classes": 0,
+      "functions": 0,
+      "tests": 0,
+      "symbols": 1,
+      "sourcePaths": [
+        "naas_abi_core/__init__.py"
+      ]
+    },
+    {
+      "id": "core/integration",
+      "label": "Integration",
+      "layer": "runtime",
+      "files": 2,
+      "lines": 35,
+      "classes": 3,
+      "functions": 1,
+      "tests": 0,
+      "symbols": 7,
+      "sourcePaths": [
+        "naas_abi_core/integration/__init__.py",
+        "naas_abi_core/integration/integration.py"
+      ]
+    },
+    {
+      "id": "services/model_registry",
+      "label": "Model Registry",
+      "layer": "runtime",
+      "files": 4,
+      "lines": 531,
+      "classes": 6,
+      "functions": 36,
+      "tests": 1,
+      "symbols": 68,
+      "sourcePaths": [
+        "naas_abi_core/services/model_registry/ModelRegistryFactory.py",
+        "naas_abi_core/services/model_registry/ModelRegistryPort.py",
+        "naas_abi_core/services/model_registry/ModelRegistryService.py",
+        "naas_abi_core/services/model_registry/__init__.py"
+      ]
+    },
+    {
+      "id": "core/models",
+      "label": "Models",
+      "layer": "runtime",
+      "files": 6,
+      "lines": 537,
+      "classes": 11,
+      "functions": 3,
+      "tests": 0,
+      "symbols": 24,
+      "sourcePaths": [
+        "naas_abi_core/models/Model.py",
+        "naas_abi_core/models/opencode/Base.py",
+        "naas_abi_core/models/opencode/OpencodeFileEvent.py",
+        "naas_abi_core/models/opencode/OpencodeMessage.py",
+        "naas_abi_core/models/opencode/OpencodeSession.py",
+        "naas_abi_core/models/opencode/__init__.py"
+      ]
+    },
+    {
+      "id": "core/module",
+      "label": "Module",
+      "layer": "runtime",
+      "files": 9,
+      "lines": 777,
+      "classes": 9,
+      "functions": 33,
+      "tests": 2,
+      "symbols": 62,
+      "sourcePaths": [
+        "naas_abi_core/module/Module.py",
+        "naas_abi_core/module/ModuleAgentLoader.py",
+        "naas_abi_core/module/ModuleComponentLoader.py",
+        "naas_abi_core/module/ModuleModelLoader.py",
+        "naas_abi_core/module/ModuleOrchestrationLoader.py",
+        "naas_abi_core/module/ModulePipelineLoader.py",
+        "naas_abi_core/module/ModuleToolLoader.py",
+        "naas_abi_core/module/ModuleUtils.py",
+        "naas_abi_core/module/ModuleWorkflowLoader.py"
+      ]
+    },
+    {
+      "id": "core/modules",
+      "label": "Modules",
+      "layer": "runtime",
+      "files": 5,
+      "lines": 429,
+      "classes": 8,
+      "functions": 17,
+      "tests": 0,
+      "symbols": 30,
+      "sourcePaths": [
+        "naas_abi_core/modules/bfo/__init__.py",
+        "naas_abi_core/modules/cco/__init__.py",
+        "naas_abi_core/modules/templatablesparqlquery/__init__.py",
+        "naas_abi_core/modules/templatablesparqlquery/workflows/GenericWorkflow.py",
+        "naas_abi_core/modules/templatablesparqlquery/workflows/TemplatableSparqlQueryLoader.py"
+      ]
+    },
+    {
+      "id": "core/orchestrations",
+      "label": "Orchestrations",
+      "layer": "runtime",
+      "files": 2,
+      "lines": 22,
+      "classes": 2,
+      "functions": 4,
+      "tests": 0,
+      "symbols": 8,
+      "sourcePaths": [
+        "naas_abi_core/orchestrations/DagsterOrchestration.py",
+        "naas_abi_core/orchestrations/Orchestrations.py"
+      ]
+    },
+    {
+      "id": "core/pipeline",
+      "label": "Pipeline",
+      "layer": "runtime",
+      "files": 2,
+      "lines": 74,
+      "classes": 3,
+      "functions": 3,
+      "tests": 0,
+      "symbols": 13,
+      "sourcePaths": [
+        "naas_abi_core/pipeline/__init__.py",
+        "naas_abi_core/pipeline/pipeline.py"
+      ]
+    },
+    {
+      "id": "core/services",
+      "label": "Services",
+      "layer": "runtime",
+      "files": 2,
+      "lines": 22,
+      "classes": 1,
+      "functions": 4,
+      "tests": 0,
+      "symbols": 7,
+      "sourcePaths": [
+        "naas_abi_core/services/ServiceBase.py",
+        "naas_abi_core/services/__init__.py"
+      ]
+    },
+    {
+      "id": "core/utils",
+      "label": "Utils",
+      "layer": "runtime",
+      "files": 25,
+      "lines": 9746,
+      "classes": 23,
+      "functions": 286,
+      "tests": 11,
+      "symbols": 473,
+      "sourcePaths": [
+        "naas_abi_core/utils/Expose.py",
+        "naas_abi_core/utils/Graph.py",
+        "naas_abi_core/utils/JSON.py",
+        "naas_abi_core/utils/LazyLoader.py",
+        "naas_abi_core/utils/Logger.py",
+        "naas_abi_core/utils/OntologyReasoner.py",
+        "naas_abi_core/utils/OntologyYaml.py",
+        "naas_abi_core/utils/SPARQL.py",
+        "naas_abi_core/utils/Storage.py",
+        "naas_abi_core/utils/StorageUtils.py",
+        "naas_abi_core/utils/String.py",
+        "naas_abi_core/utils/Workers.py",
+        "naas_abi_core/utils/__init__.py",
+        "naas_abi_core/utils/onto2py/__init__.py",
+        "naas_abi_core/utils/onto2py/__main__.py",
+        "naas_abi_core/utils/onto2py/onto2py.py",
+        "naas_abi_core/utils/ontology_checker.py",
+        "naas_abi_core/utils/process_api.py",
+        "naas_abi_core/utils/validate_bfo_ontology.py",
+        "naas_abi_core/utils/versionstore/__init__.py",
+        "naas_abi_core/utils/versionstore/benchmark.py",
+        "naas_abi_core/utils/versionstore/registry.py",
+        "naas_abi_core/utils/versionstore/revision.py",
+        "naas_abi_core/utils/versionstore/store.py",
+        "naas_abi_core/utils/versionstore/uuid7.py"
+      ]
+    },
+    {
+      "id": "core/workflow",
+      "label": "Workflow",
+      "layer": "runtime",
+      "files": 2,
+      "lines": 53,
+      "classes": 3,
+      "functions": 2,
+      "tests": 0,
+      "symbols": 8,
+      "sourcePaths": [
+        "naas_abi_core/workflow/__init__.py",
+        "naas_abi_core/workflow/workflow.py"
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "source": "abi/agents/AbiAgent",
+      "target": "abi/agents/tools",
+      "count": 4,
+      "relations": {
+        "imports": 2,
+        "calls": 2
+      }
+    },
+    {
+      "source": "abi/agents/AbiAgent",
+      "target": "abi/module/module",
+      "count": 1,
+      "relations": {
+        "imports": 1
+      }
+    },
+    {
+      "source": "abi/agents/AbiAgent",
+      "target": "core/module",
+      "count": 1,
+      "relations": {
+        "imports": 1
+      }
+    },
+    {
+      "source": "abi/agents/AbiAgent",
+      "target": "core/modules",
+      "count": 1,
+      "relations": {
+        "imports": 1
+      }
+    },
+    {
+      "source": "abi/agents/AbiAgent",
+      "target": "services/agent",
+      "count": 10,
+      "relations": {
+        "imports_from": 2,
+        "inherits": 1,
+        "references": 3,
+        "calls": 2,
+        "imports": 2
+      }
+    },
+    {
+      "source": "abi/agents/CodingAgent",
+      "target": "services/agent",
+      "count": 8,
+      "relations": {
+        "imports_from": 2,
+        "inherits": 1,
+        "references": 1,
+        "imports": 3,
+        "calls": 1
+      }
+    },
+    {
+      "source": "abi/agents/OntologyEngineerAgent",
+      "target": "abi/module/module",
+      "count": 1,
+      "relations": {
+        "imports": 1
+      }
+    },
+    {
+      "source": "abi/agents/OntologyEngineerAgent",
+      "target": "services/agent",
+      "count": 11,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 1,
+        "references": 6,
+        "calls": 2,
+        "imports": 1
+      }
+    },
+    {
+      "source": "abi/agents/PlatformServicesAgent",
+      "target": "abi/agents/tools",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "imports": 1,
+        "calls": 1
+      }
+    },
+    {
+      "source": "abi/agents/PlatformServicesAgent",
+      "target": "abi/module/module",
+      "count": 1,
+      "relations": {
+        "imports": 1
+      }
+    },
+    {
+      "source": "abi/agents/PlatformServicesAgent",
+      "target": "services/agent",
+      "count": 11,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 1,
+        "references": 6,
+        "calls": 2,
+        "imports": 1
+      }
+    },
+    {
+      "source": "abi/agents/SlidesAgent",
+      "target": "abi/agents/slides",
+      "count": 11,
+      "relations": {
+        "imports": 5,
+        "calls": 6
+      }
+    },
+    {
+      "source": "abi/agents/SlidesAgent",
+      "target": "abi/agents/tools",
+      "count": 2,
+      "relations": {
+        "imports": 1,
+        "calls": 1
+      }
+    },
+    {
+      "source": "abi/agents/SlidesAgent",
+      "target": "services/agent",
+      "count": 10,
+      "relations": {
+        "imports_from": 2,
+        "inherits": 1,
+        "references": 3,
+        "calls": 3,
+        "imports": 1
+      }
+    },
+    {
+      "source": "abi/agents/slides",
+      "target": "abi/module/module",
+      "count": 1,
+      "relations": {
+        "imports": 1
+      }
+    },
+    {
+      "source": "abi/agents/slides",
+      "target": "services/agent",
+      "count": 1,
+      "relations": {
+        "imports_from": 1
+      }
+    },
+    {
+      "source": "abi/agents/slides",
+      "target": "services/model_registry",
+      "count": 4,
+      "relations": {
+        "imports": 3,
+        "calls": 1
+      }
+    },
+    {
+      "source": "abi/agents/tools",
+      "target": "abi/agents/slides",
+      "count": 16,
+      "relations": {
+        "imports": 8,
+        "calls": 8
+      }
+    },
+    {
+      "source": "abi/agents/tools",
+      "target": "abi/apps/nexus",
+      "count": 24,
+      "relations": {
+        "imports": 14,
+        "imports_from": 1,
+        "calls": 9
+      }
+    },
+    {
+      "source": "abi/agents/tools",
+      "target": "abi/module/module",
+      "count": 3,
+      "relations": {
+        "imports": 3
+      }
+    },
+    {
+      "source": "abi/agents/tools",
+      "target": "adapters/coding_environment",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "imports": 1,
+        "calls": 1
+      }
+    },
+    {
+      "source": "abi/agents/tools",
+      "target": "core/engine",
+      "count": 2,
+      "relations": {
+        "imports": 1,
+        "calls": 1
+      }
+    },
+    {
+      "source": "abi/agents/tools",
+      "target": "core/utils",
+      "count": 2,
+      "relations": {
+        "imports": 1,
+        "calls": 1
+      }
+    },
+    {
+      "source": "abi/agents/tools",
+      "target": "services/agent",
+      "count": 13,
+      "relations": {
+        "imports_from": 5,
+        "imports": 3,
+        "calls": 5
+      }
+    },
+    {
+      "source": "abi/agents/tools",
+      "target": "services/source_control",
+      "count": 4,
+      "relations": {
+        "imports_from": 1,
+        "imports": 2,
+        "calls": 1
+      }
+    },
+    {
+      "source": "abi/apps/nexus",
+      "target": "abi/agents/slides",
+      "count": 12,
+      "relations": {
+        "imports": 6,
+        "calls": 6
+      }
+    },
+    {
+      "source": "abi/apps/nexus",
+      "target": "abi/agents/tools",
+      "count": 12,
+      "relations": {
+        "imports": 6,
+        "calls": 6
+      }
+    },
+    {
+      "source": "abi/apps/nexus",
+      "target": "abi/module/module",
+      "count": 31,
+      "relations": {
+        "imports": 31
+      }
+    },
+    {
+      "source": "abi/apps/nexus",
+      "target": "abi/ontologies/ontologies",
+      "count": 239,
+      "relations": {
+        "references": 234,
+        "imports_from": 1,
+        "imports": 2,
+        "calls": 2
+      }
+    },
+    {
+      "source": "abi/apps/nexus",
+      "target": "adapters/coding_environment",
+      "count": 8,
+      "relations": {
+        "imports_from": 2,
+        "imports": 3,
+        "calls": 3
+      }
+    },
+    {
+      "source": "abi/apps/nexus",
+      "target": "core/apps",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "imports": 1,
+        "calls": 1
+      }
+    },
+    {
+      "source": "abi/apps/nexus",
+      "target": "core/engine",
+      "count": 4,
+      "relations": {
+        "imports": 2,
+        "calls": 2
+      }
+    },
+    {
+      "source": "abi/apps/nexus",
+      "target": "core/models",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "imports": 2
+      }
+    },
+    {
+      "source": "abi/apps/nexus",
+      "target": "core/utils",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "imports": 1,
+        "calls": 1
+      }
+    },
+    {
+      "source": "abi/apps/nexus",
+      "target": "services/activity_log",
+      "count": 6,
+      "relations": {
+        "imports_from": 2,
+        "references": 1,
+        "imports": 2,
+        "calls": 1
+      }
+    },
+    {
+      "source": "abi/apps/nexus",
+      "target": "services/agent",
+      "count": 12,
+      "relations": {
+        "imports_from": 2,
+        "references": 3,
+        "imports": 4,
+        "calls": 3
+      }
+    },
+    {
+      "source": "abi/apps/nexus",
+      "target": "services/cache",
+      "count": 22,
+      "relations": {
+        "imports_from": 9,
+        "references": 3,
+        "imports": 10
+      }
+    },
+    {
+      "source": "abi/apps/nexus",
+      "target": "services/coding_environment",
+      "count": 39,
+      "relations": {
+        "imports_from": 4,
+        "references": 19,
+        "imports": 16
+      }
+    },
+    {
+      "source": "abi/apps/nexus",
+      "target": "services/dataset",
+      "count": 15,
+      "relations": {
+        "imports_from": 5,
+        "references": 5,
+        "imports": 5
+      }
+    },
+    {
+      "source": "abi/apps/nexus",
+      "target": "services/email",
+      "count": 23,
+      "relations": {
+        "imports_from": 5,
+        "references": 12,
+        "calls": 1,
+        "imports": 5
+      }
+    },
+    {
+      "source": "abi/apps/nexus",
+      "target": "services/event",
+      "count": 9,
+      "relations": {
+        "imports_from": 3,
+        "inherits": 1,
+        "imports": 3,
+        "calls": 2
+      }
+    },
+    {
+      "source": "abi/apps/nexus",
+      "target": "services/object_storage",
+      "count": 43,
+      "relations": {
+        "imports_from": 14,
+        "references": 15,
+        "imports": 14
+      }
+    },
+    {
+      "source": "abi/apps/nexus",
+      "target": "services/source_control",
+      "count": 90,
+      "relations": {
+        "imports_from": 6,
+        "references": 51,
+        "calls": 3,
+        "imports": 30
+      }
+    },
+    {
+      "source": "abi/apps/nexus",
+      "target": "services/triple_store",
+      "count": 40,
+      "relations": {
+        "imports_from": 3,
+        "references": 34,
+        "imports": 3
+      }
+    },
+    {
+      "source": "abi/apps/nexus",
+      "target": "services/vector_store",
+      "count": 7,
+      "relations": {
+        "imports_from": 2,
+        "references": 3,
+        "imports": 2
+      }
+    },
+    {
+      "source": "abi/apps/oxigraph_admin",
+      "target": "abi/module/module",
+      "count": 1,
+      "relations": {
+        "imports": 1
+      }
+    },
+    {
+      "source": "abi/apps/oxigraph_admin",
+      "target": "services/triple_store",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "references": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "abi/apps/sparql_terminal",
+      "target": "abi/module/module",
+      "count": 1,
+      "relations": {
+        "imports": 1
+      }
+    },
+    {
+      "source": "abi/apps/sparql_terminal",
+      "target": "services/triple_store",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "references": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "abi/module/module",
+      "target": "abi/agents/slides",
+      "count": 3,
+      "relations": {
+        "re_exports": 1,
+        "imports": 1,
+        "calls": 1
+      }
+    },
+    {
+      "source": "abi/module/module",
+      "target": "abi/apps/nexus",
+      "count": 7,
+      "relations": {
+        "re_exports": 2,
+        "imports": 2,
+        "imports_from": 1,
+        "calls": 2
+      }
+    },
+    {
+      "source": "abi/module/module",
+      "target": "abi/pipelines/pipelines",
+      "count": 6,
+      "relations": {
+        "imports": 3,
+        "calls": 3
+      }
+    },
+    {
+      "source": "abi/module/module",
+      "target": "core/module",
+      "count": 7,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 2,
+        "re_exports": 1,
+        "imports": 3
+      }
+    },
+    {
+      "source": "abi/module/module",
+      "target": "services/activity_log",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "re_exports": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "abi/module/module",
+      "target": "services/bus",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "re_exports": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "abi/module/module",
+      "target": "services/cache",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "re_exports": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "abi/module/module",
+      "target": "services/dataset",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "re_exports": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "abi/module/module",
+      "target": "services/email",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "re_exports": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "abi/module/module",
+      "target": "services/event",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "re_exports": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "abi/module/module",
+      "target": "services/model_registry",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "re_exports": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "abi/module/module",
+      "target": "services/object_storage",
+      "count": 6,
+      "relations": {
+        "imports_from": 2,
+        "references": 1,
+        "re_exports": 1,
+        "imports": 2
+      }
+    },
+    {
+      "source": "abi/module/module",
+      "target": "services/secret",
+      "count": 5,
+      "relations": {
+        "imports_from": 1,
+        "re_exports": 1,
+        "imports": 2,
+        "calls": 1
+      }
+    },
+    {
+      "source": "abi/module/module",
+      "target": "services/triple_store",
+      "count": 6,
+      "relations": {
+        "imports_from": 2,
+        "references": 1,
+        "re_exports": 1,
+        "imports": 2
+      }
+    },
+    {
+      "source": "abi/module/module",
+      "target": "services/vector_store",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "re_exports": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "abi/orchestrations/orchestrations",
+      "target": "core/orchestrations",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "abi/pipelines/pipelines",
+      "target": "abi/module/module",
+      "count": 4,
+      "relations": {
+        "imports": 4
+      }
+    },
+    {
+      "source": "abi/pipelines/pipelines",
+      "target": "abi/ontologies/ontologies",
+      "count": 22,
+      "relations": {
+        "imports_from": 1,
+        "references": 10,
+        "imports": 10,
+        "calls": 1
+      }
+    },
+    {
+      "source": "abi/pipelines/pipelines",
+      "target": "abi/workflows/workflows",
+      "count": 6,
+      "relations": {
+        "imports_from": 1,
+        "imports": 3,
+        "calls": 2
+      }
+    },
+    {
+      "source": "abi/pipelines/pipelines",
+      "target": "core/engine",
+      "count": 8,
+      "relations": {
+        "imports_from": 4,
+        "imports": 4
+      }
+    },
+    {
+      "source": "abi/pipelines/pipelines",
+      "target": "core/pipeline",
+      "count": 42,
+      "relations": {
+        "inherits": 18,
+        "references": 6,
+        "imports": 12,
+        "imports_from": 6
+      }
+    },
+    {
+      "source": "abi/pipelines/pipelines",
+      "target": "core/utils",
+      "count": 26,
+      "relations": {
+        "imports_from": 14,
+        "imports": 6,
+        "calls": 6
+      }
+    },
+    {
+      "source": "abi/pipelines/pipelines",
+      "target": "services/agent",
+      "count": 1,
+      "relations": {
+        "imports": 1
+      }
+    },
+    {
+      "source": "abi/pipelines/pipelines",
+      "target": "services/object_storage",
+      "count": 2,
+      "relations": {
+        "imports_from": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "abi/pipelines/pipelines",
+      "target": "services/triple_store",
+      "count": 12,
+      "relations": {
+        "imports_from": 6,
+        "imports": 6
+      }
+    },
+    {
+      "source": "abi/workflows/workflows",
+      "target": "abi/module/module",
+      "count": 2,
+      "relations": {
+        "imports": 2
+      }
+    },
+    {
+      "source": "abi/workflows/workflows",
+      "target": "core/engine",
+      "count": 2,
+      "relations": {
+        "imports_from": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "abi/workflows/workflows",
+      "target": "core/utils",
+      "count": 12,
+      "relations": {
+        "imports_from": 8,
+        "imports": 2,
+        "calls": 2
+      }
+    },
+    {
+      "source": "abi/workflows/workflows",
+      "target": "core/workflow",
+      "count": 31,
+      "relations": {
+        "inherits": 15,
+        "references": 1,
+        "imports_from": 5,
+        "imports": 10
+      }
+    },
+    {
+      "source": "abi/workflows/workflows",
+      "target": "services/triple_store",
+      "count": 6,
+      "relations": {
+        "imports_from": 3,
+        "imports": 3
+      }
+    },
+    {
+      "source": "adapters/activity_log",
+      "target": "services/activity_log",
+      "count": 9,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 1,
+        "references": 3,
+        "calls": 1,
+        "imports": 3
+      }
+    },
+    {
+      "source": "adapters/bus",
+      "target": "core/utils",
+      "count": 1,
+      "relations": {
+        "imports_from": 1
+      }
+    },
+    {
+      "source": "adapters/bus",
+      "target": "services/bus",
+      "count": 6,
+      "relations": {
+        "imports_from": 2,
+        "inherits": 2,
+        "imports": 2
+      }
+    },
+    {
+      "source": "adapters/cache",
+      "target": "services/cache",
+      "count": 34,
+      "relations": {
+        "imports_from": 3,
+        "inherits": 3,
+        "references": 10,
+        "calls": 9,
+        "imports": 9
+      }
+    },
+    {
+      "source": "adapters/cache",
+      "target": "services/object_storage",
+      "count": 5,
+      "relations": {
+        "imports_from": 2,
+        "references": 1,
+        "imports": 2
+      }
+    },
+    {
+      "source": "adapters/coding_environment",
+      "target": "services/agent",
+      "count": 2,
+      "relations": {
+        "imports": 1,
+        "calls": 1
+      }
+    },
+    {
+      "source": "adapters/coding_environment",
+      "target": "services/coding_environment",
+      "count": 89,
+      "relations": {
+        "imports_from": 4,
+        "inherits": 4,
+        "references": 32,
+        "calls": 24,
+        "imports": 25
+      }
+    },
+    {
+      "source": "adapters/dataset",
+      "target": "services/dataset",
+      "count": 36,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 1,
+        "references": 16,
+        "calls": 8,
+        "imports": 10
+      }
+    },
+    {
+      "source": "adapters/email",
+      "target": "services/email",
+      "count": 42,
+      "relations": {
+        "imports_from": 8,
+        "inherits": 5,
+        "references": 7,
+        "imports": 16,
+        "calls": 6
+      }
+    },
+    {
+      "source": "adapters/event",
+      "target": "services/event",
+      "count": 14,
+      "relations": {
+        "imports_from": 2,
+        "inherits": 1,
+        "references": 3,
+        "calls": 5,
+        "imports": 3
+      }
+    },
+    {
+      "source": "adapters/keyvalue",
+      "target": "services/keyvalue",
+      "count": 12,
+      "relations": {
+        "imports_from": 2,
+        "inherits": 2,
+        "imports": 4,
+        "calls": 4
+      }
+    },
+    {
+      "source": "adapters/object_storage",
+      "target": "services/object_storage",
+      "count": 19,
+      "relations": {
+        "imports_from": 3,
+        "inherits": 3,
+        "references": 3,
+        "calls": 2,
+        "imports": 8
+      }
+    },
+    {
+      "source": "adapters/source_control",
+      "target": "services/source_control",
+      "count": 223,
+      "relations": {
+        "imports_from": 3,
+        "inherits": 3,
+        "references": 84,
+        "calls": 71,
+        "imports": 62
+      }
+    },
+    {
+      "source": "adapters/vector_store",
+      "target": "services/vector_store",
+      "count": 27,
+      "relations": {
+        "imports_from": 3,
+        "inherits": 3,
+        "references": 9,
+        "calls": 3,
+        "imports": 9
+      }
+    },
+    {
+      "source": "core/apps",
+      "target": "core/engine",
+      "count": 12,
+      "relations": {
+        "imports_from": 3,
+        "references": 2,
+        "calls": 3,
+        "imports": 4
+      }
+    },
+    {
+      "source": "core/apps",
+      "target": "core/orchestrations",
+      "count": 2,
+      "relations": {
+        "imports_from": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "core/apps",
+      "target": "core/utils",
+      "count": 2,
+      "relations": {
+        "imports": 1,
+        "calls": 1
+      }
+    },
+    {
+      "source": "core/apps",
+      "target": "services/agent",
+      "count": 5,
+      "relations": {
+        "imports_from": 1,
+        "references": 1,
+        "imports": 2,
+        "calls": 1
+      }
+    },
+    {
+      "source": "core/engine",
+      "target": "adapters/activity_log",
+      "count": 2,
+      "relations": {
+        "imports": 1,
+        "calls": 1
+      }
+    },
+    {
+      "source": "core/engine",
+      "target": "adapters/bus",
+      "count": 4,
+      "relations": {
+        "imports": 2,
+        "calls": 2
+      }
+    },
+    {
+      "source": "core/engine",
+      "target": "adapters/cache",
+      "count": 6,
+      "relations": {
+        "imports": 3,
+        "calls": 3
+      }
+    },
+    {
+      "source": "core/engine",
+      "target": "adapters/coding_environment",
+      "count": 8,
+      "relations": {
+        "imports": 4,
+        "calls": 4
+      }
+    },
+    {
+      "source": "core/engine",
+      "target": "adapters/dataset",
+      "count": 2,
+      "relations": {
+        "imports": 1,
+        "calls": 1
+      }
+    },
+    {
+      "source": "core/engine",
+      "target": "adapters/email",
+      "count": 10,
+      "relations": {
+        "imports": 5,
+        "calls": 5
+      }
+    },
+    {
+      "source": "core/engine",
+      "target": "adapters/event",
+      "count": 2,
+      "relations": {
+        "imports": 1,
+        "calls": 1
+      }
+    },
+    {
+      "source": "core/engine",
+      "target": "adapters/keyvalue",
+      "count": 4,
+      "relations": {
+        "imports": 2,
+        "calls": 2
+      }
+    },
+    {
+      "source": "core/engine",
+      "target": "adapters/object_storage",
+      "count": 8,
+      "relations": {
+        "imports": 4,
+        "calls": 4
+      }
+    },
+    {
+      "source": "core/engine",
+      "target": "adapters/source_control",
+      "count": 6,
+      "relations": {
+        "imports": 3,
+        "calls": 3
+      }
+    },
+    {
+      "source": "core/engine",
+      "target": "adapters/vector_store",
+      "count": 6,
+      "relations": {
+        "imports": 3,
+        "calls": 3
+      }
+    },
+    {
+      "source": "core/engine",
+      "target": "core/module",
+      "count": 29,
+      "relations": {
+        "imports_from": 6,
+        "references": 14,
+        "imports": 9
+      }
+    },
+    {
+      "source": "core/engine",
+      "target": "core/utils",
+      "count": 1,
+      "relations": {
+        "imports_from": 1
+      }
+    },
+    {
+      "source": "core/engine",
+      "target": "services/activity_log",
+      "count": 17,
+      "relations": {
+        "imports_from": 5,
+        "references": 6,
+        "calls": 1,
+        "imports": 5
+      }
+    },
+    {
+      "source": "core/engine",
+      "target": "services/bus",
+      "count": 17,
+      "relations": {
+        "imports_from": 5,
+        "references": 6,
+        "calls": 1,
+        "imports": 5
+      }
+    },
+    {
+      "source": "core/engine",
+      "target": "services/cache",
+      "count": 26,
+      "relations": {
+        "imports_from": 5,
+        "references": 12,
+        "inherits": 2,
+        "calls": 1,
+        "imports": 6
+      }
+    },
+    {
+      "source": "core/engine",
+      "target": "services/coding_environment",
+      "count": 15,
+      "relations": {
+        "imports_from": 4,
+        "references": 6,
+        "calls": 1,
+        "imports": 4
+      }
+    },
+    {
+      "source": "core/engine",
+      "target": "services/dataset",
+      "count": 17,
+      "relations": {
+        "imports_from": 5,
+        "references": 6,
+        "calls": 1,
+        "imports": 5
+      }
+    },
+    {
+      "source": "core/engine",
+      "target": "services/email",
+      "count": 17,
+      "relations": {
+        "imports_from": 5,
+        "references": 6,
+        "calls": 1,
+        "imports": 5
+      }
+    },
+    {
+      "source": "core/engine",
+      "target": "services/event",
+      "count": 22,
+      "relations": {
+        "imports_from": 6,
+        "references": 9,
+        "calls": 1,
+        "imports": 6
+      }
+    },
+    {
+      "source": "core/engine",
+      "target": "services/keyvalue",
+      "count": 17,
+      "relations": {
+        "imports_from": 5,
+        "references": 6,
+        "calls": 1,
+        "imports": 5
+      }
+    },
+    {
+      "source": "core/engine",
+      "target": "services/model_registry",
+      "count": 17,
+      "relations": {
+        "imports_from": 4,
+        "references": 8,
+        "calls": 1,
+        "imports": 4
+      }
+    },
+    {
+      "source": "core/engine",
+      "target": "services/object_storage",
+      "count": 17,
+      "relations": {
+        "imports_from": 5,
+        "references": 6,
+        "calls": 1,
+        "imports": 5
+      }
+    },
+    {
+      "source": "core/engine",
+      "target": "services/secret",
+      "count": 31,
+      "relations": {
+        "imports_from": 8,
+        "references": 7,
+        "calls": 5,
+        "imports": 11
+      }
+    },
+    {
+      "source": "core/engine",
+      "target": "services/source_control",
+      "count": 15,
+      "relations": {
+        "imports_from": 4,
+        "references": 6,
+        "calls": 1,
+        "imports": 4
+      }
+    },
+    {
+      "source": "core/engine",
+      "target": "services/triple_store",
+      "count": 34,
+      "relations": {
+        "imports_from": 6,
+        "references": 7,
+        "calls": 8,
+        "imports": 13
+      }
+    },
+    {
+      "source": "core/engine",
+      "target": "services/vector_store",
+      "count": 17,
+      "relations": {
+        "imports_from": 5,
+        "references": 6,
+        "calls": 1,
+        "imports": 5
+      }
+    },
+    {
+      "source": "core/foundation",
+      "target": "core/utils",
+      "count": 2,
+      "relations": {
+        "imports_from": 1,
+        "re_exports": 1
+      }
+    },
+    {
+      "source": "core/module",
+      "target": "core/engine",
+      "count": 6,
+      "relations": {
+        "imports_from": 2,
+        "references": 2,
+        "imports": 2
+      }
+    },
+    {
+      "source": "core/module",
+      "target": "core/integration",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "references": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "core/module",
+      "target": "core/models",
+      "count": 4,
+      "relations": {
+        "imports_from": 1,
+        "imports": 3
+      }
+    },
+    {
+      "source": "core/module",
+      "target": "core/orchestrations",
+      "count": 6,
+      "relations": {
+        "imports_from": 2,
+        "references": 2,
+        "imports": 2
+      }
+    },
+    {
+      "source": "core/module",
+      "target": "core/pipeline",
+      "count": 6,
+      "relations": {
+        "imports_from": 2,
+        "references": 2,
+        "imports": 2
+      }
+    },
+    {
+      "source": "core/module",
+      "target": "core/utils",
+      "count": 14,
+      "relations": {
+        "imports_from": 7,
+        "references": 2,
+        "imports": 4,
+        "calls": 1
+      }
+    },
+    {
+      "source": "core/module",
+      "target": "core/workflow",
+      "count": 6,
+      "relations": {
+        "imports_from": 2,
+        "references": 2,
+        "imports": 2
+      }
+    },
+    {
+      "source": "core/module",
+      "target": "services/model_registry",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "references": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "core/modules",
+      "target": "core/module",
+      "count": 21,
+      "relations": {
+        "imports_from": 3,
+        "inherits": 6,
+        "re_exports": 3,
+        "imports": 9
+      }
+    },
+    {
+      "source": "core/modules",
+      "target": "core/utils",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "imports": 1,
+        "calls": 1
+      }
+    },
+    {
+      "source": "core/modules",
+      "target": "services/object_storage",
+      "count": 6,
+      "relations": {
+        "imports_from": 2,
+        "re_exports": 2,
+        "imports": 2
+      }
+    },
+    {
+      "source": "core/modules",
+      "target": "services/triple_store",
+      "count": 15,
+      "relations": {
+        "imports_from": 5,
+        "references": 2,
+        "re_exports": 3,
+        "imports": 5
+      }
+    },
+    {
+      "source": "core/pipeline",
+      "target": "core/utils",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "core/pipeline",
+      "target": "services/triple_store",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "references": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "core/services",
+      "target": "core/engine",
+      "count": 2,
+      "relations": {
+        "imports_from": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "core/utils",
+      "target": "core/pipeline",
+      "count": 1,
+      "relations": {
+        "imports": 1
+      }
+    },
+    {
+      "source": "core/utils",
+      "target": "core/workflow",
+      "count": 1,
+      "relations": {
+        "imports": 1
+      }
+    },
+    {
+      "source": "core/utils",
+      "target": "services/object_storage",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "references": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "core/utils",
+      "target": "services/triple_store",
+      "count": 7,
+      "relations": {
+        "imports_from": 2,
+        "references": 3,
+        "imports": 2
+      }
+    },
+    {
+      "source": "core/workflow",
+      "target": "core/utils",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "services/activity_log",
+      "target": "adapters/activity_log",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "imports": 1,
+        "calls": 1
+      }
+    },
+    {
+      "source": "services/activity_log",
+      "target": "core/services",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "services/agent",
+      "target": "core/engine",
+      "count": 9,
+      "relations": {
+        "imports_from": 2,
+        "imports": 3,
+        "calls": 4
+      }
+    },
+    {
+      "source": "services/agent",
+      "target": "core/models",
+      "count": 22,
+      "relations": {
+        "imports_from": 6,
+        "references": 7,
+        "calls": 3,
+        "imports": 6
+      }
+    },
+    {
+      "source": "services/agent",
+      "target": "core/utils",
+      "count": 11,
+      "relations": {
+        "imports_from": 7,
+        "inherits": 2,
+        "imports": 2
+      }
+    },
+    {
+      "source": "services/agent",
+      "target": "services/cache",
+      "count": 8,
+      "relations": {
+        "imports_from": 4,
+        "imports": 4
+      }
+    },
+    {
+      "source": "services/agent",
+      "target": "services/event",
+      "count": 9,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 7,
+        "imports": 1
+      }
+    },
+    {
+      "source": "services/bus",
+      "target": "core/services",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "services/bus",
+      "target": "services/event",
+      "count": 5,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 3,
+        "imports": 1
+      }
+    },
+    {
+      "source": "services/cache",
+      "target": "adapters/cache",
+      "count": 6,
+      "relations": {
+        "imports_from": 2,
+        "imports": 2,
+        "calls": 2
+      }
+    },
+    {
+      "source": "services/cache",
+      "target": "core/engine",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "references": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "services/cache",
+      "target": "core/services",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "services/cache",
+      "target": "core/utils",
+      "count": 4,
+      "relations": {
+        "imports_from": 1,
+        "imports": 2,
+        "calls": 1
+      }
+    },
+    {
+      "source": "services/cache",
+      "target": "services/event",
+      "count": 5,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 3,
+        "imports": 1
+      }
+    },
+    {
+      "source": "services/cache",
+      "target": "services/object_storage",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "references": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "services/coding_environment",
+      "target": "adapters/coding_environment",
+      "count": 11,
+      "relations": {
+        "imports_from": 3,
+        "imports": 4,
+        "calls": 4
+      }
+    },
+    {
+      "source": "services/coding_environment",
+      "target": "core/services",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "services/coding_environment",
+      "target": "services/event",
+      "count": 5,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 2,
+        "imports": 2
+      }
+    },
+    {
+      "source": "services/dataset",
+      "target": "adapters/dataset",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "imports": 1,
+        "calls": 1
+      }
+    },
+    {
+      "source": "services/dataset",
+      "target": "core/services",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "services/email",
+      "target": "adapters/email",
+      "count": 15,
+      "relations": {
+        "imports_from": 5,
+        "imports": 5,
+        "calls": 5
+      }
+    },
+    {
+      "source": "services/email",
+      "target": "core/services",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "services/email",
+      "target": "services/event",
+      "count": 4,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 2,
+        "imports": 1
+      }
+    },
+    {
+      "source": "services/event",
+      "target": "adapters/bus",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "imports": 1,
+        "calls": 1
+      }
+    },
+    {
+      "source": "services/event",
+      "target": "adapters/event",
+      "count": 14,
+      "relations": {
+        "imports_from": 2,
+        "imports": 2,
+        "calls": 10
+      }
+    },
+    {
+      "source": "services/event",
+      "target": "core/services",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "services/event",
+      "target": "core/utils",
+      "count": 4,
+      "relations": {
+        "imports_from": 1,
+        "imports": 2,
+        "calls": 1
+      }
+    },
+    {
+      "source": "services/event",
+      "target": "services/bus",
+      "count": 15,
+      "relations": {
+        "imports_from": 4,
+        "references": 3,
+        "inherits": 1,
+        "imports": 4,
+        "calls": 3
+      }
+    },
+    {
+      "source": "services/keyvalue",
+      "target": "core/services",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "services/keyvalue",
+      "target": "services/event",
+      "count": 5,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 3,
+        "imports": 1
+      }
+    },
+    {
+      "source": "services/model_registry",
+      "target": "core/models",
+      "count": 31,
+      "relations": {
+        "imports_from": 2,
+        "references": 20,
+        "calls": 2,
+        "imports": 7
+      }
+    },
+    {
+      "source": "services/model_registry",
+      "target": "core/services",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "services/object_storage",
+      "target": "adapters/object_storage",
+      "count": 13,
+      "relations": {
+        "imports_from": 4,
+        "imports": 4,
+        "calls": 5
+      }
+    },
+    {
+      "source": "services/object_storage",
+      "target": "core/services",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "services/object_storage",
+      "target": "core/utils",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "imports": 1,
+        "calls": 1
+      }
+    },
+    {
+      "source": "services/object_storage",
+      "target": "services/event",
+      "count": 4,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 2,
+        "imports": 1
+      }
+    },
+    {
+      "source": "services/secret",
+      "target": "core/services",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "services/secret",
+      "target": "core/utils",
+      "count": 1,
+      "relations": {
+        "imports_from": 1
+      }
+    },
+    {
+      "source": "services/secret",
+      "target": "services/event",
+      "count": 5,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 3,
+        "imports": 1
+      }
+    },
+    {
+      "source": "services/source_control",
+      "target": "adapters/source_control",
+      "count": 8,
+      "relations": {
+        "imports_from": 2,
+        "imports": 3,
+        "calls": 3
+      }
+    },
+    {
+      "source": "services/source_control",
+      "target": "core/services",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "services/source_control",
+      "target": "services/event",
+      "count": 5,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 2,
+        "imports": 2
+      }
+    },
+    {
+      "source": "services/triple_store",
+      "target": "core/services",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "services/triple_store",
+      "target": "core/utils",
+      "count": 22,
+      "relations": {
+        "references": 15,
+        "imports_from": 1,
+        "imports": 2,
+        "calls": 4
+      }
+    },
+    {
+      "source": "services/triple_store",
+      "target": "services/event",
+      "count": 10,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 8,
+        "imports": 1
+      }
+    },
+    {
+      "source": "services/triple_store",
+      "target": "services/keyvalue",
+      "count": 2,
+      "relations": {
+        "imports_from": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "services/triple_store",
+      "target": "services/object_storage",
+      "count": 8,
+      "relations": {
+        "imports_from": 3,
+        "references": 1,
+        "imports": 3,
+        "calls": 1
+      }
+    },
+    {
+      "source": "services/vector_store",
+      "target": "adapters/vector_store",
+      "count": 2,
+      "relations": {
+        "imports": 1,
+        "calls": 1
+      }
+    },
+    {
+      "source": "services/vector_store",
+      "target": "core/services",
+      "count": 3,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 1,
+        "imports": 1
+      }
+    },
+    {
+      "source": "services/vector_store",
+      "target": "services/event",
+      "count": 8,
+      "relations": {
+        "imports_from": 1,
+        "inherits": 6,
+        "imports": 1
+      }
+    }
+  ],
+  "extraction": {
+    "nodes": 8897,
+    "edges": 25761,
+    "skippedFiles": []
+  }
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/architecture-graph.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/architecture-graph.tsx
@@ -1,0 +1,80 @@
+'use client';
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { architecture } from './architecture-model';
+import { describeDependency, graphPositions, graphRoute, GRAPH_COLUMN, DIAGRAM_LAYERS } from './graph-model';
+import { LinkTooltip, type LinkHover } from './link-tooltip';
+import { useInfrastructure } from './infrastructure-store';
+
+export default function ArchitectureGraph() {
+  const { componentId, layerId, command, select } = useInfrastructure();
+  const nodes = useMemo(graphPositions, []);
+  const positions = useMemo(() => new Map(nodes.map(n => [n.id, n])), [nodes]);
+  const root = useRef<HTMLDivElement>(null);
+  const svg = useRef<SVGSVGElement>(null);
+  const markerId = useId().replaceAll(':', '');
+  const bounds = useMemo(() => {
+    const x = Math.min(...nodes.map(n => n.x)) - 150, y = Math.min(...nodes.map(n => n.y)) - 110;
+    return { x, y, w: Math.max(...nodes.map(n => n.x)) - x + 150, h: Math.max(...nodes.map(n => n.y)) - y + 50 };
+  }, [nodes]);
+  const [view, setView] = useState(bounds);
+  const [hover, setHover] = useState<LinkHover>(null);
+  const down = useRef<{ x: number; y: number; view: typeof bounds; moved: boolean } | null>(null);
+  const previous = useRef(command.sequence);
+  const connected = new Set([componentId]);
+  architecture.edges.forEach(e => { if (e.source === componentId || e.target === componentId) { connected.add(e.source); connected.add(e.target); } });
+  useEffect(() => {
+    if (previous.current === command.sequence) return;
+    previous.current = command.sequence; setHover(null);
+    if (command.type !== 'focus') {
+      const factor = command.type === 'in' ? 0.8 : 1.25;
+      setView(v => { const w = Math.max(bounds.w * 0.12, Math.min(bounds.w * 3, v.w * factor)); const ratio = w / v.w; return { x: v.x + (v.w - w) / 2, y: v.y + v.h * (1 - ratio) / 2, w, h: v.h * ratio }; });
+    } else setView(bounds);
+  }, [command, bounds]);
+  useEffect(() => {
+    const element = root.current!;
+    function wheel(e: WheelEvent) {
+      e.preventDefault(); setHover(null);
+      const rect = element.getBoundingClientRect(); const px = (e.clientX - rect.left) / rect.width, py = (e.clientY - rect.top) / rect.height;
+      setView(v => { const w = Math.max(bounds.w * 0.12, Math.min(bounds.w * 3, v.w * Math.exp(e.deltaY * 0.001))); const ratio = w / v.w; return { x: v.x + v.w * px * (1 - ratio), y: v.y + v.h * py * (1 - ratio), w, h: v.h * ratio }; });
+    }
+    element.addEventListener('wheel', wheel, { passive: false });
+    return () => element.removeEventListener('wheel', wheel);
+  }, [bounds]);
+  return <div className="infrastructure-graph" ref={root}>
+    <svg ref={svg} viewBox={`${view.x} ${view.y} ${view.w} ${view.h}`} aria-label="ABI architecture diagram" onPointerDown={e => { if (e.button !== 0) return; down.current = { x: e.clientX, y: e.clientY, view, moved: false }; }} onPointerMove={e => {
+      const d = down.current; if (!d || !e.buttons) return;
+      if (Math.hypot(e.clientX - d.x, e.clientY - d.y) < 4 && !d.moved) return;
+      d.moved = true; e.currentTarget.setPointerCapture(e.pointerId); setHover(null);
+      const scale = svg.current!.getScreenCTM()!.a;
+      setView({ ...d.view, x: d.view.x - (e.clientX - d.x) / scale, y: d.view.y - (e.clientY - d.y) / scale });
+    }} onPointerUp={e => { if (e.currentTarget.hasPointerCapture(e.pointerId)) e.currentTarget.releasePointerCapture(e.pointerId); }} onPointerCancel={() => { down.current = null; }} onPointerLeave={() => { setHover(null); }}>
+      <defs><marker id={markerId} viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor" /></marker></defs>
+      {DIAGRAM_LAYERS.map((layer, i) => <g key={layer.id} className="infrastructure-graph-lane">
+        <rect x={i * GRAPH_COLUMN - 122} y={-88} width={244} height={Math.max(...nodes.map(n => n.y)) + 124} rx={6} />
+        <path d={`M ${i * GRAPH_COLUMN - 110} -72 h 220`} style={{ stroke: layer.color }} />
+        <text x={i * GRAPH_COLUMN - 110} y={-48}>{layer.label}</text>
+        <text className="infrastructure-graph-lane-count" x={i * GRAPH_COLUMN - 110} y={-30}>{architecture.components.filter(c => c.layer === layer.id).length} components</text>
+      </g>)}
+      {architecture.edges.map(edge => {
+        const a = positions.get(edge.source)!, b = positions.get(edge.target)!;
+        const relevant = componentId ? edge.source === componentId || edge.target === componentId
+          : layerId ? architecture.components.some(c => (c.id === edge.source || c.id === edge.target) && c.layer === layerId) : true;
+        if (!relevant) return null;
+        const route = graphRoute(a, b);
+        const path = route.map((p, i) => `${i ? 'L' : 'M'} ${p.x} ${p.y}`).join(' ');
+        const show = (x: number, y: number) => { const r = root.current!.getBoundingClientRect(); setHover({ edge, x: Math.max(8, Math.min(x - r.left + 12, r.width - 300)), y: Math.max(8, Math.min(y - r.top + 12, r.height - 100)) }); };
+        return <g key={`${edge.source}:${edge.target}`} className={`infrastructure-graph-edge ${componentId || layerId ? 'is-focused' : 'is-relevant'}`}>
+          <path d={path} markerEnd={`url(#${markerId})`} />
+          <path d={path} className="infrastructure-graph-edge-hit" tabIndex={0} aria-label={`${describeDependency(edge).title}. ${describeDependency(edge).detail}`} onPointerMove={e => { if (!e.buttons) show(e.clientX, e.clientY); }} onPointerLeave={() => setHover(null)} onFocus={e => { const r = e.currentTarget.getBoundingClientRect(); show(r.x + r.width / 2, r.y + r.height / 2); }} onBlur={() => setHover(null)} />
+        </g>;
+      })}
+      {architecture.components.map(c => {
+        const p = positions.get(c.id)!; const layer = architecture.layers.find(l => l.id === c.layer)!;
+        const active = componentId ? connected.has(c.id) : !layerId || layerId === c.layer;
+        return <g key={c.id} transform={`translate(${p.x},${p.y})`} className={`infrastructure-graph-node ${active ? 'is-relevant' : ''} ${componentId === c.id ? 'is-selected' : ''}`} role="button" tabIndex={0} aria-label={`${c.label}, ${layer.label}, ${c.files} files`} onClick={() => { if (!down.current?.moved) select(c.layer, c.id); down.current = null; }} onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); select(c.layer, c.id); } }}>
+          <title>{c.label} · {layer.label}</title><rect x="-110" y="-24" width="220" height="48" rx="4" /><rect x="-110" y="-24" width="4" height="48" style={{ fill: layer.color, stroke: 'none' }} /><text x="-96" y="-2">{c.label.length > 27 ? `${c.label.slice(0, 26)}…` : c.label}</text><text className="infrastructure-graph-node-detail" x="-96" y="13">{c.files} files</text>
+        </g>;
+      })}
+    </svg><LinkTooltip hover={hover} />
+  </div>;
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/architecture-model.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/architecture-model.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { architecture, componentPosition, focusDistance, PLANE_DEPTH, PLANE_WIDTH } from './architecture-model';
+
+describe('ABI camera framing', () => {
+  for (const [width, height] of [[1400, 650], [500, 650], [300, 450], [900, 300]]) {
+    for (const expanded of [false, true]) {
+      it(`fits the complete ${expanded ? 'expanded' : 'normal'} plane at ${width}×${height}`, () => {
+        const distance = focusDistance(width, height, expanded);
+        const visibleDepth = (distance - 1) * 2 * Math.tan(Math.PI / 9);
+        const scale = expanded ? 1.2 : 1;
+        expect(visibleDepth).toBeGreaterThan(PLANE_DEPTH * scale);
+        expect(visibleDepth * width / height).toBeGreaterThan(PLANE_WIDTH * scale);
+      });
+    }
+  }
+  it('keeps all source components inside their plane', () => {
+    for (const layer of architecture.layers) {
+      const components = architecture.components.filter(c => c.layer === layer.id);
+      components.forEach((_, i) => {
+        const p = componentPosition(i, components.length, false);
+        expect(Math.abs(p.x) + 3.35 / 2).toBeLessThan(PLANE_WIDTH / 2);
+        expect(Math.abs(p.z) + 1.5 / 2).toBeLessThan(PLANE_DEPTH / 2);
+      });
+    }
+  });
+  it('has valid directed dependency endpoints and no self links', () => {
+    const ids = new Set(architecture.components.map(c => c.id));
+    for (const edge of architecture.edges) {
+      expect(ids.has(edge.source) && ids.has(edge.target)).toBe(true);
+      expect(edge.source).not.toBe(edge.target);
+      expect(edge.count).toBeGreaterThan(0);
+    }
+  });
+});

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/architecture-model.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/architecture-model.ts
@@ -1,0 +1,20 @@
+import snapshot from './abi-architecture.json';
+
+export const architecture = snapshot;
+export type Component = (typeof snapshot.components)[number];
+export type Layer = (typeof snapshot.layers)[number];
+export const PLANE_WIDTH = 12;
+export const PLANE_DEPTH = 11;
+
+/** Fits both plane dimensions; aspect changes must never crop the focused layer. */
+export function focusDistance(width: number, height: number, expanded: boolean) {
+  const aspect = Math.max(1, width) / Math.max(1, height);
+  const scale = expanded ? 1.2 : 1;
+  return Math.max(PLANE_DEPTH, PLANE_WIDTH / aspect) * scale / (2 * Math.tan(Math.PI / 9)) * 1.18 + 1;
+}
+export function componentPosition(index: number, count: number, expanded: boolean) {
+  const columns = 3;
+  const rows = Math.ceil(count / columns);
+  const spread = expanded ? 1.2 : 1;
+  return { x: ((index % columns) - 1) * 3.7 * spread, z: (Math.floor(index / columns) - (rows - 1) / 2) * 1.8 * spread };
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/architecture-scene.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/architecture-scene.tsx
@@ -1,0 +1,291 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { settleCameraPose } from './camera-pose';
+import { LinkTooltip, type LinkHover } from './link-tooltip';
+import { segmentDistance } from './graph-model';
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { architecture, componentPosition, focusDistance, PLANE_DEPTH, PLANE_WIDTH } from './architecture-model';
+
+type Props = {
+  layer: string | null; component: string | null; expanded: boolean; dependencies: boolean;
+  command: { type: 'focus' | 'in' | 'out'; sequence: number };
+  onSelect: (layer: string, component?: string) => void;
+};
+
+export default function ArchitectureScene(props: Props) {
+  const host = useRef<HTMLDivElement>(null);
+  const latest = useRef(props);
+  latest.current = props;
+  const update = useRef<() => void>(() => {});
+  const [hover, setHover] = useState<LinkHover>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    const container = host.current;
+    if (!container) return;
+    let renderer: THREE.WebGLRenderer;
+    try { renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false }); }
+    catch { setError(true); return; }
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    // Read the effective theme, including organization and system preferences.
+    function readPalette() {
+      const style = getComputedStyle(container!);
+      const token = (name: string, fallback: string) => style.getPropertyValue(name).trim() || fallback;
+      return {
+        background: token('--background-hex', '#FCFCFC'),
+        card: token('--card-hex', '#FFFFFF'),
+        text: token('--foreground-hex', '#18181B'),
+        muted: token('--muted-foreground-hex', '#71717A'),
+        selected: token('--muted-bg-hex', '#EBEBEE'),
+        border: token('--border-hex', '#E3E3E7'),
+      };
+    }
+    let palette = readPalette();
+    function layerColor(color: string) {
+      const light = new THREE.Color(palette.background).getHSL({ h: 0, s: 0, l: 0 }).l > 0.5;
+      return new THREE.Color(color).lerp(new THREE.Color(palette.text), light ? 0.55 : 0).getStyle();
+    }
+    renderer.setClearColor(palette.background);
+    container.appendChild(renderer.domElement);
+    renderer.domElement.setAttribute('aria-label', 'Interactive ABI architecture. Use the layer and component buttons for keyboard navigation.');
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(40, 1, 0.1, 250);
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.enableDamping = true; controls.dampingFactor = 0.08;
+    controls.minDistance = 4; controls.maxDistance = 150;
+    controls.maxPolarAngle = Math.PI * 0.85;
+    const planes = new Map<string, THREE.Group>();
+    const tiles = new Map<string, THREE.Group>();
+    const clickable: THREE.Object3D[] = [];
+    const textures: THREE.Texture[] = [];
+    const redrawLabels: (() => void)[] = [];
+    const lines = new THREE.Group(); scene.add(lines);
+    const grid = new THREE.GridHelper(80, 40, palette.border, palette.border);
+    grid.material.vertexColors = false;
+    grid.material.color.set(palette.border);
+    grid.position.y = -0.6; scene.add(grid);
+    const boxGeo = new THREE.BoxGeometry(3.35, 0.16, 1.5);
+    const edgeGeo = new THREE.EdgesGeometry(boxGeo);
+    function label(text: string, detail: string, color: string) {
+      const canvas = document.createElement('canvas'); canvas.width = 768; canvas.height = 256;
+      const ctx = canvas.getContext('2d')!;
+      const texture = new THREE.CanvasTexture(canvas); texture.colorSpace = THREE.SRGBColorSpace;
+      function draw() {
+        ctx.fillStyle = palette.card; ctx.fillRect(0, 0, 768, 256);
+        ctx.fillStyle = layerColor(color); ctx.fillRect(24, 34, 7, 185);
+        ctx.font = '500 37px sans-serif';
+        let title = text;
+        while (ctx.measureText(title).width > 680) title = title.slice(0, -2);
+        if (title !== text) title += '…';
+        ctx.fillStyle = palette.text; ctx.fillText(title, 52, 105);
+        ctx.fillStyle = palette.muted; ctx.font = '28px monospace'; ctx.fillText(detail, 52, 171);
+        texture.needsUpdate = true;
+      }
+      redrawLabels.push(draw); draw();
+      textures.push(texture);
+      const mesh = new THREE.Mesh(new THREE.PlaneGeometry(3.27, 1.42), new THREE.MeshBasicMaterial({ map: texture, side: THREE.DoubleSide }));
+      mesh.rotation.x = -Math.PI / 2; mesh.position.y = 0.09;
+      return mesh;
+    }
+    function layerLabel(text: string, color: string) {
+      // Match texture and plane aspect ratios so the title is never squeezed.
+      const canvas = document.createElement('canvas'); canvas.width = 1024; canvas.height = 128;
+      const ctx = canvas.getContext('2d')!;
+      const texture = new THREE.CanvasTexture(canvas);
+      texture.colorSpace = THREE.SRGBColorSpace;
+      texture.anisotropy = Math.min(8, renderer.capabilities.getMaxAnisotropy());
+      function draw() {
+        ctx.fillStyle = palette.card; ctx.fillRect(0, 0, canvas.width, canvas.height);
+        ctx.fillStyle = layerColor(color); ctx.fillRect(24, 24, 6, 80);
+        ctx.fillStyle = palette.text; ctx.font = '500 44px sans-serif';
+        ctx.textBaseline = 'middle'; ctx.fillText(text, 52, 64);
+        texture.needsUpdate = true;
+      }
+      redrawLabels.push(draw); draw(); textures.push(texture);
+      const mesh = new THREE.Mesh(new THREE.PlaneGeometry(5.2, 0.65), new THREE.MeshBasicMaterial({ map: texture, side: THREE.DoubleSide }));
+      mesh.rotation.x = -Math.PI / 2;
+      return mesh;
+    }
+    architecture.layers.forEach((layer, index) => {
+      const group = new THREE.Group(); group.position.y = (4 - index) * 3;
+      planes.set(layer.id, group); scene.add(group);
+      const geometry = new THREE.BoxGeometry(PLANE_WIDTH, 0.08, PLANE_DEPTH);
+      const surface = new THREE.Mesh(geometry, new THREE.MeshBasicMaterial({ color: layer.color, transparent: true, opacity: 0.09, depthWrite: false }));
+      surface.userData = { layer: layer.id }; clickable.push(surface); group.add(surface);
+      group.add(new THREE.LineSegments(new THREE.EdgesGeometry(geometry), new THREE.LineBasicMaterial({ color: layer.color, transparent: true, opacity: 0.6 })));
+      const components = architecture.components.filter(c => c.layer === layer.id);
+      const title = layerLabel(`0${5 - index}  ${layer.label}`, layer.color);
+      title.position.set(-3.1, 0.07, 5);
+      title.userData = { layer: layer.id }; group.add(title); clickable.push(title);
+      components.forEach((component, i) => {
+        const tile = new THREE.Group(); const p = componentPosition(i, components.length, false);
+        tile.position.set(p.x, 0.18, p.z); tile.userData = { index: i, count: components.length };
+        const box = new THREE.Mesh(boxGeo, new THREE.MeshBasicMaterial({ color: palette.card }));
+        box.userData = { layer: layer.id, component: component.id };
+        const face = label(component.label, `${component.files} files · ${component.functions} functions`, layer.color);
+        face.userData = box.userData;
+        const outline = new THREE.LineSegments(edgeGeo, new THREE.LineBasicMaterial({ color: layer.color, transparent: true, opacity: 0.48 }));
+        tile.add(box, face, outline); group.add(tile); tiles.set(component.id, tile); clickable.push(box, face);
+      });
+    });
+    const cameraGoal = new THREE.Vector3(); const targetGoal = new THREE.Vector3();
+    let flying = true; let lastCommand = -1;
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    function disposeLines() {
+      setHover(null);
+      for (const child of [...lines.children]) {
+        const line = child as THREE.Line;
+        line.geometry.dispose(); (line.material as THREE.Material).dispose(); lines.remove(child);
+      }
+    }
+    function sync(forceFit = false) {
+      const state = latest.current;
+      planes.forEach((plane, id) => {
+        plane.visible = !state.layer || state.layer === id;
+        plane.scale.set(state.expanded ? 1.2 : 1, 1, state.expanded ? 1.2 : 1);
+      });
+      tiles.forEach((tile, id) => {
+        // Tiles retain their dimensions while the plate expands around them.
+        const scale = state.expanded ? 1 / 1.2 : 1;
+        tile.scale.set(scale, 1, scale);
+        tile.position.y = state.expanded ? 0.7 : 0.18;
+        const outline = tile.children[2] as THREE.LineSegments;
+        const mat = outline.material as THREE.LineBasicMaterial;
+        mat.opacity = id === state.component ? 1 : 0.48;
+        (tile.children[0] as THREE.Mesh<THREE.BoxGeometry, THREE.MeshBasicMaterial>).material.color.set(id === state.component ? palette.selected : palette.card);
+      });
+      scene.updateMatrixWorld(true); disposeLines();
+      if (state.dependencies) architecture.edges.forEach(edge => {
+        if (state.component && edge.source !== state.component && edge.target !== state.component) return;
+        const from = tiles.get(edge.source)!; const to = tiles.get(edge.target)!;
+        if (!from.parent?.visible || !to.parent?.visible) return;
+        const start = from.getWorldPosition(new THREE.Vector3()); const end = to.getWorldPosition(new THREE.Vector3());
+        start.y += 0.15; end.y += 0.15;
+        const line = new THREE.Line(new THREE.BufferGeometry().setFromPoints([start, end]), new THREE.LineBasicMaterial({ color: state.component ? palette.text : palette.muted, transparent: true, opacity: state.component ? 0.7 : 0.18 }));
+        line.userData.edge = edge;
+        lines.add(line);
+      });
+      grid.visible = !state.layer;
+      if (state.command.sequence !== lastCommand) {
+        lastCommand = state.command.sequence;
+        if (!forceFit && (state.command.type === 'in' || state.command.type === 'out')) {
+          targetGoal.copy(controls.target);
+          const offset = camera.position.clone().sub(controls.target);
+          offset.setLength(THREE.MathUtils.clamp(offset.length() * (state.command.type === 'in' ? 0.8 : 1.25), 4, 150));
+          cameraGoal.copy(targetGoal).add(offset);
+        } else if (state.layer) {
+          const y = planes.get(state.layer)!.position.y;
+          const distance = focusDistance(container!.clientWidth, container!.clientHeight, state.expanded);
+          targetGoal.set(0, y, 0);
+          cameraGoal.set(0, y + distance, 0.001);
+        } else {
+          targetGoal.set(0, 6, 0);
+          const distance = Math.max(30, 27 / camera.aspect);
+          cameraGoal.copy(targetGoal).add(new THREE.Vector3(0.35, 1.25, 1).normalize().multiplyScalar(distance));
+        }
+        flying = true;
+      }
+    }
+    function applyTheme() {
+      palette = readPalette();
+      renderer.setClearColor(palette.background);
+      grid.material.color.set(palette.border);
+      architecture.layers.forEach(layer => {
+        const group = planes.get(layer.id)!;
+        group.traverse(obj => {
+          const material = (obj as THREE.Mesh).material;
+          if (!material || Array.isArray(material)) return;
+          if (material instanceof THREE.LineBasicMaterial || (material instanceof THREE.MeshBasicMaterial && material.transparent && !material.map)) material.color.set(layerColor(layer.color));
+        });
+      });
+      redrawLabels.forEach(draw => draw());
+      // Update materials without changing the camera, selection or decomposition.
+      sync();
+    }
+    applyTheme();
+    const themeObserver = new MutationObserver(applyTheme);
+    for (let ancestor: HTMLElement | null = container; ancestor; ancestor = ancestor.parentElement) {
+      themeObserver.observe(ancestor, { attributes: true, attributeFilter: ['class', 'style', 'data-theme'] });
+    }
+    update.current = sync;
+    function resize() {
+      const width = Math.max(1, container!.clientWidth); const height = Math.max(1, container!.clientHeight);
+      renderer.setSize(width, height); camera.aspect = width / height; camera.updateProjectionMatrix();
+      lastCommand = -1; sync(true);
+    }
+    const observer = new ResizeObserver(resize); observer.observe(container);
+    resize(); settleCameraPose(camera, controls, cameraGoal, targetGoal);
+    const pointer = new THREE.Vector2(); const raycaster = new THREE.Raycaster();
+    let down = { x: 0, y: 0 };
+    function onDown(e: PointerEvent) { down = { x: e.clientX, y: e.clientY }; }
+    function onUp(e: PointerEvent) {
+      if (Math.hypot(e.clientX - down.x, e.clientY - down.y) > 5 || e.button !== 0) return;
+      const rect = renderer.domElement.getBoundingClientRect();
+      pointer.set((e.clientX - rect.left) / rect.width * 2 - 1, -((e.clientY - rect.top) / rect.height) * 2 + 1);
+      raycaster.setFromCamera(pointer, camera);
+      const hit = raycaster.intersectObjects(clickable).find(h => h.object.parent?.visible && (h.object.parent?.parent === scene || h.object.parent?.parent?.visible));
+      if (hit) latest.current.onSelect(hit.object.userData.layer, hit.object.userData.component);
+    }
+    function onMove(e: PointerEvent) {
+      if (e.buttons) { setHover(null); return; }
+      const rect = renderer.domElement.getBoundingClientRect();
+      const x = e.clientX - rect.left, y = e.clientY - rect.top;
+      let best = 9; let next: LinkHover = null;
+      for (const object of lines.children) {
+        const line = object as THREE.Line;
+        const positions = line.geometry.getAttribute('position');
+        const a = new THREE.Vector3().fromBufferAttribute(positions, 0).project(camera);
+        const b = new THREE.Vector3().fromBufferAttribute(positions, 1).project(camera);
+        if (a.z < -1 || a.z > 1 || b.z < -1 || b.z > 1) continue;
+        const distance = segmentDistance(x, y, (a.x + 1) * rect.width / 2, (1 - a.y) * rect.height / 2, (b.x + 1) * rect.width / 2, (1 - b.y) * rect.height / 2);
+        if (distance < best) { best = distance; next = { edge: line.userData.edge, x: Math.max(8, Math.min(x + 12, rect.width - 300)), y: Math.max(8, Math.min(y + 12, rect.height - 100)) }; }
+      }
+      setHover(next);
+    }
+    function clearHover() { setHover(null); }
+    function stopFlight() { flying = false; clearHover(); }
+    function contextLost(e: Event) { e.preventDefault(); setError(true); }
+    controls.addEventListener('start', stopFlight);
+    renderer.domElement.addEventListener('pointermove', onMove);
+    renderer.domElement.addEventListener('pointerleave', clearHover);
+    renderer.domElement.addEventListener('pointerdown', onDown);
+    renderer.domElement.addEventListener('pointerup', onUp);
+    renderer.domElement.addEventListener('webglcontextlost', contextLost);
+    let frame = 0; let previous = performance.now();
+    function animate(now: number) {
+      frame = requestAnimationFrame(animate);
+      const dt = Math.min((now - previous) / 1000, 0.1); previous = now;
+      if (flying) {
+        const alpha = reducedMotion ? 1 : 1 - Math.exp(-7 * dt);
+        camera.position.lerp(cameraGoal, alpha); controls.target.lerp(targetGoal, alpha);
+        camera.lookAt(controls.target);
+        if (camera.position.distanceTo(cameraGoal) < 0.005 && controls.target.distanceTo(targetGoal) < 0.005) {
+          settleCameraPose(camera, controls, cameraGoal, targetGoal);
+          flying = false;
+        }
+      } else {
+        controls.update();
+      }
+      renderer.render(scene, camera);
+    }
+    frame = requestAnimationFrame(animate);
+    return () => {
+      cancelAnimationFrame(frame); observer.disconnect(); themeObserver.disconnect(); controls.dispose(); update.current = () => {};
+      renderer.domElement.removeEventListener('pointermove', onMove);
+      renderer.domElement.removeEventListener('pointerleave', clearHover);
+      renderer.domElement.removeEventListener('pointerdown', onDown); renderer.domElement.removeEventListener('pointerup', onUp);
+      renderer.domElement.removeEventListener('webglcontextlost', contextLost);
+      scene.traverse(obj => {
+        const mesh = obj as THREE.Mesh;
+        mesh.geometry?.dispose();
+        if (mesh.material) (Array.isArray(mesh.material) ? mesh.material : [mesh.material]).forEach(m => m.dispose());
+      });
+      textures.forEach(texture => texture.dispose()); renderer.dispose(); renderer.domElement.remove();
+    };
+  }, []);
+
+  useEffect(() => { update.current(); }, [props.layer, props.component, props.expanded, props.dependencies, props.command]);
+  return <div className="infrastructure-scene" ref={host}><LinkTooltip hover={hover} />{error && <div className="infrastructure-scene-error" role="status">3D rendering is unavailable. You can still explore every layer, component and dependency in the panels.</div>}</div>;
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/camera-pose.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/camera-pose.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { PerspectiveCamera, Vector3 } from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { settleCameraPose } from './camera-pose';
+import { focusDistance, PLANE_WIDTH, PLANE_DEPTH } from './architecture-model';
+
+describe('face-on layer focus', () => {
+  for (const y of [0, 3, 6, 9, 12]) {
+    it(`settles upright and fits the plane at height ${y}`, () => {
+      const camera = new PerspectiveCamera(40, 1000 / 700, 0.1, 250);
+      const controls = new OrbitControls(camera);
+      controls.enableDamping = true;
+      const target = new Vector3(0, y, 0);
+      const goal = new Vector3(0, y + focusDistance(1000, 700, false), 0.001);
+      // The former transition stopped with this small error, leaving a diagonal view.
+      camera.position.copy(goal).add(new Vector3(0.004, 0, 0));
+      controls.target.copy(target); controls.update();
+      settleCameraPose(camera, controls, goal, target);
+      camera.updateMatrixWorld(true);
+      const left = new Vector3(-PLANE_WIDTH / 2, y, 0).project(camera);
+      const right = new Vector3(PLANE_WIDTH / 2, y, 0).project(camera);
+      expect(left.y).toBeCloseTo(right.y, 8);
+      expect(left.x).toBeLessThan(right.x);
+      for (const x of [-PLANE_WIDTH / 2, PLANE_WIDTH / 2]) for (const z of [-PLANE_DEPTH / 2, PLANE_DEPTH / 2]) {
+        const corner = new Vector3(x, y, z).project(camera);
+        expect(Math.abs(corner.x)).toBeLessThan(1);
+        expect(Math.abs(corner.y)).toBeLessThan(1);
+      }
+      expect(controls.enableDamping).toBe(true);
+    });
+  }
+});

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/camera-pose.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/camera-pose.ts
@@ -1,0 +1,14 @@
+import type { PerspectiveCamera, Vector3 } from 'three';
+import type { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+
+/** Flush orbit inertia, then settle exactly: tiny X errors near the pole cause large roll. */
+export function settleCameraPose(camera: PerspectiveCamera, controls: OrbitControls, position: Vector3, target: Vector3) {
+  const damping = controls.enableDamping;
+  controls.enableDamping = false;
+  controls.update();
+  camera.position.copy(position);
+  controls.target.copy(target);
+  camera.lookAt(target);
+  controls.update();
+  controls.enableDamping = damping;
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/graph-model.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/graph-model.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { architecture } from './architecture-model';
+import { describeDependency, graphPositions, segmentDistance, graphRoute, GRAPH_NODE_WIDTH, GRAPH_NODE_HEIGHT, DIAGRAM_LAYERS } from './graph-model';
+describe('dependency graph', () => {
+  it('measures proximity in screen pixels, including endpoints and zero length links', () => {
+    expect(segmentDistance(50, 6, 0, 0, 100, 0)).toBe(6);
+    expect(segmentDistance(110, 0, 0, 0, 100, 0)).toBe(10);
+    expect(segmentDistance(3, 4, 0, 0, 0, 0)).toBe(5);
+  });
+  it('places every component at a finite deterministic position', () => {
+    const nodes = graphPositions();
+    expect(nodes).toEqual(graphPositions());
+    expect(new Set(nodes.map(n => n.id))).toEqual(new Set(architecture.components.map(n => n.id)));
+    expect(nodes.every(n => Number.isFinite(n.x) && Number.isFinite(n.y))).toBe(true);
+  });
+  it('labels the direction and extracted relationship counts', () => {
+    const edge = architecture.edges[0]; const label = describeDependency(edge);
+    expect(label.title).toBe(`${architecture.components.find(c => c.id === edge.source)!.label} → ${architecture.components.find(c => c.id === edge.target)!.label}`);
+    for (const [relation, count] of Object.entries(edge.relations)) expect(label.detail).toContain(`${relation.replaceAll('_', ' ')}: ${count}`);
+  });
+});
+
+describe('architectural map spacing', () => {
+  it('keeps every card separate and in its architectural column', () => {
+    const nodes = graphPositions();
+    for (let i = 0; i < nodes.length; i++) {
+      const a = nodes[i];
+      const component = architecture.components.find(c => c.id === a.id)!;
+      expect(DIAGRAM_LAYERS[a.column].id).toBe(component.layer);
+      for (const b of nodes.slice(i + 1)) {
+        expect(Math.abs(a.x - b.x) >= GRAPH_NODE_WIDTH + 16 || Math.abs(a.y - b.y) >= GRAPH_NODE_HEIGHT + 16).toBe(true);
+      }
+    }
+  });
+  it('routes all dependencies around other cards', () => {
+    const nodes = graphPositions();
+    const positions = new Map(nodes.map(n => [n.id, n]));
+    for (const edge of architecture.edges) {
+      const route = graphRoute(positions.get(edge.source)!, positions.get(edge.target)!);
+      for (let i = 1; i < route.length; i++) {
+        const a = route[i - 1], b = route[i];
+        expect(a.x === b.x || a.y === b.y).toBe(true);
+        for (const node of nodes.filter(n => n.id !== edge.source && n.id !== edge.target)) {
+          const left = node.x - GRAPH_NODE_WIDTH / 2, right = node.x + GRAPH_NODE_WIDTH / 2;
+          const top = node.y - GRAPH_NODE_HEIGHT / 2, bottom = node.y + GRAPH_NODE_HEIGHT / 2;
+          const crosses = a.y === b.y
+            ? a.y > top && a.y < bottom && Math.max(a.x,b.x) > left && Math.min(a.x,b.x) < right
+            : a.x > left && a.x < right && Math.max(a.y,b.y) > top && Math.min(a.y,b.y) < bottom;
+          expect(crosses, `${edge.source} → ${edge.target} crosses ${node.id}`).toBe(false);
+        }
+      }
+    }
+  });
+});

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/graph-model.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/graph-model.ts
@@ -1,0 +1,37 @@
+import { architecture } from './architecture-model';
+export type Dependency = (typeof architecture.edges)[number];
+export function describeDependency(edge: Dependency) {
+  const label = (id: string) => architecture.components.find(c => c.id === id)?.label ?? id;
+  return { title: `${label(edge.source)} → ${label(edge.target)}`, detail: Object.entries(edge.relations).map(([name, count]) => `${name.replaceAll('_', ' ')}: ${count}`).join(' · ') };
+}
+export function segmentDistance(px: number, py: number, ax: number, ay: number, bx: number, by: number) {
+  const dx = bx - ax, dy = by - ay;
+  const t = Math.max(0, Math.min(1, ((px - ax) * dx + (py - ay) * dy) / (dx * dx + dy * dy || 1)));
+  return Math.hypot(px - ax - t * dx, py - ay - t * dy);
+}
+// Read the diagram from infrastructure foundations to user-facing applications.
+export const DIAGRAM_LAYERS = [...architecture.layers].reverse();
+export const GRAPH_COLUMN = 320;
+export const GRAPH_ROW = 68;
+export const GRAPH_NODE_WIDTH = 220;
+export const GRAPH_NODE_HEIGHT = 48;
+/** Fixed architectural lanes: positions never depend on the number of links. */
+export function graphPositions() {
+  return DIAGRAM_LAYERS.flatMap((layer, column) =>
+    architecture.components.filter(c => c.layer === layer.id)
+      .sort((a, b) => a.label.localeCompare(b.label))
+      .map((c, row) => ({ id: c.id, x: column * GRAPH_COLUMN, y: row * GRAPH_ROW, column, row })));
+}
+export function graphRoute(a: { x: number; y: number }, b: { x: number; y: number }) {
+  const direction = b.x >= a.x ? 1 : -1;
+  const start = { x: a.x + direction * GRAPH_NODE_WIDTH / 2, y: a.y };
+  const end = { x: b.x - direction * GRAPH_NODE_WIDTH / 2, y: b.y };
+  if (a.x === b.x) {
+    end.x = b.x + GRAPH_NODE_WIDTH / 2;
+    return [start, { x: start.x + 24, y: start.y }, { x: start.x + 24, y: end.y }, end];
+  }
+  // Horizontal runs occupy row gaps; vertical runs stay in column gutters.
+  const sx = start.x + direction * 20, tx = end.x - direction * 20;
+  const corridor = a.y + GRAPH_ROW / 2;
+  return [start, { x: sx, y: a.y }, { x: sx, y: corridor }, { x: tx, y: corridor }, { x: tx, y: b.y }, end];
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/infrastructure-menu.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/infrastructure-menu.tsx
@@ -1,0 +1,30 @@
+'use client';
+import { useEffect, useRef } from 'react';
+import { architecture } from './architecture-model';
+import { useInfrastructure } from './infrastructure-store';
+import './infrastructure.css';
+
+export function InfrastructureMenu() {
+  const { viewMode, setViewMode, expanded, dependencies, reset, move, toggleExpanded, toggleDependencies } = useInfrastructure();
+  const root = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const close = (e: Event) => {
+      if ((e instanceof KeyboardEvent && e.key === 'Escape') || (e.type === 'pointerdown' && !root.current?.contains(e.target as Node))) root.current?.querySelectorAll('details').forEach(d => { d.open = false; });
+    };
+    document.addEventListener('pointerdown', close); document.addEventListener('keydown', close);
+    return () => { document.removeEventListener('pointerdown', close); document.removeEventListener('keydown', close); };
+  }, []);
+  function run(action: () => void) { action(); root.current?.querySelectorAll('details').forEach(d => { d.open = false; }); }
+  function download() {
+    const url = URL.createObjectURL(new Blob([JSON.stringify(architecture, null, 2)], { type: 'application/json' }));
+    const a = document.createElement('a'); a.href = url; a.download = 'abi-architecture.json'; a.click(); setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }
+  return <div className="infrastructure-menu" ref={root}>
+    <span className="infrastructure-menu-title">Infrastructure</span>
+    <details onToggle={e => { if (e.currentTarget.open) root.current?.querySelectorAll('details').forEach(d => { if (d !== e.currentTarget) d.open = false; }); }}><summary>File</summary><div className="infrastructure-menu-popup"><button onClick={() => run(download)}>Export architecture…</button></div></details>
+    <details onToggle={e => { if (e.currentTarget.open) root.current?.querySelectorAll('details').forEach(d => { if (d !== e.currentTarget) d.open = false; }); }}><summary>View</summary><div className="infrastructure-menu-popup">
+      <button aria-pressed={viewMode === 'layers'} onClick={() => run(() => setViewMode('layers'))}>Layers view</button><button aria-pressed={viewMode === 'graph'} onClick={() => run(() => setViewMode('graph'))}>Diagram view</button><hr /><button onClick={() => run(reset)}>Entire system</button><button onClick={() => run(() => move())}>Fit view</button><button onClick={() => run(() => move('in'))}>Zoom in</button><button onClick={() => run(() => move('out'))}>Zoom out</button><hr />
+      <button disabled={viewMode === 'graph'} aria-pressed={expanded} onClick={() => run(toggleExpanded)}>Decompose <span>{expanded ? '✓' : ''}</span></button><button disabled={viewMode === 'graph'} aria-pressed={dependencies || viewMode === 'graph'} onClick={() => run(toggleDependencies)}>Dependencies <span>{dependencies ? '✓' : ''}</span></button>
+    </div></details>
+  </div>;
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/infrastructure-section.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/infrastructure-section.tsx
@@ -1,0 +1,39 @@
+'use client';
+import { useMemo, type CSSProperties } from 'react';
+import { ArrowDownLeft, ArrowUpRight, Layers, Search } from 'lucide-react';
+import { architecture } from './architecture-model';
+import { useInfrastructure } from './infrastructure-store';
+import './infrastructure.css';
+const number = (n: number) => n.toLocaleString('en-US');
+export function InfrastructureSection() {
+  const { layerId, componentId, search, tab, select, reset, setSearch, setTab, setComponentId } = useInfrastructure();
+  const layer = architecture.layers.find(l => l.id === layerId);
+  const component = architecture.components.find(c => c.id === componentId);
+  const componentMap = useMemo(() => new Map(architecture.components.map(c => [c.id, c])), []);
+  const filtered = architecture.components.filter(c => (!layerId || c.layer === layerId) && `${c.label} ${c.id}`.toLowerCase().includes(search.toLowerCase()));
+  const selectedComponents = component ? [component] : architecture.components.filter(c => !layerId || c.layer === layerId);
+  const sum = (key: 'files' | 'lines' | 'classes' | 'functions' | 'tests') => selectedComponents.reduce((n, c) => n + c[key], 0);
+  const outbound = architecture.edges.filter(e => e.source === componentId);
+  const inbound = architecture.edges.filter(e => e.target === componentId);
+  return <div className="infrastructure-sidebar">
+    <div className="infrastructure-sidebar-tabs"><button aria-pressed={tab === 'layers'} onClick={() => setTab('layers')}>Architecture</button><button aria-pressed={tab === 'inspector'} onClick={() => setTab('inspector')}>Inspector</button></div>
+    {tab === 'layers' ? <>
+      <button className={`infrastructure-tree-row ${!layerId ? 'is-active' : ''}`} onClick={reset}><Layers size={14} /><span>Entire system</span><small>{architecture.components.length}</small></button>
+      {architecture.layers.map((item) => <button key={item.id} className={`infrastructure-tree-row ${layerId === item.id ? 'is-active' : ''}`} aria-pressed={layerId === item.id} onClick={() => select(item.id)}><span className="infrastructure-layer-dot" style={{ '--layer-color': item.color } as CSSProperties} /><span>{item.label}</span><small>{architecture.components.filter(c => c.layer === item.id).length}</small></button>)}
+      <label className="infrastructure-search"><Search size={14} /><input aria-label="Search components" placeholder="Find a component…" value={search} onChange={e => setSearch(e.target.value)} /></label>
+      <div className="infrastructure-component-list">{filtered.map(c => <button key={c.id} onClick={() => select(c.layer, c.id)}><span><strong>{c.label}</strong><small>{c.files} files</small></span><ArrowUpRight size={13} /></button>)}{!filtered.length && <p>No matching components.</p>}</div>
+    </> : <div className="infrastructure-inspector">        <div className="infrastructure-inspector-title" aria-live="polite"><div className="infrastructure-eyebrow">{component ? 'COMPONENT' : layer ? 'LAYER OVERVIEW' : 'SYSTEM OVERVIEW'}</div><h2>{component?.label ?? layer?.label ?? 'ABI architecture'}</h2><p>{component ? component.id : layer?.description ?? 'Five logical layers, from applications to infrastructure adapters. Select a layer to bring its plane into focus.'}</p></div>
+        <div className="infrastructure-metrics">{([['Source files', sum('files')], ['Lines of code', sum('lines')], ['Classes', sum('classes')], ['Functions', sum('functions')], ['Test files', sum('tests')], ['Components', selectedComponents.length]] as const).map(([label, value]) => <div key={label}><span>{label}</span><strong>{number(value)}</strong></div>)}</div>
+        <p className="infrastructure-metric-note">Python only · lines include comments and blanks · test files are counted, not executed.</p>
+        {component ? <>
+          <button className="infrastructure-back" onClick={() => setComponentId(null)}>← All components in this layer</button>
+          <div className="infrastructure-dependencies"><h3><ArrowUpRight size={14} /> Depends on <span>{outbound.length}</span></h3>{outbound.length ? outbound.map(edge => <button key={edge.target} onClick={() => select(componentMap.get(edge.target)!.layer, edge.target)}><span>{componentMap.get(edge.target)!.label}<small>{Object.entries(edge.relations).map(([relation, count]) => `${relation.replaceAll('_', ' ')}: ${count}`).join(' · ')}</small></span><ArrowUpRight size={14} /></button>) : <p>No cross-component dependencies resolved.</p>}
+          <h3><ArrowDownLeft size={14} /> Used by <span>{inbound.length}</span></h3>{inbound.length ? inbound.map(edge => <button key={edge.source} onClick={() => select(componentMap.get(edge.source)!.layer, edge.source)}><span>{componentMap.get(edge.source)!.label}<small>{edge.count} extracted relationships</small></span><ArrowUpRight size={14} /></button>) : <p>No incoming dependencies resolved.</p>}</div>
+          <details className="infrastructure-files"><summary>Source files ({component.sourcePaths.length})</summary>{component.sourcePaths.map(path => <code key={path}>{path}</code>)}</details>
+        </> : <>
+          <label className="infrastructure-search"><Search size={15} /><input aria-label="Search components" placeholder="Find a component…" value={search} onChange={e => setSearch(e.target.value)} /></label>
+          <div className="infrastructure-component-list">{filtered.map(c => <button key={c.id} onClick={() => select(c.layer, c.id)}><span><strong>{c.label}</strong><small>{c.files} files · {c.functions} functions</small></span><ArrowUpRight size={14} /></button>)}{!filtered.length && <p>No components match “{search}”.</p>}</div>
+        </>}</div>}
+    <details className="infrastructure-about"><summary>About this map</summary><p>{architecture.extractor} · {architecture.revision}</p><p>{architecture.scope}</p><p>{architecture.edges.length} resolved component dependencies. Dynamic wiring may be absent.</p></details>
+  </div>;
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/infrastructure-store.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/infrastructure-store.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+
+type State = {
+  viewMode: 'layers' | 'graph'; setViewMode: (mode: 'layers' | 'graph') => void;
+  layerId: string | null; componentId: string | null; expanded: boolean; dependencies: boolean;
+  search: string; tab: 'layers' | 'inspector';
+  command: { type: 'focus' | 'in' | 'out'; sequence: number };
+  move: (type?: 'focus' | 'in' | 'out') => void;
+  select: (layer: string, component?: string) => void;
+  reset: () => void;
+  setComponentId: (id: string | null) => void;
+  setSearch: (search: string) => void;
+  setTab: (tab: 'layers' | 'inspector') => void;
+  toggleExpanded: () => void; toggleDependencies: () => void;
+};
+export const useInfrastructure = create<State>((set) => ({
+  viewMode: 'layers', setViewMode: viewMode => set({ viewMode }),
+  layerId: null, componentId: null, expanded: false, dependencies: true, search: '', tab: 'layers',
+  command: { type: 'focus', sequence: 0 },
+  move: (type = 'focus') => set(s => ({ command: { type, sequence: s.command.sequence + 1 } })),
+  select: (layerId, componentId) => set(s => ({ layerId, componentId: componentId ?? null, tab: componentId ? 'inspector' : 'layers', command: { type: 'focus', sequence: s.command.sequence + 1 } })),
+  reset: () => set(s => ({ layerId: null, componentId: null, expanded: false, dependencies: true, search: '', tab: 'layers', command: { type: 'focus', sequence: s.command.sequence + 1 } })),
+  setComponentId: componentId => set({ componentId, tab: componentId ? 'inspector' : 'layers' }),
+  setSearch: search => set({ search }), setTab: tab => set({ tab }),
+  toggleExpanded: () => set(s => ({ expanded: !s.expanded, command: { type: 'focus', sequence: s.command.sequence + 1 } })),
+  toggleDependencies: () => set(s => ({ dependencies: !s.dependencies })),
+}));

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/infrastructure.css
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/infrastructure.css
@@ -1,0 +1,91 @@
+.infrastructure-page { height:100%; display:flex; flex-direction:column; min-height:0; color:var(--foreground-hex); }
+.infrastructure-viewport { position:relative; flex:1; display:flex; flex-direction:column; min-height:250px; background:var(--background-hex); color:var(--foreground-hex); }
+.infrastructure-view-heading { display:flex; align-items:center; gap:12px; padding:16px 20px; font-size:12px; color:var(--muted-foreground-hex); }
+.infrastructure-view-heading button { color:var(--foreground-hex); }
+.infrastructure-exit { margin-left:auto; font-size:11px; }
+.infrastructure-canvas-area { position:relative; flex:1; min-height:0; }
+.infrastructure-scene { position:absolute; inset:0; }
+.infrastructure-scene canvas { display:block; width:100%; height:100%; touch-action:none; }
+.infrastructure-scene-error { position:absolute; inset:0; display:grid; place-content:center; padding:32px; color:var(--muted-foreground-hex); background:var(--background-hex); font-size:13px; text-align:center; z-index:2; }
+.infrastructure-view-tools { position:absolute; right:16px; top:60px; display:flex; flex-direction:column; border:1px solid var(--border-hex); background:var(--background-hex); border-radius:var(--org-border-radius,0px); }
+.infrastructure-view-tools button { padding:9px; color:var(--muted-foreground-hex); }
+.infrastructure-view-tools button:hover { color:var(--foreground-hex); background:var(--muted-bg-hex); }
+.infrastructure-view-footer { display:flex; flex-wrap:wrap; justify-content:space-between; gap:8px; padding:10px 20px; font-size:10px; color:var(--muted-foreground-hex); }
+.infrastructure-sidebar { color:var(--foreground-hex); font-size:12px; }
+.infrastructure-sidebar-tabs { display:flex; gap:4px; margin-bottom:12px; padding:0 2px 8px; border-bottom:1px solid var(--border-hex); }
+.infrastructure-sidebar-tabs button { padding:6px 8px; color:var(--muted-foreground-hex); border-radius:var(--org-border-radius,0px); }
+.infrastructure-sidebar-tabs button[aria-pressed=true] { color:var(--workspace-accent,var(--color-primary)); background:color-mix(in srgb,var(--workspace-accent,var(--color-primary)) 10%,transparent); }
+.infrastructure-tree-row { display:flex; align-items:center; gap:8px; width:100%; padding:8px; text-align:left; border-radius:var(--org-border-radius,0px); color:var(--muted-foreground-hex); }
+.infrastructure-tree-row>span:not(.infrastructure-layer-dot) { flex:1; }
+.infrastructure-tree-row small { font-size:10px; font-variant-numeric:tabular-nums; }
+.infrastructure-tree-row:hover,.infrastructure-tree-row.is-active { background:color-mix(in srgb,var(--workspace-accent,var(--color-primary)) 10%,transparent); color:var(--workspace-accent,var(--color-primary)); }
+.infrastructure-layer-dot { width:8px; height:8px; border:1px solid var(--layer-color); flex-shrink:0; margin:0 3px; }
+.infrastructure-search { display:flex; align-items:center; gap:8px; border:1px solid var(--border-hex); border-radius:var(--org-border-radius,0px); padding:8px; margin:16px 4px 6px; color:var(--muted-foreground-hex); }
+.infrastructure-search input { min-width:0; width:100%; font-size:12px; background:transparent; color:var(--foreground-hex); }
+.infrastructure-component-list button,.infrastructure-dependencies button { width:100%; display:flex; align-items:center; justify-content:space-between; gap:8px; text-align:left; padding:8px; border-radius:var(--org-border-radius,0px); }
+.infrastructure-component-list button:hover,.infrastructure-dependencies button:hover { background:color-mix(in srgb,var(--workspace-accent,var(--color-primary)) 8%,transparent); }
+.infrastructure-component-list strong,.infrastructure-dependencies button { font-size:12px; font-weight:400; }
+.infrastructure-component-list small,.infrastructure-dependencies small { display:block; font-size:10px; line-height:1.6; color:var(--muted-foreground-hex); margin-top:2px; overflow-wrap:anywhere; }
+.infrastructure-component-list svg,.infrastructure-dependencies svg { flex-shrink:0; color:var(--muted-foreground-hex); }
+.infrastructure-component-list p,.infrastructure-dependencies p { font-size:11px; color:var(--muted-foreground-hex); padding:8px; }
+.infrastructure-inspector { padding:4px; }
+.infrastructure-eyebrow { font:10px monospace; letter-spacing:0.6px; color:var(--muted-foreground-hex); }
+.infrastructure-inspector-title h2 { font-size:16px; font-weight:500; margin:8px 0; overflow-wrap:anywhere; }
+.infrastructure-inspector-title p { font-size:11px; line-height:1.7; color:var(--muted-foreground-hex); overflow-wrap:anywhere; }
+.infrastructure-metrics { margin-top:16px; }
+.infrastructure-metrics>div { display:flex; justify-content:space-between; align-items:center; padding:7px 0; border-bottom:1px solid var(--border-hex); font-size:11px; }
+.infrastructure-metrics span { color:var(--muted-foreground-hex); }
+.infrastructure-metrics strong { font-weight:500; font-variant-numeric:tabular-nums; }
+.infrastructure-metric-note { font-size:10px; color:var(--muted-foreground-hex); line-height:1.6; margin-top:8px; }
+.infrastructure-back { font-size:11px; margin:16px 0 8px; color:var(--muted-foreground-hex); }
+.infrastructure-dependencies h3 { display:flex; align-items:center; gap:7px; font-size:11px; font-weight:500; margin-top:16px; }
+.infrastructure-dependencies h3 span { margin-left:auto; color:var(--muted-foreground-hex); }
+.infrastructure-files,.infrastructure-about { margin-top:20px; font-size:11px; color:var(--muted-foreground-hex); }
+.infrastructure-about { padding:10px 8px; border-top:1px solid var(--border-hex); }
+.infrastructure-about p { margin-top:8px; font-size:10px; line-height:1.7; }
+.infrastructure-files code { display:block; font-size:10px; overflow-wrap:anywhere; padding:8px 0; }
+.infrastructure-menu { display:flex; align-items:center; gap:4px; color:var(--foreground-hex); font-size:12px; }
+.infrastructure-menu-title { margin-right:4px; font-size:12px; font-weight:600; color:var(--foreground-hex); }
+.infrastructure-menu details { position:relative; }
+.infrastructure-menu summary { list-style:none; padding:6px 8px; cursor:pointer; border-radius:var(--org-border-radius,0px); }
+.infrastructure-menu summary::-webkit-details-marker { display:none; }
+.infrastructure-menu details[open]>summary,.infrastructure-menu summary:hover { background:var(--border-hex); }
+.infrastructure-menu-popup { position:absolute; left:0; top:100%; min-width:200px; padding:4px; border:1px solid var(--border-hex); border-radius:var(--org-border-radius,0px); background:var(--background-hex); box-shadow:0 8px 24px #00000020; z-index:210; }
+.infrastructure-menu-popup button { width:100%; padding:8px 10px; text-align:left; display:flex; justify-content:space-between; font-size:12px; }
+.infrastructure-menu-popup button:hover { background:var(--border-hex); }
+.infrastructure-menu-popup hr { border-color:var(--border-hex); margin:4px 0; }
+.infrastructure-page button,.infrastructure-sidebar button,.infrastructure-menu button,.infrastructure-sidebar summary { cursor:pointer; }
+.infrastructure-page button:focus-visible,.infrastructure-sidebar button:focus-visible,.infrastructure-sidebar input:focus-visible,.infrastructure-menu button:focus-visible,.infrastructure-menu summary:focus-visible { outline:2px solid var(--workspace-accent,var(--color-primary)); outline-offset:2px; }
+.infrastructure-mobile-nav { display:none; }
+@media(max-width:767px) { .infrastructure-mobile-nav { display:block; padding:8px 12px; background:var(--background-hex); border-bottom:1px solid var(--border-hex); } .infrastructure-mobile-nav>details { margin-top:8px; font-size:12px; } .infrastructure-mobile-nav>details>.infrastructure-sidebar { max-height:45vh; overflow:auto; padding-top:12px; } .infrastructure-view-heading { padding:12px; } .infrastructure-view-footer { padding:10px 12px; } }
+.infrastructure-view-selector { display:flex; border:1px solid var(--border-hex); padding:2px; border-radius:var(--org-border-radius,0px); gap:2px; }
+.infrastructure-view-selector button { padding:5px 9px; color:var(--muted-foreground-hex); }
+.infrastructure-view-selector button[aria-pressed=true] { color:var(--foreground-hex); background:var(--muted-bg-hex); }
+.infrastructure-link-tooltip { position:absolute; z-index:5; width:280px; max-width:calc(100% - 16px); padding:10px 12px; pointer-events:none; border:1px solid var(--border-hex); border-radius:var(--org-border-radius,0px); background:var(--card-hex); color:var(--foreground-hex); box-shadow:0 4px 16px #00000020; font-size:11px; line-height:1.6; overflow-wrap:anywhere; }
+.infrastructure-link-tooltip strong,.infrastructure-link-tooltip span,.infrastructure-link-tooltip small { display:block; }
+.infrastructure-link-tooltip span,.infrastructure-link-tooltip small { color:var(--muted-foreground-hex); }
+.infrastructure-graph { position:absolute; inset:0; overflow:hidden; }
+.infrastructure-graph>svg { width:100%; height:100%; touch-action:none; cursor:grab; }
+.infrastructure-graph>svg:active { cursor:grabbing; }
+.infrastructure-graph-edge { color:var(--muted-foreground-hex); opacity:0.08; }
+.infrastructure-graph-edge:hover,.infrastructure-graph-edge:focus-within { opacity:1; color:var(--workspace-accent,var(--color-primary)); }
+.infrastructure-graph-edge path { fill:none; stroke:currentColor; stroke-width:1; vector-effect:non-scaling-stroke; }
+.infrastructure-graph-edge .infrastructure-graph-edge-hit { stroke:transparent; stroke-width:14; pointer-events:stroke; cursor:help; outline:none; }
+.infrastructure-graph-node { opacity:0.3; cursor:pointer; }
+.infrastructure-graph-node.is-relevant { opacity:1; }
+.infrastructure-graph-node>rect { fill:var(--card-hex); stroke:var(--border-hex); vector-effect:non-scaling-stroke; }
+.infrastructure-graph-node:hover>rect,.infrastructure-graph-node:focus>rect,.infrastructure-graph-node.is-selected>rect { stroke:var(--workspace-accent,var(--color-primary)); stroke-width:2; }
+.infrastructure-graph-node text { fill:var(--foreground-hex); font:11px sans-serif; pointer-events:none; }
+.infrastructure-graph-node .infrastructure-graph-node-detail { fill:var(--muted-foreground-hex); font-size:9px; }
+.infrastructure-menu-popup button:disabled { opacity:0.4; cursor:default; }
+@media(max-width:767px) { .infrastructure-view-heading { flex-wrap:wrap; gap:8px; } }
+.infrastructure-graph-lane>rect { fill:var(--muted-bg-hex); fill-opacity:0.24; stroke:var(--border-hex); stroke-opacity:0.5; vector-effect:non-scaling-stroke; }
+.infrastructure-graph-lane>path { stroke-width:3; vector-effect:non-scaling-stroke; }
+.infrastructure-graph-lane>text { fill:var(--foreground-hex); font:500 14px sans-serif; }
+.infrastructure-graph-lane .infrastructure-graph-lane-count { fill:var(--muted-foreground-hex); font:11px sans-serif; }
+.infrastructure-graph-edge.is-relevant { opacity:0.15; }
+.infrastructure-graph-edge.is-focused { opacity:0.65; }
+.infrastructure-graph-edge:hover,.infrastructure-graph-edge:focus-within { opacity:1; }
+.infrastructure-graph-edge path { stroke-linejoin:round; }
+.infrastructure-graph-node text { font-size:13px; }
+.infrastructure-graph-node .infrastructure-graph-node-detail { font-size:11px; }

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/infrastructure.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/infrastructure.tsx
@@ -1,0 +1,27 @@
+'use client';
+import dynamic from 'next/dynamic';
+import { useMemo } from 'react';
+import { Focus, Minus, Plus, RotateCcw } from 'lucide-react';
+import { Header } from '@/components/shell/header';
+import { architecture } from './architecture-model';
+import { useInfrastructure } from './infrastructure-store';
+import { InfrastructureMenu } from './infrastructure-menu';
+import { InfrastructureSection } from './infrastructure-section';
+import './infrastructure.css';
+const ArchitectureScene = dynamic(() => import('./architecture-scene'), { ssr: false, loading: () => <div className="infrastructure-scene-error">Loading architecture…</div> });
+const ArchitectureGraph = dynamic(() => import('./architecture-graph'), { ssr: false });
+export default function Infrastructure() {
+  const { viewMode, setViewMode, layerId, componentId, expanded, dependencies, command, select, reset, move } = useInfrastructure();
+  const menu = useMemo(() => <InfrastructureMenu />, []);
+  const layer = architecture.layers.find(l => l.id === layerId);
+  return <section className="infrastructure-page" aria-label="ABI infrastructure">
+    <Header title="Infrastructure" nav={menu} />
+    <div className="infrastructure-mobile-nav"><InfrastructureMenu /><details><summary>Architecture & inspector</summary><InfrastructureSection /></details></div>
+    <div className="infrastructure-viewport">
+      <div className="infrastructure-view-heading"><div className="infrastructure-view-selector" aria-label="Visualization"><button aria-pressed={viewMode === 'layers'} onClick={() => setViewMode('layers')}>Layers</button><button aria-pressed={viewMode === 'graph'} onClick={() => setViewMode('graph')}>Diagram</button></div><button onClick={reset}>ABI</button><span>/</span><span>{layer?.label ?? 'Entire system'}</span>{layer && <button className="infrastructure-exit" onClick={reset}>Exit focus</button>}</div>
+      <div className="infrastructure-canvas-area">{viewMode === 'graph' ? <ArchitectureGraph /> : <ArchitectureScene layer={layerId} component={componentId} expanded={expanded} dependencies={dependencies} command={command} onSelect={select} />}</div>
+      <div className="infrastructure-view-tools"><button onClick={() => move()} title="Fit view" aria-label="Fit view"><Focus size={16} /></button><button onClick={() => move('in')} title="Zoom in" aria-label="Zoom in"><Plus size={16} /></button><button onClick={() => move('out')} title="Zoom out" aria-label="Zoom out"><Minus size={16} /></button><button onClick={reset} title="Reset view" aria-label="Reset view"><RotateCcw size={16} /></button></div>
+      <footer className="infrastructure-view-footer"><span>{viewMode === 'graph' ? 'Drag to pan · Scroll to zoom · Hover links for details' : 'Drag to orbit · Scroll to zoom · Hover links for details'}</span><span>Source snapshot · {architecture.components.length} components{dependencies || viewMode === 'graph' ? ' · Dependencies shown' : ''}</span></footer>
+    </div>
+  </section>;
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/link-tooltip.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/link-tooltip.tsx
@@ -1,0 +1,7 @@
+import { describeDependency, type Dependency } from './graph-model';
+export type LinkHover = { edge: Dependency; x: number; y: number } | null;
+export function LinkTooltip({ hover }: { hover: LinkHover }) {
+  if (!hover) return null;
+  const description = describeDependency(hover.edge);
+  return <div className="infrastructure-link-tooltip" role="tooltip" style={{ left: hover.x, top: hover.y }}><strong>{description.title}</strong><span>{description.detail}</span><small>{hover.edge.count} extracted relationships</small></div>;
+}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/page.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/page.tsx
@@ -1,0 +1,1 @@
+export { default } from './infrastructure';

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/layout.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/app/workspace/[workspaceId]/settings/layout.tsx
@@ -4,9 +4,9 @@ import { usePathname } from 'next/navigation';
 import { useWorkspaceStore } from '@/stores/workspace';
 import { Header } from '@/components/shell/header';
 
-// Service embeds want the full content area (width and height) instead of
+// Service embeds and architecture visualization use the full content area instead of
 // the centered card layout every other settings page uses.
-const FULL_PAGE_PATTERN = /\/settings\/services\/[^/]+$/;
+const FULL_PAGE_PATTERN = /\/settings\/(?:services\/[^/]+|infrastructure)$/;
 
 export default function SettingsLayout({
   children,
@@ -21,10 +21,10 @@ export default function SettingsLayout({
 
   return (
     <div className="flex h-full flex-col">
-      <Header
+      {!pathname?.endsWith('/settings/infrastructure') && <Header
         title="Settings"
         subtitle={currentWorkspace?.name || 'Configure your workspace'}
-      />
+      />}
 
       {isFullPage ? (
         <div className="flex-1 overflow-hidden">{children}</div>

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/mobile/mobile-more-sheet.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/mobile/mobile-more-sheet.tsx
@@ -2,7 +2,7 @@
 
 import { createPortal } from 'react-dom';
 import {
-  Search, BrainCircuit, Waypoints, Database, Map, Presentation, Store, Settings, Activity, X, Home,
+  Search, BrainCircuit, Waypoints, Database, Map, Presentation, Store, Settings, Activity, X, Home, Blocks,
 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
@@ -34,6 +34,7 @@ const MORE_ITEMS: MoreItem[] = [
   { id: 'marketplace', label: 'Marketplace', icon: <Store size={18} />, href: '/marketplace', section: 'marketplace', feature: 'marketplace' },
   { id: 'settings', label: 'Settings', icon: <Settings size={18} />, href: '/settings', section: 'settings', feature: 'settings.workspace' },
   { id: 'admin-events', label: 'Events', icon: <Activity size={18} />, href: '/admin/events', section: 'events', superadmin: true },
+  { id: 'infrastructure', label: 'Infrastructure', icon: <Blocks size={18} />, href: '/settings/infrastructure', section: 'infrastructure', feature: 'settings.workspace' },
 ];
 
 interface MobileMoreSheetProps {

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/settings-nav.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/settings-nav.tsx
@@ -6,6 +6,7 @@ import {
   Cpu,
   Download,
   HardDrive,
+  Blocks,
   Server,
   Shield,
   Users,
@@ -41,6 +42,7 @@ export const SETTINGS_GROUPS: SettingsNavGroup[] = [
     items: [
       { href: '/settings/theme', label: 'Theme', icon: Brush },
       { href: '/settings/members', label: 'Members', icon: Users },
+      { href: '/settings/infrastructure', label: 'Infrastructure', icon: Blocks },
       { href: '/settings/servers', label: 'Servers', icon: Server },
       { href: '/settings/secrets', label: 'Secrets', icon: Shield },
       { href: '/settings/export', label: 'Data Export', icon: Download },

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/index.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/index.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import {
-  Map as MapIcon, Search, MessageSquare, BrainCircuit, Waypoints, Folder, Database, Code, Presentation, LayoutGrid, Store, Settings, Activity, Home,
+  Map as MapIcon, Search, MessageSquare, BrainCircuit, Waypoints, Folder, Database, Code, Presentation, LayoutGrid, Store, Settings, Activity, Home, Blocks,
 } from 'lucide-react';
 import { useRouter, usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
@@ -156,6 +156,10 @@ export function Sidebar() {
   useEffect(() => {
     if (lastReconciledPathRef.current === pathname) return;
     lastReconciledPathRef.current = pathname;
+    if (pathname.endsWith('/settings/infrastructure')) {
+      setActivePanelSection('infrastructure');
+      return;
+    }
     if (!urlSection) {
       // Events is an admin route with its own feed panel; the rest of /admin/
       // is full-bleed.
@@ -230,6 +234,7 @@ export function Sidebar() {
       case 'slides':   return getWorkspacePath(currentWorkspaceId, '/slides');
       case 'apps':         return getWorkspacePath(currentWorkspaceId, '/apps');
       case 'marketplace':  return getWorkspacePath(currentWorkspaceId, '/marketplace');
+      case 'infrastructure': return getWorkspacePath(currentWorkspaceId, '/settings/infrastructure');
       case 'settings':     return getWorkspacePath(currentWorkspaceId, '/settings');
       case 'workspaces':   return getWorkspacePath(currentWorkspaceId, '/home');
       case 'events':       return getWorkspacePath(currentWorkspaceId, '/admin/events');
@@ -541,20 +546,22 @@ export function Sidebar() {
           labeled ? 'px-2' : 'items-center px-2'
         )}
       >
-        {isSuperadmin && [
-          { key: 'admin-events', href: '/admin/events', label: 'Events', description: 'Recent platform activity', icon: <Activity size={18} /> },
-        ].map((item) => {
+        {[
+          { key: 'admin-events', href: '/admin/events', label: 'Events', description: 'Recent platform activity', icon: <Activity size={18} />, section: 'events' as SidebarSection, visible: isSuperadmin },
+          { key: 'infrastructure', href: '/settings/infrastructure', label: 'Infrastructure', description: 'Explore ABI layers, components and dependencies', icon: <Blocks size={18} />, section: 'infrastructure' as SidebarSection, visible: canSettingsWorkspace },
+        ].filter((item) => item.visible).map((item) => {
           const base = getWorkspacePath(currentWorkspaceId, item.href);
           const active = pathname.startsWith(base);
           return (
             <button
               key={item.key}
-              onClick={() => { setActivePanelSection('events'); router.push(base); }}
+              onClick={() => { setActivePanelSection(item.section); router.push(base); }}
               onPointerEnter={(e) => showHoverTip({ id: item.key, ...item }, e.currentTarget)}
               onPointerLeave={hideHoverTip}
               onFocus={(e) => showHoverTip({ id: item.key, ...item }, e.currentTarget)}
               onBlur={hideHoverTip}
               aria-label={item.label}
+              aria-current={active ? 'page' : undefined}
               className={cn(
                 'flex items-center rounded-lg transition-all outline-none focus-visible:ring-0',
                 'hover:bg-workspace-accent-10 hover:text-workspace-accent',
@@ -568,7 +575,7 @@ export function Sidebar() {
           );
         })}
         {BOTTOM_SECTIONS.filter((s) => isFeatureEnabled(s.feature)).map((section) => {
-          const active = isSectionActive(section);
+          const active = isSectionActive(section) && !pathname.startsWith(getWorkspacePath(currentWorkspaceId, '/settings/infrastructure'));
           return (
             <button
               key={section.id}

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/section-labels.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/section-labels.ts
@@ -21,6 +21,7 @@ export const SECTION_LABELS: Record<SidebarSection, string> = {
   marketplace: 'Marketplace',
   settings: 'Settings',
   events: 'Events',
+  infrastructure: 'Infrastructure',
 };
 
 /** Panel titles that open the section home. Slides goes to the cover gallery. */

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/section-panel.tsx
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/components/shell/sidebar/section-panel.tsx
@@ -54,6 +54,7 @@ const AppsSection = dynamic(() => import('./apps-section').then((m) => m.AppsSec
   ssr: false,
   loading: sectionLoading,
 });
+const InfrastructureSection = dynamic(() => import('@/app/workspace/[workspaceId]/settings/infrastructure/infrastructure-section').then(m => m.InfrastructureSection), { ssr: false, loading: sectionLoading });
 const SettingsSection = dynamic(() => import('./settings-section').then((m) => m.SettingsSection), {
   ssr: false,
   loading: sectionLoading,
@@ -68,6 +69,7 @@ const WorkspacesSection = dynamic(
 );
 
 function SectionContent({ section }: { section: SidebarSection }) {
+  const canSettings = useFeature('settings.workspace');
   const canMaps = useFeature('maps');
   const canChat = useFeature('chat');
   const canFiles = useFeature('files');
@@ -90,6 +92,7 @@ function SectionContent({ section }: { section: SidebarSection }) {
   if (section === 'slides' && canSlides) return <SlidesSection collapsed={false} detailOnly />;
   if (section === 'apps' && canApps) return <AppsSection collapsed={false} detailOnly />;
   if (section === 'marketplace' && canMarketplace) return <MarketplaceSection collapsed={false} detailOnly />;
+  if (section === 'infrastructure' && canSettings) return <InfrastructureSection />;
   if (section === 'settings') return <SettingsSection collapsed={false} detailOnly />;
   // Superadmin-only route; the dock only offers it to superadmins.
   if (section === 'events') return <EventsSection collapsed={false} detailOnly />;

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/feature-access.test.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/feature-access.test.ts
@@ -60,6 +60,7 @@ describe('getFeatureForWorkspacePath', () => {
     );
     expect(getFeatureForWorkspacePath('/workspace/ws1/settings/agents')).toBe('agents');
     expect(getFeatureForWorkspacePath('/workspace/ws1/settings/theme')).toBe('settings.workspace');
+    expect(getFeatureForWorkspacePath('/workspace/ws1/settings/infrastructure')).toBe('settings.workspace');
     expect(getFeatureForWorkspacePath('/workspace/ws1/organization')).toBe('settings.organization');
     expect(getFeatureForWorkspacePath('/workspace/ws1/organization/billing')).toBe('settings.organization');
     expect(getFeatureForWorkspacePath('/workspace/ws1/apps')).toBe('apps');

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/quick-open.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/lib/quick-open.ts
@@ -37,6 +37,7 @@ export const QUICK_OPEN_SECTIONS: readonly QuickOpenSection[] = [
   { id: 'code', label: 'Code', href: '/code', feature: 'code' },
   { id: 'marketplace', label: 'Marketplace', href: '/marketplace', feature: 'marketplace' },
   { id: 'settings', label: 'Settings', href: '/settings', feature: 'settings.workspace' },
+  { id: 'infrastructure', label: 'Infrastructure', href: '/settings/infrastructure', feature: 'settings.workspace' },
 ];
 
 export const QUICK_OPEN_GROUP_LABEL: Record<QuickOpenGroup, string> = {

--- a/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
+++ b/libs/naas-abi/naas_abi/apps/nexus/apps/web/src/stores/workspace.ts
@@ -198,7 +198,7 @@ export interface GitCommit {
 }
 
 // Sidebar expandable sections
-export type SidebarSection = 'home' | 'workspaces' | 'maps' | 'chat' | 'search' | 'files' | 'datasets' | 'code' | 'slides' | 'ontology' | 'graph' | 'apps' | 'marketplace' | 'settings' | 'events';
+export type SidebarSection = 'home' | 'workspaces' | 'maps' | 'chat' | 'search' | 'files' | 'datasets' | 'code' | 'slides' | 'ontology' | 'graph' | 'apps' | 'marketplace' | 'settings' | 'events' | 'infrastructure';
 
 const RETIRED_PANEL_SECTIONS = new Set<string>(['lab']);
 

--- a/libs/naas-abi/naas_abi/apps/nexus/pnpm-lock.yaml
+++ b/libs/naas-abi/naas_abi/apps/nexus/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       tailwind-merge:
         specifier: ^2.2.1
         version: 2.6.1
+      three:
+        specifier: ^0.186.0
+        version: 0.186.0
       zustand:
         specifier: ^4.5.7
         version: 4.5.7(@types/react@18.3.27)(react@18.3.1)
@@ -118,6 +121,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.2.18
         version: 18.3.7(@types/react@18.3.27)
+      '@types/three':
+        specifier: ^0.185.4
+        version: 0.185.4
       autoprefixer:
         specifier: ^10.4.17
         version: 10.4.24(postcss@8.5.6)
@@ -315,6 +321,10 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+    dev: true
+
+  /@dimforge/rapier3d-compat@0.12.0:
+    resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
     dev: true
 
   /@egjs/hammerjs@2.0.17:
@@ -2612,6 +2622,10 @@ packages:
     dependencies:
       tslib: 2.8.1
 
+  /@tweenjs/tween.js@23.1.3:
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+    dev: true
+
   /@tybys/wasm-util@0.10.1:
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
     requiresBuild: true
@@ -2692,6 +2706,21 @@ packages:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
+  /@types/stats.js@0.17.4:
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+    dev: true
+
+  /@types/three@0.185.4:
+    resolution: {integrity: sha512-gAsBIC07NIFrxjbf7tH2t71c38uulFfk/RFoC7FNBSjMRAQ8J1x/RBvusX0N5PJouaYFJawXQqfCQ0RKUx/1nA==}
+    dependencies:
+      '@dimforge/rapier3d-compat': 0.12.0
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.4
+      '@types/webxr': 0.5.24
+      fflate: 0.8.3
+      meshoptimizer: 1.1.1
+    dev: true
+
   /@types/trusted-types@2.0.7:
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
     requiresBuild: true
@@ -2704,6 +2733,10 @@ packages:
   /@types/unist@3.0.3:
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
     dev: false
+
+  /@types/webxr@0.5.24:
+    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
+    dev: true
 
   /@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.3):
     resolution: {integrity: sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==}
@@ -4414,6 +4447,10 @@ packages:
       picomatch: 4.0.3
     dev: true
 
+  /fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+    dev: true
+
   /file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -5363,6 +5400,10 @@ packages:
   /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+    dev: true
+
+  /meshoptimizer@1.1.1:
+    resolution: {integrity: sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==}
     dev: true
 
   /micromark-core-commonmark@2.0.3:
@@ -6868,6 +6909,10 @@ packages:
     dependencies:
       any-promise: 1.3.0
     dev: true
+
+  /three@0.186.0:
+    resolution: {integrity: sha512-cr/fIM2ddMSVbYVgkfD4jLJv7Fh/8ZTjvo+7gQeSVGUZHxpx9FDwoL5iC7hUz/LiRA8wMbqfnb90xKfm1/HHkQ==}
+    dev: false
 
   /tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}

--- a/libs/naas-abi/naas_abi/apps/nexus/scripts/build_abi_architecture.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/scripts/build_abi_architecture.py
@@ -1,0 +1,262 @@
+"""Build a public code-architecture snapshot; never reads configuration or secrets.
+
+Run from Nexus: python3 scripts/build_abi_architecture.py
+Uses Graphify's local AST extractor (no LLM). Temporary corpus contains only
+Python sources, excluding tests, migrations, virtualenvs and generated outputs.
+"""
+
+import argparse
+import ast
+import json
+import shutil
+import subprocess
+import tempfile
+from collections import Counter
+from datetime import UTC, datetime
+from pathlib import Path
+
+LAYERS = [
+    {
+        "id": "applications",
+        "label": "Agents & applications",
+        "description": "ABI agents, workflows, pipelines and the Nexus application.",
+        "color": "#B8A3F5",
+    },
+    {
+        "id": "runtime",
+        "label": "Execution & models",
+        "description": "Engine, module lifecycle, agent execution and model abstractions.",
+        "color": "#8EACF5",
+    },
+    {
+        "id": "knowledge",
+        "label": "Knowledge & data",
+        "description": "Ontologies, structured datasets, vector search and the triple store.",
+        "color": "#62C5C2",
+    },
+    {
+        "id": "platform",
+        "label": "Platform services",
+        "description": "Service contracts for events, storage, secrets and integrations.",
+        "color": "#D5B679",
+    },
+    {
+        "id": "adapters",
+        "label": "Infrastructure adapters",
+        "description": "Concrete implementations of service ports; availability is not runtime health.",
+        "color": "#92A4BC",
+    },
+]
+EXCLUDED = {"node_modules", ".venv", "__pycache__", ".next", "migrations", ".git"}
+RELATIONS = {
+    "imports",
+    "imports_from",
+    "calls",
+    "uses",
+    "inherits",
+    "references",
+    "re_exports",
+}
+
+
+def is_test(path):
+    return (
+        "tests" in path.parts
+        or path.name.startswith("test_")
+        or path.stem.endswith("_test")
+    )
+
+
+def classify(path):
+    p = path.parts
+    if p[0] == "naas_abi":
+        section = p[1] if len(p) > 2 else "module"
+        name = (
+            p[2].removesuffix(".py")
+            if section in {"agents", "apps"} and len(p) > 2
+            else section
+        )
+        if name == "__init__":
+            section = name = "module"
+        layer = "knowledge" if section == "ontologies" else "applications"
+        return f"abi/{section}/{name}", name, layer
+    if len(p) > 3 and p[1] == "services":
+        service = p[2]
+        if "adapters" in p:
+            return f"adapters/{service}", service + " adapters", "adapters"
+        layer = (
+            "knowledge"
+            if service in {"ontology", "triple_store", "vector_store", "dataset"}
+            else "runtime"
+            if service in {"agent", "coding_environment", "model_registry"}
+            else "platform"
+        )
+        return f"services/{service}", service, layer
+    section = p[1] if len(p) > 2 else "foundation"
+    return f"core/{section}", section, "runtime"
+
+
+def build(libs, graph):
+    files = {}
+    components = {}
+    errors = []
+    for package, folder in [
+        ("naas-abi", "naas_abi"),
+        ("naas-abi-core", "naas_abi_core"),
+    ]:
+        for f in sorted((libs / package / folder).rglob("*.py")):
+            rel = f.relative_to(libs / package)
+            if EXCLUDED.intersection(rel.parts):
+                continue
+            cid, name, layer = classify(rel)
+            c = components.setdefault(
+                cid,
+                {
+                    "id": cid,
+                    "label": name.replace("_", " ").title() if name.islower() else name,
+                    "layer": layer,
+                    "files": 0,
+                    "lines": 0,
+                    "classes": 0,
+                    "functions": 0,
+                    "tests": 0,
+                    "symbols": 0,
+                    "sourcePaths": [],
+                },
+            )
+            if is_test(rel):
+                c["tests"] += 1
+                continue
+            source = f.read_text(encoding="utf-8")
+            try:
+                tree = ast.parse(source)
+            except SyntaxError:
+                errors.append(rel.as_posix())
+                continue
+            files[rel.as_posix()] = cid
+            c["files"] += 1
+            c["lines"] += len(source.splitlines())
+            c["classes"] += sum(isinstance(n, ast.ClassDef) for n in ast.walk(tree))
+            c["functions"] += sum(
+                isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+                for n in ast.walk(tree)
+            )
+            c["sourcePaths"].append(rel.as_posix())
+    components = {k: v for k, v in components.items() if v["files"]}
+    nodes = {n["id"]: files.get(n.get("source_file", "")) for n in graph["nodes"]}
+    for cid in nodes.values():
+        if cid in components:
+            components[cid]["symbols"] += 1
+    edges = Counter()
+    kinds = {}
+    for e in graph["edges"]:
+        a, b = nodes.get(e["source"]), nodes.get(e["target"])
+        if (
+            a
+            and b
+            and a != b
+            and e.get("confidence") == "EXTRACTED"
+            and e.get("relation") in RELATIONS
+        ):
+            edges[a, b] += 1
+            kinds.setdefault((a, b), Counter())[e["relation"]] += 1
+    try:
+        revision = subprocess.check_output(
+            ["git", "-C", str(libs), "rev-parse", "--short", "HEAD"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except subprocess.CalledProcessError:
+        revision = "unknown"
+    return {
+        "schemaVersion": 1,
+        "generatedAt": datetime.now(UTC).isoformat(),
+        "revision": revision,
+        "extractor": "Graphify · local AST",
+        "extractorVersion": "0.9.57",
+        "scope": "Python source in naas_abi and naas_abi_core. Tests counted separately; migrations excluded. Shared code architecture, not workspace deployment or live telemetry.",
+        "layers": LAYERS,
+        "components": sorted(
+            components.values(), key=lambda c: (c["layer"], c["label"])
+        ),
+        "edges": [
+            {"source": a, "target": b, "count": n, "relations": dict(kinds[a, b])}
+            for (a, b), n in sorted(edges.items())
+        ],
+        "extraction": {
+            "nodes": len(graph["nodes"]),
+            "edges": len(graph["edges"]),
+            "skippedFiles": errors,
+        },
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--libs", type=Path, default=Path(__file__).resolve().parents[5]
+    )
+    parser.add_argument(
+        "--graph",
+        type=Path,
+        help="Reuse Graphify JSON extracted from the same relative Python corpus",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path(__file__).resolve().parents[1]
+        / "apps/web/src/app/workspace/[workspaceId]/settings/infrastructure/abi-architecture.json",
+    )
+    args = parser.parse_args()
+    libs = args.libs.resolve()
+    for package, folder in [
+        ("naas-abi", "naas_abi"),
+        ("naas-abi-core", "naas_abi_core"),
+    ]:
+        if not (libs / package / folder).is_dir():
+            parser.error(f"Missing {libs / package / folder}")
+    with tempfile.TemporaryDirectory(prefix="abi-architecture-") as tmp:
+        tmp = Path(tmp)
+        if args.graph:
+            graph = json.loads(args.graph.read_text())
+        else:
+            corpus = tmp / "corpus"
+            for package, folder in [
+                ("naas-abi", "naas_abi"),
+                ("naas-abi-core", "naas_abi_core"),
+            ]:
+                for f in (libs / package / folder).rglob("*.py"):
+                    rel = f.relative_to(libs / package)
+                    if EXCLUDED.intersection(rel.parts) or is_test(rel):
+                        continue
+                    dest = corpus / rel
+                    dest.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copyfile(f, dest)
+            subprocess.run(
+                [
+                    "uvx",
+                    "--from",
+                    "graphifyy==0.9.57",
+                    "graphify",
+                    "extract",
+                    str(corpus),
+                    "--code-only",
+                    "--no-cluster",
+                    "--max-workers",
+                    "2",
+                    "--out",
+                    str(tmp / "result"),
+                ],
+                check=True,
+            )
+            graph = json.loads((tmp / "result/graphify-out/graph.json").read_text())
+        result = build(libs, graph)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(result, indent=2) + "\n")
+        print(
+            f"Wrote {len(result['components'])} components and {len(result['edges'])} dependencies to {args.output}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/libs/naas-abi/naas_abi/apps/nexus/scripts/build_abi_architecture_test.py
+++ b/libs/naas-abi/naas_abi/apps/nexus/scripts/build_abi_architecture_test.py
@@ -1,0 +1,97 @@
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "snapshot", Path(__file__).with_name("build_abi_architecture.py")
+)
+snapshot = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(snapshot)
+
+
+class ArchitectureSnapshotTest(unittest.TestCase):
+    def test_adapters_are_separated_from_service_contracts(self):
+        self.assertEqual(
+            snapshot.classify(Path("naas_abi_core/services/event/EventService.py"))[2],
+            "platform",
+        )
+        self.assertEqual(
+            snapshot.classify(
+                Path("naas_abi_core/services/event/adapters/secondary/Redis.py")
+            )[2],
+            "adapters",
+        )
+        self.assertEqual(
+            snapshot.classify(
+                Path("naas_abi_core/services/triple_store/TripleStore.py")
+            )[2],
+            "knowledge",
+        )
+
+    def test_counts_and_edges_ignore_tests_unresolved_and_inferred_links(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            agent = "naas_abi/agents/ExampleAgent.py"
+            service = "naas_abi_core/services/agent/Agent.py"
+            for package, name, text in [
+                ("naas-abi", agent, "class ExampleAgent:\n    def run(self): pass\n"),
+                ("naas-abi-core", service, "def run(): pass\n"),
+                (
+                    "naas-abi-core",
+                    service.replace("Agent.py", "Agent_test.py"),
+                    "def test_run(): pass\n",
+                ),
+            ]:
+                f = root / package / name
+                f.parent.mkdir(parents=True, exist_ok=True)
+                f.write_text(text)
+            graph = {
+                "nodes": [
+                    {"id": "a", "source_file": agent},
+                    {"id": "b", "source_file": service},
+                ],
+                "edges": [
+                    {
+                        "source": "a",
+                        "target": "b",
+                        "confidence": "EXTRACTED",
+                        "relation": "calls",
+                    },
+                    {
+                        "source": "a",
+                        "target": "b",
+                        "confidence": "INFERRED",
+                        "relation": "calls",
+                    },
+                    {
+                        "source": "a",
+                        "target": "external",
+                        "confidence": "EXTRACTED",
+                        "relation": "imports",
+                    },
+                    {
+                        "source": "a",
+                        "target": "a",
+                        "confidence": "EXTRACTED",
+                        "relation": "calls",
+                    },
+                ],
+            }
+            result = snapshot.build(root, graph)
+            self.assertEqual(len(result["edges"]), 1)
+            self.assertEqual(result["edges"][0]["count"], 1)
+            self.assertEqual(sum(c["files"] for c in result["components"]), 2)
+            self.assertEqual(sum(c["tests"] for c in result["components"]), 1)
+            self.assertEqual(sum(c["functions"] for c in result["components"]), 2)
+            self.assertFalse(
+                any(
+                    str(root) in p
+                    for c in result["components"]
+                    for p in c["sourcePaths"]
+                )
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add Settings → Infrastructure: a map of the shared ABI Python codebase (layers, diagram, inspector).
- Gate it with the existing workspace session and `settings.workspace`. The page does not read secrets, send source to a model, or represent a workspace deployment.
- Snapshot is build-time Graphify AST over `naas_abi` and `naas_abi_core`. Marketplace, TTL, and TypeScript stay out.

Fixes #1265

## Test plan

- [ ] Open Infrastructure from Settings, the dock, mobile More, and the command palette on a workspace with `settings.workspace`
- [ ] Hide those entry points when the flag is off
- [ ] Switch Layers and Diagram; select a layer and a component; confirm Depends on / Used by
- [ ] Fit, zoom, reset, decompose, and toggle dependencies
- [ ] Export the snapshot and confirm it matches the committed JSON
- [ ] From Nexus: `python3 -m unittest discover -s scripts -p '*_test.py'`
- [ ] From `apps/web`: `pnpm typecheck` and `pnpm dlx vitest@3.2.4 run 'src/app/workspace/[workspaceId]/settings/infrastructure'`