### PR TITLE
perf(core): reuse DuckLake snapshot read connections

### DIFF
--- a/libs/naas-abi-core/naas_abi_core/services/dataset/AGENTS.md
+++ b/libs/naas-abi-core/naas_abi_core/services/dataset/AGENTS.md
@@ -119,10 +119,17 @@ trade-off. One caveat: because the connection is kept open for the process's
 lifetime, it does not re-run `_configure_object_store`'s `CREATE OR REPLACE
 SECRET`, so a deployment that rotates S3/MinIO credentials at runtime needs
 the process restarted (or the adapter recreated) to pick up new ones — a
-fresh-per-call connection previously did this implicitly. A pinned
-`query(snapshot_id=...)` (time travel) still gets its own fresh,
-snapshot-specific connection, since `SNAPSHOT_VERSION` is fixed at ATTACH
-time and can't be shared with the latest-snapshot read connection.
+fresh-per-call connection previously did this implicitly. Pinned
+`query(snapshot_id=...)` calls reuse up to four snapshot-specific connections,
+with a 60-second lifetime checked on cache access. `SNAPSHOT_VERSION` is fixed
+at ATTACH time, so these remain separate from the latest-snapshot connection.
+Every query still validates snapshot existence through the DuckLake metadata
+`ducklake_snapshot` primary key rather than listing the entire snapshot history,
+and uses an independent cursor.
+Eviction drops cache ownership without closing active readers' connections.
+Flush clears the snapshot cache; a failed pinned query retires its connection
+without replaying SQL. These are bounded process-local connection defaults,
+not a result cache or a change to snapshot retention.
 
 Ambiguous object-store transport failures are not replayed automatically: a timeout
 may arrive after metadata committed, and replaying an append could duplicate rows.

--- a/libs/naas-abi-core/naas_abi_core/services/dataset/adapters/secondary/DatasetSecondaryAdapterDuckLake.py
+++ b/libs/naas-abi-core/naas_abi_core/services/dataset/adapters/secondary/DatasetSecondaryAdapterDuckLake.py
@@ -8,6 +8,7 @@ import logging
 import random
 import threading
 import time
+from collections import OrderedDict
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -125,8 +126,9 @@ class DatasetSecondaryAdapterDuckLake(IDatasetPort):
     cost, and a long-held ATTACH sees commits from other connections without
     re-attaching. Each call still gets its own cursor off that connection, so
     concurrent reads are independent and one call's error can't poison another's.
-    A pinned ``query(snapshot_id=...)`` (time travel) still gets a fresh,
-    snapshot-specific connection, since SNAPSHOT_VERSION is fixed at ATTACH time.
+    Pinned queries reuse a bounded cache of snapshot-specific connections,
+    since SNAPSHOT_VERSION is fixed at ATTACH time. Each query validates that
+    its snapshot still exists and uses an independent cursor.
     """
 
     def __init__(
@@ -187,6 +189,8 @@ class DatasetSecondaryAdapterDuckLake(IDatasetPort):
         )
         self._read_connection: Any | None = None
         self._read_connection_lock = threading.Lock()
+        self._snapshot_connections: OrderedDict[int, tuple[float, Any]] = OrderedDict()
+        self._snapshot_connection_lock = threading.Lock()
         self._prepare_local_paths()
 
     def create(self, spec: DatasetSpec) -> DatasetInfo:
@@ -325,14 +329,40 @@ class DatasetSecondaryAdapterDuckLake(IDatasetPort):
 
         if not self._snapshot_exists(snapshot_id):
             raise DatasetSnapshotNotFoundError(snapshot_id)
+        connection = self._get_snapshot_connection(snapshot_id)
+        cursor = connection.cursor()
         try:
-            con = self._connect(snapshot_id=snapshot_id)
-        except Exception as exc:
-            raise DatasetSnapshotNotFoundError(snapshot_id) from exc
-        try:
-            return self._run_query(con, sql, namespace)
+            return self._run_query(cursor, sql, namespace)
+        except Exception:
+            # Retire on failure, including stale inline tables after an external
+            # flush. Never replay arbitrary query SQL automatically.
+            with self._snapshot_connection_lock:
+                entry = self._snapshot_connections.get(snapshot_id)
+                if entry is not None and entry[1] is connection:
+                    del self._snapshot_connections[snapshot_id]
+            raise
         finally:
-            con.close()
+            cursor.close()
+
+    def _get_snapshot_connection(self, snapshot_id: int) -> Any:
+        with self._snapshot_connection_lock:
+            now = time.monotonic()
+            for version, (created, _) in list(self._snapshot_connections.items()):
+                if now - created >= 60:
+                    del self._snapshot_connections[version]
+            entry = self._snapshot_connections.get(snapshot_id)
+            if entry is None:
+                try:
+                    connection = self._connect(snapshot_id=snapshot_id)
+                except Exception as exc:
+                    raise DatasetSnapshotNotFoundError(snapshot_id) from exc
+                entry = (time.monotonic(), connection)
+                self._snapshot_connections[snapshot_id] = entry
+            self._snapshot_connections.move_to_end(snapshot_id)
+            while len(self._snapshot_connections) > 4:
+                # Drop cache ownership, not active readers' references.
+                self._snapshot_connections.popitem(last=False)
+            return entry[1]
 
     def _run_query(self, con: Any, sql: str, namespace: str) -> QueryResult:
         con.execute(f"USE {self._qualified_schema(namespace)}")
@@ -408,6 +438,8 @@ class DatasetSecondaryAdapterDuckLake(IDatasetPort):
         # must attach again; existing cursors retain their connection reference.
         with self._read_connection_lock:
             self._read_connection = None
+        with self._snapshot_connection_lock:
+            self._snapshot_connections.clear()
         return result
 
     def compact(self, name: str, *, namespace: str = "default") -> QueryResult:
@@ -600,7 +632,8 @@ class DatasetSecondaryAdapterDuckLake(IDatasetPort):
         def read(con: Any) -> bool:
             return (
                 con.execute(
-                    "SELECT 1 FROM abi_datasets.snapshots() WHERE snapshot_id = ?",
+                    f"SELECT 1 FROM {self._ident(f'__ducklake_metadata_{CATALOG_ALIAS}')}.ducklake_snapshot "
+                    "WHERE snapshot_id = ?",
                     [snapshot_id],
                 ).fetchone()
                 is not None

--- a/libs/naas-abi-core/naas_abi_core/services/dataset/adapters/secondary/DatasetSecondaryAdapterDuckLake.py
+++ b/libs/naas-abi-core/naas_abi_core/services/dataset/adapters/secondary/DatasetSecondaryAdapterDuckLake.py
@@ -632,7 +632,7 @@ class DatasetSecondaryAdapterDuckLake(IDatasetPort):
         def read(con: Any) -> bool:
             return (
                 con.execute(
-                    f"SELECT 1 FROM {self._ident(f'__ducklake_metadata_{CATALOG_ALIAS}')}.ducklake_snapshot "
+                    'SELECT 1 FROM "__ducklake_metadata_abi_datasets".ducklake_snapshot '
                     "WHERE snapshot_id = ?",
                     [snapshot_id],
                 ).fetchone()

--- a/libs/naas-abi-core/naas_abi_core/services/dataset/adapters/secondary/DatasetSecondaryAdapterDuckLake_test.py
+++ b/libs/naas-abi-core/naas_abi_core/services/dataset/adapters/secondary/DatasetSecondaryAdapterDuckLake_test.py
@@ -264,6 +264,67 @@ class TestDatasetSecondaryAdapterDuckLake(DatasetSecondaryAdapterContract):
         assert result.rows == []
         assert len(connect_calls) == 1
 
+    def test_pinned_reads_reuse_connection_and_keep_snapshots_isolated(
+        self, adapter, monkeypatch
+    ):
+        adapter.create(
+            DatasetSpec(name="events", columns=(ColumnSpec(name="id", type="integer"),))
+        )
+        first = adapter.write("events", [{"id": 1}]).snapshot_id
+        second = adapter.write("events", [{"id": 2}]).snapshot_id
+        connect = adapter._connect
+        snapshots = []
+
+        def counted(**kwargs):
+            snapshots.append(kwargs.get("snapshot_id"))
+            return connect(**kwargs)
+
+        adapter.list()
+        monkeypatch.setattr(adapter, "_connect", counted)
+
+        def read(snapshot):
+            return adapter.query(
+                "SELECT id FROM events ORDER BY id", snapshot_id=snapshot
+            ).rows
+
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            results = list(executor.map(read, [first, second] * 8))
+        assert results == [[{"id": 1}], [{"id": 1}, {"id": 2}]] * 8
+        assert sorted(snapshots) == sorted([first, second])
+        with pytest.raises(Exception):
+            adapter.query("SELECT * FROM absent", snapshot_id=first)
+        assert read(first) == [{"id": 1}]
+
+    def test_snapshot_connection_cache_is_bounded(self, adapter):
+        adapter.create(
+            DatasetSpec(name="events", columns=(ColumnSpec(name="id", type="integer"),))
+        )
+        versions = [adapter.write("events", [{"id": n}]).snapshot_id for n in range(6)]
+        for version in versions:
+            adapter.query("SELECT count(*) FROM events", snapshot_id=version)
+        assert len(adapter._snapshot_connections) <= 4
+        assert adapter.query("SELECT id FROM events", snapshot_id=versions[0]).rows == [
+            {"id": 0}
+        ]
+
+    def test_retiring_snapshot_cache_does_not_interrupt_active_cursor(self, adapter):
+        adapter.create(
+            DatasetSpec(name="events", columns=(ColumnSpec(name="id", type="integer"),))
+        )
+        snapshot = adapter.write("events", [{"id": 1}]).snapshot_id
+        cursor = adapter._get_snapshot_connection(snapshot).cursor()
+        try:
+            adapter.flush("events")
+            assert not adapter._snapshot_connections
+            assert cursor.execute(
+                "SELECT id FROM abi_datasets.default.events"
+            ).fetchall() == [(1,)]
+        finally:
+            cursor.close()
+        assert adapter.query("SELECT id FROM events", snapshot_id=snapshot).rows == [
+            {"id": 1}
+        ]
+
     def test_connect_owns_ducklake_catalog_migrations(self, adapter, monkeypatch):
         import duckdb
 


### PR DESCRIPTION
Pinned dataset queries currently open a fresh DuckDB connection and enumerate snapshot history for each page. Reuse up to four snapshot-specific connections for 60 seconds, with independent cursors and live snapshot validation through the metadata primary key. Flush and query failures retire cached connections without interrupting active readers or replaying SQL.

Validation: dataset suite 54 passed, 1 skipped; concurrent snapshot isolation, bounded eviction, failed queries, and active readers during flush covered. Ruff passes. No retention, credentials, or persistence-format changes.

The metadata lookup follows the DuckLake snapshot-table contract: https://ducklake.select/docs/stable/specification/tables/ducklake_snapshot
